### PR TITLE
:bug: Fix synchronization error in load

### DIFF
--- a/lamindb/db/_load.py
+++ b/lamindb/db/_load.py
@@ -15,6 +15,8 @@ def populate_dtransform_in(dobject):
     jupynb_name = meta.live.title
     engine = settings.instance.db_engine()
 
+    committed = False
+
     with sqm.Session(engine) as session:
         result = session.get(core.jupynb, (jupynb_id, jupynb_v))
         if result is None:
@@ -32,6 +34,7 @@ def populate_dtransform_in(dobject):
                 )
             )
             session.commit()
+            committed = True
             logger.info(
                 f"Added notebook {jupynb_name!r} ({jupynb_id}, {jupynb_v}) by"
                 f" user {settings.user.handle}."
@@ -54,11 +57,14 @@ def populate_dtransform_in(dobject):
                 )
             )
             session.commit()
+            committed = True
             logger.info(
                 f"Added dobject ({dobject.id}, {dobject.v}) as input for dtransform"
                 f" ({dtransform_id})."
             )
-    settings.instance._update_cloud_sqlite_file()
+    if committed:
+        # nothing to update if the db file wasn't changed
+        settings.instance._update_cloud_sqlite_file()
 
 
 def load(dobject: core.dobject):

--- a/lamindb/db/_query.py
+++ b/lamindb/db/_query.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import bionty as bt
 import pandas as pd
 from lndb_setup import settings
@@ -149,7 +151,7 @@ def query_dobject(
     storage_id: str = None,
     time_created=None,
     time_updated=None,
-    where: dict[str, dict] = None,
+    where: Dict[str, dict] = None,
     as_df: bool = False,
 ):
     """Query from dobject."""


### PR DESCRIPTION
If `load` is called on the same `dobject` twice in the same notebook in cloud mode, then the error arises
`OverwriteNewerCloudError: Local file (C:\Users\sergei.rybakov\AppData\Local\laminlabs\lamindb\Cache\lnsc-example\lnsc-example.lndb) for cloud path (gs://lnsc-example/lnsc-example.lndb) is newer in the cloud disk, but is being requested to be uploaded to the cloud. Either (1) redownload changes from the cloud or (2) pass `force_overwrite_to_cloud=True` to overwrite.`
This happens because `populate_dtransform_in` doesn't change the cache db file and tries to upload it to the cloud, but now the corresponding cloud file is newer and this triggers the error. 