### PR TITLE
🚸 Ignore `synonyms` in `from_values` to incentivize explicit curation process

### DIFF
--- a/lamindb/_from_values.py
+++ b/lamindb/_from_values.py
@@ -93,7 +93,6 @@ def get_existing_records(
     iterable_idx: pd.Index,
     field: Field,
     kwargs: Dict = {},
-    ignore_synonyms: bool = True,
 ):
     field_name = field.field.name
     model = field.field.model
@@ -108,26 +107,6 @@ def get_existing_records(
         if species_record is not None:
             kwargs.update({"species": species_record})
             condition.update({"species__name": species_record.name})
-
-    syn_msg = ""
-    syn_mapper = {}
-    if not ignore_synonyms:
-        # map synonyms based on the DB reference
-        syn_mapper = model.map_synonyms(
-            iterable_idx, species=kwargs.get("species"), return_mapper=True
-        )
-        if len(syn_mapper) > 0:
-            s = "" if len(syn_mapper) == 1 else "s"
-            names = list(syn_mapper.keys())
-            print_values = ", ".join(names[:5])
-            if len(names) > 5:
-                print_values += ", ..."
-            syn_msg = (
-                "validated"
-                f" {colors.green(f'{len(syn_mapper)} {model.__name__} record{s}')}"  # noqa
-                f" on {colors.green('synonyms')}: {print_values}"
-            )
-            iterable_idx = iterable_idx.to_frame().rename(index=syn_mapper).index
 
     # get all existing records in the db
     # if necessary, create records for the values in kwargs
@@ -148,9 +127,9 @@ def get_existing_records(
     # order by causes a factor 10 in runtime
     # records = query_set.order_by(preserved).list()
 
-    n_name = len(records) - len(syn_mapper)
+    n_name = len(records)
     names = [getattr(record, field_name) for record in records]
-    names = [name for name in names if name not in syn_mapper.values()]
+    names = [name for name in names]
     if n_name > 0:
         s = "" if n_name == 1 else "s"
         print_values = ", ".join(names[:20])
@@ -161,9 +140,6 @@ def get_existing_records(
             f" {colors.green(f'{n_name} {model.__name__} record{s}')}"
             f" on {colors.green(f'{field_name}')}: {print_values}"
         )
-    # make sure that synonyms logging appears after the field logging
-    if len(syn_msg) > 0:
-        logger.info(syn_msg)
 
     existing_values = iterable_idx.intersection(
         query_set.values_list(field_name, flat=True)
@@ -176,7 +152,6 @@ def get_existing_records(
 def create_records_from_bionty(
     iterable_idx: pd.Index,
     field: Field,
-    ignore_synonyms: bool = True,
     **kwargs,
 ):
     model = field.field.model
@@ -193,27 +168,6 @@ def create_records_from_bionty(
     # filter the columns in bionty df based on fields
     bionty_df = _filter_bionty_df_columns(model=model, bionty_object=bionty_object)
 
-    # map synonyms in the bionty reference
-    msg_syn = ""
-    syn_mapper = {}
-    if not ignore_synonyms:
-        try:
-            syn_mapper = bionty_object.map_synonyms(iterable_idx, return_mapper=True)
-        except KeyError:
-            pass
-        if len(syn_mapper) > 0:
-            s = "" if len(syn_mapper) == 1 else "s"
-            names = list(syn_mapper.keys())
-            print_values = ", ".join(names[:20])
-            if len(names) > 20:
-                print_values += ", ..."
-            msg_syn = (
-                "validated"
-                f" {colors.purple(f'{len(syn_mapper)} {model.__name__} record{s} from Bionty')}"  # noqa
-                f" on {colors.purple('synonyms')}: {print_values}"
-            )
-            iterable_idx = iterable_idx.to_frame().rename(index=syn_mapper).index
-
     # create records for values that are found in the bionty reference
     mapped_values = iterable_idx.intersection(bionty_df[field_name])
 
@@ -226,9 +180,9 @@ def create_records_from_bionty(
             records.append(model(**bk, **kwargs))
 
         # number of records that matches field (not synonyms)
-        n_name = len(records) - len(syn_mapper)
+        n_name = len(records)
         names = [getattr(record, field_name) for record in records]
-        names = [name for name in names if name not in syn_mapper.values()]
+        names = [name for name in names]
         if n_name > 0:
             s = "" if n_name == 1 else "s"
             print_values = ", ".join(names[:20])
@@ -241,9 +195,6 @@ def create_records_from_bionty(
             )
             logger.success(msg)
 
-    # make sure that synonyms logging appears after the field logging
-    if len(msg_syn) > 0:
-        logger.success(msg_syn)
     # warning about multi matches
     if len(multi_msg) > 0:
         logger.warning(multi_msg)

--- a/lamindb/_from_values.py
+++ b/lamindb/_from_values.py
@@ -89,7 +89,12 @@ def get_or_create_records(
         settings.upon_create_search_names = upon_create_search_names
 
 
-def get_existing_records(iterable_idx: pd.Index, field: Field, kwargs: Dict = {}):
+def get_existing_records(
+    iterable_idx: pd.Index,
+    field: Field,
+    kwargs: Dict = {},
+    ignore_synonyms: bool = True,
+):
     field_name = field.field.name
     model = field.field.model
     condition: Dict = {}
@@ -104,24 +109,25 @@ def get_existing_records(iterable_idx: pd.Index, field: Field, kwargs: Dict = {}
             kwargs.update({"species": species_record})
             condition.update({"species__name": species_record.name})
 
-    # map synonyms based on the DB reference
-    syn_mapper = model.map_synonyms(
-        iterable_idx, species=kwargs.get("species"), return_mapper=True
-    )
-
     syn_msg = ""
-    if len(syn_mapper) > 0:
-        s = "" if len(syn_mapper) == 1 else "s"
-        names = list(syn_mapper.keys())
-        print_values = ", ".join(names[:5])
-        if len(names) > 5:
-            print_values += ", ..."
-        syn_msg = (
-            "validated"
-            f" {colors.green(f'{len(syn_mapper)} {model.__name__} record{s}')}"  # noqa
-            f" on {colors.green('synonyms')}: {print_values}"
+    syn_mapper = {}
+    if not ignore_synonyms:
+        # map synonyms based on the DB reference
+        syn_mapper = model.map_synonyms(
+            iterable_idx, species=kwargs.get("species"), return_mapper=True
         )
-        iterable_idx = iterable_idx.to_frame().rename(index=syn_mapper).index
+        if len(syn_mapper) > 0:
+            s = "" if len(syn_mapper) == 1 else "s"
+            names = list(syn_mapper.keys())
+            print_values = ", ".join(names[:5])
+            if len(names) > 5:
+                print_values += ", ..."
+            syn_msg = (
+                "validated"
+                f" {colors.green(f'{len(syn_mapper)} {model.__name__} record{s}')}"  # noqa
+                f" on {colors.green('synonyms')}: {print_values}"
+            )
+            iterable_idx = iterable_idx.to_frame().rename(index=syn_mapper).index
 
     # get all existing records in the db
     # if necessary, create records for the values in kwargs
@@ -170,6 +176,7 @@ def get_existing_records(iterable_idx: pd.Index, field: Field, kwargs: Dict = {}
 def create_records_from_bionty(
     iterable_idx: pd.Index,
     field: Field,
+    ignore_synonyms: bool = True,
     **kwargs,
 ):
     model = field.field.model
@@ -187,29 +194,30 @@ def create_records_from_bionty(
     bionty_df = _filter_bionty_df_columns(model=model, bionty_object=bionty_object)
 
     # map synonyms in the bionty reference
-    try:
-        syn_mapper = bionty_object.map_synonyms(iterable_idx, return_mapper=True)
-    except KeyError:
-        # no synonyms column
-        syn_mapper = {}
-    msg_syn: str = ""
-    if len(syn_mapper) > 0:
-        s = "" if len(syn_mapper) == 1 else "s"
-        names = list(syn_mapper.keys())
-        print_values = ", ".join(names[:20])
-        if len(names) > 20:
-            print_values += ", ..."
-        msg_syn = (
-            "validated"
-            f" {colors.purple(f'{len(syn_mapper)} {model.__name__} record{s} from Bionty')}"  # noqa
-            f" on {colors.purple('synonyms')}: {print_values}"
-        )
-
-        iterable_idx = iterable_idx.to_frame().rename(index=syn_mapper).index
+    msg_syn = ""
+    syn_mapper = {}
+    if not ignore_synonyms:
+        try:
+            syn_mapper = bionty_object.map_synonyms(iterable_idx, return_mapper=True)
+        except KeyError:
+            pass
+        if len(syn_mapper) > 0:
+            s = "" if len(syn_mapper) == 1 else "s"
+            names = list(syn_mapper.keys())
+            print_values = ", ".join(names[:20])
+            if len(names) > 20:
+                print_values += ", ..."
+            msg_syn = (
+                "validated"
+                f" {colors.purple(f'{len(syn_mapper)} {model.__name__} record{s} from Bionty')}"  # noqa
+                f" on {colors.purple('synonyms')}: {print_values}"
+            )
+            iterable_idx = iterable_idx.to_frame().rename(index=syn_mapper).index
 
     # create records for values that are found in the bionty reference
     mapped_values = iterable_idx.intersection(bionty_df[field_name])
 
+    multi_msg = ""
     if len(mapped_values) > 0:
         bionty_kwargs, multi_msg = _bulk_create_dicts_from_df(
             keys=mapped_values, column_name=field_name, df=bionty_df
@@ -232,12 +240,13 @@ def create_records_from_bionty(
                 f" on {colors.purple(f'{field_name}')}: {print_values}"
             )
             logger.success(msg)
-        # make sure that synonyms logging appears after the field logging
-        if len(msg_syn) > 0:
-            logger.success(msg_syn)
-        # warning about multi matches
-        if len(multi_msg) > 0:
-            logger.warning(multi_msg)
+
+    # make sure that synonyms logging appears after the field logging
+    if len(msg_syn) > 0:
+        logger.success(msg_syn)
+    # warning about multi matches
+    if len(multi_msg) > 0:
+        logger.warning(multi_msg)
 
     # return the values that are not found in the bionty reference
     unmapped_values = iterable_idx.difference(mapped_values)

--- a/tests/test_from_values.py
+++ b/tests/test_from_values.py
@@ -49,9 +49,15 @@ def test_from_values_species():
         Gene.from_values(["ABC1"], Gene.symbol)
 
     settings.species = "human"
-    records = Gene.from_values(["ABC1"], Gene.symbol)
+    values = ["ABC1"]
+    curated_values = Gene.bionty().map_synonyms(values)
+    print(curated_values)
+    records = Gene.from_values(curated_values, Gene.symbol)
     assert records[0].ensembl_gene_id == "ENSG00000068097"
 
     settings.species = "mouse"
-    records = Gene.from_values(["ABC1"], Gene.symbol)
+    values = ["ABC1"]
+    curated_values = Gene.bionty().map_synonyms(values)
+    print(curated_values)
+    records = Gene.from_values(curated_values, Gene.symbol)
     assert records[0].ensembl_gene_id == "ENSMUSG00000015243"


### PR DESCRIPTION
As discussed, @sunnyosun, I'm pretty sure we'll have much less headache if we completely remove `map_synonyms` from any automated and validation-related functionality.

It's a great curation tool, but can make things much more complicated if it silently acts under-the-hood.

Less magic should also lead to less bugs. Testing the scenario we encountered before refactoring the below would be very complicated itself.

- https://github.com/laminlabs/lamin-usecases/pull/19