### PR TITLE
🏗️ Introduce `lamindb.context` and enable `ln.Run` to create contexts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@v3
         with:
+          submodules: recursive
           fetch-depth: 0
       - name: Checkout lndocs
         uses: actions/checkout@v3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lnschema-core"]
+	path = lnschema-core
+	url = https://github.com/laminlabs/lnschema-core.git

--- a/docs/faq/data-validation.ipynb
+++ b/docs/faq/data-validation.ipynb
@@ -309,7 +309,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.12 ('base1')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -323,7 +323,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.9.15"
   }
  },
  "nbformat": 4,

--- a/docs/faq/ingest.ipynb
+++ b/docs/faq/ingest.ipynb
@@ -50,20 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "NO_SOURCE_ERROR = \"\"\"\n",
-    "Error: Please link a data source using the `source` argument.\n",
-    "Fix: Link a data source by passing a run, e.g., via\n",
-    "\n",
-    "pipeline = ln.select(\"My ingestion pipeline\").one()\n",
-    "run = lns.Run(pipeline=pipeline)\n",
-    "dobject = ln.DObject(..., source=run)\n",
-    "\n",
-    "Or, if you're in a notebook, call `ln.nb.header()` at the top, which creates\n",
-    "a global run context for the notebook.\n",
-    "\n",
-    "More details: https://lamin.ai/docs/faq/ingest\n",
-    "\"\"\"\n",
-    "with pytest.raises(ValueError, match=re.escape(NO_SOURCE_ERROR)):\n",
+    "with pytest.raises(ValueError):\n",
     "    dobject = ln.DObject(df)"
    ]
   },
@@ -211,10 +198,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "NO_NAME_ERROR = \"\"\"\n",
-    "Pass a name in `ln.DObject(..., name=name)` when ingesting in-memory data.\n",
-    "\"\"\"\n",
-    "with pytest.raises(ValueError, match=re.escape(NO_NAME_ERROR)):\n",
+    "with pytest.raises(ValueError):\n",
     "    dobject = ln.DObject(df)"
    ]
   }

--- a/docs/faq/ingest.ipynb
+++ b/docs/faq/ingest.ipynb
@@ -109,15 +109,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run.pipeline_id"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "dobject = ln.DObject(df, source=run, name=\"My test data\")"
    ]
   },

--- a/docs/faq/ingest.ipynb
+++ b/docs/faq/ingest.ipynb
@@ -109,6 +109,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "run.pipeline_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "dobject = ln.DObject(df, source=run, name=\"My test data\")"
    ]
   },

--- a/docs/faq/session.ipynb
+++ b/docs/faq/session.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "0d888635-4514-41a2-807d-41e20e684f72",
    "metadata": {},
@@ -41,6 +40,26 @@
    "source": [
     "pipeline = lns.Pipeline(name=\"Transform A\")\n",
     "run = lns.Run(name=\"Solve Problem X\", pipeline=pipeline)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d888a710-f385-4acc-84d3-d319e4d7a37b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b923629c-910c-425c-9104-945052304d80",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run"
    ]
   },
   {
@@ -335,7 +354,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py39",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -349,7 +368,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.9.15"
   },
   "nbproject": {
    "id": "KGYsQOIpS43O",

--- a/docs/faq/track-runin.ipynb
+++ b/docs/faq/track-runin.ipynb
@@ -13,8 +13,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By default, run inputs are not tracked automatically, you can track them manually following our [pipeline guide](https://lamin.ai/docs/db/guide/pipeline).\n",
-    "\n",
     "You may turn on run inputs tracking by setting {attr}`lamindb.settings.track_run_inputs_upon_load` to `True`: loaded dobjects will be automatically added as the inputs of the current notebook run."
    ]
   },
@@ -79,8 +77,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with ln.Session() as ss:\n",
-    "    print(ss.select(lns.Run, id=ln.nb.run.id).one().inputs)"
+    "# with ln.Session() as ss:\n",
+    "#     print(ss.select(lns.Run, id=ln.nb.run.id).one().inputs)"
    ]
   },
   {
@@ -114,8 +112,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with ln.Session() as ss:\n",
-    "    print(ss.select(lns.Run, id=ln.nb.run.id).one().inputs)"
+    "# with ln.Session() as ss:\n",
+    "#     print(ss.select(lns.Run, id=ln.nb.run.id).one().inputs)"
    ]
   },
   {

--- a/docs/faq/track-runin.ipynb
+++ b/docs/faq/track-runin.ipynb
@@ -166,10 +166,10 @@
    "outputs": [],
    "source": [
     "# [Not for users] clean up for CI\n",
-    "with ln.Session() as ss:\n",
-    "    run = ss.select(lns.Run, id=ln.nb.run.id).one()\n",
-    "    run.inputs = []\n",
-    "    ss.add(run)"
+    "# with ln.Session() as ss:\n",
+    "#     run = ss.select(lns.Run, id=ln.nb.run.id).one()\n",
+    "#     run.inputs = []\n",
+    "#     ss.add(run)"
    ]
   }
  ],

--- a/docs/faq/track-runin.ipynb
+++ b/docs/faq/track-runin.ipynb
@@ -95,7 +95,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "adata = dobject.load(is_run_input=True)"
+    "# adata = dobject.load(is_run_input=True)"
    ]
   },
   {
@@ -152,7 +152,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "adata = dobject.load()"
+    "# adata = dobject.load()"
    ]
   },
   {

--- a/docs/faq/track-runin.ipynb
+++ b/docs/faq/track-runin.ipynb
@@ -90,20 +90,11 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "adata = dobject.load(is_run_input=True)"
-   ]
-  },
-  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can see the fcs file has now been added to the run inputs:"
+    "You can see the fcs file is now being added to the run inputs:"
    ]
   },
   {
@@ -113,6 +104,8 @@
    "outputs": [],
    "source": [
     "with ln.Session() as ss:\n",
+    "    dobject = ss.select(ln.DObject, suffix=\".fcs\").one()\n",
+    "    adata = dobject.load(is_run_input=True)\n",
     "    assert len(ss.select(lns.Run, id=ln.nb.run.id).one().inputs) == 1\n",
     "    print(ss.select(lns.Run, id=ln.nb.run.id).one().inputs)"
    ]
@@ -153,7 +146,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "adata = dobject.load()"
+    "with ln.Session() as ss:\n",
+    "    dobject = ss.select(ln.DObject, suffix=\".fcs\").one()\n",
+    "    adata = dobject.load()"
    ]
   },
   {

--- a/docs/faq/track-runin.ipynb
+++ b/docs/faq/track-runin.ipynb
@@ -77,8 +77,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# with ln.Session() as ss:\n",
-    "#     print(ss.select(lns.Run, id=ln.nb.run.id).one().inputs)"
+    "with ln.Session() as ss:\n",
+    "    assert len(ss.select(lns.Run, id=ln.nb.run.id).one().inputs) == 0"
    ]
   },
   {
@@ -95,7 +95,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# adata = dobject.load(is_run_input=True)"
+    "adata = dobject.load(is_run_input=True)"
    ]
   },
   {
@@ -112,8 +112,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# with ln.Session() as ss:\n",
-    "#     print(ss.select(lns.Run, id=ln.nb.run.id).one().inputs)"
+    "with ln.Session() as ss:\n",
+    "    assert len(ss.select(lns.Run, id=ln.nb.run.id).one().inputs) == 1\n",
+    "    print(ss.select(lns.Run, id=ln.nb.run.id).one().inputs)"
    ]
   },
   {
@@ -152,7 +153,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# adata = dobject.load()"
+    "adata = dobject.load()"
    ]
   },
   {
@@ -166,10 +167,10 @@
    "outputs": [],
    "source": [
     "# [Not for users] clean up for CI\n",
-    "# with ln.Session() as ss:\n",
-    "#     run = ss.select(lns.Run, id=ln.nb.run.id).one()\n",
-    "#     run.inputs = []\n",
-    "#     ss.add(run)"
+    "with ln.Session() as ss:\n",
+    "    run = ss.select(lns.Run, id=ln.nb.run.id).one()\n",
+    "    run.inputs = []\n",
+    "    ss.add(run)"
    ]
   }
  ],

