### PR TITLE
🐛 Fix backed for non-adata zarr

### DIFF
--- a/lamindb/core/storage/_backed_access.py
+++ b/lamindb/core/storage/_backed_access.py
@@ -733,7 +733,7 @@ class BackedAccessor:
 
 
 def backed_access(
-    artifact_or_filepath: Artifact | Path, using_key: str | None
+    artifact_or_filepath: Artifact | Path, using_key: str | None = None
 ) -> AnnDataAccessor | BackedAccessor:
     if isinstance(artifact_or_filepath, Artifact):
         filepath = filepath_from_artifact(artifact_or_filepath, using_key=using_key)
@@ -747,7 +747,7 @@ def backed_access(
         conn, storage = registry.open("zarr", filepath)
     else:
         raise ValueError(
-            "file should have .h5, .hdf5, .h5ad, .zarr suffix, not"
+            "object should have .h5, .hdf5, .h5ad, .zarr suffix, not"
             f" {filepath.suffix}."
         )
 

--- a/lamindb/core/storage/_backed_access.py
+++ b/lamindb/core/storage/_backed_access.py
@@ -751,7 +751,7 @@ def backed_access(
             f" {filepath.suffix}."
         )
 
-    if filepath.suffix in (".h5ad", ".zarr"):
+    if filepath.suffix == ".h5ad":
         return AnnDataAccessor(conn, storage, name)
     else:
         if get_spec(storage).encoding_type == "anndata":

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,4 +1,5 @@
 import shutil
+from pathlib import Path
 
 import h5py
 import lamindb as ln
@@ -6,7 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import zarr
-from lamindb.core.storage._backed_access import backed_access
+from lamindb.core.storage._backed_access import BackedAccessor, backed_access
 from lamindb.core.storage._zarr import read_adata_zarr, write_adata_zarr
 from lamindb.core.storage.objects import infer_suffix, write_to_file
 from lamindb.core.storage.paths import read_adata_h5ad
@@ -180,3 +181,16 @@ def test_backed_bad_format(bad_adata_path):
 
     access.close()
     bad_adata_path.unlink()
+
+
+def test_backed_zarr_not_adata():
+    zarr_pth = Path("./not_adata.zarr")
+    store = zarr.open(zarr_pth, mode="w")
+    store["test"] = "test"
+
+    access = backed_access(zarr_pth)
+
+    assert isinstance(access, BackedAccessor)
+    assert access.storage["test"] == "test"
+
+    shutil.rmtree(zarr_pth)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -191,6 +191,6 @@ def test_backed_zarr_not_adata():
     access = backed_access(zarr_pth)
 
     assert isinstance(access, BackedAccessor)
-    assert access.storage["test"] == "test"
+    assert access.storage["test"][...] == "test"
 
     shutil.rmtree(zarr_pth)


### PR DESCRIPTION
It was broken here https://github.com/laminlabs/lamindb/pull/1577
Also adds a test.