### PR TITLE
🚸 Prefix auto-storage-key with `lndb/`

### DIFF
--- a/docs/guide/01-files-folders.ipynb
+++ b/docs/guide/01-files-folders.ipynb
@@ -93,7 +93,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Files: serialized objects"
+    "## Files"
    ]
   },
   {
@@ -232,15 +232,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import lamindb as ln"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {
     "tags": [
      "hide-cell"
@@ -312,7 +303,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "!ls -R ./myobjects"
@@ -630,10 +625,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
-    "!ls ./myobjects"
+    "!ls -R ./myobjects"
    ]
   },
   {

--- a/docs/storage/add-replace-stage.ipynb
+++ b/docs/storage/add-replace-stage.ipynb
@@ -75,7 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key_path = root / f\"{file.id}{file.suffix}\""
+    "key_path = root / f\"lndb/{file.id}{file.suffix}\""
    ]
   },
   {
@@ -146,7 +146,7 @@
    "outputs": [],
    "source": [
     "old_key_path = key_path\n",
-    "new_key_path = root / f\"{file.id}{file.suffix}\""
+    "new_key_path = root / f\"lndb/{file.id}{file.suffix}\""
    ]
   },
   {

--- a/lamindb/_amend_file.py
+++ b/lamindb/_amend_file.py
@@ -128,7 +128,8 @@ def stream(
 
 def _track_run_input(file: File, is_run_input: Optional[bool] = None):
     if is_run_input is None:
-        logger.hint("Track this file as a run input by passing `is_run_input=True`")
+        if context.run is not None:
+            logger.hint("Track this file as a run input by passing `is_run_input=True`")
         track_run_input = settings.track_run_inputs_upon_load
     else:
         track_run_input = is_run_input

--- a/lamindb/_delete.py
+++ b/lamindb/_delete.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Union, overload  # noqa
 
 from lnschema_core import BaseORM, File, RunInput
 
-from lamindb._file_access import storage_key_from_file
+from lamindb._file_access import auto_storage_key_from_file
 from lamindb.dev.storage import delete_storage
 
 from ._logger import colors, logger
@@ -88,7 +88,7 @@ def delete(  # type: ignore
         if is_file:
             # save storage key before deleting the record
             # after the deletion file.id is None
-            storage_key = storage_key_from_file(record)
+            storage_key = auto_storage_key_from_file(record)
             # delete run_ins related to the file that's to be deleted
             run_ins = select(RunInput, file_id=record.id).all()
             for run_in in run_ins:

--- a/lamindb/_file.py
+++ b/lamindb/_file.py
@@ -9,6 +9,7 @@ from lamin_logger import logger
 from lnschema_core import File, Run, ids
 from lnschema_core.types import DataLike, PathLike
 
+from lamindb._file_access import storage_key_from_file
 from lamindb._select import select
 from lamindb._settings import settings
 from lamindb.dev.hashing import hash_file
@@ -365,7 +366,7 @@ def replace_file(
             )
     else:
         file.key = kwargs["key"]
-        old_storage = f"{file.id}{file.suffix}"
+        old_storage = storage_key_from_file(file)
         new_storage = (
             file.key if file.key is not None else f"{file.id}{kwargs['suffix']}"
         )

--- a/lamindb/_file.py
+++ b/lamindb/_file.py
@@ -9,7 +9,7 @@ from lamin_logger import logger
 from lnschema_core import File, Run, ids
 from lnschema_core.types import DataLike, PathLike
 
-from lamindb._file_access import storage_key_from_file
+from lamindb._file_access import auto_storage_key_from_file
 from lamindb._select import select
 from lamindb._settings import settings
 from lamindb.dev.hashing import hash_file
@@ -366,7 +366,7 @@ def replace_file(
             )
     else:
         file.key = kwargs["key"]
-        old_storage = storage_key_from_file(file)
+        old_storage = auto_storage_key_from_file(file)
         new_storage = (
             file.key if file.key is not None else f"{file.id}{kwargs['suffix']}"
         )

--- a/lamindb/_file_access.py
+++ b/lamindb/_file_access.py
@@ -7,7 +7,7 @@ from lnschema_core.models import File, Folder, Storage
 
 
 # add type annotations back asap when re-organizing the module
-def storage_key_from_file(file: File):
+def auto_storage_key_from_file(file: File):
     if file.key is None:
         return f"lndb/{file.id}{file.suffix}"
     else:
@@ -42,7 +42,7 @@ def attempt_accessing_path(file_or_folder: Union[File, Folder], storage_key: str
 # add type annotations back asap when re-organizing the module
 def filepath_from_file_or_folder(file_or_folder: Union[File, Folder]):
     if isinstance(file_or_folder, File):
-        storage_key = storage_key_from_file(file_or_folder)
+        storage_key = auto_storage_key_from_file(file_or_folder)
     else:
         storage_key = file_or_folder.key
         if storage_key is None:

--- a/lamindb/_save.py
+++ b/lamindb/_save.py
@@ -7,7 +7,7 @@ from django.db import transaction
 from lamin_logger import logger
 from lnschema_core.models import BaseORM, File
 
-from lamindb._file_access import storage_key_from_file
+from lamindb._file_access import auto_storage_key_from_file
 from lamindb.dev.storage import delete_storage, store_object, write_adata_zarr
 from lamindb.dev.storage._file import print_hook
 
@@ -169,7 +169,7 @@ def prepare_error_message(records, stored_files, exception) -> str:
 def upload_data_object(file) -> None:
     """Store and add file and its linked entries."""
     # do NOT hand-craft the storage key!
-    file_storage_key = storage_key_from_file(file)
+    file_storage_key = auto_storage_key_from_file(file)
     if hasattr(file, "_to_store") and file._to_store and file.suffix != ".zarr":
         logger.hint(f"storing object {file.name} with key {file_storage_key}")
         store_object(file._local_filepath, file_storage_key)


### PR DESCRIPTION
We don't like to clutter the root of storage locations anymore, anticipating that users will use auto-storage keys together with semantic keys.