### PR TITLE
🚚 Rename `ORM.select()` to `ORM.filter()`

### DIFF
--- a/docs/biology/00-registries.ipynb
+++ b/docs/biology/00-registries.ipynb
@@ -253,7 +253,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_celltype = lb.CellType.select(name=\"my cell type\").one()\n",
+    "my_celltype = lb.CellType.filter(name=\"my cell type\").one()\n",
     "my_celltype.parents.add(celltype_record)"
    ]
   },
@@ -271,7 +271,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This cell type and all its parents can now be queried & searched in the registry using `lb.CellType.select` and `lb.CellType.search`.\n",
+    "This cell type and all its parents can now be queried & searched in the registry using `lb.CellType.filter` and `lb.CellType.search`.\n",
     "\n",
     "Further down the guide, we'll see how this will help us to annotate and validate files & datasets!"
    ]
@@ -473,7 +473,7 @@
    },
    "outputs": [],
    "source": [
-    "lb.CellType.select().df()"
+    "lb.CellType.filter().df()"
    ]
   },
   {
@@ -647,7 +647,7 @@
    },
    "outputs": [],
    "source": [
-    "lb.BiontySource.select(currently_used=True).df()"
+    "lb.BiontySource.filter(currently_used=True).df()"
    ]
   },
   {
@@ -664,7 +664,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cell_type_record = lb.CellType.select(name=\"hepatocyte\").one()\n",
+    "cell_type_record = lb.CellType.filter(name=\"hepatocyte\").one()\n",
     "cell_type_record.bionty_source"
    ]
   },

--- a/docs/biology/10-scrna.ipynb
+++ b/docs/biology/10-scrna.ipynb
@@ -87,7 +87,7 @@
     "\n",
     "# strain\n",
     "lb.ExperimentalFactor.from_bionty(ontology_id=\"EFO:0004472\").save()\n",
-    "record = lb.ExperimentalFactor.select(ontology_id=\"EFO:0004472\").one()\n",
+    "record = lb.ExperimentalFactor.filter(ontology_id=\"EFO:0004472\").one()\n",
     "record.add_synonym(\"C57BL/6N\")\n",
     "\n",
     "# developmental stage\n",

--- a/docs/biology/11-scrna-1.ipynb
+++ b/docs/biology/11-scrna-1.ipynb
@@ -56,7 +56,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.File.select(tissues__name__icontains=\"lymph node\").distinct().df()"
+    "ln.File.filter(tissues__name__icontains=\"lymph node\").distinct().df()"
    ]
   },
   {
@@ -65,7 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.File.select(cell_types__name__icontains=\"monocyte\").distinct().df()"
+    "ln.File.filter(cell_types__name__icontains=\"monocyte\").distinct().df()"
    ]
   },
   {
@@ -74,7 +74,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.File.select(labels__name=\"female\").distinct().df()"
+    "ln.File.filter(labels__name=\"female\").distinct().df()"
    ]
   },
   {
@@ -90,8 +90,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "file1 = ln.File.select(description=\"Conde22\").one()\n",
-    "file2 = ln.File.select(description=\"10x reference pbmc68k\").one()"
+    "file1 = ln.File.filter(description=\"Conde22\").one()\n",
+    "file2 = ln.File.filter(description=\"10x reference pbmc68k\").one()"
    ]
   },
   {

--- a/docs/biology/20-flow.ipynb
+++ b/docs/biology/20-flow.ipynb
@@ -200,7 +200,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.File.select(feature_sets__cell_markers=cell_markers.cd14).df()"
+    "ln.File.filter(feature_sets__cell_markers=cell_markers.cd14).df()"
    ]
   },
   {
@@ -216,8 +216,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "file1 = ln.File.select(feature_sets__cell_markers=cell_markers.cd14).all()[0]\n",
-    "file2 = ln.File.select(feature_sets__cell_markers=cell_markers.cd14).all()[1]"
+    "file1 = ln.File.filter(feature_sets__cell_markers=cell_markers.cd14).all()[0]\n",
+    "file2 = ln.File.filter(feature_sets__cell_markers=cell_markers.cd14).all()[1]"
    ]
   },
   {
@@ -253,7 +253,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lb.CellMarker.select().df().head(10)"
+    "lb.CellMarker.filter().df().head(10)"
    ]
   },
   {
@@ -267,7 +267,7 @@
    "outputs": [],
    "source": [
     "# throw error if there is none\n",
-    "ln.File.select(feature_sets__cell_markers=cell_markers.cd14).exists()\n",
+    "ln.File.filter(feature_sets__cell_markers=cell_markers.cd14).exists()\n",
     "# clean up test instance\n",
     "!lamin delete test-flow\n",
     "!rm -r test-flow"

--- a/docs/faq/acid.ipynb
+++ b/docs/faq/acid.ipynb
@@ -171,7 +171,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert len(ln.File.select().all()) == 0"
+    "assert len(ln.File.filter().all()) == 0"
    ]
   },
   {
@@ -241,7 +241,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "files = ln.File.select().all()\n",
+    "files = ln.File.filter().all()\n",
     "assert len(files) == 0"
    ]
   },

--- a/docs/faq/idempotency.ipynb
+++ b/docs/faq/idempotency.ipynb
@@ -478,7 +478,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "file4.select(hash=\"KCEXRahJ-Ui9Y6nksQ8z1A\").df()"
+    "file4.filter(hash=\"KCEXRahJ-Ui9Y6nksQ8z1A\").df()"
    ]
   },
   {
@@ -492,7 +492,7 @@
    },
    "outputs": [],
    "source": [
-    "assert len(file.select(hash=\"KCEXRahJ-Ui9Y6nksQ8z1A\").list()) == 2"
+    "assert len(file.filter(hash=\"KCEXRahJ-Ui9Y6nksQ8z1A\").list()) == 2"
    ]
   },
   {

--- a/docs/faq/notebooks.ipynb
+++ b/docs/faq/notebooks.ipynb
@@ -76,7 +76,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.Run.select().df()"
+    "ln.Run.filter().df()"
    ]
   },
   {

--- a/docs/faq/track-run-inputs.ipynb
+++ b/docs/faq/track-run-inputs.ipynb
@@ -97,7 +97,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "file = ln.File.select(description=\"My image\").one()"
+    "file = ln.File.filter(description=\"My image\").one()"
    ]
   },
   {
@@ -123,7 +123,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.Run.select(id=ln.context.run.id).one().input_files.all()"
+    "ln.Run.filter(id=ln.context.run.id).one().input_files.all()"
    ]
   },
   {
@@ -136,7 +136,7 @@
    },
    "outputs": [],
    "source": [
-    "assert len(ln.Run.select(id=ln.context.run.id).one().input_files.all()) == 0"
+    "assert len(ln.Run.filter(id=ln.context.run.id).one().input_files.all()) == 0"
    ]
   },
   {
@@ -178,7 +178,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for input in ln.Run.select(id=ln.context.run.id).one().input_files.all():\n",
+    "for input in ln.Run.filter(id=ln.context.run.id).one().input_files.all():\n",
     "    print(input)"
    ]
   },