--- a/docs/guide/03-files.ipynb
+++ b/docs/guide/03-files.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -20,7 +19,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -33,7 +31,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -41,7 +38,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -72,7 +68,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -126,7 +121,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -143,7 +137,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -160,7 +153,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -168,7 +160,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -224,7 +215,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -239,7 +229,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -256,7 +245,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -269,7 +257,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -277,7 +264,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -294,7 +280,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -302,7 +287,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -330,7 +314,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py39",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -344,7 +328,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.9.15"
   },
   "nbproject": {
    "id": "NJvdsWWbJlZS",
@@ -363,5 +347,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/guide/08-run.ipynb
+++ b/docs/guide/08-run.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Track notebook & pipeline runs: `Pipeline`, `Notebook`, `Run`\n"
+    "# Track data sources: `Pipeline`, `Notebook`, `Run`\n"
    ]
   },
   {
@@ -23,10 +23,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Jupyter notebooks"
+    "## Notebook run"
    ]
   },
   {
@@ -38,23 +39,6 @@
    ]
   },
   {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{important}\n",
-    "\n",
-    "`ln.nb.header()` tracks notebooks and takes care of the follwing:\n",
-    "1. Add a `Notebook` record `notebook` to the database\n",
-    "2. Add a `Run` record `run`, linked against `notebook` to the database\n",
-    "3. Expose `run` as `ln.nb.run`\n",
-    "4. Ensure that `ln.add(dobject)` sets `dobject.source = run`\n",
-    "5. Enable to track run inputs via `ln.DObject.load(is_run_input=True)`\n",
-    "\n",
-    "```"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -63,7 +47,7 @@
     "import lamindb as ln\n",
     "import lamindb.schema as lns\n",
     "\n",
-    "ln.nb.header()"
+    "ln.context.track()"
    ]
   },
   {
@@ -71,7 +55,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's track where the data was ingested:"
+    "Let us query where `DObject` \"iris_new\" had been ingested:"
    ]
   },
   {
@@ -114,11 +98,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Track data from a pipeline run\n",
-    "\n",
-    "Tracking data from a pipeline follows roughly the same steps as {doc}`/guide/files`, except:\n",
-    "\n",
-    "A `Run` record needs to be created from a `Pipeline` record and pass to the `ln.DObject`"
+    "## Pipeline run"
    ]
   },
   {
@@ -135,10 +115,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create a BFX pipeline:"
+    "When working with a pipeline, we'll register it before running it."
    ]
   },
   {
@@ -153,10 +134,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And a pipeline run:"
+    "We can then use the {class}`~lamindb.context` as before (if we don't register a pipeline with the correct name, we'll be asked to):"
    ]
   },
   {
@@ -165,16 +147,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run = lns.Run(pipeline=pipeline, name=\"ingest-fastq\")\n",
-    "\n",
-    "run"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We see the run points to the pipeline:"
+    "ln.context.track(pipeline_name=\"10x scRNA-seq nextseq\")"
    ]
   },
   {
@@ -183,14 +156,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run.pipeline"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let us ingest data from this pipeline run."
+    "ln.context.pipeline"
    ]
   },
   {
@@ -199,7 +165,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filepath"
+    "ln.context.run"
    ]
   },
   {
@@ -208,7 +174,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dobject_fq = ln.DObject(filepath, source=run)"
+    "dobject_fastq = ln.DObject(filepath)"
    ]
   },
   {
@@ -217,41 +183,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dobject_fq"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dobject_fq.source"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dobject_fq = ln.add(dobject_fq)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can now select dobject by `run`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ln.select(ln.DObject).join(lns.Run, name=\"ingest-fastq\").df()"
+    "ln.add(dobject_fastq)"
    ]
   },
   {
@@ -259,7 +191,95 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Track run outputs"
+    "We can also manually pass a run:\n",
+    "```\n",
+    "run = lns.Run(pipeline=pipeline, name=\"ingest-fastq\")\n",
+    "ln.DObject(filepath, source=run)\n",
+    "```"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Track run inputs"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's now register another pipeline:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline = ln.add(lns.Pipeline(name=\"Cell Ranger\", v=\"7\"))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's create a run context for it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln.context.track(pipeline_name=\"Cell Ranger\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln.context.run"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can opt to track any data object we load as an input for the current run:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dobject_fastq = ln.select(ln.DObject, name=\"input.fastq.gz\").one()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To process in the pipeline, we typically need to load it (download it from the cloud, access the on-disk or in-memory representation):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dobject_fastq.load(is_run_input=True)"
    ]
   },
   {
@@ -285,50 +305,12 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's now register another pipeline, which will use cellranger to analyze the scRNA-seq data from the input fastq file."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "pipeline = ln.add(lns.Pipeline(v=\"7\", name=\"Cell Ranger v7\"))\n",
-    "run = lns.Run(pipeline=pipeline, name=\"cellranger scRNA-seq\")\n",
-    "\n",
-    "run"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{note}\n",
-    "\n",
-    "Linking run input files will allow data lineage tracking.\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "run.inputs.append(dobject_fq)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dobject = ln.DObject(output_filepath, source=run)\n",
+    "dobject = ln.DObject(output_filepath)\n",
     "\n",
     "ln.add(dobject)"
    ]
@@ -357,24 +339,6 @@
     "with ln.Session() as ss:\n",
     "    run = ss.select(lns.Run).join(ln.DObject, name=\"output\", suffix=\".bam\").one()\n",
     "    print(run.inputs)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You can query the notebook that belongs to a run id like this:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "nb = ln.select(lns.Notebook).join(lns.Run, id=ln.nb.run.id).one()\n",
-    "\n",
-    "nb"
    ]
   }
  ],

--- a/docs/guide/08-run.ipynb
+++ b/docs/guide/08-run.ipynb
@@ -270,26 +270,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's query input data for this pipeline, a fastq."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dobject_fastq = ln.select(ln.DObject, name=\"input\").one()"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To process in the pipeline, we typically need to load it (download it from the cloud, access the on-disk or in-memory representation).\n",
+    "Let's query input data for this pipeline, a fastq.\n",
     "\n",
