### PR TITLE
🔥 Remove lnhub-rest dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
 ]
 dependencies = [
     # Lamin pinned packages
-    "lnhub_rest==0.5.1",  # NOT pinned in lndb, just a lower bound there
     "lndb==0.36.0",
     "lnschema_core==0.29.1",
     "lnschema_wetlab==0.13.4",


### PR DESCRIPTION
Would be much better if only lndb was dependent of lnhub-rest.