### PR TITLE
🚸 Auto-populate relationship-associated foreign key fields

### DIFF
--- a/lamindb/_check_versions.py
+++ b/lamindb/_check_versions.py
@@ -7,8 +7,8 @@ from packaging import version
 if version.parse(lndb_setup_v) != version.parse("0.30.9"):
     raise RuntimeError("Upgrade lndb_setup! pip install lndb_setup==0.30.9")
 
-if version.parse(lnschema_core_v) != version.parse("0.25.2"):
-    raise RuntimeError("lamindb needs lnschema_core==0.25.2")
+if version.parse(lnschema_core_v) != version.parse("0.25.3"):
+    raise RuntimeError("lamindb needs lnschema_core==0.25.3")
 
 if version.parse(bionty_v) != version.parse("0.6.4"):
     raise RuntimeError("lamindb needs bionty==0.6.4")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 dependencies = [
     # Lamin pinned packages
     "lndb_setup==0.30.9",
-    "lnschema_core==0.25.2",
+    "lnschema_core==0.25.3",
     "lnschema_wetlab==0.13.3",
     "lnschema_bionty==0.6.8",
     "bionty==0.6.4",


### PR DESCRIPTION
By upgrading lnschema_core to 0.25.3.