### PR TITLE
💥 Move `lns.DFolder` to `ln.DFolder`

### DIFF
--- a/docs/faq/ingest-folder.ipynb
+++ b/docs/faq/ingest-folder.ipynb
@@ -145,15 +145,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dfolder.load_dobject(key=\"filtered_feature_bc_matrix/features.tsv.gz\")"
-   ]
-  },
-  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},

--- a/docs/faq/ingest-folder.ipynb
+++ b/docs/faq/ingest-folder.ipynb
@@ -20,26 +20,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from lamindb._folder import get_dfolder_kwargs_from_data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "get_dfolder_kwargs_from_data(\n",
-    "    \"/Users/sunnysun/Documents/repos.nosync/lamindb/docs/guide/mytest/sample_001\"\n",
-    ")"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/faq/ingest-folder.ipynb
+++ b/docs/faq/ingest-folder.ipynb
@@ -9,9 +9,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table><tbody><tr><td style='text-align: left;'><b>author</b></td><td style='text-align: left;'>Test User1 (testuser1)</td></tr><tr><td style='text-align: left;'><b>id</b></td><td style='text-align: left;'>QrRt<span style='opacity:0.3'>GnxmM3Bo</span></td></tr><tr><td style='text-align: left;'><b>version</b></td><td style='text-align: left;'>0</td></tr><tr><td style='text-align: left;'><b>time_init</b></td><td style='text-align: left;'>2023-02-17 04:58</td></tr><tr><td style='text-align: left;'><b>time_run</b></td><td style='text-align: left;'>2023-02-22 04:17</td></tr><tr><td style='text-align: left;'><b>pypackage</b></td><td style='text-align: left;'>lamindb==0.28.0 lndb==0.35.0</td></tr></tbody></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ℹ️ Instance: testuser1/fasta\n",
+      "ℹ️ Loaded notebook: QrRtGnxmM3Bo v0\n",
+      "ℹ️ Loaded run: rNRSgT2bKiSXHpYqgdsb\n"
+     ]
+    }
+   ],
    "source": [
     "import lamindb as ln\n",
     "import lamindb.schema as lns\n",
@@ -28,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,18 +59,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/Users/sunnysun/Documents/repos.nosync/redun-lamin-fasta/docs/guide/fasta')"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "settings.instance.storage.root"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PosixPath('/Users/sunnysun/Documents/repos.nosync/redun-lamin-fasta/docs/guide/fasta/sample_001')"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "filedir = ln.dev.datasets.generate_cell_ranger_files(\n",
     "    \"sample_001\", settings.instance.storage.root\n",
@@ -65,65 +109,93 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's first create a `DFolder` record:"
+    "Let's use pass a folder path to `ln.DFolder`, which creates a DFolder record"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DFolder(id='0qC8TzGZ1rfxktGkVBx0', name='sample_001', created_by='DzTjkKse')"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "dfolder = ln.DFolder(name=filedir.name)\n",
+    "dfolder = ln.DFolder(folder=filedir)\n",
     "\n",
     "dfolder"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create dobjects correspond to each of the file inside the DFolder:"
+    "Meanwhile creates dobject records correspond to each of the file inside the DFolder:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[DObject(id='oRn8S9x1adngXCzCbV9T', name='web_summary', suffix='.html', size=6, hash='Rkh9pjzWErNtxuMIjAe3aw', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
+       " DObject(id='WOvH07nOEAlCwN0iv55h', name='metrics_summary', suffix='.csv', size=6, hash='k4NHcq4GjH5E6i7IfQ62Pg', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
+       " DObject(id='AUTck6DviEg9TKvO2jpJ', name='molecule_info', suffix='.h5', size=6, hash='sG_RdqopACwFxH34y9zRiw', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
+       " DObject(id='T84UDRxUspxnZYXFO6HA', name='possorted_genome_bam', suffix='.bam.bai', size=6, hash='_2AsrqrIEflAVxwAwGxsqQ', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
+       " DObject(id='mXi7NOPbofuANkJc5fdG', name='cloupe', suffix='.cloupe', size=6, hash='x3i-lwZkpdIAJjw9soch-Q', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
+       " DObject(id='blSMTYQUA2oaZg888GeM', name='possorted_genome_bam', suffix='.bam', size=6, hash='S32VL6wPD7u4bDYeZ3B19g', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
+       " DObject(id='ii4PmhTvgS4pJNyfnds1', name='filtered_feature_bc_matrix', suffix='.h5', size=6, hash='uxjK0yNHEVODAb69YzZOfQ', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
+       " DObject(id='L2DclRXtqkGFMzyOnnY3', name='raw_feature_bc_matrix', suffix='.h5', size=6, hash='kWndudBGBPeh-NDbP51VZQ', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
+       " DObject(id='cpU6dz68AAGXgkW5pk1t', name='features', suffix='.tsv.gz', size=6, hash='rr60TTqXqb-2xzGVWsutAA', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
+       " DObject(id='YwWC24fipqfCGLl7KL9m', name='barcodes', suffix='.tsv.gz', size=6, hash='lnbmSBD1TeLBr-Qt24LE5A', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
+       " DObject(id='OX0xP0ScXqh9eph1rAQS', name='matrix', suffix='.mtx.gz', size=6, hash='RA9fu54KX06td2KtrIR-ZQ', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
+       " DObject(id='2kEokHwzfe3IqopaQ1vr', name='analysis', suffix='.csv', size=6, hash='aMpnc-CQQRUJhCtrxgj-Tg', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
+       " DObject(id='UBQDho1moPYYiq2O9EfG', name='features', suffix='.tsv.gz', size=6, hash='4L97A8Xg5zMdJpQ-nUj0jQ', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
+       " DObject(id='BayorjRyMVer3eEk9oxI', name='barcodes', suffix='.tsv.gz', size=6, hash='VuNA6lZcH_2SPG6zhJMgSg', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
+       " DObject(id='JK2lQJaDY2tWFKvwxUA1', name='matrix', suffix='.mtx.gz', size=6, hash='MgdXMKC-I77RvhJ0aE23qA', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B')]"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "dobjects = []\n",
-    "\n",
-    "for f in filedir.glob(\"**/*\"):\n",
-    "    print(f)\n",
-    "    if f.is_file():\n",
-    "        dobjects.append(ln.DObject(f))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Link dobjects to the dfolder:"
+    "dfolder.dobjects"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "dfolder.dobjects = dobjects"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DFolder(id='0qC8TzGZ1rfxktGkVBx0', name='sample_001', created_by='DzTjkKse', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8))"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "ln.add(dfolder)"
    ]