@@ -192,7 +192,7 @@
    },
    "outputs": [],
    "source": [
-    "assert len(ln.Run.select(id=ln.context.run.id).one().input_files.all()) == 1"
+    "assert len(ln.Run.filter(id=ln.context.run.id).one().input_files.all()) == 1"
    ]
   },
   {
@@ -226,7 +226,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "file = ln.File.select(description=\"My csv\").one()"
+    "file = ln.File.filter(description=\"My csv\").one()"
    ]
   },
   {
@@ -244,7 +244,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for input in ln.Run.select(id=ln.context.run.id).one().input_files.all():\n",
+    "for input in ln.Run.filter(id=ln.context.run.id).one().input_files.all():\n",
     "    print(input)"
    ]
   },
@@ -258,7 +258,7 @@
    },
    "outputs": [],
    "source": [
-    "assert len(ln.Run.select(id=ln.context.run.id).one().input_files.all()) == 2"
+    "assert len(ln.Run.filter(id=ln.context.run.id).one().input_files.all()) == 2"
    ]
   },
   {

--- a/docs/guide/data-lineage.ipynb
+++ b/docs/guide/data-lineage.ipynb
@@ -112,7 +112,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transform = ln.Transform.select(name=\"Cell Ranger\", version=\"7.2.0\").one()"
+    "transform = ln.Transform.filter(name=\"Cell Ranger\", version=\"7.2.0\").one()"
    ]
   },
   {
@@ -146,7 +146,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "files = ln.File.select(key__startswith=\"fastq/perturbseq\").all()\n",
+    "files = ln.File.filter(key__startswith=\"fastq/perturbseq\").all()\n",
     "filepaths = [file.stage() for file in files]"
    ]
   },
@@ -289,7 +289,7 @@
     "transform = ln.Transform(name=\"GWS CRIPSRa analysis\", type=\"notebook\")\n",
     "ln.track(transform)\n",
     "\n",
-    "file_wgs = ln.File.select(key=\"schmidt22-crispra-gws-IFNG.csv\").one()\n",
+    "file_wgs = ln.File.filter(key=\"schmidt22-crispra-gws-IFNG.csv\").one()\n",
     "df = file_wgs.load().set_index(\"id\")\n",
     "hits_df = df[df[\"pos|fdr\"] < 0.01].copy()\n",
     "file_hits = ln.File(hits_df, description=\"hits from schmidt22 crispra GWS\")\n",
@@ -309,7 +309,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "file = ln.File.select(description=\"hits from schmidt22 crispra GWS\").one()\n",
+    "file = ln.File.filter(description=\"hits from schmidt22 crispra GWS\").one()\n",
     "file.view_lineage()"
    ]
   },
@@ -345,7 +345,7 @@
     ")\n",
     "ln.track(transform)\n",
     "\n",
-    "file_ps = ln.File.select(description__icontains=\"perturbseq\").one()\n",
+    "file_ps = ln.File.filter(description__icontains=\"perturbseq\").one()\n",
     "adata = file_ps.load()\n",
     "screen_hits = file_hits.load()\n",
     "import scanpy as sc\n",
@@ -378,7 +378,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "file = ln.File.select(key__contains=\"figures/matrixplot\").one()\n",
+    "file = ln.File.filter(key__contains=\"figures/matrixplot\").one()\n",
     "file.view_lineage()"
    ]
   },
@@ -584,7 +584,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.File.select(transform=transform).df()"
+    "ln.File.filter(transform=transform).df()"
    ]
   },
   {
@@ -601,7 +601,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "file = ln.File.select().first()\n",
+    "file = ln.File.filter().first()\n",
     "file.transform"
    ]
   },
@@ -645,7 +645,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.Transform.select(created_by=users.testuser2).df()"
+    "ln.Transform.filter(created_by=users.testuser2).df()"
    ]
   },
   {
@@ -662,7 +662,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.Transform.select(created_by=users.testuser2, type=\"notebook\").df()"
+    "ln.Transform.filter(created_by=users.testuser2, type=\"notebook\").df()"
    ]
   },
   {

--- a/docs/guide/select.ipynb
+++ b/docs/guide/select.ipynb
@@ -195,7 +195,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.File.select(created_by=user).df()"
+    "ln.File.filter(created_by=user).df()"
    ]
   },
   {
@@ -319,7 +319,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.File.select(run__created_by__handle__startswith=\"testuse\").df()"
+    "ln.File.filter(run__created_by__handle__startswith=\"testuse\").df()"
    ]
   },
   {
@@ -370,7 +370,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.File.select(suffix=\".jpg\", created_by=user).df()"
+    "ln.File.filter(suffix=\".jpg\", created_by=user).df()"
    ]
   },
   {
@@ -398,7 +398,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.File.select(created_by=user, size__lt=1e4).df()"
+    "ln.File.filter(created_by=user, size__lt=1e4).df()"
    ]
   },
   {
@@ -419,7 +419,7 @@
    "source": [
     "from django.db.models import Q\n",
     "\n",
-    "ln.File.select().filter(Q(suffix=\".jpg\") | Q(suffix=\".fastq.gz\")).df()"
+    "ln.File.filter().filter(Q(suffix=\".jpg\") | Q(suffix=\".fastq.gz\")).df()"
    ]
   },
   {
@@ -438,7 +438,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.File.select(suffix__in=[\".jpg\", \".fastq.gz\"]).df()"
+    "ln.File.filter(suffix__in=[\".jpg\", \".fastq.gz\"]).df()"
    ]
   },
   {
@@ -457,7 +457,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.File.select().order_by(\"-updated_at\").df()"
+    "ln.File.filter().order_by(\"-updated_at\").df()"
    ]
   },
   {
@@ -476,7 +476,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.Transform.select(name__contains=\"search\").df().head(10)"
+    "ln.Transform.filter(name__contains=\"search\").df().head(10)"
    ]
   },
   {
@@ -494,7 +494,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.Transform.select(name__icontains=\"Search\").df().head(10)"
+    "ln.Transform.filter(name__icontains=\"Search\").df().head(10)"
    ]
   },
   {
@@ -513,7 +513,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.Transform.select(name__startswith=\"Look up\").df()"
+    "ln.Transform.filter(name__startswith=\"Look up\").df()"
    ]
   },
   {

--- a/docs/guide/stream.ipynb
+++ b/docs/guide/stream.ipynb
@@ -91,7 +91,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "file = ln.File.select(key=\"lndb-storage/pbmc68k.h5ad\").one()"
+    "file = ln.File.filter(key=\"lndb-storage/pbmc68k.h5ad\").one()"
    ]
   },
   {
@@ -362,7 +362,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "file = ln.File.select(key=\"lndb-storage/testfile.hdf5\").one()"
+    "file = ln.File.filter(key=\"lndb-storage/testfile.hdf5\").one()"
    ]
   },
   {

--- a/docs/guide/tutorial1.ipynb
+++ b/docs/guide/tutorial1.ipynb
@@ -125,7 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.Storage.select().df()  # more on select statements later!"
+    "ln.Storage.filter().df()  # more on select statements later!"
    ]
   },
   {
@@ -518,7 +518,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.File.select(key=\"images/paradisi05_laminopathic_nuclei.jpg\").df()"
+    "ln.File.filter(key=\"images/paradisi05_laminopathic_nuclei.jpg\").df()"
    ]
   },
   {
@@ -528,7 +528,7 @@
    "outputs": [],
    "source": [
     "users = ln.User.lookup(\"handle\")\n",
-    "ln.File.select(created_by=users.testuser1).df()"
+    "ln.File.filter(created_by=users.testuser1).df()"
    ]
   },
   {
@@ -537,7 +537,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transform = ln.Transform.select(id=\"NJvdsWWbJlZSz8\").one()\n",
+    "transform = ln.Transform.filter(id=\"NJvdsWWbJlZSz8\").one()\n",
     "transform"
    ]
   },
