### PR TITLE
🎨 More validation for `File` creation, fix some aspects of zarr backend

### DIFF
--- a/lamindb/_file.py
+++ b/lamindb/_file.py
@@ -104,7 +104,8 @@ def process_pathlike(
 def process_data(
     provisional_id: str,
     data: Union[PathLike, DataLike],
-    format,
+    format: Optional[str],
+    key: Optional[str],
     skip_existence_check: bool = False,
 ) -> Tuple[Any, Union[Path, UPath], str, Storage, bool]:
     """Serialize a data object that's provided as file or in memory."""
@@ -119,7 +120,19 @@ def process_data(
     elif isinstance(data, (pd.DataFrame, AnnData)):  # DataLike, spelled out
         storage = lamindb_setup.settings.storage.record
         memory_rep = data
+        if key is not None:
+            key_suffix = PurePosixPath(key).suffix
+            # use suffix as the (adata) format if the format is not provided
+            if isinstance(data, AnnData) and format is None:
+                format = key_suffix[1:]
+        else:
+            key_suffix = None
         suffix = infer_suffix(data, format)
+        if key_suffix is not None and key_suffix != suffix:
+            raise ValueError(
+                f"The suffix '{key_suffix}' of the provided key is incorrect, it should"
+                f" be '{suffix}'."
+            )
         cache_name = f"{provisional_id}{suffix}"
         filepath = lamindb_setup.settings.storage.cache_dir / cache_name
         # Alex: I don't understand the line below
@@ -296,15 +309,8 @@ def get_file_kwargs_from_data(
 ):
     run = get_run(run)
     memory_rep, filepath, suffix, storage, use_existing_storage_key = process_data(
-        provisional_id, data, format, skip_check_exists
+        provisional_id, data, format, key, skip_check_exists
     )
-    if memory_rep is not None and key is not None:
-        key_suffix = PurePosixPath(key).suffix
-        if key_suffix != suffix:
-            raise ValueError(
-                f"The suffix '{key_suffix}' of the provided key is incorrect, it should"
-                f" be '{suffix}'."
-            )
     # the following will return a localpath that is not None if filepath is local
     # it will return a cloudpath that is not None if filepath is on the cloud
     local_filepath, cloud_filepath, size, hash_and_type = get_path_size_hash(

--- a/lamindb/_file.py
+++ b/lamindb/_file.py
@@ -125,7 +125,7 @@ def process_data(
         # Alex: I don't understand the line below
         if filepath.suffixes == []:
             filepath = filepath.with_suffix(suffix)
-        if suffix != ".zarr":
+        if suffix not in {".zarr", ".zrad"}:
             write_to_file(data, filepath)
         use_existing_storage_key = False
     else:
@@ -198,7 +198,7 @@ def get_path_size_hash(
     localpath = None
     hash_and_type: Tuple[Optional[str], Optional[str]]
 
-    if suffix == ".zarr":
+    if suffix in {".zarr", ".zrad"}:
         if memory_rep is not None:
             size = size_adata(memory_rep)
         else:
@@ -810,7 +810,7 @@ def load(
 
 
 def stage(self, is_run_input: Optional[bool] = None) -> Path:
-    if self.suffix in (".zrad", ".zarr"):
+    if self.suffix in {".zrad", ".zarr"}:
         raise RuntimeError("zarr object can't be staged, please use load() or stream()")
     _track_run_input(self, is_run_input)
 

--- a/lamindb/_file.py
+++ b/lamindb/_file.py
@@ -298,6 +298,13 @@ def get_file_kwargs_from_data(
     memory_rep, filepath, suffix, storage, use_existing_storage_key = process_data(
         provisional_id, data, format, skip_check_exists
     )
+    if memory_rep is not None and key is not None:
+        key_suffix = PurePosixPath(key).suffix
+        if key_suffix != suffix:
+            raise ValueError(
+                f"The suffix '{key_suffix}' of the provided key is incorrect, it should"
+                f" be '{suffix}'."
+            )
     # the following will return a localpath that is not None if filepath is local
     # it will return a cloudpath that is not None if filepath is on the cloud
     local_filepath, cloud_filepath, size, hash_and_type = get_path_size_hash(

--- a/lamindb/_file.py
+++ b/lamindb/_file.py
@@ -121,9 +121,9 @@ def process_data(
         storage = lamindb_setup.settings.storage.record
         memory_rep = data
         if key is not None:
-            key_suffix = PurePosixPath(key).suffix
+            key_suffix = extract_suffix_from_path(PurePosixPath(key), arg_name="key")
             # use suffix as the (adata) format if the format is not provided
-            if isinstance(data, AnnData) and format is None:
+            if isinstance(data, AnnData) and format is None and len(key_suffix) > 0:
                 format = key_suffix[1:]
         else:
             key_suffix = None

--- a/lamindb/_save.py
+++ b/lamindb/_save.py
@@ -240,10 +240,7 @@ def upload_data_object(file) -> None:
     # do NOT hand-craft the storage key!
     file_storage_key = auto_storage_key_from_file(file)
     msg = f"storing file '{file.id}' at '{file_storage_key}'"
-    if hasattr(file, "_to_store") and file._to_store and file.suffix != ".zarr":
-        logger.save(msg)
-        store_object(file._local_filepath, file_storage_key)
-    elif (
+    if (
         file.suffix in {".zarr", ".zrad"}
         and hasattr(file, "_memory_rep")
         and file._memory_rep is not None
@@ -254,3 +251,6 @@ def upload_data_object(file) -> None:
             print_hook, filepath=file_storage_key, action="uploading"
         )
         write_adata_zarr(file._memory_rep, storagepath, callback=print_progress)
+    elif hasattr(file, "_to_store") and file._to_store:
+        logger.save(msg)
+        store_object(file._local_filepath, file_storage_key)

--- a/lamindb/dev/storage/file.py
+++ b/lamindb/dev/storage/file.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Literal, Union
+from typing import Literal, Optional, Union
 
 import anndata as ad
 import fsspec
@@ -48,11 +48,14 @@ KNOWN_SUFFIXES = {
 }
 
 
-def extract_suffix_from_path(path: Union[UPath, Path]) -> str:
+def extract_suffix_from_path(
+    path: Union[UPath, Path], arg_name: Optional[str] = None
+) -> str:
     if len(path.suffixes) <= 1:
         return path.suffix
     else:
-        msg = "file has more than one suffix (path.suffixes), "
+        arg_name = "file" if arg_name is None else arg_name  # for the warning
+        msg = f"{arg_name} has more than one suffix (path.suffixes), "
         # first check the 2nd-to-last suffix because it might be followed by .gz
         # or another compression-related suffix
         if path.suffixes[-2] in KNOWN_SUFFIXES:

--- a/lamindb/dev/storage/file.py
+++ b/lamindb/dev/storage/file.py
@@ -149,7 +149,7 @@ def store_object(localpath: Union[str, Path, UPath], storagekey: str) -> float:
         size = sum(f.stat().st_size for f in localpath.rglob("*") if f.is_file())
 
     if not isinstance(storagepath, LocalPathClasses):
-        if localpath.suffix != ".zarr":
+        if localpath.suffix not in {".zarr", ".zrad"}:
             cb = ProgressCallback("uploading")
         else:
             # todo: make proper progress bar for zarr

--- a/lamindb/dev/storage/object.py
+++ b/lamindb/dev/storage/object.py
@@ -12,7 +12,11 @@ def infer_suffix(dmem, adata_format: Optional[str] = None):
         if adata_format is not None:
             # below should be zrad, not zarr
             if adata_format not in ("h5ad", "zarr", "zrad"):
-                raise ValueError
+                raise ValueError(
+                    "Error when specifying AnnData storage format, it should be"
+                    f" 'h5ad', 'zarr' or 'zrad', not '{adata_format}'. Check 'format'"
+                    " or the suffix of 'key'."
+                )
             return "." + adata_format
         return ".h5ad"
     elif isinstance(dmem, DataFrame):

--- a/lamindb/dev/storage/object.py
+++ b/lamindb/dev/storage/object.py
@@ -11,7 +11,7 @@ def infer_suffix(dmem, adata_format: Optional[str] = None):
     if isinstance(dmem, AnnData):
         if adata_format is not None:
             # below should be zrad, not zarr
-            if adata_format not in ("h5ad", "zarr"):
+            if adata_format not in ("h5ad", "zarr", "zrad"):
                 raise ValueError
             return "." + adata_format
         return ".h5ad"

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -653,5 +653,5 @@ def test_invalid_suffix(inpt):
         file = ln.File(inpt, key="abc.def")  # noqa
     assert (
         error.exconly().partition(",")[0]
-        == "ValueError: The suffix '.cgf' of the provided key is incorrect"
+        == "ValueError: The suffix '.def' of the provided key is incorrect"
     )

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -655,10 +655,12 @@ def test_zarr_folder_upload():
     ln.settings.storage = previous_storage
 
 
-@pytest.mark.parametrize("inpt", [adata, df])
-def test_invalid_suffix(inpt):
+def test_df_suffix():
+    file = ln.File(df, key="test_.parquet")
+    assert file.suffix == ".parquet"
+
     with pytest.raises(ValueError) as error:
-        file = ln.File(inpt, key="abc.def")  # noqa
+        file = ln.File(df, key="test_.def")
     assert (
         error.exconly().partition(",")[0]
         == "ValueError: The suffix '.def' of the provided key is incorrect"
@@ -678,7 +680,7 @@ def test_adata_suffix():
     assert file.suffix == ".zrad"
 
     with pytest.raises(ValueError) as error:
-        file = ln.File(adata, key="abc.def")
+        file = ln.File(adata, key="test_.def")
     assert (
         error.exconly().partition(",")[0]
         == "ValueError: Error when specifying AnnData storage format"

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -637,7 +637,7 @@ def test_zarr_folder_upload():
     zarr_path = Path("./test_adata.zrad")
     write_adata_zarr(adata, zarr_path, callback)
 
-    file = ln.File(zarr_path)
+    file = ln.File(zarr_path, key="test_adata.zrad")
     file.save()
 
     assert isinstance(file.path, CloudPath) and file.path.exists()

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -19,6 +19,7 @@ from lamindb._file import (
     get_relative_path_to_directory,
     process_data,
 )
+from lamindb.dev.storage._zarr import write_adata_zarr
 from lamindb.dev.storage.file import (
     AUTO_KEY_PREFIX,
     auto_storage_key_from_id_suffix,
@@ -624,3 +625,23 @@ def test_file_zarr():
     file.save()
     file.delete(storage=False)
     UPath("test.zarr").unlink()
+
+
+def test_zarr_folder_upload():
+    previous_storage = ln.setup.settings.storage.root_as_str
+    ln.settings.storage = "s3://lamindb-test"
+
+    def callback(*args, **kwargs):
+        pass
+
+    zarr_path = Path("./default_storage/test_adata.zrad")
+    write_adata_zarr(adata, zarr_path, callback)
+
+    file = ln.File(zarr_path)
+    file.save()
+
+    assert isinstance(file.path, CloudPath) and file.path.exists()
+
+    file.delete(storage=True)
+    delete_storage(zarr_path)
+    ln.settings.storage = previous_storage

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -678,6 +678,8 @@ def test_adata_suffix():
     assert file.suffix == ".zrad"
     file = ln.File(adata, format="zrad", key="test_.zrad")
     assert file.suffix == ".zrad"
+    file = ln.File(adata, key="test_")
+    assert file.suffix == ".h5ad"
 
     with pytest.raises(ValueError) as error:
         file = ln.File(adata, key="test_.def")

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -678,8 +678,6 @@ def test_adata_suffix():
     assert file.suffix == ".zrad"
     file = ln.File(adata, format="zrad", key="test_.zrad")
     assert file.suffix == ".zrad"
-    file = ln.File(adata, key="test_")
-    assert file.suffix == ".h5ad"
 
     with pytest.raises(ValueError) as error:
         file = ln.File(adata, key="test_.def")
@@ -693,4 +691,11 @@ def test_adata_suffix():
     assert (
         error.exconly().partition(",")[0]
         == "ValueError: The suffix '.zrad' of the provided key is incorrect"
+    )
+
+    with pytest.raises(ValueError) as error:
+        file = ln.File(adata, key="test_")
+    assert (
+        error.exconly().partition(",")[0]
+        == "ValueError: The suffix '' of the provided key is incorrect"
     )

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -634,7 +634,7 @@ def test_zarr_folder_upload():
     def callback(*args, **kwargs):
         pass
 
-    zarr_path = Path("./default_storage/test_adata.zrad")
+    zarr_path = Path("./test_adata.zrad")
     write_adata_zarr(adata, zarr_path, callback)
 
     file = ln.File(zarr_path)

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -130,7 +130,7 @@ def test_is_new_version_of_versioned_file():
 
     # AUTO_KEY_PREFIX
     with pytest.raises(ValueError) as error:
-        ln.File(df, key=".lamindb/")
+        ln.File(df, key=".lamindb/test_df.parquet")
     assert error.exconly() == "ValueError: Key cannot start with .lamindb/"
 
 
@@ -560,14 +560,22 @@ def test_serialize_paths():
     up_str = "s3://lamindb-ci/test-data/test.csv"
     up_upath = UPath(up_str)
 
-    _, filepath, _, _, _ = process_data("id", fp_str, None, skip_existence_check=True)
+    _, filepath, _, _, _ = process_data(
+        "id", fp_str, None, None, skip_existence_check=True
+    )
     assert isinstance(filepath, LocalPathClasses)
-    _, filepath, _, _, _ = process_data("id", fp_path, None, skip_existence_check=True)
+    _, filepath, _, _, _ = process_data(
+        "id", fp_path, None, None, skip_existence_check=True
+    )
     assert isinstance(filepath, LocalPathClasses)
 
-    _, filepath, _, _, _ = process_data("id", up_str, None, skip_existence_check=True)
+    _, filepath, _, _, _ = process_data(
+        "id", up_str, None, None, skip_existence_check=True
+    )
     assert isinstance(filepath, CloudPath)
-    _, filepath, _, _, _ = process_data("id", up_upath, None, skip_existence_check=True)
+    _, filepath, _, _, _ = process_data(
+        "id", up_upath, None, None, skip_existence_check=True
+    )
     assert isinstance(filepath, CloudPath)
 
 
@@ -654,4 +662,31 @@ def test_invalid_suffix(inpt):
     assert (
         error.exconly().partition(",")[0]
         == "ValueError: The suffix '.def' of the provided key is incorrect"
+    )
+
+
+def test_adata_suffix():
+    file = ln.File(adata, key="test_.h5ad")
+    assert file.suffix == ".h5ad"
+    file = ln.File(adata, format="h5ad", key="test_.h5ad")
+    assert file.suffix == ".h5ad"
+    file = ln.File(adata, key="test_.zarr")
+    assert file.suffix == ".zarr"
+    file = ln.File(adata, key="test_.zrad")
+    assert file.suffix == ".zrad"
+    file = ln.File(adata, format="zrad", key="test_.zrad")
+    assert file.suffix == ".zrad"
+
+    with pytest.raises(ValueError) as error:
+        file = ln.File(adata, key="abc.def")
+    assert (
+        error.exconly().partition(",")[0]
+        == "ValueError: Error when specifying AnnData storage format"
+    )
+
+    with pytest.raises(ValueError) as error:
+        file = ln.File(adata, format="h5ad", key="test.zrad")
+    assert (
+        error.exconly().partition(",")[0]
+        == "ValueError: The suffix '.zrad' of the provided key is incorrect"
     )

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -645,3 +645,13 @@ def test_zarr_folder_upload():
     file.delete(storage=True)
     delete_storage(zarr_path)
     ln.settings.storage = previous_storage
+
+
+@pytest.mark.parametrize("inpt", [adata, df])
+def test_invalid_suffix(inpt):
+    with pytest.raises(ValueError) as error:
+        file = ln.File(inpt, key="abc.def")  # noqa
+    assert (
+        error.exconly().partition(",")[0]
+        == "ValueError: The suffix '.cgf' of the provided key is incorrect"
+    )


### PR DESCRIPTION
- Fixes `zarr` or `zrad` objects upload from disk and adds a test for this.
- Adds validation of `key`'s suffix for in-memory objects in `File`.