@@ -145,9 +217,86 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>name</th>\n",
+       "      <th>suffix</th>\n",
+       "      <th>size</th>\n",
+       "      <th>hash</th>\n",
+       "      <th>source_id</th>\n",
+       "      <th>storage_id</th>\n",
+       "      <th>created_at</th>\n",
+       "      <th>updated_at</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>id</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>WOvH07nOEAlCwN0iv55h</th>\n",
+       "      <td>metrics_summary</td>\n",
+       "      <td>.csv</td>\n",
+       "      <td>6</td>\n",
+       "      <td>k4NHcq4GjH5E6i7IfQ62Pg</td>\n",
+       "      <td>rNRSgT2bKiSXHpYqgdsb</td>\n",
+       "      <td>s60t5y7B</td>\n",
+       "      <td>2023-02-22 04:18:08</td>\n",
+       "      <td>None</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                 name suffix  size                    hash  \\\n",
+       "id                                                                           \n",
+       "WOvH07nOEAlCwN0iv55h  metrics_summary   .csv     6  k4NHcq4GjH5E6i7IfQ62Pg   \n",
+       "\n",
+       "                                 source_id storage_id          created_at  \\\n",
+       "id                                                                          \n",
+       "WOvH07nOEAlCwN0iv55h  rNRSgT2bKiSXHpYqgdsb   s60t5y7B 2023-02-22 04:18:08   \n",
+       "\n",
+       "                     updated_at  \n",
+       "id                               \n",
+       "WOvH07nOEAlCwN0iv55h       None  "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "ln.select(ln.DObject, name=\"metrics_summary\").join(ln.DObject.dfolders).where(\n",
     "    ln.DFolder.name == \"sample_001\"\n",
