### PR TITLE
♻️ Do not use `DatabaseWrapper` directly

### DIFF
--- a/lamindb/_filter.py
+++ b/lamindb/_filter.py
@@ -3,10 +3,6 @@ from uuid import UUID
 
 import dj_database_url
 from django.db import connections
-from django.db.backends.postgresql.base import (
-    DatabaseWrapper as DatabaseWrapperPostgres,
-)
-from django.db.backends.sqlite3.base import DatabaseWrapper as DatabaseWrapperSQLite
 from lamindb_setup._init_instance import InstanceSettings
 from lamindb_setup._load_instance import get_owner_name_from_identifier
 from lamindb_setup.dev._hub_core import load_instance
@@ -22,11 +18,8 @@ def add_db_connection(isettings: InstanceSettings, using: str):
     db_config["TIME_ZONE"] = "UTC"
     db_config["OPTIONS"] = {}
     db_config["AUTOCOMMIT"] = True
-    if isettings.dialect == "sqlite":
-        db_wrapper = DatabaseWrapperSQLite(db_config, alias=using)
-    else:
-        db_wrapper = DatabaseWrapperPostgres(db_config, alias=using)
-    connections[using] = db_wrapper
+
+    connections.settings[using] = db_config
 
 
 def filter(Registry: Type[Registry], using: str = None, **expressions) -> QuerySet:


### PR DESCRIPTION
https://github.com/django/django/blob/679212a47ac3e22a6fbb6ee3cd4c09f29aae8b5d/django/utils/connection.py#L56
https://github.com/django/django/blob/679212a47ac3e22a6fbb6ee3cd4c09f29aae8b5d/django/db/utils.py#L191

Using a specific `DatabaseWrapper` seems to be unneeded, this might be important if we want to add support for databases other than sqlite and postgres.