### PR TITLE
🔥 Remove `top_hit` param from search

### DIFF
--- a/docs/biology/01-registries.ipynb
+++ b/docs/biology/01-registries.ipynb
@@ -88,7 +88,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Search a cell tpye"
+    "### Search a cell type"
    ]
   },
   {
@@ -97,7 +97,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gd_tcell = celltype_bt.search(\"gamma delta T cell\", top_hit=True)\n",
+    "gd_tcell = celltype_bt.search(\"gamma delta T cell\", return_queryset=True).first()\n",
     "gd_tcell"
    ]
   },

--- a/docs/biology/01-registries.ipynb
+++ b/docs/biology/01-registries.ipynb
@@ -97,8 +97,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gd_tcell = celltype_bt.search(\"gamma delta T cell\", return_queryset=True).first()\n",
-    "gd_tcell"
+    "celltype_bt.search(\"gamma delta T cell\").head(3)"
    ]
   },
   {

--- a/docs/biology/04-samples.ipynb
+++ b/docs/biology/04-samples.ipynb
@@ -72,7 +72,7 @@
    },
    "outputs": [],
    "source": [
-    "ln.File(ln.dev.datasets.file_mini_csv(), name=\"My mini dataset\").save()"
+    "ln.File(ln.dev.datasets.file_mini_csv(), description=\"My mini dataset\").save()"
    ]
   },
   {

--- a/docs/guide/02-data-lineage.ipynb
+++ b/docs/guide/02-data-lineage.ipynb
@@ -111,7 +111,7 @@
    "source": [
     "transform = ln.Transform.select(name=\"Cell Ranger\", version=\"7.2.0\").one()\n",
     "# or search\n",
-    "# transform = ln.Transform.search(\"Cell Ranger\", top_hit=True)"
+    "# transform = ln.Transform.search(\"Cell Ranger\", return_queryset=True).first()"
    ]
   },
   {
@@ -308,7 +308,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transform = ln.Transform.search(\"Track data lineage\", top_hit=True)"
+    "transform = ln.Transform.search(\"Track data lineage\", return_queryset=True).first()"
    ]
   },
   {
@@ -464,7 +464,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transform = ln.Transform.search(\"Track data lineage\", top_hit=True)"
+    "transform = ln.Transform.search(\"Track data lineage\", return_queryset=True).first()"
    ]
   },
   {

--- a/docs/guide/03-select.ipynb
+++ b/docs/guide/03-select.ipynb
@@ -247,7 +247,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.File.search(\"iris\", top_hit=True)"
+    "ln.File.search(\"iris\", return_queryset=True)"
    ]
   },
   {

--- a/docs/guide/03-select.ipynb
+++ b/docs/guide/03-select.ipynb
@@ -83,9 +83,9 @@
    "outputs": [],
    "source": [
     "# save some dummy files\n",
-    "ln.File(ln.dev.datasets.file_jpg_paradisi05(), name=\"My image\").save()\n",
-    "ln.File(ln.dev.datasets.df_iris(), name=\"My iris dataset\").save()\n",
-    "ln.File(ln.dev.datasets.file_fastq(), name=\"My fastq\").save()"
+    "ln.File(ln.dev.datasets.file_jpg_paradisi05(), description=\"My image\").save()\n",
+    "ln.File(ln.dev.datasets.df_iris(), description=\"My iris dataset\").save()\n",
+    "ln.File(ln.dev.datasets.file_fastq(), description=\"My fastq\").save()"
    ]
   },
   {
@@ -247,7 +247,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.File.search(\"iris\", return_queryset=True)"
+    "ln.File.search(\"iris\", return_queryset=True).first()"
    ]
   },
   {

--- a/lamindb/_orm.py
+++ b/lamindb/_orm.py
@@ -178,8 +178,25 @@ def _search(
         case_sensitive=case_sensitive,
     )
 
+    # search in both key and description fields for file
+    if orm.__name__ == "File" and field == "key":
+        result2 = base_search(
+            df=pd.DataFrame(query_set.values("id", "description")),
+            string=string,
+            field="description",
+            limit=limit,
+            synonyms_field=None,
+            case_sensitive=case_sensitive,
+        )
+        result = (
+            result.reset_index()
+            .merge(result2.reset_index(), how="outer")
+            .drop(columns=["index"], errors="ignore")
+            .set_index("id")
+        )
+
     if return_queryset:
-        return _order_queryset_by_ids(query_set, result["id"])
+        return _order_queryset_by_ids(query_set, result.reset_index()["id"])
     else:
         return result
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     # !!! They cannot be pinned ANYWHERE else !!!
     "lnschema_core==0.38.4",
     "lamindb_setup==0.48.8",
-    "lamin_logger==0.8.0",
+    "lamin_logger==0.8.1",
     # Lamin GREATEREQ packages
     "erdiagram>=0.1.2",
     # others


### PR DESCRIPTION
With https://github.com/laminlabs/lamin-logger/pull/37.

Added `return_queryset` to return a queryset from `search`