@@ -164,7 +313,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,9 +325,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[DObject(id='2kEokHwzfe3IqopaQ1vr', name='analysis', suffix='.csv', size=6, hash='aMpnc-CQQRUJhCtrxgj-Tg', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
+       " DObject(id='AUTck6DviEg9TKvO2jpJ', name='molecule_info', suffix='.h5', size=6, hash='sG_RdqopACwFxH34y9zRiw', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
+       " DObject(id='BayorjRyMVer3eEk9oxI', name='barcodes', suffix='.tsv.gz', size=6, hash='VuNA6lZcH_2SPG6zhJMgSg', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
+       " DObject(id='JK2lQJaDY2tWFKvwxUA1', name='matrix', suffix='.mtx.gz', size=6, hash='MgdXMKC-I77RvhJ0aE23qA', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
+       " DObject(id='L2DclRXtqkGFMzyOnnY3', name='raw_feature_bc_matrix', suffix='.h5', size=6, hash='kWndudBGBPeh-NDbP51VZQ', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
+       " DObject(id='OX0xP0ScXqh9eph1rAQS', name='matrix', suffix='.mtx.gz', size=6, hash='RA9fu54KX06td2KtrIR-ZQ', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
+       " DObject(id='T84UDRxUspxnZYXFO6HA', name='possorted_genome_bam', suffix='.bam.bai', size=6, hash='_2AsrqrIEflAVxwAwGxsqQ', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
+       " DObject(id='UBQDho1moPYYiq2O9EfG', name='features', suffix='.tsv.gz', size=6, hash='4L97A8Xg5zMdJpQ-nUj0jQ', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
+       " DObject(id='WOvH07nOEAlCwN0iv55h', name='metrics_summary', suffix='.csv', size=6, hash='k4NHcq4GjH5E6i7IfQ62Pg', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
+       " DObject(id='YwWC24fipqfCGLl7KL9m', name='barcodes', suffix='.tsv.gz', size=6, hash='lnbmSBD1TeLBr-Qt24LE5A', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
+       " DObject(id='blSMTYQUA2oaZg888GeM', name='possorted_genome_bam', suffix='.bam', size=6, hash='S32VL6wPD7u4bDYeZ3B19g', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
+       " DObject(id='cpU6dz68AAGXgkW5pk1t', name='features', suffix='.tsv.gz', size=6, hash='rr60TTqXqb-2xzGVWsutAA', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
+       " DObject(id='ii4PmhTvgS4pJNyfnds1', name='filtered_feature_bc_matrix', suffix='.h5', size=6, hash='uxjK0yNHEVODAb69YzZOfQ', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
+       " DObject(id='mXi7NOPbofuANkJc5fdG', name='cloupe', suffix='.cloupe', size=6, hash='x3i-lwZkpdIAJjw9soch-Q', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
+       " DObject(id='oRn8S9x1adngXCzCbV9T', name='web_summary', suffix='.html', size=6, hash='Rkh9pjzWErNtxuMIjAe3aw', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8))]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "dobjects"
    ]

--- a/docs/faq/ingest-folder.ipynb
+++ b/docs/faq/ingest-folder.ipynb
@@ -122,7 +122,7 @@
    "outputs": [],
    "source": [
     "ss = ln.Session()\n",
-    "dfolder = ss.select(ln.DFolder, name=\"sample_001\").one()\n",
+    "dfolder = ss.select(ln.DFolder, name=\"sample_001\").first()\n",
     "dobjects = dfolder.dobjects\n",
     "ss.close()"
    ]
@@ -143,6 +143,15 @@
    "outputs": [],
    "source": [
     "dfolder.tree()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dfolder.load_dobject(key=\"filtered_feature_bc_matrix/features.tsv.gz\")"
    ]
   },
   {

--- a/docs/faq/ingest-folder.ipynb
+++ b/docs/faq/ingest-folder.ipynb
@@ -121,10 +121,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ss = ln.Session()\n",
-    "dfolder = ss.select(ln.DFolder, name=\"sample_001\").first()\n",
-    "dobjects = dfolder.dobjects\n",
-    "ss.close()"
+    "with ln.Session() as ss:\n",
+    "    dfolder = ss.select(ln.DFolder, name=\"sample_001\").first()\n",
+    "    dobjects = dfolder.dobjects"
    ]
   },
   {

--- a/docs/faq/ingest-folder.ipynb
+++ b/docs/faq/ingest-folder.ipynb
@@ -13,24 +13,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import lndb"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "lndb.init(storage=\"testfolder\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import lamindb as ln\n",
     "import lamindb.schema as lns\n",
     "\n",
@@ -51,15 +33,6 @@
    "outputs": [],
    "source": [
     "from lndb import settings"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "settings.instance.storage.root"
    ]
   },
   {
@@ -170,15 +143,6 @@
    "outputs": [],
    "source": [
     "dfolder.tree()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# dfolder.load(\"raw_feature_bc_matrix/matrix.mtx.gz\")"
    ]
   },
   {

--- a/docs/faq/ingest-folder.ipynb
+++ b/docs/faq/ingest-folder.ipynb
@@ -20,6 +20,26 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lamindb._folder import get_dfolder_kwargs_from_data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_dfolder_kwargs_from_data(\n",
+    "    \"/Users/sunnysun/Documents/repos.nosync/lamindb/docs/guide/mytest/sample_001\"\n",
+    ")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -33,6 +53,15 @@
    "outputs": [],
    "source": [
     "from lndb import settings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "settings.instance.storage.root"
    ]
   },
   {

--- a/docs/faq/ingest-folder.ipynb
+++ b/docs/faq/ingest-folder.ipynb
@@ -77,7 +77,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dfolder = lns.DFolder(name=filedir.name)\n",
+    "dfolder = ln.DFolder(name=filedir.name)\n",
     "\n",
     "dfolder"
    ]
@@ -150,7 +150,7 @@
    "outputs": [],
    "source": [
     "ln.select(ln.DObject, name=\"metrics_summary\").join(ln.DObject.dfolders).where(\n",
-    "    lns.DFolder.name == \"sample_001\"\n",
+    "    ln.DFolder.name == \"sample_001\"\n",
     ").df()"
    ]
   },
@@ -169,7 +169,7 @@
    "outputs": [],
    "source": [
     "ss = ln.Session()\n",
-    "dfolder = ss.select(lns.DFolder, name=\"sample_001\").one()\n",
+    "dfolder = ss.select(ln.DFolder, name=\"sample_001\").one()\n",
     "dobjects = dfolder.dobjects\n",
     "ss.close()"
    ]

--- a/docs/faq/ingest-folder.ipynb
+++ b/docs/faq/ingest-folder.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,49 +18,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "ℹ️ Loading schema modules: core==0.28.0 \n",
-      "ℹ️ Created instance testuser1/testfolder\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "lndb.init(storage=\"testfolder\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<table><tbody><tr><td style='text-align: left;'><b>author</b></td><td style='text-align: left;'>Test User1 (testuser1)</td></tr><tr><td style='text-align: left;'><b>id</b></td><td style='text-align: left;'>QrRt<span style='opacity:0.3'>GnxmM3Bo</span></td></tr><tr><td style='text-align: left;'><b>version</b></td><td style='text-align: left;'>0</td></tr><tr><td style='text-align: left;'><b>time_init</b></td><td style='text-align: left;'>2023-02-17 04:58</td></tr><tr><td style='text-align: left;'><b>time_run</b></td><td style='text-align: left;'>2023-02-22 07:12</td></tr><tr><td style='text-align: left;'><b>pypackage</b></td><td style='text-align: left;'>lamindb==0.28.0 lndb==0.35.0 seedir==0.4.2</td></tr></tbody></table>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "ℹ️ Instance: testuser1/testfolder\n",
-      "ℹ️ Added notebook: QrRtGnxmM3Bo v0\n",
-      "ℹ️ Added run: cOKGbgxPFof6hnBZVtGD\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import lamindb as ln\n",
     "import lamindb.schema as lns\n",
@@ -77,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,40 +55,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "PosixPath('/Users/sunnysun/Documents/repos.nosync/lamin-platform/src/lamindb/docs/faq/testfolder')"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "settings.instance.storage.root"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "PosixPath('/Users/sunnysun/Documents/repos.nosync/lamin-platform/src/lamindb/docs/faq/testfolder/sample_001')"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "filedir = ln.dev.datasets.generate_cell_ranger_files(\n",
     "    \"sample_001\", settings.instance.storage.root\n",
@@ -145,20 +92,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DFolder(id='X6KxqCcJXTaS4CXAIdvU', name='sample_001', created_by='DzTjkKse')"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "dfolder = ln.DFolder(folder=filedir)\n",
     "\n",
@@ -175,54 +111,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[DObject(id='u3Vb5fZYhTxqRCEtzZNk', name='web_summary', suffix='.html', size=6, hash='CI8aOEjlaU1BUXC5EZ1N7Q', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
-       " DObject(id='Kp4TlxDtbHlEFUmXkXY9', name='metrics_summary', suffix='.csv', size=6, hash='E5OGhMr3RqFFOVWQaIT4mg', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
-       " DObject(id='mKvmsVnfp2zmiR1BG72n', name='molecule_info', suffix='.h5', size=6, hash='S1naTPO5ZhdXJ0kUObNqzQ', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
-       " DObject(id='CqP9nfqz83rIp6oRUrUX', name='possorted_genome_bam', suffix='.bam.bai', size=6, hash='FnPr8pQC6xVL5Wfqy65vaw', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
-       " DObject(id='YYnVy087TJA7T1JNzV8t', name='cloupe', suffix='.cloupe', size=6, hash='bt5hchtqQNDpN5fGHtEyWg', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
-       " DObject(id='Bah4KaKMPxqxT7h32jLv', name='possorted_genome_bam', suffix='.bam', size=6, hash='3AWDUu6109jsFMY62zJErw', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
-       " DObject(id='mvvSNrjgWBIzPkeqrfKA', name='filtered_feature_bc_matrix', suffix='.h5', size=6, hash='yPB8rC-Ey0p1OvLlLdpvgg', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
-       " DObject(id='U1v0oMv7CIyhQHLG8dE2', name='raw_feature_bc_matrix', suffix='.h5', size=6, hash='aZgcdRknqzgPyOAD9ixA6A', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
-       " DObject(id='UKYo5mX5evhgBXmd1D4s', name='features', suffix='.tsv.gz', size=6, hash='w46Jh-73EM0ba_NstNZKOg', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
-       " DObject(id='811uh4mxE8OtoQL7dbQI', name='barcodes', suffix='.tsv.gz', size=6, hash='yGlfjRbKCNjn_J9lz6ZuVw', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
-       " DObject(id='63dIUIJrwZkNiaom7z9b', name='matrix', suffix='.mtx.gz', size=6, hash='NxVONWh7YeUMP1fK6wgQAA', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
-       " DObject(id='teynTHYUNkyMiLIWwZph', name='analysis', suffix='.csv', size=6, hash='wQOGvu_KhtAp4v1UGAQtHw', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
-       " DObject(id='4dzpg6hrN18aGBTNEP5P', name='features', suffix='.tsv.gz', size=6, hash='fkPzd7f-FObGXNO_C-ONSA', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
-       " DObject(id='n4CMxIZsqQCRUOLFFfWX', name='barcodes', suffix='.tsv.gz', size=6, hash='zXkoIIqFlCGYmiFzRlF7lA', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
-       " DObject(id='4qPnxQhgnYukqIXWm0zj', name='matrix', suffix='.mtx.gz', size=6, hash='OQlsRfdLcJ8c66KzaJmevQ', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN')]"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "dfolder.dobjects"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "DFolder(id='X6KxqCcJXTaS4CXAIdvU', name='sample_001', created_by='DzTjkKse', created_at=datetime.datetime(2023, 2, 22, 7, 13, 18))"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ln.add(dfolder)"
    ]
@@ -244,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,58 +156,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[DObject(id='4dzpg6hrN18aGBTNEP5P', name='features', suffix='.tsv.gz', size=6, hash='fkPzd7f-FObGXNO_C-ONSA', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN', created_at=datetime.datetime(2023, 2, 22, 7, 13, 18)),\n",
-       " DObject(id='4qPnxQhgnYukqIXWm0zj', name='matrix', suffix='.mtx.gz', size=6, hash='OQlsRfdLcJ8c66KzaJmevQ', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN', created_at=datetime.datetime(2023, 2, 22, 7, 13, 18))]"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "dobjects[:2]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "sample_001\n",
-      "├── web_summary.html\n",
-      "├── metrics_summary.csv\n",
-      "├── molecule_info.h5\n",
-      "├── filtered_feature_bc_matrix\n",
-      "│   ├── features.tsv.gz\n",
-      "│   ├── barcodes.tsv.gz\n",
-      "│   └── matrix.mtx.gz\n",
-      "├── analysis\n",
-      "│   └── analysis.csv\n",
-      "├── raw_feature_bc_matrix\n",
-      "│   ├── features.tsv.gz\n",
-      "│   ├── barcodes.tsv.gz\n",
-      "│   └── matrix.mtx.gz\n",
-      "├── possorted_genome_bam.bam.bai\n",
-      "├── cloupe.cloupe\n",
-      "├── possorted_genome_bam.bam\n",
-      "├── filtered_feature_bc_matrix.h5\n",
-      "└── raw_feature_bc_matrix.h5\n",
-      "\n",
-      "3 directories, 15 files\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "dfolder.tree()"
    ]
@@ -331,86 +191,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>name</th>\n",
-       "      <th>suffix</th>\n",
-       "      <th>size</th>\n",
-       "      <th>hash</th>\n",
-       "      <th>source_id</th>\n",
-       "      <th>storage_id</th>\n",
-       "      <th>created_at</th>\n",
-       "      <th>updated_at</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>id</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>WOvH07nOEAlCwN0iv55h</th>\n",
-       "      <td>metrics_summary</td>\n",
-       "      <td>.csv</td>\n",
-       "      <td>6</td>\n",
-       "      <td>k4NHcq4GjH5E6i7IfQ62Pg</td>\n",
-       "      <td>rNRSgT2bKiSXHpYqgdsb</td>\n",
-       "      <td>s60t5y7B</td>\n",
-       "      <td>2023-02-22 04:18:08</td>\n",
-       "      <td>None</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                 name suffix  size                    hash  \\\n",
-       "id                                                                           \n",
-       "WOvH07nOEAlCwN0iv55h  metrics_summary   .csv     6  k4NHcq4GjH5E6i7IfQ62Pg   \n",
-       "\n",
-       "                                 source_id storage_id          created_at  \\\n",
-       "id                                                                          \n",
-       "WOvH07nOEAlCwN0iv55h  rNRSgT2bKiSXHpYqgdsb   s60t5y7B 2023-02-22 04:18:08   \n",
-       "\n",
-       "                     updated_at  \n",
-       "id                               \n",
-       "WOvH07nOEAlCwN0iv55h       None  "
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "ln.select(ln.DObject, name=\"metrics_summary\").join(ln.DObject.dfolders).where(\n",
     "    ln.DFolder.name == \"sample_001\"\n",

--- a/docs/faq/ingest-folder.ipynb
+++ b/docs/faq/ingest-folder.ipynb
@@ -11,11 +11,38 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "import lndb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ℹ️ Loading schema modules: core==0.28.0 \n",
+      "ℹ️ Created instance testuser1/testfolder\n"
+     ]
+    }
+   ],
+   "source": [
+    "lndb.init(storage=\"testfolder\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<table><tbody><tr><td style='text-align: left;'><b>author</b></td><td style='text-align: left;'>Test User1 (testuser1)</td></tr><tr><td style='text-align: left;'><b>id</b></td><td style='text-align: left;'>QrRt<span style='opacity:0.3'>GnxmM3Bo</span></td></tr><tr><td style='text-align: left;'><b>version</b></td><td style='text-align: left;'>0</td></tr><tr><td style='text-align: left;'><b>time_init</b></td><td style='text-align: left;'>2023-02-17 04:58</td></tr><tr><td style='text-align: left;'><b>time_run</b></td><td style='text-align: left;'>2023-02-22 04:17</td></tr><tr><td style='text-align: left;'><b>pypackage</b></td><td style='text-align: left;'>lamindb==0.28.0 lndb==0.35.0</td></tr></tbody></table>"
+       "<table><tbody><tr><td style='text-align: left;'><b>author</b></td><td style='text-align: left;'>Test User1 (testuser1)</td></tr><tr><td style='text-align: left;'><b>id</b></td><td style='text-align: left;'>QrRt<span style='opacity:0.3'>GnxmM3Bo</span></td></tr><tr><td style='text-align: left;'><b>version</b></td><td style='text-align: left;'>0</td></tr><tr><td style='text-align: left;'><b>time_init</b></td><td style='text-align: left;'>2023-02-17 04:58</td></tr><tr><td style='text-align: left;'><b>time_run</b></td><td style='text-align: left;'>2023-02-22 07:12</td></tr><tr><td style='text-align: left;'><b>pypackage</b></td><td style='text-align: left;'>lamindb==0.28.0 lndb==0.35.0 seedir==0.4.2</td></tr></tbody></table>"
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -28,9 +55,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "ℹ️ Instance: testuser1/fasta\n",
-      "ℹ️ Loaded notebook: QrRtGnxmM3Bo v0\n",
-      "ℹ️ Loaded run: rNRSgT2bKiSXHpYqgdsb\n"
+      "ℹ️ Instance: testuser1/testfolder\n",
+      "ℹ️ Added notebook: QrRtGnxmM3Bo v0\n",
+      "ℹ️ Added run: cOKGbgxPFof6hnBZVtGD\n"
      ]
     }
    ],
