### PR TITLE
🎨 Disable multiple select results for .add and .delete by fields

### DIFF
--- a/docs/guide/03-add-delete.ipynb
+++ b/docs/guide/03-add-delete.ipynb
@@ -246,24 +246,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fca31b9b",
-   "metadata": {},
-   "source": [
-    "If a schema table and kwargs are provided, all records that matches the fields will be deleted from the DB."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8a7041a4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ln.delete(lns.Project, name=\"B1\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "8c3d8f53",
    "metadata": {},
    "source": [

--- a/lamindb/_delete.py
+++ b/lamindb/_delete.py
@@ -55,10 +55,11 @@ def delete(  # type: ignore
         records = [record]
     else:
         model = record
-        results = select(model, **fields).all()
-        if len(results) == 0:
-            return None
-        records = results
+        results = select(model, **fields).one_or_none()
+        if results is None:
+            return results
+        else:
+            records = [results]
 
     settings.instance._cloud_sqlite_locker.lock()
     session = settings.instance.session()

--- a/lamindb/dev/db/_add.py
+++ b/lamindb/dev/db/_add.py
@@ -73,13 +73,11 @@ def add(  # type: ignore
         records = [record]
     else:
         model = dobject_to_sqm(record)
-        results = select(model, **fields).all()
-        if len(results) == 1:
-            return results[0]
-        elif len(results) > 1:
-            return results
-        else:
+        results = select(model, **fields).one_or_none()
+        if results is None:
             records = [model(**fields)]
+        else:
+            return results
 
     if session is None:  # assume global session
         session = setup_settings.instance.session()

--- a/lamindb/dev/db/_add.py
+++ b/lamindb/dev/db/_add.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import List, Union, overload  # noqa
 
 import sqlmodel as sqm
+from lamin_logger import logger
 from lndb import settings as setup_settings
 from lndb.dev import UPath
 from lnschema_core import DObject
@@ -77,6 +78,7 @@ def add(  # type: ignore
         if results is None:
             records = [model(**fields)]
         else:
+            logger.info("An existing record is found in the DB:")
             return results
 
     if session is None:  # assume global session


### PR DESCRIPTION
MultipleResultsFound error will be raised with:
- `ln.add(Entity, **kwargs)`
- `ln.delete(Entity, **kwargs)`

Log whether `.add` returns an existing entry