### PR TITLE
🏗️ Re-architect transform id

### DIFF
--- a/docs/faq/03-notebooks.ipynb
+++ b/docs/faq/03-notebooks.ipynb
@@ -86,9 +86,8 @@
     "# test re-initialize notebook if it got renamed\n",
     "from lamindb._context import reinitialize_notebook\n",
     "\n",
-    "transform, metadata = reinitialize_notebook(id=\"FkCpHEubpDGY\", name=\"new-nb-name\")\n",
-    "assert transform.id != \"FkCpHEubpDGY\"\n",
-    "assert transform.name == \"new-nb-name\""
+    "transform, metadata = reinitialize_notebook(id=\"FkCpHEubpDGY\")\n",
+    "assert transform.id != \"FkCpHEubpDGY\""
    ]
   },
   {

--- a/docs/guide/02-provenance.ipynb
+++ b/docs/guide/02-provenance.ipynb
@@ -511,7 +511,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.select(ln.Transform, title__contains=\"provenance\").df()"
+    "ln.select(ln.Transform, name__contains=\"provenance\").df()"
    ]
   },
   {

--- a/docs/guide/02-provenance.ipynb
+++ b/docs/guide/02-provenance.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "{class}`~lamindb.File` objects are the {attr}`~lamindb.Run.inputs` and {attr}`~lamindb.Run.outputs` of run {class}`~lamindb.Run` objects. What is run is a {class}`~lamindb.Transform`.\n",
     "\n",
-    "In each `File` object, access the generating {class}`~lamindb.Run` and {class}`~lamindb.Transform` objects via {attr}`lamindb.File.run` and {attr}`lamindb.File.transform`."
+    "From a `File` object, access the generating {class}`~lamindb.Run` and {class}`~lamindb.Transform` via {attr}`~lamindb.File.run` and {attr}`~lamindb.File.transform`."
    ]
   },
   {

--- a/docs/guide/03-select.ipynb
+++ b/docs/guide/03-select.ipynb
@@ -254,7 +254,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.select(ln.Transform, type=\"notebook\", title__contains=\"Query\").df()"
+    "ln.select(ln.Transform, type=\"notebook\", name__contains=\"Query\").df()"
    ]
   },
   {
@@ -360,7 +360,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.select(ln.Transform, title__contains=\"lookup\").df()"
+    "ln.select(ln.Transform, name__contains=\"lookup\").df()"
    ]
   },
   {
@@ -379,7 +379,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.select(ln.Transform, title__startswith=\"Query\").df()"
+    "ln.select(ln.Transform, name__startswith=\"Query\").df()"
    ]
   },
   {

--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -74,7 +74,6 @@ Developer API:
 .. autosummary::
    :toctree: .
 
-   link
    context
    settings
    types

--- a/lamindb/_amend_file.py
+++ b/lamindb/_amend_file.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from anndata import AnnData
 from anndata import __version__ as anndata_v
+from lamin_logger import logger
 from lamindb_setup import settings as setup_settings
 from lnschema_core import File
 from lnschema_core.models import filepath_from_file_or_folder
@@ -54,11 +55,12 @@ makes some configurable default choices (e.g., serialize a `DataFrame` as a
 """
 
 
-def backed(self: File) -> AnnDataAccessor:
+def backed(file: File, is_run_input: Optional[bool] = None) -> AnnDataAccessor:
     """Return a cloud-backed AnnData object for streaming."""
-    if self.suffix not in (".h5ad", ".zrad", ".zarr"):
+    _track_run_input(file, is_run_input)
+    if file.suffix not in (".h5ad", ".zrad", ".zarr"):
         raise ValueError("File should have an AnnData object as the underlying data")
-    return AnnDataAccessor(self)
+    return AnnDataAccessor(file)
 
 
 def subsetter(self: File) -> LazyDataFrame:
@@ -127,6 +129,7 @@ def stream(
 
 def _track_run_input(file: File, is_run_input: Optional[bool] = None):
     if is_run_input is None:
+        logger.hint("Track this file as a run input by passing `is_run_input=True`")
         track_run_input = settings.track_run_inputs_upon_load
     else:
         track_run_input = is_run_input

--- a/lamindb/_check_versions.py
+++ b/lamindb/_check_versions.py
@@ -8,8 +8,8 @@ from packaging import version
 if os.getenv("GITHUB_ACTIONS") is None:
     # Lamin PINNED packages
 
-    if version.parse(lnschema_core_v) != version.parse("0.35a6"):
-        logger.warning("lamindb needs lnschema_core==0.35a6")
+    if version.parse(lnschema_core_v) != version.parse("0.35a7"):
+        logger.warning("lamindb needs lnschema_core==0.35a7")
 
     if version.parse(lamindb_setup_v) < version.parse("0.46a4"):
         logger.warning("Upgrade lamindb_setup! pip install lamindb_setup==0.46a4")

--- a/lamindb/_context.py
+++ b/lamindb/_context.py
@@ -95,7 +95,7 @@ def reinitialize_notebook(
         nb_dev.write_notebook(nb, _filepath)
         raise SystemExit(msg_init_complete)
 
-    transform = Transform(id=new_id, version=new_version, type="notebook")
+    transform = Transform(stem_id=new_id, version=new_version, type="notebook")
     return transform, metadata
 
 

--- a/lamindb/_context.py
+++ b/lamindb/_context.py
@@ -1,6 +1,7 @@
 import builtins
 import os
 import re
+from datetime import datetime
 from pathlib import Path, PurePath
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -214,6 +215,8 @@ class context:
         if not new_run:
             run = ln.select(ln.Run, transform=transform).order_by("-created_at").first()
             if run is not None:
+                run.run_at = datetime.utcnow()
+                run.save()
                 logger.info(f"Loaded: {run}")
 
         if run is None:

--- a/lamindb/_context.py
+++ b/lamindb/_context.py
@@ -175,9 +175,8 @@ class context:
                 return None
         else:
             transform_exists = None
-            if (
-                transform.id is not None
-            ):  # transform has an id but unclear whether already saved
+            if transform.id is not None:
+                # transform has an id but unclear whether already saved
                 transform_exists = ln.select(Transform, id=transform.id).first()
             if transform_exists is None:
                 transform_exists = ln.save(transform)
@@ -195,7 +194,7 @@ class context:
                 ln.select(ln.Run, transform=cls.transform)
                 .order_by("-created_at")
                 .first()
-            )  # noqa
+            )
             if run is not None:  # loaded latest run
                 run.run_at = datetime.utcnow()  # update run time
                 run.save()

--- a/lamindb/_context.py
+++ b/lamindb/_context.py
@@ -142,8 +142,6 @@ class context:
                 when automatic inference fails.
         """
         cls.instance = settings.instance
-        logger.info(f"Instance: {cls.instance.identifier}")
-        logger.info(f"User: {settings.user.handle}")
         import lamindb as ln
 
         if transform is None:

--- a/lamindb/_context.py
+++ b/lamindb/_context.py
@@ -13,13 +13,6 @@ from lnschema_core import Run, Transform
 
 is_run_from_ipython = getattr(builtins, "__IPYTHON__", False)
 
-msg_init_complete = (
-    "⚠️ Destructive operation! ⚠️\n\nAre you sure you saved the notebook before running"
-    " `ln.track()`?\n - If not, hit save, and *overwrite* the notebook file.\n - If"
-    " yes, hit save, and *discard* editor content.\n\nConsider using Jupyter Lab or"
-    " Notebook for a seamless interactive notebook tracking experience."
-)
-
 msg_path_failed = (
     "Failed to infer notebook path.\nFix: Either track manually via"
     " `ln.track(ln.Transform(name='My notebook'))` or pass"
@@ -60,7 +53,7 @@ def reinitialize_notebook(
     id: str, metadata: Optional[Dict] = None
 ) -> Tuple[Transform, Dict]:
     from nbproject import dev as nb_dev
-    from nbproject._header import _env, _filepath
+    from nbproject._header import _filepath
 
     new_id, new_version = id, None
     if "NBPRJ_TEST_NBPATH" not in os.environ:
@@ -86,15 +79,6 @@ def reinitialize_notebook(
     if new_version is None:
         new_version = "0"
     metadata["version"] = new_version
-
-    # in "lab" & "notebook", we push the metadata write to the end of track execution
-    # by returning metadata below
-    if _env not in ("lab", "notebook", "test"):
-        if nb is None:
-            nb = nb_dev.read_notebook(_filepath)
-        nb.metadata["nbproject"] = metadata
-        nb_dev.write_notebook(nb, _filepath)
-        raise SystemExit(msg_init_complete)
 
     transform = Transform(stem_id=new_id, version=new_version, type="notebook")
     return transform, metadata

--- a/lamindb/_context.py
+++ b/lamindb/_context.py
@@ -175,7 +175,9 @@ class context:
                 return None
         else:
             transform_exists = None
-            if transform.id is not None:  # id based look-up
+            if (
+                transform.id is not None
+            ):  # transform has an id but unclear whether already saved
                 transform_exists = ln.select(Transform, id=transform.id).first()
             if transform_exists is None:
                 transform_exists = ln.save(transform)
@@ -193,14 +195,15 @@ class context:
                 ln.select(ln.Run, transform=cls.transform)
                 .order_by("-created_at")
                 .first()
-            )
+            )  # noqa
             if run is not None:  # loaded latest run
                 run.run_at = datetime.utcnow()  # update run time
                 run.save()
                 logger.info(f"Loaded: {run}")
 
         if run is None:  # create new run
-            ln.Run(transform=cls.transform).save()
+            run = ln.Run(transform=cls.transform)
+            run.save()
             logger.success(f"Saved: {run}")
         cls.run = run
 

--- a/lamindb/_context.py
+++ b/lamindb/_context.py
@@ -308,7 +308,7 @@ class context:
             version = "0"
             title = None
 
-        transform = ln.select(Transform, uid=id, version=version).one_or_none()
+        transform = ln.select(Transform, stem_id=id, version=version).one_or_none()
         if transform is None:
             transform = Transform(
                 stem_id=id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     # Lamin PINNED packages
     # !!! These packages should ALWAYS be pinned, do not unpin !!!
     # !!! They cannot be pinned ANYWHERE else !!!
-    "lnschema_core==0.35a6",
+    "lnschema_core==0.35a7",
     "lamindb_setup==0.46a4",
     # Lamin GREATEREQ packages
     "erdiagram>=0.1.2",


### PR DESCRIPTION
Transform was the only without a universal id for 2 days now - a relict of Django not supporting composite primary keys

This is now mitigated through introducing a stem_id that characterizes the notebook up to version

We also remove the title field and instead introduce a short_name field

- https://github.com/laminlabs/lnschema-core/pull/186