-    "To track it as an input for the current run, set `is_run_input=True`:"
+    "To process in the pipeline, we need to `load()` it (download it from the cloud and access the on-disk or in-memory representation).\n",
+    "\n",
+    "To track it as an input for the current run, set `is_run_input=True`."
    ]
   },
   {
@@ -298,7 +283,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dobject_fastq.load(is_run_input=True)"
+    "with ln.Session() as ss:\n",
+    "    dobject_fastq = ln.select(ln.DObject, name=\"input\").one()\n",
+    "    dobject_fastq.load(is_run_input=True)"
    ]
   },
   {

--- a/docs/guide/08-run.ipynb
+++ b/docs/guide/08-run.ipynb
@@ -41,7 +41,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We've already seen a few examples that tracks data from notebooks, for instanace: {doc}`/guide/files`"
+    "The metadata of Jupyter notebooks is automatically detected:"
    ]
   },
   {
@@ -73,7 +73,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let us query where `DObject` \"iris_new\" had been ingested:"
+    "Let us query where `DObject` \"iris_new\" has been ingested:"
    ]
   },
   {
@@ -82,21 +82,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.select(lns.Notebook).join(lns.Run).join(ln.DObject, name=\"iris_new\").one()"
+    "ln.select(lns.Notebook).join(lns.Run).join(ln.DObject, name=\"iris_new\").first()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Alternatively, you can query for the run that contains a notebook attribute:\n",
-    "\n",
-    "```{admonition} What is ln.Session()?\n",
-    ":class: important\n",
-    "\n",
-    "Why do we need session here? Find out in our [Session guide](https://lamin.ai/docs/db/faq/session).\n",
-    "\n",
-    "```"
+    "Alternatively, you can query for the run that contains a notebook attribute:"
    ]
   },
   {
@@ -106,8 +99,8 @@
    "outputs": [],
    "source": [
     "with ln.Session() as ss:\n",
-    "    source_run = ss.select(lns.Run).join(ln.DObject, name=\"iris_new\").one()\n",
-    "    print(source_run.notebook)"
+    "    dobject = ss.select(ln.DObject, name=\"iris_new\").one()\n",
+    "    print(dobject.source.notebook)"
    ]
   },
   {
@@ -162,24 +155,6 @@
    "outputs": [],
    "source": [
     "ln.Run(pipeline_name=\"10x scRNA-seq nextseq\", global_context=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ln.context.pipeline"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ln.context.run"
    ]
   },
   {
@@ -257,15 +232,6 @@
    "outputs": [],
    "source": [
     "ln.Run(pipeline_name=\"Cell Ranger\", global_context=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ln.context.run"
    ]
   },
   {

--- a/docs/guide/08-run.ipynb
+++ b/docs/guide/08-run.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Track data sources: `Pipeline`, `Notebook`, `Run`\n"
+    "# Track data lineage: `Pipeline`, `Notebook`, `Run`\n"
    ]
   },
   {
@@ -15,11 +15,21 @@
    "source": [
     "## What is a `Run`?\n",
     "\n",
-    "{class}`~lamindb.DObject` are transformed by instances of {class}`~lamindb.schema.Run` and appear as {meth}`~lamindb.schema.Run.inputs` and {meth}`~lamindb.schema.Run.outputs`.\n",
+    "{class}`~lamindb.DObject` are transformed by instances of {class}`~lamindb.schema.Run`. They are the {attr}`~lamindb.schema.Run.inputs` and {attr}`~lamindb.schema.Run.outputs` of runs.\n",
     "\n",
-    "`Run` can be created from:\n",
-    "1. A Jupyter `Notebook`: interactive environment\n",
-    "2. A `Pipeline`: versioned code"
+    "Conversely, the {attr}`~lamindb.DObject.source` of {class}`~lamindb.DObject` is always the output of a run!\n",
+    "\n",
+    "In the default schema, a `Run` can be created from a `Notebook` or a `Pipeline`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import lamindb as ln\n",
+    "import lamindb.schema as lns"
    ]
   },
   {
@@ -35,7 +45,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We've see a few examples that tracks data from notebooks, for instanace: {doc}`/guide/files`"
+    "We've already seen a few examples that tracks data from notebooks, for instanace: {doc}`/guide/files`"
    ]
   },
   {
@@ -44,9 +54,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import lamindb as ln\n",
-    "import lamindb.schema as lns\n",
-    "\n",
     "ln.context.track()"
    ]
   },
@@ -207,11 +214,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "While run outputs are automatically tracked as data sources, run inputs aren't.\n",
+    "\n",
+    "However, you can simply call `is_run_input` upon loading `DObject`."
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's now register another pipeline:"
+    "Let's register a downstream pipeline:"
    ]
   },
   {
@@ -228,7 +244,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's create a run context for it:"
+    "And a run context for it:"
    ]
   },
   {
@@ -254,7 +270,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can opt to track any data object we load as an input for the current run:"
+    "Let's query input data for this pipeline, a fastq."
    ]
   },
   {
@@ -267,10 +283,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To process in the pipeline, we typically need to load it (download it from the cloud, access the on-disk or in-memory representation):"
+    "To process in the pipeline, we typically need to load it (download it from the cloud, access the on-disk or in-memory representation).\n",
+    "\n",
+    "To track it as an input for the current run, set `is_run_input=True`:"
    ]
   },
   {

--- a/docs/guide/08-run.ipynb
+++ b/docs/guide/08-run.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -9,7 +8,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -33,7 +31,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -41,7 +38,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -58,7 +54,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -75,7 +70,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -101,7 +95,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -122,7 +115,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -141,7 +133,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -194,7 +185,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -206,7 +196,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -223,7 +212,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -240,7 +228,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -266,7 +253,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -322,7 +308,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -350,7 +335,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py39",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -364,7 +349,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.9.15"
   },
   "nbproject": {
    "id": "1LCd8kco9lZU",
@@ -383,5 +368,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/guide/08-run.ipynb
+++ b/docs/guide/08-run.ipynb
@@ -284,7 +284,7 @@
    "outputs": [],
    "source": [
     "with ln.Session() as ss:\n",
-    "    dobject_fastq = ln.select(ln.DObject, name=\"input\").one()\n",
+    "    dobject_fastq = ss.select(ln.DObject, name=\"input\").one()\n",
     "    dobject_fastq.load(is_run_input=True)"
    ]
   },

--- a/docs/guide/08-run.ipynb
+++ b/docs/guide/08-run.ipynb
@@ -263,7 +263,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dobject_fastq = ln.select(ln.DObject, name=\"input.fastq.gz\").one()"
+    "dobject_fastq = ln.select(ln.DObject, name=\"input\").one()"
    ]
   },
   {

--- a/docs/guide/08-run.ipynb
+++ b/docs/guide/08-run.ipynb
@@ -50,7 +50,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.context.track()"
+    "ln.Run(global_context=True, load_latest=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we passed `global_context=True`, we don't need to keep track of the run record ourselves, but can access it via `ln.context`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln.context.run"
    ]
   },
   {
@@ -145,7 +161,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.context.track(pipeline_name=\"10x scRNA-seq nextseq\")"
+    "ln.Run(pipeline_name=\"10x scRNA-seq nextseq\", global_context=True)"
    ]
   },
   {
@@ -240,7 +256,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.context.track(pipeline_name=\"Cell Ranger\")"
+    "ln.Run(pipeline_name=\"Cell Ranger\", global_context=True)"
    ]
   },
   {

--- a/docs/guide/08-run.ipynb
+++ b/docs/guide/08-run.ipynb
@@ -259,6 +259,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dobject_fastq.targets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln.add(dobject_fastq)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "tags": [
      "hide-cell"
@@ -311,6 +329,7 @@
    "source": [
     "with ln.Session() as ss:\n",
     "    run = ss.select(lns.Run).join(ln.DObject, name=\"output\", suffix=\".bam\").one()\n",
+    "    assert run.inputs[0].name == \"input\"\n",
     "    print(run.inputs)"
    ]
   }

--- a/docs/guide/15-query-book.ipynb
+++ b/docs/guide/15-query-book.ipynb
@@ -291,9 +291,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.select(lns.Pipeline).join(lns.Run).join(\n",
-    "    ln.DObject, name=\"input\", suffix=\".fastq.gz\"\n",
-    ").one()"
+    "with ln.Session() as ss:\n",
+    "    dobject = ss.select(ln.DObject, name=\"input\", suffix=\".fastq.gz\").one()\n",
+    "    print(dobject.source.pipeline)"
    ]
   },
   {
@@ -410,7 +410,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.9.15"
   },
   "nbproject": {
    "id": "2l46gxQHI6Ud",

--- a/docs/guide/15-query-book.ipynb
+++ b/docs/guide/15-query-book.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -23,7 +22,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -31,7 +29,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -75,7 +72,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -94,7 +90,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -113,7 +108,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -130,7 +124,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -147,7 +140,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -164,7 +156,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -172,7 +163,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -180,7 +170,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -226,7 +215,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -234,7 +222,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -253,7 +240,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -270,7 +256,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -278,7 +263,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -297,7 +281,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -314,7 +297,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -322,7 +304,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -339,7 +320,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -358,7 +338,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -377,7 +356,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -396,7 +374,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py39",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -429,5 +407,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/guide/15-query-book.ipynb
+++ b/docs/guide/15-query-book.ipynb
@@ -369,7 +369,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.select(lns.User).join(lns.Pipeline, name=\"Cell Ranger v7\", v=\"7\").one()"
+    "ln.select(lns.User).join(lns.Pipeline, name=\"Cell Ranger\", v=\"7\").one()"
    ]
   }
  ],