@@ -50,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,16 +86,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "PosixPath('/Users/sunnysun/Documents/repos.nosync/redun-lamin-fasta/docs/guide/fasta')"
+       "PosixPath('/Users/sunnysun/Documents/repos.nosync/lamin-platform/src/lamindb/docs/faq/testfolder')"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -79,16 +106,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "PosixPath('/Users/sunnysun/Documents/repos.nosync/redun-lamin-fasta/docs/guide/fasta/sample_001')"
+       "PosixPath('/Users/sunnysun/Documents/repos.nosync/lamin-platform/src/lamindb/docs/faq/testfolder/sample_001')"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -118,16 +145,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "DFolder(id='0qC8TzGZ1rfxktGkVBx0', name='sample_001', created_by='DzTjkKse')"
+       "DFolder(id='X6KxqCcJXTaS4CXAIdvU', name='sample_001', created_by='DzTjkKse')"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -148,30 +175,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[DObject(id='oRn8S9x1adngXCzCbV9T', name='web_summary', suffix='.html', size=6, hash='Rkh9pjzWErNtxuMIjAe3aw', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
-       " DObject(id='WOvH07nOEAlCwN0iv55h', name='metrics_summary', suffix='.csv', size=6, hash='k4NHcq4GjH5E6i7IfQ62Pg', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
-       " DObject(id='AUTck6DviEg9TKvO2jpJ', name='molecule_info', suffix='.h5', size=6, hash='sG_RdqopACwFxH34y9zRiw', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
-       " DObject(id='T84UDRxUspxnZYXFO6HA', name='possorted_genome_bam', suffix='.bam.bai', size=6, hash='_2AsrqrIEflAVxwAwGxsqQ', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
-       " DObject(id='mXi7NOPbofuANkJc5fdG', name='cloupe', suffix='.cloupe', size=6, hash='x3i-lwZkpdIAJjw9soch-Q', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
-       " DObject(id='blSMTYQUA2oaZg888GeM', name='possorted_genome_bam', suffix='.bam', size=6, hash='S32VL6wPD7u4bDYeZ3B19g', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
-       " DObject(id='ii4PmhTvgS4pJNyfnds1', name='filtered_feature_bc_matrix', suffix='.h5', size=6, hash='uxjK0yNHEVODAb69YzZOfQ', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
-       " DObject(id='L2DclRXtqkGFMzyOnnY3', name='raw_feature_bc_matrix', suffix='.h5', size=6, hash='kWndudBGBPeh-NDbP51VZQ', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
-       " DObject(id='cpU6dz68AAGXgkW5pk1t', name='features', suffix='.tsv.gz', size=6, hash='rr60TTqXqb-2xzGVWsutAA', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
-       " DObject(id='YwWC24fipqfCGLl7KL9m', name='barcodes', suffix='.tsv.gz', size=6, hash='lnbmSBD1TeLBr-Qt24LE5A', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
-       " DObject(id='OX0xP0ScXqh9eph1rAQS', name='matrix', suffix='.mtx.gz', size=6, hash='RA9fu54KX06td2KtrIR-ZQ', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
-       " DObject(id='2kEokHwzfe3IqopaQ1vr', name='analysis', suffix='.csv', size=6, hash='aMpnc-CQQRUJhCtrxgj-Tg', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
-       " DObject(id='UBQDho1moPYYiq2O9EfG', name='features', suffix='.tsv.gz', size=6, hash='4L97A8Xg5zMdJpQ-nUj0jQ', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
-       " DObject(id='BayorjRyMVer3eEk9oxI', name='barcodes', suffix='.tsv.gz', size=6, hash='VuNA6lZcH_2SPG6zhJMgSg', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B'),\n",
-       " DObject(id='JK2lQJaDY2tWFKvwxUA1', name='matrix', suffix='.mtx.gz', size=6, hash='MgdXMKC-I77RvhJ0aE23qA', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B')]"
+       "[DObject(id='u3Vb5fZYhTxqRCEtzZNk', name='web_summary', suffix='.html', size=6, hash='CI8aOEjlaU1BUXC5EZ1N7Q', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
+       " DObject(id='Kp4TlxDtbHlEFUmXkXY9', name='metrics_summary', suffix='.csv', size=6, hash='E5OGhMr3RqFFOVWQaIT4mg', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
+       " DObject(id='mKvmsVnfp2zmiR1BG72n', name='molecule_info', suffix='.h5', size=6, hash='S1naTPO5ZhdXJ0kUObNqzQ', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
+       " DObject(id='CqP9nfqz83rIp6oRUrUX', name='possorted_genome_bam', suffix='.bam.bai', size=6, hash='FnPr8pQC6xVL5Wfqy65vaw', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
+       " DObject(id='YYnVy087TJA7T1JNzV8t', name='cloupe', suffix='.cloupe', size=6, hash='bt5hchtqQNDpN5fGHtEyWg', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
+       " DObject(id='Bah4KaKMPxqxT7h32jLv', name='possorted_genome_bam', suffix='.bam', size=6, hash='3AWDUu6109jsFMY62zJErw', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
+       " DObject(id='mvvSNrjgWBIzPkeqrfKA', name='filtered_feature_bc_matrix', suffix='.h5', size=6, hash='yPB8rC-Ey0p1OvLlLdpvgg', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
+       " DObject(id='U1v0oMv7CIyhQHLG8dE2', name='raw_feature_bc_matrix', suffix='.h5', size=6, hash='aZgcdRknqzgPyOAD9ixA6A', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
+       " DObject(id='UKYo5mX5evhgBXmd1D4s', name='features', suffix='.tsv.gz', size=6, hash='w46Jh-73EM0ba_NstNZKOg', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
+       " DObject(id='811uh4mxE8OtoQL7dbQI', name='barcodes', suffix='.tsv.gz', size=6, hash='yGlfjRbKCNjn_J9lz6ZuVw', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
+       " DObject(id='63dIUIJrwZkNiaom7z9b', name='matrix', suffix='.mtx.gz', size=6, hash='NxVONWh7YeUMP1fK6wgQAA', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
+       " DObject(id='teynTHYUNkyMiLIWwZph', name='analysis', suffix='.csv', size=6, hash='wQOGvu_KhtAp4v1UGAQtHw', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
+       " DObject(id='4dzpg6hrN18aGBTNEP5P', name='features', suffix='.tsv.gz', size=6, hash='fkPzd7f-FObGXNO_C-ONSA', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
+       " DObject(id='n4CMxIZsqQCRUOLFFfWX', name='barcodes', suffix='.tsv.gz', size=6, hash='zXkoIIqFlCGYmiFzRlF7lA', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN'),\n",
+       " DObject(id='4qPnxQhgnYukqIXWm0zj', name='matrix', suffix='.mtx.gz', size=6, hash='OQlsRfdLcJ8c66KzaJmevQ', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN')]"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -182,16 +209,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "DFolder(id='0qC8TzGZ1rfxktGkVBx0', name='sample_001', created_by='DzTjkKse', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8))"
+       "DFolder(id='X6KxqCcJXTaS4CXAIdvU', name='sample_001', created_by='DzTjkKse', created_at=datetime.datetime(2023, 2, 22, 7, 13, 18))"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -205,6 +232,93 @@
    "metadata": {},
    "source": [
     "## Query files in dfolder"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Retrieve dobjects from a dfolder:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ss = ln.Session()\n",
+    "dfolder = ss.select(ln.DFolder, name=\"sample_001\").one()\n",
+    "dobjects = dfolder.dobjects\n",
+    "ss.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[DObject(id='4dzpg6hrN18aGBTNEP5P', name='features', suffix='.tsv.gz', size=6, hash='fkPzd7f-FObGXNO_C-ONSA', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN', created_at=datetime.datetime(2023, 2, 22, 7, 13, 18)),\n",
+       " DObject(id='4qPnxQhgnYukqIXWm0zj', name='matrix', suffix='.mtx.gz', size=6, hash='OQlsRfdLcJ8c66KzaJmevQ', source_id='cOKGbgxPFof6hnBZVtGD', storage_id='a7FdvJcN', created_at=datetime.datetime(2023, 2, 22, 7, 13, 18))]"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dobjects[:2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sample_001\n",
+      "├── web_summary.html\n",
+      "├── metrics_summary.csv\n",
+      "├── molecule_info.h5\n",
+      "├── filtered_feature_bc_matrix\n",
+      "│   ├── features.tsv.gz\n",
+      "│   ├── barcodes.tsv.gz\n",
+      "│   └── matrix.mtx.gz\n",
+      "├── analysis\n",
+      "│   └── analysis.csv\n",
+      "├── raw_feature_bc_matrix\n",
+      "│   ├── features.tsv.gz\n",
+      "│   ├── barcodes.tsv.gz\n",
+      "│   └── matrix.mtx.gz\n",
+      "├── possorted_genome_bam.bam.bai\n",
+      "├── cloupe.cloupe\n",
+      "├── possorted_genome_bam.bam\n",
+      "├── filtered_feature_bc_matrix.h5\n",
+      "└── raw_feature_bc_matrix.h5\n",
+      "\n",
+      "3 directories, 15 files\n"
+     ]
+    }
+   ],
+   "source": [
+    "dfolder.tree()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# dfolder.load(\"raw_feature_bc_matrix/matrix.mtx.gz\")"
    ]
   },
   {
@@ -301,60 +415,6 @@
     "ln.select(ln.DObject, name=\"metrics_summary\").join(ln.DObject.dfolders).where(\n",
     "    ln.DFolder.name == \"sample_001\"\n",
     ").df()"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Retrieve dobjects from a dfolder"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ss = ln.Session()\n",
-    "dfolder = ss.select(ln.DFolder, name=\"sample_001\").one()\n",
-    "dobjects = dfolder.dobjects\n",
-    "ss.close()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[DObject(id='2kEokHwzfe3IqopaQ1vr', name='analysis', suffix='.csv', size=6, hash='aMpnc-CQQRUJhCtrxgj-Tg', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
-       " DObject(id='AUTck6DviEg9TKvO2jpJ', name='molecule_info', suffix='.h5', size=6, hash='sG_RdqopACwFxH34y9zRiw', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
-       " DObject(id='BayorjRyMVer3eEk9oxI', name='barcodes', suffix='.tsv.gz', size=6, hash='VuNA6lZcH_2SPG6zhJMgSg', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
-       " DObject(id='JK2lQJaDY2tWFKvwxUA1', name='matrix', suffix='.mtx.gz', size=6, hash='MgdXMKC-I77RvhJ0aE23qA', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
-       " DObject(id='L2DclRXtqkGFMzyOnnY3', name='raw_feature_bc_matrix', suffix='.h5', size=6, hash='kWndudBGBPeh-NDbP51VZQ', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
-       " DObject(id='OX0xP0ScXqh9eph1rAQS', name='matrix', suffix='.mtx.gz', size=6, hash='RA9fu54KX06td2KtrIR-ZQ', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
-       " DObject(id='T84UDRxUspxnZYXFO6HA', name='possorted_genome_bam', suffix='.bam.bai', size=6, hash='_2AsrqrIEflAVxwAwGxsqQ', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
-       " DObject(id='UBQDho1moPYYiq2O9EfG', name='features', suffix='.tsv.gz', size=6, hash='4L97A8Xg5zMdJpQ-nUj0jQ', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
-       " DObject(id='WOvH07nOEAlCwN0iv55h', name='metrics_summary', suffix='.csv', size=6, hash='k4NHcq4GjH5E6i7IfQ62Pg', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
-       " DObject(id='YwWC24fipqfCGLl7KL9m', name='barcodes', suffix='.tsv.gz', size=6, hash='lnbmSBD1TeLBr-Qt24LE5A', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
-       " DObject(id='blSMTYQUA2oaZg888GeM', name='possorted_genome_bam', suffix='.bam', size=6, hash='S32VL6wPD7u4bDYeZ3B19g', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
-       " DObject(id='cpU6dz68AAGXgkW5pk1t', name='features', suffix='.tsv.gz', size=6, hash='rr60TTqXqb-2xzGVWsutAA', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
-       " DObject(id='ii4PmhTvgS4pJNyfnds1', name='filtered_feature_bc_matrix', suffix='.h5', size=6, hash='uxjK0yNHEVODAb69YzZOfQ', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
-       " DObject(id='mXi7NOPbofuANkJc5fdG', name='cloupe', suffix='.cloupe', size=6, hash='x3i-lwZkpdIAJjw9soch-Q', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8)),\n",
-       " DObject(id='oRn8S9x1adngXCzCbV9T', name='web_summary', suffix='.html', size=6, hash='Rkh9pjzWErNtxuMIjAe3aw', source_id='rNRSgT2bKiSXHpYqgdsb', storage_id='s60t5y7B', created_at=datetime.datetime(2023, 2, 22, 4, 18, 8))]"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "dobjects"
    ]
   }
  ],

