### PR TITLE
✨ Change replace to work with virtual keys

### DIFF
--- a/docs/storage/add-replace-stage.ipynb
+++ b/docs/storage/add-replace-stage.ipynb
@@ -19,7 +19,7 @@
    },
    "outputs": [],
    "source": [
-    "instance_name = f\"lamindb-ci-test-add-replace-stage\"\n",
+    "instance_name = \"lamindb-ci-test-add-replace-stage\"\n",
     "\n",
     "!lamin init --storage s3://lamindb-ci --name {instance_name}"
    ]
@@ -624,7 +624,7 @@
     "# we use the path in the next section\n",
     "path_in_storage = file.path\n",
     "\n",
-    "file.delete(permanent=False, storage=True)"
+    "file.delete(storage=False)"
    ]
   },
   {

--- a/docs/storage/add-replace-stage.ipynb
+++ b/docs/storage/add-replace-stage.ipynb
@@ -31,6 +31,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import pytest\n",
     "import lamindb as ln\n",
     "from lamindb_setup.dev.upath import UPath\n",
     "from lamindb.dev.storage.file import AUTO_KEY_PREFIX"
@@ -620,7 +621,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "file.delete(permanent=True, storage=True)"
+    "# we use the path in the next section\n",
+    "path_in_storage = file.path\n",
+    "\n",
+    "file.delete(permanent=False, storage=True)"
    ]
   },
   {
@@ -659,6 +663,28 @@
    "outputs": [],
    "source": [
     "file.save()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91f5c9f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with pytest.raises(ValueError):\n",
+    "    file.replace(path_in_storage)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "44cc0b24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# return an existing file if the hash is the same\n",
+    "assert file == file.replace(\"./test-files/iris.csv\")"
    ]
   },
   {
@@ -731,6 +757,16 @@
    "outputs": [],
    "source": [
     "file.delete(permanent=True, storage=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0c63e8f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path_in_storage.unlink()"
    ]
   },
   {

--- a/docs/storage/add-replace-stage.ipynb
+++ b/docs/storage/add-replace-stage.ipynb
@@ -624,7 +624,7 @@
     "# we use the path in the next section\n",
     "path_in_storage = file.path\n",
     "\n",
-    "file.delete(storage=False)"
+    "file.delete(permanent=True, storage=False)"
    ]
   },
   {

--- a/docs/storage/add-replace-stage.ipynb
+++ b/docs/storage/add-replace-stage.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "30fd690f",
    "metadata": {},
@@ -38,7 +37,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "9c68908d",
    "metadata": {},
@@ -158,7 +156,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "025eb582",
    "metadata": {},
@@ -248,12 +245,11 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "bff43702",
    "metadata": {},
    "source": [
-    "## Save with manually passed `key`"
+    "## Save with manually passed real `key`"
    ]
   },
   {
@@ -273,7 +269,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "file = ln.File(\"./test-files/iris.csv\", key=f\"iris.csv\")"
+    "file = ln.File(\"./test-files/iris.csv\", key=\"iris.csv\")"
    ]
   },
   {
@@ -293,7 +289,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key_path = root / f\"iris.csv\""
+    "key_path = root / \"iris.csv\""
    ]
   },
   {
@@ -327,7 +323,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "f926635d",
    "metadata": {},
@@ -343,7 +338,7 @@
    "outputs": [],
    "source": [
     "old_key_path = key_path\n",
-    "new_key_path = root / f\"new_iris.csv\""
+    "new_key_path = root / \"new_iris.csv\""
    ]
   },
   {
@@ -404,7 +399,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "new_key_path = root / f\"iris.data\""
+    "new_key_path = root / \"iris.data\""
    ]
   },
   {
@@ -449,7 +444,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "35544933",
    "metadata": {},
@@ -504,7 +498,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key_path = root / f\"iris.parquet\""
+    "key_path = root / \"iris.parquet\""
    ]
   },
   {
@@ -534,7 +528,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert file.key == f\"iris.parquet\""
+    "assert file.key == \"iris.parquet\""
    ]
   },
   {
@@ -585,7 +579,7 @@
    "outputs": [],
    "source": [
     "old_key_path = key_path\n",
-    "new_key_path = root / f\"iris.csv\""
+    "new_key_path = root / \"iris.csv\""
    ]
   },
   {
@@ -630,6 +624,116 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "22bde7cf",
+   "metadata": {},
+   "source": [
+    "## Save with manually passed virtual `key`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6156288b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln.settings.file_use_virtual_keys = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2231a05",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file = ln.File(\"./test-files/iris.csv\", key=\"iris.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4dee561b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file.save()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9fda35ae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fpath = file.path\n",
+    "assert fpath.suffix == \".csv\" and fpath.stem == file.uid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "94e618a0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file.replace(\"./test-files/iris.data\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e11a5fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file.save()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a261ec3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert file.key == \"iris.data\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f339fba7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert not fpath.exists()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd9a4b4f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fpath = file.path\n",
+    "assert fpath.suffix == \".data\" and fpath.stem == file.uid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0f41017",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file.delete(permanent=True, storage=True)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "ce531657",
@@ -660,7 +764,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.9.17"
   },
   "nbproject": {
    "id": "uBQMCcdYwEjA",


### PR DESCRIPTION
Now forbids to replace from a `Storage`. 

We can allow to replace from the same `Storage` as tied to the `File`, but then `key` should be changed to real from virtual.