### PR TITLE
🚸 Introduce virtual keys

### DIFF
--- a/docs/storage/add-replace-stage.ipynb
+++ b/docs/storage/add-replace-stage.ipynb
@@ -259,6 +259,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5d368157",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln.settings.file_use_virtual_keys = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "48d77993",
    "metadata": {},
    "outputs": [],

--- a/lamindb/_file.py
+++ b/lamindb/_file.py
@@ -354,6 +354,14 @@ def get_file_kwargs_from_data(
         suffix=suffix,
     )
 
+    # do we use a virtual or an actual storage key?
+    key_is_virtual = settings.file_use_virtual_keys
+
+    # if the file is already in storage, independent of the default
+    # we use an actual storage key
+    if check_path_in_storage:
+        key_is_virtual = False
+
     kwargs = dict(
         suffix=suffix,
         hash=hash,
@@ -366,6 +374,7 @@ def get_file_kwargs_from_data(
         # after object creation
         run_id=run.id if run is not None else None,
         run=run,
+        key_is_virtual=key_is_virtual,
     )
     privates = dict(
         local_filepath=local_filepath,

--- a/lamindb/_filter.py
+++ b/lamindb/_filter.py
@@ -8,15 +8,16 @@ from lamindb._query_set import QuerySet
 def filter(Registry: Type[Registry], **expressions) -> QuerySet:
     """See :meth:`~lamindb.dev.Registry.filter`."""
     if Registry in {File, Dataset}:
-        # visibility is set to 0 by default
-        visibility = "visibility"
-        if not any([e.startswith(visibility) for e in expressions]):
-            expressions[visibility] = 0
-        # if visibility is None, do not apply a filter
-        # otherwise, it would mean filtering for NULL values, which doesn't make
-        # sense for a non-NULLABLE column
-        elif visibility in expressions and expressions[visibility] is None:
-            expressions.pop(visibility)
+        # visibility is set to 0 unless expressions contains id or uid equality
+        if not ("id" in expressions or "uid" in expressions):
+            visibility = "visibility"
+            if not any([e.startswith(visibility) for e in expressions]):
+                expressions[visibility] = 0
+            # if visibility is None, do not apply a filter
+            # otherwise, it would mean filtering for NULL values, which doesn't make
+            # sense for a non-NULLABLE column
+            elif visibility in expressions and expressions[visibility] is None:
+                expressions.pop(visibility)
     qs = QuerySet(model=Registry)
     if len(expressions) > 0:
         return qs.filter(**expressions)

--- a/lamindb/dev/_settings.py
+++ b/lamindb/dev/_settings.py
@@ -58,6 +58,11 @@ class Settings:
     """
     silence_file_run_transform_warning: bool = False
     """Silence warning about missing run & transform during file creation."""
+    file_use_virtual_keys: bool = True
+    """The `key` parameter in :class:`~lamindb.File` is treated as a virtual storage key.
+
+    If `True`, the `key` is **not** used to construct file paths.
+    """
 
     @property
     def storage(self) -> Union[Path, UPath]:

--- a/lamindb/dev/storage/file.py
+++ b/lamindb/dev/storage/file.py
@@ -90,7 +90,7 @@ def extract_suffix_from_path(
 
 # add type annotations back asap when re-organizing the module
 def auto_storage_key_from_file(file: File):
-    if file.key is None:
+    if file.key is None or file.key_is_virtual:
         return auto_storage_key_from_id_suffix(file.uid, file.suffix)
     else:
         return file.key

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dependencies = [
     # Lamin PINNED packages
-    "lnschema_core==0.53.0",
+    "lnschema_core==0.54.0",
     "lamindb_setup==0.56.4",
     "lamin_utils==0.11.5",
     # others

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -220,7 +220,12 @@ def test_create_from_dataframe_using_from_df():
     file = ln.File.from_df(df, description=description)
     ln.Modality(name="random").save()
     modalities = ln.Modality.lookup()
-    file = ln.File.from_df(df, description=description, modality=modalities.random)
+    file = ln.File.from_df(
+        df,
+        key="folder/hello.parquet",
+        description=description,
+        modality=modalities.random,
+    )
     # mere access test right now
     file.features["columns"]
     assert file.description == description

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -229,12 +229,11 @@ def test_create_from_dataframe_using_from_df():
     # mere access test right now
     file.features["columns"]
     assert file.description == description
-    assert file.key is None
     assert file.accessor == "DataFrame"
     assert hasattr(file, "_local_filepath")
     assert file.key == "folder/hello.parquet"
     assert file.key_is_virtual
-    assert file.uid in file.path.to_posix()
+    assert file.uid in file.path.as_posix()
     file.save()
     # check that the local filepath has been cleared
     assert not hasattr(file, "_local_filepath")

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -339,6 +339,9 @@ def test_create_from_local_filepath(
     )
     assert file.suffix == suffix
 
+    file.save()
+    assert file.path.exists()
+
     if key is None:
         assert (
             file.key == f"my_dir/my_file{suffix}"
@@ -352,7 +355,7 @@ def test_create_from_local_filepath(
             assert file.storage.root == lamindb_setup.settings.storage.root_as_str
             assert (
                 file.path
-                == lamindb_setup.settings.storage.root / f".lamindb/{file.uid}.{suffix}"
+                == lamindb_setup.settings.storage.root / f".lamindb/{file.uid}{suffix}"
             )
     else:
         assert file.key == key
@@ -367,15 +370,10 @@ def test_create_from_local_filepath(
                 assert (
                     file.path
                     == lamindb_setup.settings.storage.root
-                    / f".lamindb/{file.uid}.{suffix}"
+                    / f".lamindb/{file.uid}{suffix}"
                 )
             else:
-                assert (
-                    file.path == lamindb_setup.settings.storage.root / f"{key}{suffix}"
-                )
-
-    file.save()
-    assert file.path.exists()
+                assert file.path == lamindb_setup.settings.storage.root / key
 
     # only delete from storage if a file copy took place
     delete_from_storage = str(test_filepath.resolve()) != str(file.path)


### PR DESCRIPTION
Slack: https://laminlabs.slack.com/archives/C04FPE8V01W/p1697280227050649

- https://github.com/laminlabs/lnschema-core/pull/310

TODO:
- Add corresponding test cases to https://github.com/laminlabs/lamindb/blob/7caa9c510cbb8dac283de895bb202826aa7530cf/docs/storage/add-replace-stage.ipynb or turn into parametrized test
- Adopt `File.view_tree()` to run on `key` instead of on paths depending on `settings.file_use_virtual_keys`