### PR TITLE
🚚 Rename `lamindb.model` to `lamindb.schema`

### DIFF
--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -11,7 +11,7 @@ Browse the API:
    :toctree: .
 
    do
-   model
+   schema
    track
    dev
    admin
@@ -33,6 +33,6 @@ from . import _setup  # noqa
 from . import admin  # noqa
 from . import dev  # noqa
 from . import do  # noqa
-from . import model  # noqa
+from . import schema  # noqa
 from . import track  # noqa
 from ._setup import Settings, load_settings  # noqa

--- a/lamindb/admin/db/_insert.py
+++ b/lamindb/admin/db/_insert.py
@@ -29,7 +29,7 @@ class insert:
         engine = get_engine()
 
         with sqm.Session(engine) as session:
-            user = db.model.user(id=user_id, email=user_email)
+            user = db.schema.user(id=user_id, email=user_email)
             session.add(user)
             session.commit()
             session.refresh(user)
@@ -72,7 +72,7 @@ class insert:
         df_interface = db.do.load("interface")
         if interface_id not in df_interface.index:
             with sqm.Session(engine) as session:
-                interface = db.model.interface(
+                interface = db.schema.interface(
                     id=interface_id,
                     v=interface_v,
                     name=interface_name,
@@ -87,7 +87,7 @@ class insert:
             )
 
         with sqm.Session(engine) as session:
-            dobject = db.model.dobject(
+            dobject = db.schema.dobject(
                 id=dobject_id,
                 v=dobject_v,
                 name=name,

--- a/lamindb/do/_ingest.py
+++ b/lamindb/do/_ingest.py
@@ -24,7 +24,7 @@ def track_ingest(dobject_id):
     interface_id = meta.store.id
 
     with sqm.Session(engine) as session:
-        track_do = db.model.track_do(
+        track_do = db.schema.track_do(
             type="ingest",
             user_id=user_id,
             interface_id=interface_id,

--- a/lamindb/schema/__init__.py
+++ b/lamindb/schema/__init__.py
@@ -4,7 +4,7 @@
 
 For a schematic of relations among models, see :class:`track.schema`.
 
-.. currentmodule:: lamindb.model
+.. currentmodule:: lamindb.schema
 
 Data models:
 


### PR DESCRIPTION
The name model in the context of a data model (table, schema) can be confusing to data scientists. For them, a model is typically a statistical model.

The name `schema` should come with no down-sides and is already referred to as that in `lamindb.track.schema`.