@@ -547,7 +547,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.File.select(transform=transform).df()"
+    "ln.File.filter(transform=transform).df()"
    ]
   },
   {
@@ -592,7 +592,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "file = ln.File.select(key=\"images/paradisi05_laminopathic_nuclei.jpg\").one()"
+    "file = ln.File.filter(key=\"images/paradisi05_laminopathic_nuclei.jpg\").one()"
    ]
   },
   {
@@ -627,7 +627,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.File.select(labels=label).df().head()"
+    "ln.File.filter(labels=label).df().head()"
    ]
   },
   {
@@ -753,7 +753,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.File.select(labels__name=\"setosa\").df()"
+    "ln.File.filter(labels__name=\"setosa\").df()"
    ]
   },
   {
@@ -803,7 +803,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.Feature.select().df()"
+    "ln.Feature.filter().df()"
    ]
   },
   {
@@ -893,7 +893,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "features_in_meters = ln.Feature.select(type=\"float\").all()"
+    "features_in_meters = ln.Feature.filter(type=\"float\").all()"
    ]
   },
   {
@@ -913,7 +913,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.Feature.select().df()"
+    "ln.Feature.filter().df()"
    ]
   },
   {
@@ -1136,7 +1136,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset = ln.Dataset.select(name=\"Iris flower dataset batch 2\").one()"
+    "dataset = ln.Dataset.filter(name=\"Iris flower dataset batch 2\").one()"
    ]
   },
   {
@@ -1145,7 +1145,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "file1 = ln.File.select(description=\"Iris flower dataset batch 1\").one()\n",
+    "file1 = ln.File.filter(description=\"Iris flower dataset batch 1\").one()\n",
     "file2 = dataset.file"
    ]
   },