--- a/docs/faq/stream.ipynb
+++ b/docs/faq/stream.ipynb
@@ -390,7 +390,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.delete(dobjects + [ln.nb.run], force=True)"
+    "ln.delete(dobjects + [ln.nb.run], delete_data_from_storage=True)"
    ]
   }
  ],

--- a/docs/guide/03-add-delete.ipynb
+++ b/docs/guide/03-add-delete.ipynb
@@ -280,7 +280,7 @@
     "\n",
     "By default only the record is deleted, and you will be asked to confirm deleting data from storage.\n",
     "\n",
-    "You may set `force=True` to auto confirm the data deletion from storage.\n",
+    "You may set `delete_data_from_storage=True` to auto confirm the data deletion from storage.\n",
     "```"
    ]
   },
@@ -291,7 +291,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.delete(dobject, force=True)"
+    "ln.delete(dobject, delete_data_from_storage=True)"
    ]
   },
   {

--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -13,6 +13,13 @@ in-memory objects (`DataFrame`, `AnnData`, etc.):
 
    DObject
 
+Data folder, a directory, a group of data objects:
+
+.. autosummary::
+   :toctree: .
+
+   DFolder
+
 Query & manipulate data:
 
 .. autosummary::
@@ -84,6 +91,7 @@ if _setup_settings.instance.storage.root is None:
     )
 _check_migrate(usettings=_setup_settings.user, isettings=_setup_settings.instance)
 
