### PR TITLE
🔥 Disable ORM relationship preview

### DIFF
--- a/docs/guide/07-session.ipynb
+++ b/docs/guide/07-session.ipynb
@@ -276,8 +276,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# with pytest.raises(DetachedInstanceError):\n",
-    "#     run_session.notebook"
+    "with pytest.raises(DetachedInstanceError):\n",
+    "    run_session.notebook"
    ]
   },
   {

--- a/lamindb/_check_versions.py
+++ b/lamindb/_check_versions.py
@@ -7,8 +7,8 @@ from packaging import version
 if version.parse(lndb_setup_v) != version.parse("0.30.12"):
     raise RuntimeError("Upgrade lndb_setup! pip install lndb_setup==0.30.12")
 
-if version.parse(lnschema_core_v) != version.parse("0.25.7"):
-    raise RuntimeError("lamindb needs lnschema_core==0.25.7")
+if version.parse(lnschema_core_v) != version.parse("0.25.8"):
+    raise RuntimeError("lamindb needs lnschema_core==0.25.8")
 
 if version.parse(bionty_v) != version.parse("0.6.5"):
     raise RuntimeError("lamindb needs bionty==0.6.5")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 dependencies = [
     # Lamin pinned packages
     "lndb_setup==0.30.12",
-    "lnschema_core==0.25.7",
+    "lnschema_core==0.25.8",
     "lnschema_wetlab==0.13.3",
     "lnschema_bionty==0.6.8",
     "bionty==0.6.5",


### PR DESCRIPTION
By upgrading `lnschema-core` to 0.25.8.