@@ -1297,7 +1297,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.File.select(key__startswith=\"sample_001/\").df().head()"
+    "ln.File.filter(key__startswith=\"sample_001/\").df().head()"
    ]
   },
   {
@@ -1305,7 +1305,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Query a specific file by passing the full key to `ln.select`:"
+    "Query a specific file by passing the full key to `ln.filter`:"
    ]
   },
   {
@@ -1314,7 +1314,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.File.select(key=\"sample_001/metrics_summary.csv\").df()"
+    "ln.File.filter(key=\"sample_001/metrics_summary.csv\").df()"
    ]
   },
   {
@@ -1419,7 +1419,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "label = ln.Label.select(name=\"project_1\").first()"
+    "label = ln.Label.filter(name=\"project_1\").first()"
    ]
   },
   {
@@ -1455,7 +1455,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.Label.select().df()"
+    "ln.Label.filter().df()"
    ]
   },
   {

--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -110,7 +110,7 @@ if _INSTANCE_SETUP:
     from . import _orm  # noqa
     from . import _transform  # noqa
     from ._delete import delete  # noqa
-    from ._filter import filter as select  # noqa
+    from ._orm import select_backward as select  # noqa
     from ._save import save  # noqa
     from ._view import view  # noqa
     from .dev._settings import settings

--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -110,8 +110,8 @@ if _INSTANCE_SETUP:
     from . import _orm  # noqa
     from . import _transform  # noqa
     from ._delete import delete  # noqa
+    from ._filter import filter as select  # noqa
     from ._save import save  # noqa
-    from ._select import select  # noqa
     from ._view import view  # noqa
     from .dev._settings import settings
 

--- a/lamindb/_context.py
+++ b/lamindb/_context.py
@@ -354,8 +354,6 @@ class run_context:
                 logger.debug("Inferring imported packages failed")
                 pass
 
-        import lamindb as ln
-
         if needs_init:
             if _env in ("lab", "notebook"):
                 cls._notebook_meta = metadata  # type: ignore
@@ -396,7 +394,7 @@ class run_context:
             version = "0"
             title = filestem
 
-        transform = ln.filter(Transform, stem_id=id, version=version).one_or_none()
+        transform = Transform.filter(stem_id=id, version=version).one_or_none()
         if transform is None:
             transform = Transform(
                 stem_id=id,

--- a/lamindb/_context.py
+++ b/lamindb/_context.py
@@ -178,7 +178,7 @@ class run_context:
             :class:`~lamindb.Transform` object of `type` `"pipeline"`:
 
             >>> ln.Transform(name="Cell Ranger", version="7.2.0", type="pipeline").save()
-            >>> transform = ln.Transform.select(name="Cell Ranger", version="7.2.0").one()
+            >>> transform = ln.Transform.filter(name="Cell Ranger", version="7.2.0").one()
             >>> ln.track(transform)
             💬 Loaded: Transform(id=ceHkZMaiHFdoB6, name=Cell Ranger, stem_id=ceHkZMaiHFdo, version=7.2.0, type=pipeline, updated_at=2023-07-10 18:37:19, created_by_id=DzTjkKse) # noqa
             ✅ Saved: Run(id=RcpWIKC8cF74Pn3RUJ1W, run_at=2023-07-10 18:37:19, transform_id=ceHkZMaiHFdoB6, created_by_id=DzTjkKse) # noqa
@@ -224,7 +224,7 @@ class run_context:
             transform_exists = None
             if transform.id is not None:
                 # transform has an id but unclear whether already saved
-                transform_exists = ln.select(Transform, id=transform.id).first()
+                transform_exists = ln.filter(Transform, id=transform.id).first()
             if transform_exists is None:
                 transform.save()
                 logger.success(f"Saved: {transform}")
@@ -239,7 +239,7 @@ class run_context:
         run = None
         if not new_run:  # try loading latest run by same user
             run = (
-                ln.Run.select(
+                ln.Run.filter(
                     transform=cls.transform, created_by_id=ln.setup.settings.user.id
                 )
                 .order_by("-created_at")
@@ -396,7 +396,7 @@ class run_context:
             version = "0"
             title = filestem
 
-        transform = ln.select(Transform, stem_id=id, version=version).one_or_none()
+        transform = ln.filter(Transform, stem_id=id, version=version).one_or_none()
         if transform is None:
             transform = Transform(
                 stem_id=id,

--- a/lamindb/_context.py
+++ b/lamindb/_context.py
@@ -224,7 +224,7 @@ class run_context:
             transform_exists = None
             if transform.id is not None:
                 # transform has an id but unclear whether already saved
-                transform_exists = ln.filter(Transform, id=transform.id).first()
+                transform_exists = Transform.filter(id=transform.id).first()
             if transform_exists is None:
                 transform.save()
                 logger.success(f"Saved: {transform}")

--- a/lamindb/_dataset.py
+++ b/lamindb/_dataset.py
@@ -68,7 +68,7 @@ def from_files(dataset: Dataset, *, name: str, files: Iterable[File]) -> Dataset
         file_id__in=file_ids
     )
     feature_set_ids = [link.feature_set_id for link in feature_set_file_links]
-    feature_sets = FeatureSet.select(id__in=feature_set_ids)
+    feature_sets = FeatureSet.filter(id__in=feature_set_ids)
     # validate consistency of hashes
     # we do not allow duplicate hashes
     file_hashes = [file.hash for file in files]

--- a/lamindb/_delete.py
+++ b/lamindb/_delete.py
@@ -33,12 +33,12 @@ def delete(  # type: ignore
 
         Delete by record:
 
-        >>> experiment = ln.select(Experiment, id=experiment_id).one()
+        >>> experiment = ln.filter(Experiment, id=experiment_id).one()
         >>> ln.delete(experiment)
 
         Delete files (delete the metadata record and the file in storage):
 
-        >>> file = ln.select(File, id=file_id).one()
+        >>> file = ln.filter(File, id=file_id).one()
         >>> ln.delete(file)
         >>> # deleting the record occurs automatically
         >>> # you will be asked whether to delete the file in storage
@@ -48,7 +48,7 @@ def delete(  # type: ignore
         Bulk delete via QuerySet:
 
         >>> ln.save(ln.Label.from_values(["Label1", "Label2", "Label3"], field="name"))
-        >>> queryset = ln.Label.select(name__icontains = "label")
+        >>> queryset = ln.Label.filter(name__icontains = "label")
         >>> queryset.list()
         [Label(id=o3FY3c5n, name=Label2, updated_at=2023-07-19 18:28:16, created_by_id=kmvZDIX9), # noqa
         Label(id=Qi3c4utq, name=Label3, updated_at=2023-07-19 18:28:16, created_by_id=kmvZDIX9), # noqa

--- a/lamindb/_feature.py
+++ b/lamindb/_feature.py
@@ -83,7 +83,7 @@ def from_df(cls, df: "pd.DataFrame") -> List["Feature"]:
             # ):  # because .categories > pd2.0, .cat.categories < pd2.0
             #     categorical = categorical.cat
             # categories = categorical.categories
-            # categoricals_with_unmapped_categories[name] = Label.select(
+            # categoricals_with_unmapped_categories[name] = Label.filter(
             #     feature=name
             # ).inspect(categories, "name", logging=False)["not_mapped"]
         else:

--- a/lamindb/_feature_manager.py
+++ b/lamindb/_feature_manager.py
@@ -14,7 +14,7 @@ def validate_and_cast_feature(
 ) -> Feature:
     if isinstance(feature, str):
         feature_name = feature
-        feature = Feature.select(name=feature_name).one_or_none()
+        feature = Feature.filter(name=feature_name).one_or_none()
         if feature is None:
             orm_types = set([record.__class__ for record in records])
             feature = Feature(
@@ -150,7 +150,7 @@ class FeatureManager:
         )
         feature_set_ids = [link.feature_set_id for link in feature_set_links.all()]
         # get all linked features of type Feature
-        feature_sets = FeatureSet.select(id__in=feature_set_ids).all()
+        feature_sets = FeatureSet.filter(id__in=feature_set_ids).all()
         linked_features_by_slot = {
             feature_set_links.filter(feature_set_id=feature_set.id)
             .one()

--- a/lamindb/_feature_set.py
+++ b/lamindb/_feature_set.py
@@ -78,7 +78,7 @@ def __init__(self, *args, **kwargs):
     n_features = len(features)
     if hash is None:
         features_hash = hash_set({feature.id for feature in features})
-        feature_set = FeatureSet.select(hash=features_hash).one_or_none()
+        feature_set = FeatureSet.filter(hash=features_hash).one_or_none()
         if feature_set is not None:
             logger.info(f"Loaded {feature_set}")
             init_self_from_db(self, feature_set)
@@ -92,7 +92,7 @@ def __init__(self, *args, **kwargs):
         type_str = None
     if modality is not None:
         if isinstance(modality, str):
-            modality_record = Modality.select(name=modality).one_or_none()
+            modality_record = Modality.filter(name=modality).one_or_none()
             if modality_record is None:
                 modality_record = Modality(name=modality)
                 modality_record.save()
@@ -152,7 +152,7 @@ def from_values(
     if not isinstance(iterable_idx[0], (str, int)):
         raise TypeError("values should be list-like of str or int")
     features_hash = hash_set(set(iterable_idx))
-    feature_set = FeatureSet.select(hash=features_hash).one_or_none()
+    feature_set = FeatureSet.filter(hash=features_hash).one_or_none()
     if feature_set is not None:
         logger.info(f"Loaded {feature_set}")
     else:

--- a/lamindb/_file.py
+++ b/lamindb/_file.py
@@ -140,7 +140,7 @@ def get_hash(
         hash, hash_type = hash_file(filepath)
     if not check_hash:
         return hash, hash_type
-    result = File.select(hash=hash).list()
+    result = File.filter(hash=hash).list()
     if len(result) > 0:
         if settings.upon_file_create_if_hash_exists == "error":
             msg = f"A file with same hash exists: {result[0]}"
@@ -831,7 +831,7 @@ def inherit_relations(self, file: File, fields: Optional[List[str]] = None):
         >>> file2 = ln.File(pd.DataFrame(index=[2,3]))
         >>> file2.save()
         >>> ln.save(ln.Label.from_values(["Label1", "Label2", "Label3"], field="name"))
-        >>> labels = ln.Label.select(name__icontains = "label").all()
+        >>> labels = ln.Label.filter(name__icontains = "label").all()
         >>> file1.labels.set(labels)
         >>> file2.inherit_relations(file1, ["labels"])
         💬 Inheriting 1 field: ['labels']

--- a/lamindb/_filter.py
+++ b/lamindb/_filter.py
@@ -5,7 +5,7 @@ from lnschema_core import ORM
 from lamindb._queryset import QuerySet
 
 
-def select(ORM: Type[ORM], **expressions) -> QuerySet:
+def filter(ORM: Type[ORM], **expressions) -> QuerySet:
     """See :meth:`~lamindb.dev.ORM.filter`."""
     qs = QuerySet(model=ORM)
     if len(expressions) > 0:

--- a/lamindb/_from_values.py
+++ b/lamindb/_from_values.py
@@ -136,9 +136,7 @@ def get_existing_records(iterable_idx: pd.Index, field: Field, kwargs: Dict = {}
     # kwargs is used to deal with species
     condition.update({f"{field_name}__in": iterable_idx.values})
 
-    from ._select import select
-
-    query_set = select(model, **condition)
+    query_set = model.filter(**condition)
 
     # new we have to sort the list of queried records
     preserved = Case(

--- a/lamindb/_from_values.py
+++ b/lamindb/_from_values.py
@@ -81,7 +81,7 @@ def get_or_create_records(
                 feature = ORM.__name__.lower()
             if isinstance(feature, str):
                 feature_name = feature
-                feature = Feature.select(name=feature).one_or_none()
+                feature = Feature.filter(name=feature).one_or_none()
             elif feature is not None:
                 feature_name = feature.name
             if feature is not None:

--- a/lamindb/_manager.py
+++ b/lamindb/_manager.py
@@ -14,9 +14,9 @@ class Manager(models.Manager):
     Examples:
 
         >>> ln.save(ln.Label.from_values(["Label1", "Label2", "Label3"], field="name"))
-        >>> labels = ln.Label.select(name__icontains = "label").all()
+        >>> labels = ln.Label.filter(name__icontains = "label").all()
         >>> ln.Label(name="Label1").save()
-        >>> label = ln.Label.select(name="Label1").one()
+        >>> label = ln.Label.filter(name="Label1").one()
         >>> label.parents.set(labels)
         >>> manager = label.parents
         >>> manager.df()
@@ -27,9 +27,9 @@ class Manager(models.Manager):
 
         Examples:
             >>> ln.save(ln.Label.from_values(["Label1", "Label2", "Label3"], field="name"))
-            >>> labels = ln.Label.select(name__icontains = "label").all()
+            >>> labels = ln.Label.filter(name__icontains = "label").all()
             >>> ln.Label(name="Label1").save()
-            >>> label = ln.Label.select(name="Label1").one()
+            >>> label = ln.Label.filter(name="Label1").one()
             >>> label.parents.set(labels)
             >>> label.parents.list()
             [Label(id=sFMcPepC, name=Label1, updated_at=2023-07-19 19:45:17, created_by_id=DzTjkKse), # noqa

--- a/lamindb/_orm.py
+++ b/lamindb/_orm.py
@@ -89,12 +89,12 @@ def __init__(orm: ORM, *args, **kwargs):
             if result == "object-with-same-name-exists":
                 if "version" in kwargs:
                     version_comment = " and version "
-                    existing_record = orm.select(
+                    existing_record = orm.filter(
                         name=kwargs["name"], version=kwargs["version"]
                     ).one_or_none()
                 else:
                     version_comment = " "
-                    existing_record = orm.select(name=kwargs["name"]).one()
+                    existing_record = orm.filter(name=kwargs["name"]).one()
                 if existing_record is not None:
                     logger.success(
                         f"Loaded record with exact same name{version_comment}"
@@ -512,7 +512,7 @@ def describe(self):
                 related_name = file_related_models.get(key)
                 related_objects = self.__getattribute__(related_name).all()
                 filelabel_links_df = (
-                    FileLabel.select(file_id=self.id)
+                    FileLabel.filter(file_id=self.id)
                     .annotate(
                         feature_name=F("feature__name"), label_name=F("label__name")
                     )

--- a/lamindb/_orm.py
+++ b/lamindb/_orm.py
@@ -735,7 +735,7 @@ METHOD_NAMES = [
     "view_parents",
 ]
 
-if _TESTING:
+if _TESTING:  # type: ignore
     from inspect import signature
 
     SIGS = {
@@ -761,5 +761,16 @@ def __get_name_with_schema__(cls) -> str:
     return f"{schema_name}.{cls.__name__}"
 
 
+def select_backward(cls, **expressions):
+    logger.warning("select() is deprecated! Please rename: ORM.filter()")
+    return cls.filter(**expressions)
+
+
+@classmethod  # type: ignore
+def select(cls, **expressions):
+    return select_backward(cls, **expressions)
+
+
 setattr(ORM, "__get_schema_name__", __get_schema_name__)
 setattr(ORM, "__get_name_with_schema__", __get_name_with_schema__)
+setattr(ORM, "select", select)  # backward compat

--- a/lamindb/_queryset.py
+++ b/lamindb/_queryset.py
@@ -37,7 +37,7 @@ class QuerySet(models.QuerySet):
     Examples:
 
         >>> ln.Label(name="my label").save()
-        >>> queryset = ln.Label.select(name="my label")
+        >>> queryset = ln.Label.filter(name="my label")
         >>> queryset
         <QuerySet [Label(id=MIeZISeF, name=my label, updated_at=2023-07-19 19:53:34, created_by_id=DzTjkKse)]> # noqa
     """
@@ -58,16 +58,16 @@ class QuerySet(models.QuerySet):
         Examples:
 
             >>> ln.save(ln.Label.from_values(["Label1", "Label2", "Label3"], field="name")) # noqa
-            >>> ln.Label.select().df()
+            >>> ln.Label.filter().df()
                           name  external_id           updated_at  created_by_id
                   id
             wsCyIq2Z  Label1         None  2023-07-19 19:14:08       DzTjkKse
             MvpDP8Y3  Label2         None  2023-07-19 19:14:08       DzTjkKse
             zKFFabCu  Label3         None  2023-07-19 19:14:08       DzTjkKse
-            >>> label = ln.Label.select(name="Label1").one()
-            >>> label = ln.Label.select(name="benchmark").one()
+            >>> label = ln.Label.filter(name="Label1").one()
+            >>> label = ln.Label.filter(name="benchmark").one()
             >>> label.parents.add(label)
-            >>> ln.Label.select().df(include=["labels__name", "labels__created_by_id"])
+            >>> ln.Label.filter().df(include=["labels__name", "labels__created_by_id"])
                       labels__name  labels__created_by_id      name  external_id           updated_at  created_by_id # noqa
                   id
             wsCyIq2Z  [benchmark]          [DzTjkKse]  Label1         None  2023-07-19 19:14:08       DzTjkKse # noqa
@@ -147,7 +147,7 @@ class QuerySet(models.QuerySet):
         Examples:
 
             >>> ln.save(ln.Label.from_values(["Label1", "Label2", "Label3"], field="name")) # noqa
-            >>> queryset = ln.Label.select(name__icontains = "project")
+            >>> queryset = ln.Label.filter(name__icontains = "project")
             >>> queryset.list()
             [Label(id=NAgTZxoo, name=Label1, updated_at=2023-07-19 19:25:48, created_by_id=DzTjkKse), # noqa
             Label(id=bnsAgKRC, name=Label2, updated_at=2023-07-19 19:25:48, created_by_id=DzTjkKse), # noqa
@@ -165,7 +165,7 @@ class QuerySet(models.QuerySet):
 
         Examples:
             >>> ln.save(ln.Label.from_values(["Label1", "Label2", "Label3"], field="name")) # noqa
-            >>> queryset = ln.Label.select(name__icontains = "project")
+            >>> queryset = ln.Label.filter(name__icontains = "project")
             >>> queryset.first()
             Label(id=NAgTZxoo, name=Label1, updated_at=2023-07-19 19:25:48, created_by_id=DzTjkKse) # noqa
         """
@@ -178,7 +178,7 @@ class QuerySet(models.QuerySet):
 
         Examples:
             >>> ln.Label(name="benchmark").save()
-            >>> ln.Label.select(name="benchmark").one()
+            >>> ln.Label.filter(name="benchmark").one()
             Label(id=gznl0GZk, name=benchmark, updated_at=2023-07-19 19:39:01, created_by_id=DzTjkKse) # noqa
         """
         if len(self) == 0:
@@ -193,9 +193,9 @@ class QuerySet(models.QuerySet):
 
         Examples:
             >>> ln.Label(name="benchmark").save()
-            >>> ln.Label.select(name="benchmark").one_or_none()
+            >>> ln.Label.filter(name="benchmark").one_or_none()
             Label(id=gznl0GZk, name=benchmark, updated_at=2023-07-19 19:39:01, created_by_id=DzTjkKse) # noqa
-            >>> ln.Label.select(name="non existing label").one_or_none()
+            >>> ln.Label.filter(name="non existing label").one_or_none()
             None
         """
         if len(self) == 0:

--- a/lamindb/_save.py
+++ b/lamindb/_save.py
@@ -56,7 +56,7 @@ def save(records: Iterable[ORM], **kwargs) -> None:  # type: ignore
 
         Update a single existing record:
 
-        >>> transform = ln.select(ln.Transform, id="0Cb86EZj").one()
+        >>> transform = ln.filter(ln.Transform, id="0Cb86EZj").one()
         >>> transform.name = "New name"
         >>> transform.save()
 

--- a/lamindb/_select.py
+++ b/lamindb/_select.py
@@ -6,7 +6,7 @@ from lamindb._queryset import QuerySet
 
 
 def select(ORM: Type[ORM], **expressions) -> QuerySet:
-    """See :meth:`~lamindb.dev.ORM.select`."""
+    """See :meth:`~lamindb.dev.ORM.filter`."""
     qs = QuerySet(model=ORM)
     if len(expressions) > 0:
         return qs.filter(**expressions)

--- a/lamindb/_view.py
+++ b/lamindb/_view.py
@@ -8,8 +8,6 @@ from lamindb_setup import settings
 from lamindb_setup.dev._setup_schema import get_schema_module_name
 from lnschema_core import ORM
 
-from ._select import select
-
 
 def view(n: int = 10, schema: Optional[str] = None, orms: Optional[List[str]] = None):
     """View data.
@@ -49,10 +47,10 @@ def view(n: int = 10, schema: Optional[str] = None, orms: Optional[List[str]] = 
             print("*" * len(section_no_color))
         for orm in sorted(filtered_orms, key=lambda x: x.__name__):
             if hasattr(orm, "updated_at"):
-                df = select(orm).order_by("-updated_at")[:n].df()
+                df = orm.filter().order_by("-updated_at")[:n].df()
             else:
                 # need to adjust in the future
-                df = select(orm).df().iloc[-n:]
+                df = orm.filter().df().iloc[-n:]
             if df.shape[0] > 0:
                 print(colors.blue(colors.bold(orm.__name__)))
                 display(df)

--- a/lamindb/dev/_view_parents.py
+++ b/lamindb/dev/_view_parents.py
@@ -134,14 +134,14 @@ def _get_parents(record: ORM, field: str, distance: int, children: bool = False)
         key = "children"
     model = record.__class__
     condition = f"{key}__{field}"
-    results = model.select(**{condition: record.__getattribute__(field)}).all()
+    results = model.filter(**{condition: record.__getattribute__(field)}).all()
     if distance < 2:
         return results
 
     d = 2
     while d < distance:
         condition = f"{key}__{condition}"
-        records = model.select(**{condition: record.__getattribute__(field)}).all()
+        records = model.filter(**{condition: record.__getattribute__(field)}).all()
 
         if len(records) == 0:
             return results
@@ -202,7 +202,7 @@ def _get_all_child_runs(file: File):
         child_runs: Set[Run] = set()
         for r in runs:
             child_runs.update(
-                Run.select(input_files__id__in=r.output_files.list("id")).list()
+                Run.filter(input_files__id__in=r.output_files.list("id")).list()
             )
         runs = child_runs
     return all_runs

--- a/lamindb/dev/storage/file.py
+++ b/lamindb/dev/storage/file.py
@@ -38,7 +38,7 @@ def attempt_accessing_path(file: File, storage_key: str):
         logger.warning(
             "file.path() is slightly slower for files outside default storage"
         )
-        storage = Storage.select(id=file.storage_id).one()
+        storage = Storage.filter(id=file.storage_id).one()
         # find a better way than passing None to instance_settings in the future!
         storage_settings = StorageSettings(storage.root)
         path = storage_settings.key_to_filepath(storage_key)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -24,8 +24,8 @@ def test_create_delete_from_single_dataframe():
     assert file.description is None
     assert dataset.hash == file.hash
     assert dataset.id == file.id
-    assert ln.File.select(id=dataset.id).one_or_none() is not None
-    assert ln.File.select(id=file.id).one_or_none() is not None
+    assert ln.File.filter(id=dataset.id).one_or_none() is not None
+    assert ln.File.filter(id=file.id).one_or_none() is not None
 
     # features
     feature_list = [
@@ -35,18 +35,18 @@ def test_create_delete_from_single_dataframe():
         "petal_width",
         "iris_species_name",
     ]
-    assert len(ln.Feature.select(name__in=feature_list).list()) == 5
-    feature_set = ln.FeatureSet.select(datasets=dataset).one()
-    feature_list_queried = ln.Feature.select(feature_sets=feature_set).list()
+    assert len(ln.Feature.filter(name__in=feature_list).list()) == 5
+    feature_set = ln.FeatureSet.filter(datasets=dataset).one()
+    feature_list_queried = ln.Feature.filter(feature_sets=feature_set).list()
     feature_list_queried = [feature.name for feature in feature_list_queried]
     assert set(feature_list_queried) == set(feature_list)
     # the feature_set is also linked to the file
-    assert ln.FeatureSet.select(files=dataset.file).one() == feature_set
+    assert ln.FeatureSet.filter(files=dataset.file).one() == feature_set
 
     # now proceed to deletion
     dataset.delete(storage=True)
-    assert ln.File.select(id=dataset.id).one_or_none() is None
-    assert ln.File.select(id=file.id).one_or_none() is None
+    assert ln.File.filter(id=dataset.id).one_or_none() is None
+    assert ln.File.filter(id=file.id).one_or_none() is None
 
 
 # def test_create_delete_from_single_anndata():
@@ -57,8 +57,8 @@ def test_create_delete_from_single_dataframe():
 #     assert file.description is None
 #     assert dataset.hash == file.hash
 #     assert dataset.id == file.id
-#     assert ln.File.select(id=dataset.id).one_or_none() is not None
-#     assert ln.File.select(id=file.id).one_or_none() is not None
+#     assert ln.File.filter(id=dataset.id).one_or_none() is not None
+#     assert ln.File.filter(id=file.id).one_or_none() is not None
 #     dataset.delete(storage=True)
-#     assert ln.File.select(id=dataset.id).one_or_none() is None
-#     assert ln.File.select(id=file.id).one_or_none() is None
+#     assert ln.File.filter(id=dataset.id).one_or_none() is None
+#     assert ln.File.filter(id=file.id).one_or_none() is None

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -6,4 +6,4 @@ def test_create_to_load():
     ln.save(transform)
     run = ln.Run(transform=transform)
     ln.save(run)
-    ln.filter(ln.Storage, root=str(ln.setup.settings.storage.root)).one()
+    ln.Storage.filter(root=str(ln.setup.settings.storage.root)).one()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -7,3 +7,6 @@ def test_create_to_load():
     run = ln.Run(transform=transform)
     ln.save(run)
     ln.Storage.filter(root=str(ln.setup.settings.storage.root)).one()
+    # test backward compat
+    ln.select(ln.Storage, root=str(ln.setup.settings.storage.root)).one()
+    ln.Storage.select(root=str(ln.setup.settings.storage.root)).one()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -6,4 +6,4 @@ def test_create_to_load():
     ln.save(transform)
     run = ln.Run(transform=transform)
     ln.save(run)
-    ln.select(ln.Storage, root=str(ln.setup.settings.storage.root)).one()
+    ln.filter(ln.Storage, root=str(ln.setup.settings.storage.root)).one()

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -58,11 +58,11 @@ def test_feature_from_df():
         feature.save()
     labels = ln.Label.from_values(df["feat3"])
     file.features.add_labels(labels, feature="feat3")
-    assert set(ln.Label.select(filelabel__feature__name="feat3").list("name")) == set(
+    assert set(ln.Label.filter(filelabel__feature__name="feat3").list("name")) == set(
         ["cond1", "cond2"]
     )
     for name in df.columns:
-        queried_feature = ln.Feature.select(name=name).one()
+        queried_feature = ln.Feature.filter(name=name).one()
         if name in categoricals:
             assert queried_feature.type == "category"
         else:

--- a/tests/test_feature_manager.py
+++ b/tests/test_feature_manager.py
@@ -18,7 +18,7 @@ def test_features_add_labels():
         == "ValueError: Please pass feature: add_labels(labels, feature='myfeature')"
     )
     file.features.add_labels(label, feature="project")
-    feature = ln.Feature.select(name="project").one()
+    feature = ln.Feature.filter(name="project").one()
     assert feature.type == "category"
     assert feature.registries == "core.Label"
     file.delete(storage=True)
@@ -38,13 +38,13 @@ def test_features_add_labels_using_anndata():
     lb.settings.auto_save_parents = False
 
     # clean up DB state
-    species_feature = ln.Feature.select(name="species").one_or_none()
+    species_feature = ln.Feature.filter(name="species").one_or_none()
     if species_feature is not None:
         species_feature.delete()
-    file = ln.File.select(description="Mini adata").one_or_none()
+    file = ln.File.filter(description="Mini adata").one_or_none()
     if file is not None:
         file.delete(storage=True)
-    ln.FeatureSet.select().all().delete()
+    ln.FeatureSet.filter().all().delete()
 
     file = ln.File.from_anndata(
         adata, description="Mini adata", var_ref=lb.Gene.ensembl_gene_id
@@ -74,7 +74,7 @@ def test_features_add_labels_using_anndata():
     assert "species" not in feature_set_obs.features.list("name")
 
     file.features.add_labels(species, feature="species")
-    feature = ln.Feature.select(name="species").one()
+    feature = ln.Feature.filter(name="species").one()
     assert feature.type == "category"
     assert feature.registries == "bionty.Species"
 
@@ -89,10 +89,10 @@ def test_features_add_labels_using_anndata():
     assert "species" in feature_set_ext.features.list("name")
 
     file.features.add_labels(cell_types + tissues)
-    feature = ln.Feature.select(name="cell_type").one()
+    feature = ln.Feature.filter(name="cell_type").one()
     assert feature.type == "category"
     assert feature.registries == "bionty.CellType"
-    feature = ln.Feature.select(name="tissue").one()
+    feature = ln.Feature.filter(name="tissue").one()
     assert feature.type == "category"
     assert feature.registries == "bionty.Tissue"
 
@@ -127,6 +127,6 @@ def test_features_add_labels_using_anndata():
     assert set(df["registries"]) == {"bionty.Species"}
 
     # clean up
-    ln.Feature.select(name="species").one().delete()
-    ln.File.select(description="Mini adata").one().delete(storage=True)
-    ln.FeatureSet.select().all().delete()
+    ln.Feature.filter(name="species").one().delete()
+    ln.File.filter(description="Mini adata").one().delete(storage=True)
+    ln.FeatureSet.filter().all().delete()

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -71,7 +71,7 @@ def test_create_from_dataframe_using_from_df(description):
     # check that the local filepath has been cleared
     assert not hasattr(file, "_local_filepath")
     feature_set_queried = file.feature_sets.get()  # exactly one
-    feature_list_queried = ln.Feature.select(feature_sets=feature_set_queried).list()
+    feature_list_queried = ln.Feature.filter(feature_sets=feature_set_queried).list()
     feature_list_queried = [feature.name for feature in feature_list_queried]
     assert set(feature_list_queried) == set(df.columns)
     file.delete(storage=True)
@@ -85,12 +85,12 @@ def test_create_from_anndata_in_memory():
     # check that the local filepath has been cleared
     assert not hasattr(file, "_local_filepath")
     feature_sets_queried = file.feature_sets.all()
-    feature_list_queried = ln.Feature.select(
+    feature_list_queried = ln.Feature.filter(
         feature_sets__in=feature_sets_queried
     ).list()
     feature_list_queried = [feature.name for feature in feature_list_queried]
     assert set(feature_list_queried) == set(adata.obs.columns)
-    feature_list_queried = lb.Gene.select(feature_sets__in=feature_sets_queried).list()
+    feature_list_queried = lb.Gene.filter(feature_sets__in=feature_sets_queried).list()
     feature_list_queried = [feature.symbol for feature in feature_list_queried]
     assert set(feature_list_queried) == set(adata.var.index)
     file.delete(storage=True)
@@ -199,7 +199,7 @@ def test_delete(get_test_filepaths):
     file.save()
     storage_path = file.path()
     file.delete(storage=True)
-    assert ln.File.select(description="My test file to delete").first() is None
+    assert ln.File.filter(description="My test file to delete").first() is None
     assert not Path(storage_path).exists()
 
 

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -73,7 +73,7 @@ def test_search_file():
     # queryset returns the same order of results
     assert res.index.tolist() == [i.id for i in res_q]
 
-    f = ln.File.select(key="test-search5").one()
+    f = ln.File.filter(key="test-search5").one()
     f.suffix = ".txt"
     f.save()
     # multi-field search

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -12,12 +12,12 @@ def test_df():
     ln.save(labels)
     for label in labels:
         label.parents.add(project_label)
-    df = ln.Label.select().df(include="parents__name")
+    df = ln.Label.filter().df(include="parents__name")
     assert df.columns[0] == "parents__name"
     # order is not conserved
     assert df["parents__name"][0] == [project_label.name]
     # pass a list
-    df = ln.Label.select().df(include=["parents__name", "parents__created_by_id"])
+    df = ln.Label.filter().df(include=["parents__name", "parents__created_by_id"])
     assert df.columns[1] == "parents__created_by_id"
     assert df["parents__name"][0] == [project_label.name]
     assert set(df["parents__created_by_id"][0]) == set([ln.setup.settings.user.id])
@@ -29,12 +29,12 @@ def test_df():
     feature_set.save()
     feature_set.features.set(features)
 
-    df = ln.FeatureSet.select(name="my feature_set").df(include="features__name")
+    df = ln.FeatureSet.filter(name="my feature_set").df(include="features__name")
     assert df.columns[0] == "features__name"
     # order is not conserved
     assert set(df["features__name"][0]) == set(feature_names)
     # pass a list
-    df = ln.FeatureSet.select(name="my feature_set").df(
+    df = ln.FeatureSet.filter(name="my feature_set").df(
         include=["features__name", "features__created_by_id"]
     )
     assert df.columns[1] == "features__created_by_id"
@@ -43,7 +43,7 @@ def test_df():
 
     # raise error for non many-to-many
     with pytest.raises(ValueError):
-        ln.Label.select().df(include="name")
+        ln.Label.filter().df(include="name")
 
     # clean up
     project_label.delete()
@@ -66,23 +66,23 @@ def test_search():
     label_names = [f"Label {i}" for i in range(3)]
     labels = [ln.Label(name=name) for name in label_names]
     ln.save(labels)
-    qs = ln.Label.select(name="Label 2").all()
+    qs = ln.Label.filter(name="Label 2").all()
     assert qs.search("Label 1").iloc[0].name == "Label 2"
     for label in labels:
         label.delete()
 
 
 def test_lookup():
-    qs = ln.User.select(handle="testuser1").all()
+    qs = ln.User.filter(handle="testuser1").all()
     lookup = qs.lookup(field="handle")
     assert lookup.testuser1.handle == "testuser1"
 
 
 def test_inspect():
-    qs = ln.User.select(handle="testuser1").all()
+    qs = ln.User.filter(handle="testuser1").all()
     assert qs.inspect(["user1", "user2"], "name")["mapped"] == []
 
 
 def test_map_synonyms():
-    qs = ln.User.select(handle="testuser1").all()
+    qs = ln.User.filter(handle="testuser1").all()
     assert qs.map_synonyms(["user1", "user2"]) == ["user1", "user2"]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -13,6 +13,6 @@ def test_settings_switch_storage():
     assert ln.setup.settings.storage.root.fs.cache_regions
     ln.settings.storage = "s3://lamindb-ci", dict(cache_regions=False)
     assert not ln.setup.settings.storage.root.fs.cache_regions
-    assert ln.Storage.select(root="s3://lamindb-ci").one_or_none() is not None
+    assert ln.Storage.filter(root="s3://lamindb-ci").one_or_none() is not None
     # switch back to default storage
     ln.settings.storage = "./default_storage"


### PR DESCRIPTION
This reduces the number of concepts to learn from 2 to 1, given `select()` is essentially a Django filter.

The name "select" stems from SQLAlchemy days.

- https://github.com/laminlabs/lnschema-core/pull/252