+from lnschema_core import DFolder  # noqa
 from lnschema_core import DObject  # noqa
 
 from . import dev  # noqa

--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -13,7 +13,7 @@ in-memory objects (`DataFrame`, `AnnData`, etc.):
 
    DObject
 
-Data folder, a directory, a group of data objects:
+Data folder, a group of data objects:
 
 .. autosummary::
    :toctree: .

--- a/lamindb/_check_versions.py
+++ b/lamindb/_check_versions.py
@@ -7,8 +7,8 @@ from packaging import version
 if version.parse(lndb_v) != version.parse("0.35.3"):
     raise RuntimeError("Upgrade lndb! pip install lndb==0.35.3")
 
-if version.parse(lnschema_core_v) != version.parse("0.28.4"):
-    raise RuntimeError("lamindb needs lnschema_core==0.28.4")
+if version.parse(lnschema_core_v) != version.parse("0.28.5"):
+    raise RuntimeError("lamindb needs lnschema_core==0.28.5")
 
 if version.parse(bionty_v) != version.parse("0.7.0"):
     raise RuntimeError("lamindb needs bionty==0.7.0")

--- a/lamindb/_check_versions.py
+++ b/lamindb/_check_versions.py
@@ -7,8 +7,8 @@ from packaging import version
 if version.parse(lndb_v) != version.parse("0.35.0"):
     raise RuntimeError("Upgrade lndb! pip install lndb==0.35.0")
 
