### PR TITLE
✨ Allow including simple related fields in `.df()`

### DIFF
--- a/lamindb/_query_set.py
+++ b/lamindb/_query_set.py
@@ -92,28 +92,9 @@ class QuerySet(models.QuerySet, CanValidate, IsTree):
         >>> queryset
     """
 
-    def df(self, include: Optional[List[str]] = None) -> pd.DataFrame:
-        """Convert to ``pd.DataFrame``.
-
-        By default, shows all fields that aren't many-to-many fields, except
-        ``created_at``.
-
-        If you'd like to include many-to-many fields, use parameter ``include``.
-
-        Args:
-            include: ``Optional[List[str]] = None`` Additional (many-to-many)
-                fields to include. Takes expressions like ``"labels__name"``
-                ``"cell_types__name"``.
-
-        Examples:
-
-            >>> ln.save(ln.ULabel.from_values(["ULabel1", "ULabel2", "ULabel3"], field="name")) # noqa
-            >>> ln.ULabel.df()
-            >>> label = ln.ULabel.filter(name="ULabel1").one()
-            >>> label = ln.ULabel.filter(name="benchmark").one()
-            >>> label.parents.add(label)
-            >>> ln.ULabel.filter().df(include=["labels__name", "labels__created_by_id"])
-        """
+    @doc_args(Registry.df.__doc__)
+    def df(self, include: Optional[Union[str, List[str]]] = None) -> pd.DataFrame:
+        """{}."""
         data = self.values()
         keys = get_keys_from_df(data, self.model)
         df = pd.DataFrame(self.values(), columns=keys)
@@ -183,6 +164,7 @@ class QuerySet(models.QuerySet, CanValidate, IsTree):
         return df
 
     def delete(self, *args, **kwargs):
+        """Delete all records in the query set."""
         if self.model in {Artifact, Collection, Transform}:
             for record in self:
                 record.delete(*args, **kwargs)
@@ -193,8 +175,6 @@ class QuerySet(models.QuerySet, CanValidate, IsTree):
         """Populate a list with the results.
 
         Examples:
-            >>> ln.save(ln.ULabel.from_values(["ULabel1", "ULabel2", "ULabel3"], field="name")) # noqa
-            >>> queryset = ln.ULabel.filter(name__icontains = "project")
             >>> queryset.list()  # list of records
             >>> queryset.list("name")  # list of values
         """
@@ -204,12 +184,9 @@ class QuerySet(models.QuerySet, CanValidate, IsTree):
             return list(self.values_list(field, flat=True))
 
     def first(self) -> Optional[Registry]:
-        """If non-empty, the first result in the query set, otherwise None.
+        """If non-empty, the first result in the query set, otherwise ``None``.
 
         Examples:
-            >>> labels = ln.ULabel.from_values(["ULabel1", "ULabel2", "ULabel3"], field="name")
-            >>> ln.save(labels)
-            >>> queryset = ln.ULabel.filter(name__icontains="project")
             >>> queryset.first()
         """
         if len(self) == 0:
@@ -217,23 +194,19 @@ class QuerySet(models.QuerySet, CanValidate, IsTree):
         return self[0]
 
     def one(self) -> Registry:
-        """Exactly one result. Throws error if there are more or none.
+        """Exactly one result. Raises error if there are more or none.
 
         Examples:
-            >>> ln.ULabel(name="benchmark").save()
             >>> ln.ULabel.filter(name="benchmark").one()
         """
         return one_helper(self)
 
     def one_or_none(self) -> Optional[Registry]:
-        """At most one result. Returns it if there is one, otherwise returns None.
+        """At most one result. Returns it if there is one, otherwise returns ``None``.
 
         Examples:
-            >>> ln.ULabel(name="benchmark").save()
             >>> ln.ULabel.filter(name="benchmark").one_or_none()
-            ULabel(id=gznl0GZk, name=benchmark, updated_at=2023-07-19 19:39:01, created_by_id=DzTjkKse) # noqa
             >>> ln.ULabel.filter(name="non existing label").one_or_none()
-            None
         """
         if len(self) == 0:
             return None

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -45,8 +45,10 @@ def test_df():
     assert set(df["features__created_by_id"].iloc[0]) == {current_user_id()}
 
     # raise error for non many-to-many
-    with pytest.raises(ValueError):
-        ln.ULabel.filter().df(include="name")
+    df = ln.ULabel.filter().df(include="created_by__name")
+    print()
+    print(df)
+    assert df.loc[1, "created_by__name"] == "Test User1"
 
     # clean up
     project_label.delete()

--- a/tests/test_queryset.py
+++ b/tests/test_queryset.py
@@ -45,10 +45,8 @@ def test_df():
     assert set(df["features__created_by_id"].iloc[0]) == {current_user_id()}
 
     # raise error for non many-to-many
-    df = ln.ULabel.filter().df(include="created_by__name")
-    print()
-    print(df)
-    assert df.loc[1, "created_by__name"] == "Test User1"
+    df = ln.ULabel.filter(name="Project 0").df(include="created_by__name")
+    assert df["created_by__name"].iloc[0] == "Test User1"
 
     # clean up
     project_label.delete()


### PR DESCRIPTION
For some reason, we didn't have this before. Now this is possible:

<img width="1026" alt="image" src="https://github.com/laminlabs/lamindb/assets/16916678/8f6753c7-be32-409c-add5-f41356d4bb91">
