### PR TITLE
✅ Add integrity tests for migrations back

### DIFF
--- a/docs/storage/upload.ipynb
+++ b/docs/storage/upload.ipynb
@@ -20,6 +20,8 @@
    },
    "outputs": [],
    "source": [
+    "instance_name = \"test-upload\"\n",
+    "\n",
     "!lamin load testuser1/{instance_name}\n",
     "!lamin delete {instance_name}\n",
     "!lamin init --storage s3://lamindb-ci --name {instance_name}"
@@ -456,7 +458,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15"
+   "version": "3.9.16"
   },
   "nbproject": {
    "id": "psZgub4FOmzS",

--- a/docs/storage/upload.ipynb
+++ b/docs/storage/upload.ipynb
@@ -294,7 +294,7 @@
    "outputs": [],
    "source": [
     "with pytest.raises(ValueError):\n",
-    "    pbmc68k_h5ad = ln.File(\"s3://bionty-assets/Species.csv\")"
+    "    pbmc68k_h5ad = ln.File(\"s3://lamin-site-assets/lamin-site-assets.lndb\")"
    ]
   },
   {


### PR DESCRIPTION
We had this with SQLAlchemy already, now we have it again:

- https://github.com/laminlabs/lamindb-setup/pull/419