-if version.parse(lnschema_core_v) != version.parse("0.28.1"):
-    raise RuntimeError("lamindb needs lnschema_core==0.28.1")
+if version.parse(lnschema_core_v) != version.parse("0.28.4"):
+    raise RuntimeError("lamindb needs lnschema_core==0.28.4")
 
 if version.parse(bionty_v) != version.parse("0.7.0"):
     raise RuntimeError("lamindb needs bionty==0.7.0")

--- a/lamindb/_check_versions.py
+++ b/lamindb/_check_versions.py
@@ -7,8 +7,8 @@ from packaging import version
 if version.parse(lndb_v) != version.parse("0.35.0"):
     raise RuntimeError("Upgrade lndb! pip install lndb==0.35.0")
 
-if version.parse(lnschema_core_v) != version.parse("0.28.0"):
-    raise RuntimeError("lamindb needs lnschema_core==0.28.0")
+if version.parse(lnschema_core_v) != version.parse("0.28.1"):
+    raise RuntimeError("lamindb needs lnschema_core==0.28.1")
 
 if version.parse(bionty_v) != version.parse("0.7.0"):
     raise RuntimeError("lamindb needs bionty==0.7.0")

--- a/lamindb/_delete.py
+++ b/lamindb/_delete.py
@@ -1,5 +1,5 @@
 import traceback
-from typing import List, Union, overload  # noqa
+from typing import List, Optional, Union, overload  # noqa
 
 import sqlmodel as sqm
 from lndb import settings
@@ -13,22 +13,34 @@ from .dev.file import delete_storage
 
 
 @overload
-def delete(record: sqm.SQLModel, force=False) -> None:
+def delete(
+    record: sqm.SQLModel,
+    delete_data_from_storage: Optional[bool] = None,
+) -> None:
     ...
 
 
 @overload
-def delete(records: List[sqm.SQLModel], force=False) -> None:  # type: ignore
+def delete(
+    records: List[sqm.SQLModel],
+    delete_data_from_storage: Optional[bool] = None,
+) -> None:  # type: ignore
     ...
 
 
 @overload
-def delete(entity: sqm.SQLModel, force=False, **fields) -> None:  # type: ignore
+def delete(
+    entity: sqm.SQLModel,
+    delete_data_from_storage: Optional[bool] = None,
+    **fields,
+) -> None:  # type: ignore
     ...
 
 
 def delete(  # type: ignore
-    record: Union[sqm.SQLModel, List[sqm.SQLModel]], force=False, **fields
+    record: Union[sqm.SQLModel, List[sqm.SQLModel]],
+    delete_data_from_storage: Optional[bool] = None,
+    **fields,
 ) -> None:
     """Delete data records & data objects.
 
@@ -47,7 +59,7 @@ def delete(  # type: ignore
 
     Args:
         record: One or multiple records as instances of `SQLModel`.
-        force: Whether to force delete data from storage.
+        delete_data_from_storage: Whether to delete data from storage.
     """
     if isinstance(record, list):
         records = record
