### PR TITLE
🚸 Return locally backed object instead of cloud backed if available, rename `to_adata()` to `to_memory()`

### DIFF
--- a/docs/guide/04-stream.ipynb
+++ b/docs/guide/04-stream.ipynb
@@ -328,7 +328,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To load the entire subset into memory as an actual `AnnData` object, use `to_adata()`:"
+    "To load the entire subset into memory as an actual `AnnData` object, use `to_memory()`:"
    ]
   },
   {
@@ -337,7 +337,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "adata_subset.to_adata()"
+    "adata_subset.to_memory()"
    ]
   },
   {

--- a/lamindb/_file.py
+++ b/lamindb/_file.py
@@ -520,6 +520,13 @@ def backed(
             f" {', '.join(suffixes)}."
         )
     _track_run_input(self, is_run_input)
+    # consider the case where an object is already locally cached
+    local_path = setup_settings.instance.storage.cloud_to_local_no_update(
+        filepath_from_file(self)
+    )
+    if local_path.exists() and self.suffix == ".h5ad":
+        return ad.read_h5ad(local_path, backed="r")
+
     from lamindb.dev.storage._backed_access import backed_access
 
     return backed_access(self)

--- a/lamindb/dev/storage/_backed_access.py
+++ b/lamindb/dev/storage/_backed_access.py
@@ -200,7 +200,7 @@ if ZARR_INSTALLED:
 
             return prepare_adata
 
-        def to_adata(self):
+        def to_memory(self):
             adata = AnnData(**self.to_dict())
             return adata
 


### PR DESCRIPTION
More consistency across cloud-backed and disk-backed! Hope this is OK, @Koncopd!