--- a/docs/guide/15-query-book.ipynb
+++ b/docs/guide/15-query-book.ipynb
@@ -282,23 +282,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Which pipeline is used for this run named \"ingest-fastq\"?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ln.select(lns.Pipeline).join(lns.Run, name=\"ingest-fastq\").one()"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Which pipeline produced this file `input.fastq.gz`?"
    ]
   },
@@ -408,23 +391,6 @@
    "outputs": [],
    "source": [
     "ln.select(lns.User).join(lns.Pipeline, name=\"Cell Ranger v7\", v=\"7\").one()"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Which user executed this run?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ln.select(lns.User).join(lns.Run, name=\"ingest-fastq\").one()"
    ]
   }
  ],

--- a/docs/guide/15-query-book.ipynb
+++ b/docs/guide/15-query-book.ipynb
@@ -338,10 +338,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Which user created this notebook titled as \"Ingest data from notebook runs\"?"
+    "Which users created notebooks with \"lineage\" in the title?"
    ]
   },
   {
@@ -351,8 +352,8 @@
    "outputs": [],
    "source": [
     "ln.select(lns.User).join(lns.Notebook).where(\n",
-    "    lns.Notebook.title.contains(\"notebook & pipeline runs\")\n",
-    ").one()"
+    "    lns.Notebook.title.contains(\"lineage\")\n",
+    ").df()"
    ]
   },
   {

--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -23,6 +23,13 @@ Query & manipulate data:
    add
    delete
 
+Manage run context:
+
+.. autosummary::
+   :toctree: .
+
+   context
+
 Manipulate data with open session:
 
 .. autosummary::
@@ -43,13 +50,6 @@ Schema - entities and their relations:
    :toctree: .
 
    schema
-
-Track Jupyter notebooks:
-
-.. autosummary::
-   :toctree: .
-
-   nb
 
 Setup:
 

--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -162,6 +162,7 @@ DObject.__doc__ = dobject_doc
 from . import dev  # noqa
 from . import schema  # noqa
 from . import setup  # noqa
+from ._context import context  # noqa
 from ._delete import delete  # noqa
 from ._nb import nb  # noqa
 from ._settings import settings

--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -104,8 +104,7 @@ else:
             " instance."
         )
 
-from lnschema_core import DFolder  # noqa
-from lnschema_core import DObject  # noqa
+from lnschema_core import DFolder, DObject, Run  # noqa
 
 dobject_doc = """Data objects in storage & memory.
 

--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -23,13 +23,6 @@ Query & manipulate data:
    add
    delete
 
-Manage run context:
-
-.. autosummary::
-   :toctree: .
-
-   context
-
 Manipulate data with open session:
 
 .. autosummary::
@@ -63,6 +56,7 @@ Developer API:
 .. autosummary::
    :toctree: .
 
+   context
    settings
    dev
 """

--- a/lamindb/_check_versions.py
+++ b/lamindb/_check_versions.py
@@ -7,8 +7,8 @@ from packaging import version
 if version.parse(lndb_v) < version.parse("0.37.4"):
     raise RuntimeError("Upgrade lndb! pip install lndb>=0.37.4")
 
-if version.parse(lnschema_core_v) != version.parse("0.29.1"):
-    raise RuntimeError("lamindb needs lnschema_core==0.29.1")
+if version.parse(lnschema_core_v) != version.parse("0.29.2"):
+    raise RuntimeError("lamindb needs lnschema_core==0.29.2")
 
 if version.parse(nbproject_v) < version.parse("0.8.3"):
     raise RuntimeError("lamindb needs nbproject>=0.8.3")

--- a/lamindb/_check_versions.py
+++ b/lamindb/_check_versions.py
@@ -10,8 +10,8 @@ if version.parse(lndb_v) < version.parse("0.37.4"):
 if version.parse(lnschema_core_v) != version.parse("0.29.1"):
     raise RuntimeError("lamindb needs lnschema_core==0.29.1")
 
-if version.parse(nbproject_v) < version.parse("0.8.2"):
-    raise RuntimeError("lamindb needs nbproject>=0.8.2")
+if version.parse(nbproject_v) < version.parse("0.8.3"):
+    raise RuntimeError("lamindb needs nbproject>=0.8.3")
 
 # ensure that the lamin package is not installed
 try:

--- a/lamindb/_context.py
+++ b/lamindb/_context.py
@@ -182,8 +182,9 @@ class context:
         import lamindb.schema as lns
 
         run = lns.Run(load_latest=load_latest, global_context=True)
-        run = ln.add(run)  # type: ignore
-        logger.info(f"Added run: {run.id}")  # type: ignore
+        if ln.select(lns.Run, id=run.id).one_or_none() is None:
+            run = ln.add(run)  # type: ignore
+            logger.info(f"Added run: {run.id}")  # type: ignore
 
     @classmethod
     def track(cls, *, pipeline_name: Optional[str] = None, load_latest=True):

--- a/lamindb/_context.py
+++ b/lamindb/_context.py
@@ -226,7 +226,7 @@ class context:
         cls.run = run
 
     @classmethod
-    def track(cls, pipeline_name: Optional[str], load_latest=True):
+    def track(cls, *, pipeline_name: Optional[str] = None, load_latest=True):
         """Track notebook/pipeline and run.
 
         When called from within a Python script, pass `pipeline_name`.

--- a/lamindb/_context.py
+++ b/lamindb/_context.py
@@ -11,15 +11,16 @@ from nbproject._is_run_from_ipython import is_run_from_ipython
 
 
 class context:
-    """Global run context.
+    """Global run context tracking data source."""
 
-    This is helpful if you don't want to ingest data from concurrent pipeline runs.
-    """
-
-    instance: InstanceSettings = settings.instance  # current instance
-    notebook: Notebook = None  # current notebook
-    pipeline: Pipeline = None  # current pipeline
-    run: Run = None  # run of this Python session
+    instance: InstanceSettings = settings.instance
+    """Current instance."""
+    notebook: Notebook = None
+    """Current notebook."""
+    pipeline: Pipeline = None
+    """Current pipeline."""
+    run: Run = None
+    """Current run."""
 
     @classmethod
     def track_notebook(
@@ -221,7 +222,8 @@ class context:
         # at this point, we have a run object
         cls.run = run
 
-    def track_all(cls, pipeline_name: Optional[str], load_latest=True):
+    @classmethod
+    def track(cls, pipeline_name: Optional[str], load_latest=True):
         """Track notebook/pipeline and run.
 
         Args:

--- a/lamindb/_context.py
+++ b/lamindb/_context.py
@@ -1,0 +1,187 @@
+from pathlib import Path
+from typing import List, Optional, Union
+
+import lnschema_core
+import nbproject
+from lamin_logger import logger
+from lndb.dev import InstanceSettings
+from lnschema_core import Notebook, Pipeline, Run, dev
+
+
+class context:
+    """Global run context.
+
+    This is helpful if you don't want to ingest data from concurrent pipeline runs.
+    """
+
+    instance: InstanceSettings = None  # current instance
+    notebook: Notebook = None  # current notebook
+    pipeline: Pipeline = None  # current pipeline
+    run: Run = None  # run of this Python session
+
+    @classmethod
+    def track_notebook(
+        cls,
+        *,
+        id: Optional[str] = None,
+        v: Optional[str] = "0",
+        name: Optional[str] = None,
+        filepath: Optional[str] = None,
+        pypackage: Union[str, List[str], None] = None,
+        editor: Optional[str] = None,
+    ):
+        """Track a Notebook global record.
+
+        Args:
+            id: Pass a notebook id manually.
+            v: Pass a notebook version manually.
+            name: Pass a notebook name manually.
+            pypackage: One or more python packages to track.
+            filepath: Filepath of notebook. Only needed if automatic inference fails.
+            editor: Editor environment. Only needed if automatic inference fails.
+                Pass `'lab'` for jupyter lab and `'notebook'` for jupyter notebook,
+                this can help to identify the correct mechanism for interactivity
+                when automatic inference fails.
+        """
+        # original location of this code was _nb
+        # legacy code here, see duplicated version in _run
+        if id is None and name is None:
+            nbproject_failed_msg = (
+                "Auto-retrieval of notebook name & title failed.\nPlease paste error"
+                " at: https://github.com/laminlabs/nbproject/issues/new \n\nFix: Run"
+                f" ln.nb.header(id={dev.id.notebook()}, name='my-notebook-name')"
+            )
+            try:
+                nbproject.header(
+                    pypackage=pypackage, filepath=filepath, env=editor, display=False
+                )
+            except Exception:
+                raise RuntimeError(nbproject_failed_msg)
+            # this contains filepath if the header was run successfully
+            from nbproject._header import _filepath
+
+            id = nbproject.meta.store.id
+            v = nbproject.meta.store.version
+            name = Path(_filepath).stem
+            title = nbproject.meta.live.title
+        elif id is None or name is None:
+            # Both id and name need to be passed if passing it manually
+            raise RuntimeError("Fix: Pass both id & name to ln.nb.header().")
+        else:
+            title = None
+
+        import lamindb as ln
+        import lamindb.schema as lns
+
+        notebook = ln.select(
+            lns.Notebook,
+            id=id,
+            v=v,
+        ).one_or_none()
+        if notebook is None:
+            notebook = lns.Notebook(
+                id=id,
+                v=v,
+                name=name,
+                title=title,
+            )
+            notebook = ln.add(notebook)
+            logger.info(f"Added notebook: {notebook.id} v{notebook.v}")
+        else:
+            logger.info(f"Loaded notebook: {notebook.id} v{notebook.v}")
+            if notebook.name != name or notebook.title != title:
+                response = input(
+                    "Updated notebook name and/or title: Do you want to assign a new id"
+                    " or version? (y/n)"
+                )
+                if response == "y":
+                    print("Notebook metadata will be re-initialized.")
+                    new_id, new_v = None, None
+                    response = input("Do you want to generate a new id? (y/n)")
+                    if response == "y":
+                        new_id = lnschema_core.dev.id.notebook()
+                    response = input(
+                        "Do you want to set a new version (e.g. '1.1')? Type 'n' for"
+                        " 'no'. (version/n)"
+                    )
+                    if new_v != "n":
+                        if new_v == "y":
+                            response = input("Please type the version: ")
+                        new_v = response
+                    if new_id is not None or new_v is not None:
+                        nbproject.meta.store.id = new_id
+                        nbproject.meta.store.version = new_v
+                        nbproject.meta.store.write()
+                        # at this point, depending on the editor, the process
+                        # might crash that is OK as upon re-running, the
+                        # notebook will have new metadata and will be registered
+                        # in the db in case the python process does not exit, we
+                        # need a new Notebook record
+                        notebook = lns.Notebook(id=id, v=v)
+
+                notebook.name = name
+                notebook.title = title
+                ln.add(notebook)
+
+        # at this point, we have a notebook object
+        cls.notebook = notebook
+
+    @classmethod
+    def track_run(
+        cls,
+        *,
+        load_latest: bool = False,
+        run: Optional[Run] = None,
+    ):
+        """Track a Notebook global record.
+
+        Args:
+            run: If `None`, either create new run or load latest.
+            load_latest: Loads the latest run of the notebook or pipeline.
+        """
+        import lamindb as ln
+        import lamindb.schema as lns
+
+        # check user input
+        # if isinstance(run, lns.Run):
+        # This here might be something we may want in the future
+        # but checking all the cases in which that run record has integrity
+        # is quite a bit of code - not now!
+        #     run_test = ln.select(lns.Run, id=run.id).one_or_none()
+        #     if run_test is None:
+        #         logger.info("Passed run does not exist, adding it")
+        #         ln.add(run)
+        if run is None and load_latest:
+            if cls.notebook is not None:
+                select_stmt = ln.select(
+                    lns.Run, notebook_id=cls.notebook.id, notebook_v=cls.notebook.v
+                )
+            elif cls.pipeline is not None:
+                select_stmt = ln.select(
+                    lns.Run, pipeline_id=cls.pipeline.id, pipeline_v=cls.pipeline.v
+                )
+            else:
+                raise RuntimeError(
+                    "Please call context.track_notebook or context.track_pipeline."
+                )
+            run = select_stmt.order_by(lns.Run.created_at.desc()).first()
+            if run is not None:
+                logger.info(f"Loaded run: {run.id}")  # type: ignore
+            else:
+                logger.info("Did not find any latest run. Creating new run.")
+
+        # create a new run if doesn't exist yet or is requested by the user
+        if run is None:
+            if cls.notebook is not None:
+                run = lns.Run(notebook_id=cls.notebook.id, notebook_v=cls.notebook.v)
+            elif cls.pipeline is not None:
+                run = lns.Run(pipeline_id=cls.pipeline.id, pipeline_v=cls.pipeline.v)
+            else:
+                raise RuntimeError(
+                    "Please call context.track_notebook or context.track_pipeline."
+                )
+            run = ln.add(run)  # type: ignore
+            logger.info(f"Added run: {run.id}")  # type: ignore
+
+        # at this point, we have a run object
+        cls.run = run

--- a/lamindb/_context.py
+++ b/lamindb/_context.py
@@ -90,9 +90,9 @@ class context:
                 title=title,
             )
             notebook = ln.add(notebook)
-            logger.info(f"Added notebook: {notebook.id} v{notebook.v}")
+            logger.info(f"Added notebook: {notebook}")
         else:
-            logger.info(f"Loaded notebook: {notebook.id} v{notebook.v}")
+            logger.info(f"Loaded notebook: {notebook}")
             if notebook.name != name or notebook.title != title:
                 response = input(
                     "Updated notebook name and/or title: Do you want to assign a new id"
@@ -242,9 +242,8 @@ class context:
         cls.instance = settings.instance
         logger.info(f"Instance: {cls.instance.identifier}")
         logger.info(f"User: {settings.user.handle}")
-        if is_run_from_ipython:
+        if is_run_from_ipython and pipeline_name is None:
             cls.track_notebook()
-            logger.info(f"Notebook: {cls.notebook}")
         else:
             if pipeline_name is None:
                 raise ValueError(

--- a/lamindb/_context.py
+++ b/lamindb/_context.py
@@ -224,6 +224,7 @@ class context:
             # however, it might be that one errors because of duplicate insertion
             # run = ln.add(run)  # type: ignore
             # logger.info(f"Added run: {run.id}")  # type: ignore
+            logger.info(f"Created run: {run.id}")
 
         # at this point, we have a run object
         cls.run = run

--- a/lamindb/_context.py
+++ b/lamindb/_context.py
@@ -152,7 +152,7 @@ class context:
         else:
             pipeline = (
                 ln.select(lns.Pipeline, name=name)
-                .order_by(lns.Run.created_at.desc())
+                .order_by(lns.Pipeline.created_at.desc())
                 .first()
             )
             if pipeline is None:

--- a/lamindb/_context.py
+++ b/lamindb/_context.py
@@ -219,8 +219,11 @@ class context:
                 raise RuntimeError(
                     "Please call context.track_notebook or context.track_pipeline."
                 )
-            run = ln.add(run)  # type: ignore
-            logger.info(f"Added run: {run.id}")  # type: ignore
+            # it seems wiser to not yet commit the run to the database here
+            # rather commit it with the first piece of data
+            # however, it might be that one errors because of duplicate insertion
+            # run = ln.add(run)  # type: ignore
+            # logger.info(f"Added run: {run.id}")  # type: ignore
 
         # at this point, we have a run object
         cls.run = run

--- a/lamindb/_context.py
+++ b/lamindb/_context.py
@@ -13,13 +13,13 @@ from nbproject._is_run_from_ipython import is_run_from_ipython
 class context:
     """Global run context tracking data source."""
 
-    instance: InstanceSettings = settings.instance
+    instance: Optional[InstanceSettings] = None
     """Current instance."""
-    notebook: Notebook = None
+    notebook: Optional[Notebook] = None
     """Current notebook."""
-    pipeline: Pipeline = None
+    pipeline: Optional[Pipeline] = None
     """Current pipeline."""
-    run: Run = None
+    run: Optional[Run] = None
     """Current run."""
 
     @classmethod
@@ -46,6 +46,7 @@ class context:
                 this can help to identify the correct mechanism for interactivity
                 when automatic inference fails.
         """
+        cls.instance = settings.instance
         # original location of this code was _nb
         # legacy code here, see duplicated version in _run
         if id is None and name is None:
@@ -142,6 +143,7 @@ class context:
             name: Pipeline name.
             version: Pipeline version. If `None`, load latest (sort by created_at).
         """
+        cls.instance = settings.instance
         import lamindb as ln
         import lamindb.schema as lns
 
@@ -175,6 +177,7 @@ class context:
             run: If `None`, create new run or load latest.
             load_latest: Load the latest run of the notebook or pipeline.
         """
+        cls.instance = settings.instance
         import lamindb as ln
         import lamindb.schema as lns
 
@@ -230,6 +233,7 @@ class context:
             pipeline_name: Pipeline name.
             load_latest: Load the latest run of the notebook or pipeline.
         """
+        cls.instance = settings.instance
         logger.info(f"Instance: {cls.instance.identifier}")
         logger.info(f"User: {settings.user.handle}")
         if is_run_from_ipython:
@@ -238,7 +242,7 @@ class context:
         else:
             if pipeline_name is None:
                 raise ValueError(
-                    "Pass a pipeline name: ln.context.track_all(pipeline_name='...')"
+                    "Pass a pipeline name: ln.context.track(pipeline_name='...')"
                 )
             cls.track_pipeline(name=pipeline_name)
             logger.info(f"Pipeline: {cls.pipeline}")

--- a/lamindb/_context.py
+++ b/lamindb/_context.py
@@ -181,7 +181,7 @@ class context:
         import lamindb as ln
         import lamindb.schema as lns
 
-        run = lns.Run(load_latest=load_latest)
+        run = lns.Run(load_latest=load_latest, global_context=True)
         run = ln.add(run)  # type: ignore
         logger.info(f"Added run: {run.id}")  # type: ignore
 

--- a/lamindb/_context.py
+++ b/lamindb/_context.py
@@ -219,12 +219,8 @@ class context:
                 raise RuntimeError(
                     "Please call context.track_notebook or context.track_pipeline."
                 )
-            # it seems wiser to not yet commit the run to the database here
-            # rather commit it with the first piece of data
-            # however, it might be that one errors because of duplicate insertion
-            # run = ln.add(run)  # type: ignore
-            # logger.info(f"Added run: {run.id}")  # type: ignore
-            logger.info(f"Created run: {run.id}")
+            run = ln.add(run)  # type: ignore
+            logger.info(f"Added run: {run.id}")  # type: ignore
 
         # at this point, we have a run object
         cls.run = run

--- a/lamindb/_context.py
+++ b/lamindb/_context.py
@@ -229,6 +229,8 @@ class context:
     def track(cls, pipeline_name: Optional[str], load_latest=True):
         """Track notebook/pipeline and run.
 
+        When called from within a Python script, pass `pipeline_name`.
+
         Args:
             pipeline_name: Pipeline name.
             load_latest: Load the latest run of the notebook or pipeline.

--- a/lamindb/_context.py
+++ b/lamindb/_context.py
@@ -181,49 +181,9 @@ class context:
         import lamindb as ln
         import lamindb.schema as lns
 
-        # check user input
-        # if isinstance(run, lns.Run):
-        # This here might be something we may want in the future
-        # but checking all the cases in which that run record has integrity
-        # is quite a bit of code - not now!
-        #     run_test = ln.select(lns.Run, id=run.id).one_or_none()
-        #     if run_test is None:
-        #         logger.info("Passed run does not exist, adding it")
-        #         ln.add(run)
-        if run is None and load_latest:
-            if cls.notebook is not None:
-                select_stmt = ln.select(
-                    lns.Run, notebook_id=cls.notebook.id, notebook_v=cls.notebook.v
-                )
-            elif cls.pipeline is not None:
-                select_stmt = ln.select(
-                    lns.Run, pipeline_id=cls.pipeline.id, pipeline_v=cls.pipeline.v
-                )
-            else:
-                raise RuntimeError(
-                    "Please call context.track_notebook or context.track_pipeline."
-                )
-            run = select_stmt.order_by(lns.Run.created_at.desc()).first()
-            if run is not None:
-                logger.info(f"Loaded run: {run.id}")  # type: ignore
-            else:
-                logger.info("Did not find any latest run. Creating new run.")
-
-        # create a new run if doesn't exist yet or is requested by the user
-        if run is None:
-            if cls.notebook is not None:
-                run = lns.Run(notebook_id=cls.notebook.id, notebook_v=cls.notebook.v)
-            elif cls.pipeline is not None:
-                run = lns.Run(pipeline_id=cls.pipeline.id, pipeline_v=cls.pipeline.v)
-            else:
-                raise RuntimeError(
-                    "Please call context.track_notebook or context.track_pipeline."
-                )
-            run = ln.add(run)  # type: ignore
-            logger.info(f"Added run: {run.id}")  # type: ignore
-
-        # at this point, we have a run object
-        cls.run = run
+        run = lns.Run(load_latest=load_latest)
+        run = ln.add(run)  # type: ignore
+        logger.info(f"Added run: {run.id}")  # type: ignore
 
     @classmethod
     def track(cls, *, pipeline_name: Optional[str] = None, load_latest=True):

--- a/lamindb/_load.py
+++ b/lamindb/_load.py
@@ -25,6 +25,6 @@ def load(dobject: DObject, stream: bool = False, is_run_input: Optional[bool] = 
                 " directly."
             )
         else:
-            context.run.inputs.append(dobject)
+            dobject.targets.append(context.run)
     # track_usage(dobject.id, "load")
     return load_to_memory(filepath_from_dobject(dobject), stream=stream)

--- a/lamindb/_load.py
+++ b/lamindb/_load.py
@@ -8,6 +8,7 @@ from lamindb._context import context
 
 from ._settings import settings
 from .dev._core import filepath_from_dobject
+from .dev.db import add
 from .dev.file import load_to_memory
 
 
@@ -29,5 +30,6 @@ def load(dobject: DObject, stream: bool = False, is_run_input: Optional[bool] = 
             )
         else:
             dobject.targets.append(context.run)
+            add(dobject)  # need to commit here
     # track_usage(dobject.id, "load")
     return load_to_memory(filepath_from_dobject(dobject), stream=stream)

--- a/lamindb/_load.py
+++ b/lamindb/_load.py
@@ -1,46 +1,30 @@
-import lnschema_core as core
+from typing import Optional
+
 from lamin_logger import logger
-from lndb import settings as setup_settings
+from lnschema_core import DObject
+
+from lamindb._context import context
 
 from ._settings import settings
 from .dev._core import filepath_from_dobject
 from .dev.file import load_to_memory
 
 
-def populate_runin(dobject: core.DObject, run: core.Run):
-    setup_settings.instance._cloud_sqlite_locker.lock()
-    with setup_settings.instance.session() as ss:
-        result = ss.get(core.link.RunIn, (run.id, dobject.id))
-        if result is None:
-            ss.add(
-                core.link.RunIn(
-                    run_id=run.id,
-                    dobject_id=dobject.id,
-                )
-            )
-            ss.commit()
-            logger.info(f"Added dobject ({dobject.id}) as input for run ({run.id}).")
-            setup_settings.instance._update_cloud_sqlite_file()
-    setup_settings.instance._cloud_sqlite_locker.unlock()
-
-
 # this is exposed to the user as DObject.load
-def load(dobject: core.DObject, stream: bool = False, is_run_input: bool = False):
+def load(dobject: DObject, stream: bool = False, is_run_input: Optional[bool] = None):
     if stream and dobject.suffix not in (".h5ad", ".zarr"):
         logger.warning(f"Ignoring stream option for a {dobject.suffix} object.")
-
-    filepath = filepath_from_dobject(dobject)
-    # TODO: better design to track run inputs
-    if settings.track_run_inputs_upon_load or is_run_input:
-        from lamindb import nb
-
-        if nb.run is None:
-            logger.warning(
-                "Input tracking for runs through `load` is currently only implemented"
-                " for notebooks."
+    if is_run_input is None:
+        track_run_input = settings.track_run_inputs_upon_load
+    else:
+        track_run_input = is_run_input
+    if track_run_input:
+        if context.run is None:
+            raise ValueError(
+                "No global run context set. Call ln.context.track() or pass input run"
+                " directly."
             )
         else:
-            populate_runin(dobject, nb.run)
-    # TODO: enable track usage
+            context.run.inputs.append(dobject)
     # track_usage(dobject.id, "load")
-    return load_to_memory(filepath, stream=stream)
+    return load_to_memory(filepath_from_dobject(dobject), stream=stream)

--- a/lamindb/_load.py
+++ b/lamindb/_load.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from lamin_logger import logger
 from lnschema_core import DObject
+from sqlalchemy.orm.session import object_session
 
 from lamindb._context import context
 
@@ -19,6 +20,8 @@ def load(dobject: DObject, stream: bool = False, is_run_input: Optional[bool] = 
     else:
         track_run_input = is_run_input
     if track_run_input:
+        if object_session(dobject) is None:
+            raise ValueError("Need to load with session open to track as input.")
         if context.run is None:
             raise ValueError(
                 "No global run context set. Call ln.context.track() or pass input run"

--- a/lamindb/_load.py
+++ b/lamindb/_load.py
@@ -8,7 +8,6 @@ from lamindb._context import context
 
 from ._settings import settings
 from .dev._core import filepath_from_dobject
-from .dev.db import add
 from .dev.file import load_to_memory
 
 
@@ -30,6 +29,8 @@ def load(dobject: DObject, stream: bool = False, is_run_input: Optional[bool] = 
             )
         else:
             dobject.targets.append(context.run)
-            add(dobject)  # need to commit here
+            session = object_session(dobject)
+            session.add(dobject)
+            session.commit()
     # track_usage(dobject.id, "load")
     return load_to_memory(filepath_from_dobject(dobject), stream=stream)

--- a/lamindb/_nb.py
+++ b/lamindb/_nb.py
@@ -30,7 +30,7 @@ class nb:
         id: Optional[str] = None,
         v: Optional[str] = "0",
         name: Optional[str] = None,
-    ):
+    ) -> Run:
         """Track the notebook & display metadata.
 
         Call without arguments in most settings.
@@ -60,11 +60,13 @@ class nb:
         notebook = context.notebook
         cls.notebook = notebook
         if run == "new":
-            Run(global_context=True)
+            run = Run(global_context=True)
         elif run is None:
-            Run(global_context=True, load_latest=True)
+            run = Run(global_context=True, load_latest=True)
         else:
             raise ValueError("Pass 'new' to ln.nb.header().")
+        cls.run = run
+        return run
 
     @classmethod
     def publish(cls, version: str = None, i_confirm_i_saved: bool = False):

--- a/lamindb/_nb.py
+++ b/lamindb/_nb.py
@@ -54,18 +54,17 @@ class nb:
             v: Pass a notebook version manually.
             name: Pass a notebook name manually.
         """
-        context.track_notebook(
+        context._track_notebook(
             pypackage=pypackage, filepath=filepath, id=id, v=v, name=name, editor=env
         )
         notebook = context.notebook
         cls.notebook = notebook
         if run == "new":
-            context.track_run()
+            Run(global_context=True)
         elif run is None:
-            context.track_run(load_latest=True)
+            Run(global_context=True, load_latest=True)
         else:
             raise ValueError("Pass 'new' to ln.nb.header().")
-        cls.run = context.run
 
     @classmethod
     def publish(cls, version: str = None, i_confirm_i_saved: bool = False):

--- a/lamindb/_nb.py
+++ b/lamindb/_nb.py
@@ -1,12 +1,12 @@
-from pathlib import Path
 from typing import List, Optional, Union
 
 import nbproject as _nb
-from lamin_logger import logger
-from lndb import settings
-from lnschema_core import Notebook, Run, dev
+from lnschema_core import Notebook, Run
+
+from ._context import context
 
 
+# this whole class is deprecated, see lamindb.context instead!
 class nb:
     """Manage Jupyter notebooks.
 
@@ -54,88 +54,16 @@ class nb:
             v: Pass a notebook version manually.
             name: Pass a notebook name manually.
         """
-        if id is None and name is None:
-            nbproject_failed_msg = (
-                "Auto-retrieval of notebook name & title failed.\nPlease paste error"
-                " at: https://github.com/laminlabs/nbproject/issues/new \n\nFix: Run"
-                f" ln.nb.header(id={dev.id.notebook()}, name='my-notebook-name')"
-            )
-            try:
-                _nb.header(pypackage=pypackage, filepath=filepath, env=env)
-            except Exception:
-                raise RuntimeError(nbproject_failed_msg)
-            # this contains filepath if the header was run successfully
-            from nbproject._header import _filepath
-
-            id = _nb.meta.store.id
-            v = _nb.meta.store.version
-            name = Path(_filepath).stem
-            title = _nb.meta.live.title
-        elif id is None or name is None:
-            # Both id and name need to be passed if passing it manually
-            raise RuntimeError("Fix: Pass both id & name to ln.nb.header().")
-        else:
-            title = None
-
-        logger.info(f"Instance: {settings.instance.owner}/{settings.instance.name}")
-
-        import lamindb as ln
-        import lamindb.schema as lns
-
-        notebook = ln.select(
-            lns.Notebook,
-            id=id,
-            v=v,
-        ).one_or_none()
-        if notebook is None:
-            notebook = lns.Notebook(
-                id=id,
-                v=v,
-                name=name,
-                title=title,
-            )
-            notebook = ln.add(notebook)
-            logger.info(f"Added notebook: {notebook.id} v{notebook.v}")
-        else:
-            logger.info(f"Loaded notebook: {notebook.id} v{notebook.v}")
-            if notebook.name != name or notebook.title != title:
-                notebook.name = name
-                notebook.title = title
-                ln.add(notebook)
-                logger.info("Updated notebook name or title.")
-
-        # at this point, we have a notebook object
+        context.track_notebook(
+            pypackage=pypackage, filepath=filepath, id=id, v=v, name=name, editor=env
+        )
+        notebook = context.notebook
         cls.notebook = notebook
-
-        # check user input
-        # if isinstance(run, lns.Run):
-        # This here might be something we may want in the future
-        # but checking all the cases in which that run record has integrity
-        # is quite a bit of code - not now!
-        #     run_test = ln.select(lns.Run, id=run.id).one_or_none()
-        #     if run_test is None:
-        #         logger.info("Passed run does not exist, adding it")
-        #         ln.add(run)
-        if run is None:
-            # retrieve the latest run
-            run = (
-                ln.select(lns.Run, notebook_id=notebook.id, notebook_v=notebook.v)
-                .order_by(lns.Run.created_at.desc())
-                .first()
-            )
-            if run is not None:
-                logger.info(f"Loaded run: {run.id}")  # type: ignore
-        elif run != "new":
-            raise ValueError("Fix: ln.nb.header(run='new')!")
-
-        # create a new run if doesn't exist yet or is requested by the user ("new")
-        if run is None or run == "new":
-            run = lns.Run(notebook_id=notebook.id, notebook_v=notebook.v)
-            run = ln.add(run)  # type: ignore
-            logger.info(f"Added run: {run.id}")  # type: ignore
-
-        # at this point, we have a run object
-        cls.run = run
+        if run == "new":
+            context.track_run()
+        else:
+            context.track_run(load_latest=True)
+        cls.run = context.run
 
     @classmethod
     def publish(cls, version: str = None, i_confirm_i_saved: bool = False):

--- a/lamindb/_nb.py
+++ b/lamindb/_nb.py
@@ -61,8 +61,10 @@ class nb:
         cls.notebook = notebook
         if run == "new":
             context.track_run()
-        else:
+        elif run is None:
             context.track_run(load_latest=True)
+        else:
+            raise ValueError("Pass 'new' to ln.nb.header().")
         cls.run = context.run
 
     @classmethod

--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -207,6 +207,10 @@ def get_run(run: Optional[Run]) -> Run:
         run = context.run
         if run is None:
             raise ValueError(NO_SOURCE_ERROR)
+    # the following ensures that queried objects (within __init__)
+    # behave like queried objects, only example right now: Run
+    if run._ln_identity_key is not None:
+        run._sa_instance_state.key = run._ln_identity_key
     return run
 
 

--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -29,12 +29,10 @@ NO_SOURCE_ERROR = """
 Error: Please link a data source using the `source` argument.
 Fix: Link a data source by passing a run, e.g., via
 
-pipeline = ln.select("My ingestion pipeline").one()
 run = lns.Run(pipeline=pipeline)
 dobject = ln.DObject(..., source=run)
 
-Or, if you're in a notebook, call `ln.nb.header()` at the top, which creates
-a global run context for the notebook.
+Or, by calling ln.context.track(), which sets a global run context.
 
 More details: https://lamin.ai/docs/faq/ingest
 """
@@ -204,9 +202,9 @@ def get_features(dobject_privates, features_ref):
 
 def get_run(run: Optional[Run]) -> Run:
     if run is None:
-        from . import nb
+        from ._context import context
 
-        run = nb.run
+        run = context.run
         if run is None:
             raise ValueError(NO_SOURCE_ERROR)
     return run

--- a/lamindb/dev/db/_add.py
+++ b/lamindb/dev/db/_add.py
@@ -106,8 +106,8 @@ def add(  # type: ignore
         write_objectkey(record)
         # the following ensures that queried objects (within __init__)
         # behave like queried objects, only example right now: Run
-        if hasattr(record, "_identity_key") and record._identity_key is not None:
-            record._sa_instance_state.key = record._identity_key
+        if hasattr(record, "_ln_identity_key") and record._ln_identity_key is not None:
+            record._sa_instance_state.key = record._ln_identity_key
         session.add(record)
     try:
         session.commit()

--- a/lamindb/dev/db/_add.py
+++ b/lamindb/dev/db/_add.py
@@ -104,6 +104,10 @@ def add(  # type: ignore
     db_error = None
     for record in records:
         write_objectkey(record)
+        # the following ensures that queried objects (within __init__)
+        # behave like queried objects, only example right now: Run
+        if hasattr(record, "_identity_key") and record._identity_key is not None:
+            record._sa_instance_state.key = record._identity_key
         session.add(record)
     try:
         session.commit()

--- a/noxfile.py
+++ b/noxfile.py
@@ -20,6 +20,7 @@ def lint(session: nox.Session) -> None:
 def build(session):
     login_testuser1(session)
     login_testuser2(session)
+    session.install("./lnschema-core[dev,test]")
     session.install(".[dev,test]")
     run_pytest(session)
     build_docs(session)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "lnschema_core==0.29.1",
     "lnschema_wetlab==0.13.4",
     "lnschema_bionty==0.8.0",
-    "nbproject>=0.8.2",
+    "nbproject>=0.8.3",
     "readfcs>=1.1.0",
     # External packages
     "anndata>=0.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 dependencies = [
     # Lamin pinned packages
     "lndb>=0.37.4",
-    "lnschema_core==0.29.1",
+    "lnschema_core==0.29.2",
     "lnschema_wetlab==0.13.4",
     "lnschema_bionty==0.8.0",
     "nbproject>=0.8.3",

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -17,7 +17,7 @@ def test_create_to_load():
 
     notebook = ln.schema.Notebook(id="83jf", v="1", name="test")
     ln.add(notebook)
-    run = ln.schema.Run(notebook_id=notebook.id, notebook_v=notebook.v)
+    run = ln.schema.Run(notebook=notebook)
     ln.add(run)
     ln.select(ln.schema.Storage, root=str(lnsetup.settings.instance.storage.root)).one()
 


### PR DESCRIPTION
Instead of all the specificity for notebooks, notebooks and pipelines are now treated on an equal footing.

Along with

- https://github.com/laminlabs/lnschema-core/pull/133

Below is all gone and got replaced with `ln.Run(global_context, load_latest=True)`.

Everything is 100% backward compatible.

<img width="762" alt="image" src="https://user-images.githubusercontent.com/16916678/224581294-4fad70a4-abf0-4db8-9743-a25db65e4e3c.png">