@@ -99,15 +111,15 @@ def delete(  # type: ignore
         if isinstance(record, DObject):
             storage_key = storage_key_from_dobject(record)
 
-            if force:
-                decide = "y"
-            else:
+            if delete_data_from_storage is None:
                 # ask to confirm deleting data from storage
                 delete_dialog = (
                     "Confirm Delete: Are you sure you want to delete"
                     f" object {storage_key} from storage? (y/n)"
                 )
                 decide = input(f"   {delete_dialog}")
+            else:
+                decide = "y" if delete_data_from_storage else "n"
 
             if decide not in ("y", "Y", "yes", "Yes", "YES"):
                 continue

--- a/lamindb/_folder.py
+++ b/lamindb/_folder.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+from typing import Optional, Union
+
+from lndb import settings as setup_settings
+from lndb.dev import UPath
+from lnschema_core import DObject as lns_DObject
+from lnschema_core import Run, Storage
+from sqlalchemy.exc import NoResultFound
+
+from ._record import get_run
+from .dev.db._select import select
+
+
+def get_dfolder_kwargs_from_data(
+    folder: Union[Path, UPath, str],
+    *,
+    name: Optional[str] = None,
+    source: Optional[Run] = None,
+):
+    run = get_run(source)
+    folderpath = UPath(folder)
+    storage_root = str(setup_settings.instance.storage.root)
+    # backwards compatibility for instances created with cloudpathlib
+    try:
+        storage = select(Storage, root=storage_root).one()
+    except NoResultFound:
+        storage = select(Storage, root=storage_root[:-1]).one()
+
+    dobjects = []
+    for f in folderpath.glob("**/*"):
+        if f.is_file():
+            dobjects.append(lns_DObject(f))
+
+    dfolder_kwargs = dict(
+        name=name,
+        run_id=run.id,
+        storage_id=storage.id,
+        source=run,
+        dobjects=dobjects,
+    )
+    return dfolder_kwargs

--- a/lamindb/_folder.py
+++ b/lamindb/_folder.py
@@ -1,6 +1,6 @@
+from itertools import islice
 from pathlib import Path
 from typing import Optional, Union
-from itertools import islice
 
 from lndb.dev import UPath
 from lnschema_core import DObject as lns_DObject
@@ -43,16 +43,16 @@ def tree(
 
     Adapted from: https://stackoverflow.com/questions/9727673/list-directory-tree-structure-in-python  # noqa
     """
-    space = '    '
-    branch = '│   '
-    tee = '├── '
-    last = '└── '
+    space = "    "
+    branch = "│   "
+    tee = "├── "
+    last = "└── "
 
     dir_path = UPath(dir_path)
     files = 0
     directories = 0
 
-    def inner(dir_path: Path, prefix: str = '', level=-1):
+    def inner(dir_path: Path, prefix: str = "", level=-1):
         nonlocal files, directories
         if not level:
             return  # 0, stop iterating
@@ -76,5 +76,5 @@ def tree(
     for line in islice(iterator, length_limit):
         print(line)
     if next(iterator, None):
-        print(f'... length_limit, {length_limit}, reached, counted:')
-    print(f'\n{directories} directories' + (f', {files} files' if files else ''))
+        print(f"... length_limit, {length_limit}, reached, counted:")
+    print(f"\n{directories} directories" + (f", {files} files" if files else ""))

--- a/lamindb/_folder.py
+++ b/lamindb/_folder.py
@@ -1,13 +1,10 @@
 from pathlib import Path
 from typing import Optional, Union
+from itertools import islice
 
-from lndb import settings as setup_settings
 from lndb.dev import UPath
 from lnschema_core import DObject as lns_DObject
-from lnschema_core import Run, Storage
-from sqlalchemy.exc import NoResultFound
-
-from .dev.db._select import select
+from lnschema_core import Run
 
 
 def get_dfolder_kwargs_from_data(
@@ -17,12 +14,12 @@ def get_dfolder_kwargs_from_data(
     source: Optional[Run] = None,
 ):
     folderpath = UPath(folder)
-    storage_root = str(setup_settings.instance.storage.root)
-    # backwards compatibility for instances created with cloudpathlib
-    try:
-        storage = select(Storage, root=storage_root).one()  # noqa
-    except NoResultFound:
-        storage = select(Storage, root=storage_root[:-1]).one()  # noqa
+    cloudpath = folderpath if isinstance(folderpath, UPath) else None
+    localpath = None if isinstance(folderpath, UPath) else folderpath
+    dfolder_privates = dict(
+        _local_filepath=localpath,
+        _cloud_filepath=cloudpath,
+    )
 
     dobjects = []
     for f in folderpath.glob("**/*"):
@@ -33,4 +30,51 @@ def get_dfolder_kwargs_from_data(
         name=folderpath.name if name is None else name,
         dobjects=dobjects,
     )
-    return dfolder_kwargs
+    return dfolder_kwargs, dfolder_privates
+
+
+def tree(
+    dir_path: Union[Path, UPath, str],
+    level: int = -1,
+    limit_to_directories: bool = False,
+    length_limit: int = 1000,
+):
+    """Given a directory Path object print a visual tree structure.
+
+    Adapted from: https://stackoverflow.com/questions/9727673/list-directory-tree-structure-in-python  # noqa
+    """
+    space = '    '
+    branch = '│   '
+    tee = '├── '
+    last = '└── '
+
+    dir_path = UPath(dir_path)
+    files = 0
+    directories = 0
+
+    def inner(dir_path: Path, prefix: str = '', level=-1):
+        nonlocal files, directories
+        if not level:
+            return  # 0, stop iterating
+        if limit_to_directories:
+            contents = [d for d in dir_path.iterdir() if d.is_dir()]
+        else:
+            contents = list(dir_path.iterdir())
+        pointers = [tee] * (len(contents) - 1) + [last]
+        for pointer, path in zip(pointers, contents):
+            if path.is_dir():
+                yield prefix + pointer + path.name
+                directories += 1
+                extension = branch if pointer == tee else space
+                yield from inner(path, prefix=prefix + extension, level=level - 1)
+            elif not limit_to_directories:
+                yield prefix + pointer + path.name
+                files += 1
+
+    print(dir_path.name)
+    iterator = inner(dir_path, level=level)
+    for line in islice(iterator, length_limit):
+        print(line)
+    if next(iterator, None):
+        print(f'... length_limit, {length_limit}, reached, counted:')
+    print(f'\n{directories} directories' + (f', {files} files' if files else ''))

--- a/lamindb/_folder.py
+++ b/lamindb/_folder.py
@@ -7,7 +7,6 @@ from lnschema_core import DObject as lns_DObject
 from lnschema_core import Run, Storage
 from sqlalchemy.exc import NoResultFound
 
-from ._record import get_run
 from .dev.db._select import select
 
 
@@ -17,25 +16,21 @@ def get_dfolder_kwargs_from_data(
     name: Optional[str] = None,
     source: Optional[Run] = None,
 ):
-    run = get_run(source)
     folderpath = UPath(folder)
     storage_root = str(setup_settings.instance.storage.root)
     # backwards compatibility for instances created with cloudpathlib
     try:
-        storage = select(Storage, root=storage_root).one()
+        storage = select(Storage, root=storage_root).one()  # noqa
     except NoResultFound:
-        storage = select(Storage, root=storage_root[:-1]).one()
+        storage = select(Storage, root=storage_root[:-1]).one()  # noqa
 
     dobjects = []
     for f in folderpath.glob("**/*"):
         if f.is_file():
-            dobjects.append(lns_DObject(f))
+            dobjects.append(lns_DObject(f, source=source))
 
     dfolder_kwargs = dict(
-        name=name,
-        run_id=run.id,
-        storage_id=storage.id,
-        source=run,
+        name=folderpath.name if name is None else name,
         dobjects=dobjects,
     )
     return dfolder_kwargs

--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -212,6 +212,7 @@ def get_path_size_hash(
 ):
     cloudpath = None
     localpath = None
+    # both cloudpath and localpath are None for zarr
     if suffix != ".zarr":
         path = UPath(filepath)  # returns Path for local
         if isinstance(path, UPath):

--- a/lamindb/dev/_core.py
+++ b/lamindb/dev/_core.py
@@ -1,4 +1,5 @@
 from lnschema_core.dev._storage import (  # noqa
+    filepath_from_dfolder,
     filepath_from_dobject,
     get_name_suffix_from_filepath,
     storage_key_from_dobject,

--- a/lamindb/dev/db/_add.py
+++ b/lamindb/dev/db/_add.py
@@ -6,7 +6,7 @@ import sqlmodel as sqm
 from lamin_logger import logger
 from lndb import settings as setup_settings
 from lndb.dev import UPath
-from lnschema_core import DObject, DFolder
+from lnschema_core import DFolder, DObject
 from sqlalchemy.orm.attributes import set_attribute
 
 from .._docs import doc_args

--- a/lamindb/schema/__init__.py
+++ b/lamindb/schema/__init__.py
@@ -27,12 +27,11 @@ Runs transform data using code:
    Pipeline
    Notebook
 
-Grouping data objects as sets or by features:
+Grouping data objects by features:
 
 .. autosummary::
    :toctree: .
 
-   DFolder
    Features
 
 Users, projects, storage locations, and usage:
@@ -72,7 +71,6 @@ import importlib as _importlib
 from lndb import settings as _settings
 from lndb.dev._setup_schema import get_schema_module_name as _get_schema_module_name
 from lnschema_core import (
-    DFolder,
     Features,
     Notebook,
     Pipeline,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     # Lamin pinned packages
     "lnhub_rest==0.5.0",  # NOT pinned in lndb, just a lower bound there
     "lndb==0.35.0",
-    "lnschema_core==0.28.1",
+    "lnschema_core==0.28.4",
     "lnschema_wetlab==0.13.4",
     "lnschema_bionty==0.7.0",
     "bionty==0.7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     # Lamin pinned packages
     "lnhub_rest==0.5.0",  # NOT pinned in lndb, just a lower bound there
     "lndb==0.35.0",
-    "lnschema_core==0.28.0",
+    "lnschema_core==0.28.1",
     "lnschema_wetlab==0.13.4",
     "lnschema_bionty==0.7.0",
     "bionty==0.7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     # Lamin pinned packages
     "lnhub_rest==0.5.1",  # NOT pinned in lndb, just a lower bound there
     "lndb==0.35.3",
-    "lnschema_core==0.28.4",
+    "lnschema_core==0.28.5",
     "lnschema_wetlab==0.13.4",
     "lnschema_bionty==0.7.0",
     "bionty==0.7.0",


### PR DESCRIPTION
- Moved `lns.DFolder` to `ln.DFolder`
- Implemented `ln.DFolder(folder=...)`
- Updated the ingest-folder notebook to reflect the API change
- Implemented `DFolder.tree()` to visualize files inside a DFolder
- Added DFolder._objectkey when DFolder is a folder/directory: https://github.com/laminlabs/lnschema-core/pull/113
---
- Coming up in the next PR: `DFolder.load_dobject(relative_path)`