### PR TITLE
🩹 Restore default `fsspec` for upload

### DIFF
--- a/lamindb/dev/db/_add.py
+++ b/lamindb/dev/db/_add.py
@@ -67,13 +67,13 @@ def add(  # type: ignore  # no support of different naming of args across overlo
         return records[0]
 
 
-def upload_data_object(dobject, use_fsspec: bool = False) -> None:
+def upload_data_object(dobject, use_fsspec: bool = True) -> None:
     """Store and add dobject and its linked entries."""
     dobject_storage_key = f"{dobject.id}{dobject.suffix}"
 
     if dobject.suffix != ".zarr":
         store_file(dobject._local_filepath, dobject_storage_key, use_fsspec=use_fsspec)
     else:
-        storepath = settings.instance.storage.key_to_filepath(dobject_storage_key)
+        storagepath = settings.instance.storage.key_to_filepath(dobject_storage_key)
         print_progress = partial(print_hook, filepath=dobject._local_filepath)
-        write_adata_zarr(dobject._memory_rep, storepath, callback=print_progress)
+        write_adata_zarr(dobject._memory_rep, storagepath, callback=print_progress)

--- a/lamindb/dev/db/_add.py
+++ b/lamindb/dev/db/_add.py
@@ -10,7 +10,7 @@ from ..file._file import print_hook
 
 
 @overload
-def add(record: sqm.SQLModel) -> sqm.SQLModel:
+def add(record: sqm.SQLModel, **kwargs) -> sqm.SQLModel:
     ...
 
 
@@ -18,12 +18,12 @@ def add(record: sqm.SQLModel) -> sqm.SQLModel:
 # Overloaded function signature 2 will never be matched: signature 1's parameter
 # type(s) are the same or broader
 @overload
-def add(records: List[sqm.SQLModel]) -> List[sqm.SQLModel]:  # type: ignore
+def add(records: List[sqm.SQLModel], **kwargs) -> List[sqm.SQLModel]:  # type: ignore
     ...
 
 
 def add(  # type: ignore  # no support of different naming of args across overloads
-    record: Union[sqm.SQLModel, List[sqm.SQLModel]]
+    record: Union[sqm.SQLModel, List[sqm.SQLModel]], **kwargs
 ) -> Union[sqm.SQLModel, List[sqm.SQLModel]]:
     """Insert or update data records in the DB ("metadata" entities).
 
@@ -53,7 +53,7 @@ def add(  # type: ignore  # no support of different naming of args across overlo
         records = [record]
     for record in records:
         if isinstance(record, DObject) and hasattr(record, "_local_filepath"):
-            upload_data_object(record)
+            upload_data_object(record, **kwargs)
     with sqm.Session(settings.instance.db_engine(), expire_on_commit=False) as session:
         for record in records:
             session.add(record)


### PR DESCRIPTION
subj, and adds optional arguments to `ln.add` to pass `use_fsspec` if needed.
https://github.com/laminlabs/lamindb/issues/360