### PR TITLE
📝 Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Stars](https://img.shields.io/github/stars/laminlabs/lamindb?logo=GitHub&color=yellow)](https://github.com/laminlabs/lamindb)
 [![codecov](https://codecov.io/gh/laminlabs/lamindb/branch/main/graph/badge.svg?token=VKMRJ7OWR3)](https://codecov.io/gh/laminlabs/lamindb)
 [![pypi](https://img.shields.io/pypi/v/lamindb?color=blue&label=pypi%20package)](https://pypi.org/project/lamindb)
+[![Documentation](https://img.shields.io/badge/Documentation-green)](https://lamin.ai/docs/guide)
 
 # LaminDB: Data lake for biology
 
@@ -14,7 +15,6 @@ Update 2023-06-14:
 
 - We completed a major migration from SQLAlchemy/SQLModel to Django, available in 0.42.0.
 - The last version before the migration is 0.41.2.
-
 ```
 
 ## Features
@@ -30,7 +30,7 @@ Free:
 
 Enterprise:
 
-- Explore & share data, submit samples (to come) & track lineage with LaminApp (deployable in your infra).
+- Explore & share data, submit samples (to come) & track lineage with LaminApp (deployable in your infrastructure).
 - Receive support, code templates & services for a BioTech data & analytics platform.
 
 ## Usage overview
@@ -241,14 +241,12 @@ LaminDB consists of the `lamindb` Python package (repository [here](https://gith
 
 LaminHub & LaminApp are not open-sourced, and neither are templates that model lab operations.
 
-Lamin's packages build on the infrastructure listed
-[above](#how-does-it-work). Previously, they were based on SQLAlchemy/SQLModel
-instead of Django, and cloudpathlib instead of fsspec.
+Lamin's packages build on the infrastructure listed [above](#how-does-it-work).
 
 ## Notebooks
 
 - Find all guide notebooks [here](https://github.com/laminlabs/lamindb/tree/main/docs/guide).
-- You can run these notebooks in hosted versions of JupyterLab, e.g., [Saturn Cloud](https://github.com/laminlabs/run-lamin-on-saturn), Google Vertex AI, and others or on Google Colab.
+- You can run these notebooks in hosted versions of JupyterLab, e.g., [Saturn Cloud](https://github.com/laminlabs/run-lamin-on-saturn), Google Vertex AI, Google Colab, and others.
 - Jupyter Lab & Notebook offer a fully interactive experience, VS Code & others require using the CLI (`lamin track my-notebook.ipynb`)
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Stars](https://img.shields.io/github/stars/laminlabs/lamindb?logo=GitHub&color=yellow)](https://github.com/laminlabs/lamindb)
 [![codecov](https://codecov.io/gh/laminlabs/lamindb/branch/main/graph/badge.svg?token=VKMRJ7OWR3)](https://codecov.io/gh/laminlabs/lamindb)
 [![pypi](https://img.shields.io/pypi/v/lamindb?color=blue&label=pypi%20package)](https://pypi.org/project/lamindb)
-[![Documentation](https://img.shields.io/badge/Documentation-green)](https://lamin.ai/docs/guide)
+[![Documentation](https://img.shields.io/badge/Documentation-green)](https://lamin.ai/docs/guide/)
 
 # LaminDB: Data lake for biology
 


### PR DESCRIPTION
Opinionated suggestions to improve the README:

1. Add a Documentation badge
2. I don't like the abbreviation "infra". Sounds too causal.
3. I removed some historical technical details that aren't important here in my opinion.

Generally, I think that we need to improve 2 things:

1. Less technical mombo-jumbo, especially if we show this on our website
2. We really need a figure that shows how this works and why it's useful. A single figure will attract more attention than a long, technical README. But I think that this is on our radar anyways.