### PR TITLE
🚚 Rename table `file` to `dobject`

### DIFF
--- a/lamindb/admin/db/_insert.py
+++ b/lamindb/admin/db/_insert.py
@@ -4,7 +4,7 @@ import lamindb as db
 from lamindb import setup
 
 from ..._logger import logger
-from ...dev.id import id_file, id_user  # noqa
+from ...dev.id import id_dobject, id_user  # noqa
 from . import get_engine
 
 
@@ -42,8 +42,10 @@ class insert:
         return user.id
 
     @classmethod
-    def file(cls, name: str, *, interface_id: str = None, interface_name: str = None):
-        """Data file with its origin."""
+    def dobject(
+        cls, name: str, *, interface_id: str = None, interface_name: str = None
+    ):
+        """Data object with its origin."""
         engine = get_engine()
         settings = setup.settings()
 
@@ -86,9 +88,9 @@ class insert:
             )
 
         with sqm.Session(engine) as session:
-            file = db.model.file(name=name, interface_id=interface_id)
-            session.add(file)
+            dobject = db.model.dobject(name=name, interface_id=interface_id)
+            session.add(dobject)
             session.commit()
-            session.refresh(file)
+            session.refresh(dobject)
 
-        return file.id
+        return dobject.id

--- a/lamindb/dev/id.py
+++ b/lamindb/dev/id.py
@@ -8,7 +8,7 @@ def id(n_char: int) -> str:
     return id
 
 
-def id_file() -> str:
+def id_dobject() -> str:
     return id(n_char=20)
 
 

--- a/lamindb/do/_ingest.py
+++ b/lamindb/do/_ingest.py
@@ -10,7 +10,7 @@ from ..admin.db import get_engine
 from ..dev.file import store_file
 
 
-def track_ingest(file_id):
+def track_ingest(dobject_id):
     engine = get_engine()
 
     from nbproject import meta
@@ -24,7 +24,7 @@ def track_ingest(file_id):
             type="ingest",
             user_id=user_id,
             interface_id=interface_id,
-            file_id=file_id,
+            dobject_id=dobject_id,
         )
         session.add(track_do)
         session.commit()
@@ -66,15 +66,16 @@ def ingest(filepath):
 
     from lamindb.admin.db import insert
 
-    file_id = insert.file(filename)
+    dobject_id = insert.dobject(filename)
 
-    filekey = f"{file_id}{filepath.suffix}"
-    store_file(filepath, filekey)
+    dobjectkey = f"{dobject_id}{filepath.suffix}"
+    store_file(filepath, dobjectkey)
 
-    track_ingest(file_id)
+    track_ingest(dobject_id)
     logger.info(
-        f"Added file {file_id} from notebook {meta.live.title!r} ({meta.store.id}) by"
-        f" user {settings.user_name} ({settings.user_id}).",
+        f"Added dobject {dobject_id} from notebook"
+        f" {meta.live.title!r} ({meta.store.id}) by user"
+        f" {settings.user_name} ({settings.user_id}).",
         flush=True,
     )
     publish()

--- a/lamindb/model/__init__.py
+++ b/lamindb/model/__init__.py
@@ -16,7 +16,7 @@ Data models:
    :members:
    :undoc-members:
 
-.. autoclass:: file
+.. autoclass:: dobject
    :members:
    :undoc-members:
 
@@ -32,4 +32,4 @@ Types:
 
 """
 from ._core import track_do_type  # noqa
-from ._core import file, interface, track_do, user  # noqa
+from ._core import dobject, interface, track_do, user  # noqa

--- a/lamindb/model/_core.py
+++ b/lamindb/model/_core.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from sqlmodel import Field, SQLModel
 
-from ..dev.id import id_file, id_track, id_user
+from ..dev.id import id_dobject, id_track, id_user
 
 
 def utcnow():
@@ -30,14 +30,18 @@ class interface(SQLModel, table=True):  # type: ignore
     time_init: datetime = Field(default_factory=utcnow, nullable=False)
 
 
-# the data file
-class file(SQLModel, table=True):  # type: ignore
-    """Ingested files.
+class dobject(SQLModel, table=True):  # type: ignore
+    """Data objects in storage & memory, often correspond to files.
 
-    These can be anything but often store dense numeral data.
+    Storage ⟷ memory examples:
+    - `.csv`, `.tsv`, `.feather`, `.parquet` ⟷ `pd.DataFrame`
+    - `.h5ad`, `.h5mu` ⟷ `anndata.AnnData`, `mudata.MuData`
+    - `.jpg`, `.png` ⟷ `np.ndarray`
+    - Zarr directory ⟷ Zarr loader
+    - TileDB store ⟷ TileDB loader
     """
 
-    id: Optional[str] = Field(default_factory=id_file, primary_key=True)
+    id: Optional[str] = Field(default_factory=id_dobject, primary_key=True)
     name: str
     interface_id: str = Field(foreign_key="interface.id")
     time_init: datetime = Field(default_factory=utcnow, nullable=False)
@@ -66,4 +70,4 @@ class track_do(SQLModel, table=True):  # type: ignore
     user_id: str = Field(foreign_key="user.id", nullable=False)
     interface_id: str = Field(foreign_key="interface.id")
     time: datetime = Field(default_factory=utcnow, nullable=False)
-    file_id: str = Field(foreign_key="file.id")
+    dobject_id: str = Field(foreign_key="dobject.id")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -10,7 +10,7 @@ def test_create_to_load():
         user="falexwolf",
     )
 
-    lndb.admin.db.insert.file("test_file.csv", interface_id="83jf")
+    lndb.admin.db.insert.dobject("test_file.csv", interface_id="83jf")
     for entity in lndb.track.schema.entities:
         lndb.do.load(entity)
 


### PR DESCRIPTION
The name file for the table was misleading and confusing!

The table doesn't actually store files, but "data objects":
1. Many data objects can be stored as files, but they can also be stored in directory blob formats, like zarr.
2. Files do **not** necessarily store data. We will likely want to store notebook _files_, but not in the file table, as they do not represent data but transformations of data!

Rephrasing:
1. The entity in what is now called the `dobject` table is a "data object". It's a collection of data that has a representation in memory, and in storage. For instance, zarr doesn't store data in a file, but in a directory.
2. Files might not store data: For instance, Jupyter notebook files play the role of a user interface in the schema, and should never end up in the file table. Same for code files. And a similar situation might hold for file types we're not yet aware of (decision docs?).

I added this table to the docstring of the `dobject` table to further illustrate this:
```
Storage ⟷ memory examples:
- `.csv`, `.tsv`, `.feather`, `.parquet` ⟷ `pd.DataFrame`, `SQLModel`, `dataclass`, etc.
- `.h5ad`, `.h5mu` ⟷ `anndata.AnnData`, `mudata.MuData`
- `.jpg`, `.png` ⟷ `np.ndarray`
- Zarr directory ⟷ Zarr loader
- TileDB store ⟷ TileDB loader
```
