### PR TITLE
🚸 `ln.track()` returns `run`, better duplicate detection and search, prettier `.describe()`, and more

### DIFF
--- a/docs/introduction.ipynb
+++ b/docs/introduction.ipynb
@@ -702,6 +702,7 @@
    "outputs": [],
    "source": [
     "collection = ln.Collection([artifact, artifact2], name=\"my RNA-seq collection\", version=\"1\")\n",
+    "collection.save()\n",
     "collection.describe()\n",
     "collection.view_lineage()"
    ]

--- a/docs/introduction.ipynb
+++ b/docs/introduction.ipynb
@@ -702,7 +702,6 @@
    "outputs": [],
    "source": [
     "collection = ln.Collection([artifact, artifact2], name=\"my RNA-seq collection\", version=\"1\")\n",
-    "collection.save(transfer_labels=True)  # transfer labels from artifacts to collection\n",
     "collection.describe()\n",
     "collection.view_lineage()"
    ]

--- a/docs/introduction.ipynb
+++ b/docs/introduction.ipynb
@@ -221,17 +221,17 @@
     "\n",
     ":::\n",
     "\n",
-    "```{dropdown} Does LaminDB give me a file system?\n",
+    "```{dropdown} How does LaminDB compare to a file system or object store?\n",
     "\n",
-    "You can organize artifacts using the `key` parameter of {class}`~lamindb.Artifact` as you would in cloud storage.\n",
+    "Similar to organizing files in file systems & object stores with paths, you can organize artifacts using the `key` parameter of {class}`~lamindb.Artifact`.\n",
     "\n",
-    "However, LaminDB encourages you to **not** rely on semantic keys.\n",
+    "However, LaminDB encourages you to **not** rely on semantic keys but instead organize your data based on metadata.\n",
     "\n",
     "Rather than memorizing names of folders and files, you find data via the entities you care about: people, code, experiments, genes, proteins, cell types, etc.\n",
     "\n",
     "LaminDB embeds each artifact into rich relational metadata and indexes them in storage with a universal ID (`uid`).\n",
     "\n",
-    "This scales much better than semantic keys, which lead to deep hierarchical information structures that hard to navigate for humans & machines.\n",
+    "This scales much better than semantic keys, which lead to deep hierarchical information structures that can become hard to navigate.\n",
     "\n",
     "```\n",
     "\n",
@@ -936,11 +936,6 @@
     "\n",
     "LaminDB was influenced by many other projects, see {doc}`docs:influences`."
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/storage/transfer-local-to-cloud.ipynb
+++ b/docs/storage/transfer-local-to-cloud.ipynb
@@ -62,24 +62,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact._state.db"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "artifact.id"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "artifact.save()"
    ]
   },

--- a/docs/storage/transfer-local-to-cloud.ipynb
+++ b/docs/storage/transfer-local-to-cloud.ipynb
@@ -35,7 +35,8 @@
     "    experiments = artifact.experiments.all()\n",
     "    try:\n",
     "        artifact.delete(permanent=True)\n",
-    "    except Exception:\n",
+    "    except Exception as e:\n",
+    "        print(e)\n",
     "        pass\n",
     "    features_sets.delete()\n",
     "    experiments.delete()\n",
@@ -53,6 +54,24 @@
    "source": [
     "artifact = ln.Artifact.using(\"testuser1/test-transfer-to-cloud\").filter(description='test-transfer-to-cloud').one()\n",
     "artifact.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact._state.db"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact.id"
    ]
   },
   {

--- a/docs/transfer.ipynb
+++ b/docs/transfer.ipynb
@@ -17,7 +17,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "!lamin init --storage ./test-transfer --schema bionty"
@@ -26,7 +30,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "import lamindb as ln\n",

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -250,7 +250,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's create a {class}`~lamindb.Artifact` object from one of the files:"
+    "Let's create a {class}`~lamindb.Artifact` object for one of the studies:"
    ]
   },
   {
@@ -264,7 +264,7 @@
    "outputs": [],
    "source": [
     "artifact = ln.Artifact(\n",
-    "    \"s3://lamindata/iris_studies/study0_raw_images/meta.csv\"\n",
+    "    \"s3://lamindata/iris_studies/study0_raw_images\"\n",
     ")\n",
     "artifact"
    ]
@@ -472,27 +472,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Many artifacts have default in-memory representations. To load artifacts into memory with a default loader, call {meth}`~lamindb.Artifact.load`: "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "df = artifact.load(index_col=0)\n",
-    "df.head()"
-   ]
-  },
-  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
@@ -510,34 +489,6 @@
     "If you'd like to replace the underlying stored object, use {meth}`~lamindb.Artifact.replace`.\n",
     "\n",
     ":::\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Register directories as artifacts"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Register an entire folder as an artifact:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "study0_data = ln.Artifact(f\"s3://lamindata/iris_studies/study0_raw_images\").save()\n",
-    "ln.Artifact.df()"
    ]
   },
   {
@@ -565,7 +516,7 @@
    },
    "outputs": [],
    "source": [
-    "ln.Artifact.search(\"meta\").df().head()"
+    "ln.Artifact.search(\"iris\").df().head()"
    ]
   },
   {
@@ -768,13 +719,6 @@
     "For instance:\n",
     "```\n",
     "new_artifact = ln.Artifact(data, is_new_version_of=old_artifact)\n",
-    "```\n",
-    "\n",
-    "If you'd like to add a registered artifact to a version family, use `add_to_version_family`.\n",
-    "\n",
-    "For instance:\n",
-    "```\n",
-    "new_artifact.add_to_version_family(old_artifact)\n",
     "```"
    ]
   },
@@ -812,7 +756,7 @@
    "outputs": [],
    "source": [
     "collection = ln.Collection(\n",
-    "    study0_data,\n",
+    "    artifact,\n",
     "    name=\"Iris collection\",\n",
     "    version=\"1\",\n",
     "    description=\"Iris study 0\",\n",
@@ -839,11 +783,11 @@
    },
    "outputs": [],
    "source": [
-    "artifacts = [study0_data]\n",
+    "artifacts = [artifact]\n",
     "for folder_name in [\"study1_raw_images\", \"study2_raw_images\"]:\n",
     "    # create an artifact for the folder\n",
-    "    artifact = ln.Artifact(f\"s3://lamindata/iris_studies/{folder_name}\").save()\n",
-    "    artifacts.append(artifact)\n",
+    "    new_artifact = ln.Artifact(f\"s3://lamindata/iris_studies/{folder_name}\").save()\n",
+    "    artifacts.append(new_artifact)\n",
     "    # create a new version of the collection\n",
     "    collection = ln.Collection(\n",
     "        artifacts, is_new_version_of=collection, description=f\"Now includes {folder_name}\"\n",

--- a/docs/tutorial2.ipynb
+++ b/docs/tutorial2.ipynb
@@ -149,8 +149,8 @@
    },
    "outputs": [],
    "source": [
-    "speciess = [ln.ULabel(name=name) for name in [\"setosa\", \"versicolor\", \"virginica\"]]\n",
-    "ln.save(speciess)"
+    "species = [ln.ULabel(name=name) for name in [\"setosa\", \"versicolor\", \"virginica\"]]\n",
+    "ln.save(species)"
    ]
   },
   {
@@ -191,7 +191,7 @@
    "outputs": [],
    "source": [
     "is_species = ln.ULabel(name=\"is_species\").save()\n",
-    "is_species.children.set(speciess)\n",
+    "is_species.children.set(species)\n",
     "is_species.view_parents(with_children=True)"
    ]
   },

--- a/docs/tutorial2.ipynb
+++ b/docs/tutorial2.ipynb
@@ -166,21 +166,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact.features.add({\"species\": df.species.unique(), \"scientist\": df.scientist.unique(), \"instrument\": df.instrument.unique()})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "ln.Feature(name='species', dtype='cat[ULabel]').save()\n",
     "ln.Feature(name='scientist', dtype='cat[ULabel]').save()\n",
     "ln.Feature(name='instrument', dtype='cat[ULabel]').save()\n",
-    "species = ln.ULabel.from_values([\"setosa\", \"versicolor\", \"virginica\"])\n",
+    "species = ln.ULabel.from_values([\"setosa\", \"versicolor\", \"virginica\"], create=True)\n",
     "ln.save(species)\n",
-    "authors = ln.ULabel.from_values([\"Barbara McClintock\", \"Edgar Anderson\"])\n",
+    "authors = ln.ULabel.from_values([\"Barbara McClintock\", \"Edgar Anderson\"], create=True)\n",
     "ln.save(authors)\n",
     "ln.ULabel(name='Leica IIIc Camera').save()"
    ]
@@ -270,23 +261,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "studies = [ln.ULabel(name=name) for name in [\"study0\", \"study1\", \"study2\"]]\n",
-    "ln.save(studies)\n",
-    "is_study = ln.ULabel(name=\"is_study\").save()\n",
-    "is_study.children.set(studies)\n",
-    "is_study.view_parents(with_children=True)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -303,22 +277,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "ulabels = ln.ULabel.lookup()\n",
-    "artifact = ln.Artifact.filter(ulabels=ulabels.study0).first()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We also see them when calling {meth}`~lamindb.core.Data.describe`:"
+    "ln.ULabel.df()"
    ]
   },
   {
@@ -331,7 +293,8 @@
    },
    "outputs": [],
    "source": [
-    "artifact.describe()"
+    "ulabels = ln.ULabel.lookup()\n",
+    "ln.Artifact.filter(ulabels=ulabels.study_0_initial_plant_gathering).one()"
    ]
   },
   {
@@ -362,17 +325,12 @@
    "outputs": [],
    "source": [
     "def run_ml_model() -> pd.DataFrame:\n",
-    "    transform = ln.Transform(name=\"Petal & sepal regressor\", type=\"pipeline\")\n",
-    "    ln.track(transform=transform)\n",
-    "    input_data = ln.Collection.filter(name__startswith=\"Iris collection\", version=\"1\").one()\n",
-    "    input_paths = [\n",
-    "        path.download_to(path.name) for path in input_data.artifacts[0].path.glob(\"*\")\n",
-    "    ]\n",
-    "    # apply ML model\n",
+    "    image_file_dir = artifact.cache()\n",
     "    output_data = ln.core.datasets.df_iris_in_meter_study1()\n",
     "    return output_data\n",
     "\n",
-    "\n",
+    "transform = ln.Transform(name=\"Petal & sepal regressor\", type=\"script\")\n",
+    "run = ln.track(transform=transform)\n",
     "df = run_ml_model()"
    ]
   },
@@ -406,6 +364,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "tags": [
      "hide-output"
@@ -413,7 +380,7 @@
    },
    "outputs": [],
    "source": [
-    "ln.core.run_context.transform.view_parents()"
+    "run.transform.view_parents()"
    ]
   },
   {
@@ -517,6 +484,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "species_labels"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -533,27 +509,7 @@
    },
    "outputs": [],
    "source": [
-    "artifact.labels.add(ulabels.study0, feature=features.study)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In addition to the `columns` feature set, we now have an `external` feature set:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "artifact.features"
+    "artifact.labels.add(ulabels.study_0_initial_plant_gathering, feature=features.study)"
    ]
   },
   {

--- a/docs/tutorial2.ipynb
+++ b/docs/tutorial2.ipynb
@@ -169,11 +169,12 @@
     "ln.Feature(name='species', dtype='cat[ULabel]').save()\n",
     "ln.Feature(name='scientist', dtype='cat[ULabel]').save()\n",
     "ln.Feature(name='instrument', dtype='cat[ULabel]').save()\n",
-    "species = ln.ULabel.from_values([\"setosa\", \"versicolor\", \"virginica\"], create=True)\n",
+    "species = ln.ULabel.from_values(df['species']unique(), create=True)\n",
     "ln.save(species)\n",
-    "authors = ln.ULabel.from_values([\"Barbara McClintock\", \"Edgar Anderson\"], create=True)\n",
+    "authors = ln.ULabel.from_values(df['scientist'].unique(), create=True)\n",
     "ln.save(authors)\n",
-    "ln.ULabel(name='Leica IIIc Camera').save()"
+    "instruments = ln.ULabel.from_values(df['instrument'].unique(), create=True)\n",
+    "ln.save(instruments)"
    ]
   },
   {

--- a/docs/tutorial2.ipynb
+++ b/docs/tutorial2.ipynb
@@ -122,7 +122,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Validate & annotate"
+    "### Annotate based on data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Often, data that you want to ingest comes with metadata.\n",
+    "\n",
+    "Here, three metadata features `species`, `scientist`, `instrument` were collected."
    ]
   },
   {
@@ -131,7 +140,59 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = pd.read_csv(artifact.path / \"meta.csv\", index_col=0)"
+    "df = pd.read_csv(artifact.path / \"meta.csv\", index_col=0)\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are only a few values for features `species`, `scientist` & `instrument`, and we'd like to label the artifact with these values:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.nunique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact.features.add({\"species\": df.species.unique(), \"scientist\": df.scientist.unique(), \"instrument\": df.instrument.unique()})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln.Feature(name='species', dtype='cat[ULabel]').save()\n",
+    "ln.Feature(name='scientist', dtype='cat[ULabel]').save()\n",
+    "ln.Feature(name='instrument', dtype='cat[ULabel]').save()\n",
+    "species = ln.ULabel.from_values([\"setosa\", \"versicolor\", \"virginica\"])\n",
+    "ln.save(species)\n",
+    "authors = ln.ULabel.from_values([\"Barbara McClintock\", \"Edgar Anderson\"])\n",
+    "ln.save(authors)\n",
+    "ln.ULabel(name='Leica IIIc Camera').save()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact.features.add({\"species\": df.species.unique(), \"scientist\": df.scientist.unique(), \"instrument\": df.instrument.unique()})\n",
+    "artifact.describe()"
    ]
   },
   {
@@ -164,20 +225,6 @@
    "metadata": {},
    "source": [
     "We study 3 species of the Iris plant: `setosa`, `versicolor` & `virginica`. Let's create 3 labels with {class}`~lamindb.ULabel`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "species = [ln.ULabel(name=name) for name in [\"setosa\", \"versicolor\", \"virginica\"]]\n",
-    "ln.save(species)"
    ]
   },
   {
@@ -243,155 +290,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Register features"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "For every set of studied labels (measured values), we typically also want an identifier for the corresponding measurement dimension: the feature.\n",
-    "\n",
-    "When we integrate datasets, feature names will label columns that store data.\n",
-    "\n",
-    "Let's create and save two {class}`~lamindb.Feature` records to identify measurements of the iris species label and the study:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "ln.Feature(name=\"iris_species_name\", dtype=\"cat\").save()\n",
-    "\n",
-    "# create a lookup object so that we can access features with auto-complete\n",
-    "features = ln.Feature.lookup()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Validate & link labels"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We already looked at the metadata for `study0`, before: "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "meta_artifact = ln.Artifact.filter(key=\"iris_studies/study0_raw_images/meta.csv\").one()\n",
-    "meta = meta_artifact.load(index_col=0)  # load a dataframe\n",
-    "meta.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Validate metadata"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Depending on the data generation process, such metadata might or might not match the labels we defined in our registries.\n",
-    "\n",
-    "Let's validate the labels by mapping the values stored in the artifact on the {class}`~lamindb.ULabel` registry:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "ln.ULabel.validate(meta[\"1\"], field=\"name\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Everything passed and no fixes are needed!\n",
-    "\n",
-    "If validation doesn't pass, {meth}`~lamindb.core.CanValidate.standardize` and {meth}`~lamindb.core.CanValidate.inspect` will help standardize data."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Label artifacts"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You can label an artifact by calling `artifact.labels.add()` and pass a single or multiple labels, and optionally, the corresponding feature.\n",
-    "\n",
-    "Let's do this based on the labels in `meta.csv`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "ln.Artifact.df()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "study_artifacts = ln.Artifact.filter(key__startswith=\"iris_studies/\", suffix=\"\").all()\n",
-    "study_labels = ln.ULabel.filter(name=\"is_study\").one().children.all()\n",
-    "for artifact, study in zip(study_artifacts, study_labels):\n",
-    "    artifact.labels.add(study, feature=features.study_name)\n",
-    "    df = pd.read_csv(artifact.path / \"meta.csv\", index_col=0)\n",
-    "    species_labels = ln.ULabel.from_values(df[\"1\"].unique())\n",
-    "    artifact.labels.add(species_labels, feature=features.iris_species_name)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Query artifacts by labels"
    ]
   },
@@ -434,49 +332,6 @@
    "outputs": [],
    "source": [
     "artifact.describe()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Label collections"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Labeling collections works in the same way as labeling artifacts:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "collection = ln.Collection.filter(name__startswith=\"Iris collection\", version=\"1\").one()\n",
-    "collection.labels.add(ulabels.study0, feature=features.study_name)\n",
-    "all_species_labels = ln.ULabel.filter(parents__name=\"is_species\").all()\n",
-    "collection.labels.add(all_species_labels, feature=features.iris_species_name)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "collection.describe()"
    ]
   },
   {
@@ -632,84 +487,19 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "artifact.features.add_feature_set(ln.FeatureSet(new_features), slot=\"columns\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Feature sets"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Get an overview of linked features:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "artifact.features"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You'll see that they're always grouped in sets that correspond to records of {class}`~lamindb.FeatureSet`.\n",
-    "\n",
-    ":::{dropdown} Why does LaminDB model feature sets, not just features?\n",
-    "\n",
-    "1. Performance: Imagine you measure the same panel of 20k transcripts in 1M samples. By modeling the panel as a feature set, you'll only need to store 1M instead of 1M x 20k = 20B links.\n",
-    "2. Interpretation: Model protein panels, gene panels, etc.\n",
-    "3. Data integration: Feature sets provide the currency that determines whether two collections can be easily concatenated.\n",
-    "\n",
-    "These reasons do not hold for label sets. Hence, LaminDB does not model label sets.\n",
-    "\n",
-    ":::\n",
-    "\n",
-    "A `slot` provides a string key to access feature sets. It's typically the accessor within the registered data object, here `pd.DataFrame.columns`.\n",
-    "\n",
-    "Let's use it to access all linked features:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "artifact.features[\"columns\"].df()"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "There is one categorical feature, let's add the species labels:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "features = ln.Feature.lookup()"
    ]
   },
   {
@@ -723,7 +513,7 @@
    "outputs": [],
    "source": [
     "species_labels = ln.ULabel.filter(parents__name=\"is_species\").all()\n",
-    "artifact.labels.add(species_labels, feature=features.iris_species_name)"
+    "artifact.labels.add(species_labels, feature=features.species)"
    ]
   },
   {
@@ -743,7 +533,7 @@
    },
    "outputs": [],
    "source": [
-    "artifact.labels.add(ulabels.study0, feature=features.study_name)"
+    "artifact.labels.add(ulabels.study0, feature=features.study)"
    ]
   },
   {
@@ -804,194 +594,7 @@
    },
    "outputs": [],
    "source": [
-    "ln.view(registries=[\"Feature\", \"FeatureSet\", \"ULabel\"])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Manage follow-up data"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Assume that a couple of weeks later, we receive a new dataset in a follow-up study 2.\n",
-    "\n",
-    "Let's track a new analysis:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "ln.settings.transform.stem_uid = \"dMtrt8YMSdl6\"\n",
-    "ln.settings.transform.version = \"1\"\n",
-    "ln.track()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Register a joint collection"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Assume we already ran all preprocessing including the ML model.\n",
-    "\n",
-    "We get a DataFrame and store it as an artifact:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "df = ln.core.datasets.df_iris_in_meter_study2()\n",
-    "ln.Artifact.from_df(df, description=\"Iris study 2 - transformed\").save()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's load it:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "artifact2 = ln.Artifact.filter(description=\"Iris study 2 - transformed\").one()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can now store the joint collection:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "collection = ln.Collection(\n",
-    "    [artifact, artifact2], name=\"Iris flower study 1 & 2 - transformed\"\n",
-    ")\n",
-    "collection.save()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Auto-concatenate datasets"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Because both datasets measured the same validated feature set, we can auto-concatenate the collection:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "collection.load().tail()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can also access & query the underlying two artifact objects:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "collection.artifacts.df()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Or look at their data lineage:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "collection.view_lineage()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Or look at the database:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "ln.view()"
+    "ln.view(registries=[\"Feature\", \"ULabel\"])"
    ]
   },
   {

--- a/docs/tutorial2.ipynb
+++ b/docs/tutorial2.ipynb
@@ -330,7 +330,7 @@
     "    output_data = ln.core.datasets.df_iris_in_meter_study1()\n",
     "    return output_data\n",
     "\n",
-    "transform = ln.Transform(name=\"Petal & sepal regressor\", type=\"script\")\n",
+    "transform = ln.Transform(name=\"Petal & sepal regressor\", type=\"pipeline\")\n",
     "run = ln.track(transform=transform)\n",
     "df = run_ml_model()"
    ]

--- a/docs/tutorial2.ipynb
+++ b/docs/tutorial2.ipynb
@@ -169,7 +169,7 @@
     "ln.Feature(name='species', dtype='cat[ULabel]').save()\n",
     "ln.Feature(name='scientist', dtype='cat[ULabel]').save()\n",
     "ln.Feature(name='instrument', dtype='cat[ULabel]').save()\n",
-    "species = ln.ULabel.from_values(df['species']unique(), create=True)\n",
+    "species = ln.ULabel.from_values(df['species'].unique(), create=True)\n",
     "ln.save(species)\n",
     "authors = ln.ULabel.from_values(df['scientist'].unique(), create=True)\n",
     "ln.save(authors)\n",

--- a/docs/tutorial2.ipynb
+++ b/docs/tutorial2.ipynb
@@ -66,7 +66,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's briefly re-cap what we learned in {doc}`/introduction`. We started with simple labeling:"
+    "Let's briefly re-cap what we learned in {doc}`/introduction`.\n",
+    "\n",
+    "### Annotate by labels\n",
+    "\n",
+    "We started with simple labeling:"
    ]
   },
   {
@@ -93,7 +97,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In general, it's good practice to associate labels with features so that we can later feed them into learning algorithms with a defined dimension:"
+    "### Annotate by features & labels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you later want to feed labels into learning algorithms alongside measured features in artifacts, associate a label with a feature:"
    ]
   },
   {
@@ -102,9 +113,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "feature = ln.Feature(name=\"study_name\", dtype=\"cat\").save()\n",
+    "feature = ln.Feature(name=\"study\", dtype=\"cat\").save()\n",
     "artifact.labels.add(study0, feature)\n",
     "artifact.describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Validate & annotate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(artifact.path / \"meta.csv\", index_col=0)"
    ]
   },
   {

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -186,8 +186,6 @@ def process_data(
 
 def get_stat_or_artifact(
     path: UPath,
-    suffix: str,
-    memory_rep: Any | None = None,
     check_hash: bool = True,
     using_key: str | None = None,
 ) -> tuple[int, str | None, str | None, int | None] | Artifact:
@@ -338,8 +336,6 @@ def get_artifact_kwargs_from_data(
     )
     stat_or_artifact = get_stat_or_artifact(
         path=path,
-        suffix=suffix,
-        memory_rep=memory_rep,
         using_key=using_key,
     )
     if isinstance(stat_or_artifact, Artifact):

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -261,7 +261,7 @@ def get_stat_or_artifact(
                     f"You're trying to re-create this artifact in trash: {result[0]}"
                     "Either permanently delete it with `artifact.delete(permanent=True)` or restore it with `artifact.restore()`"
                 )
-            logger.warning(f"returning existing artifact with same hash: {result[0]}")
+            logger.important(f"returning existing artifact with same hash: {result[0]}")
             return result[0]
     else:
         return size, hash, hash_type, n_objects

--- a/lamindb/_collection.py
+++ b/lamindb/_collection.py
@@ -331,21 +331,23 @@ def save(self, transfer_labels: bool = False, using: str | None = None) -> None:
     # we don't allow updating the collection of artifacts
     # if users want to update the set of artifacts, they
     # have to create a new collection
-    links = [
-        CollectionArtifact(collection_id=self.id, artifact_id=artifact.id)
-        for artifact in self._artifacts
-    ]
-    # the below seems to preserve the order of the list in the
-    # auto-incrementing integer primary
-    # merely using .unordered_artifacts.set(*...) doesn't achieve this
-    # we need ignore_conflicts=True so that this won't error if links already exist
-    CollectionArtifact.objects.bulk_create(links, ignore_conflicts=True)
+    if hasattr(self, "_artifacts"):
+        links = [
+            CollectionArtifact(collection_id=self.id, artifact_id=artifact.id)
+            for artifact in self._artifacts
+        ]
+        # the below seems to preserve the order of the list in the
+        # auto-incrementing integer primary
+        # merely using .unordered_artifacts.set(*...) doesn't achieve this
+        # we need ignore_conflicts=True so that this won't error if links already exist
+        CollectionArtifact.objects.bulk_create(links, ignore_conflicts=True)
     save_feature_set_links(self)
     if using is not None:
         logger.warning("using argument is ignored")
     if transfer_labels:
-        for artifact in self._artifacts:
-            self.labels.add_from(artifact)
+        if hasattr(self, "_artifacts"):
+            for artifact in self._artifacts:
+                self.labels.add_from(artifact)
 
 
 # docstring handled through attach_func_to_class_method

--- a/lamindb/_collection.py
+++ b/lamindb/_collection.py
@@ -322,7 +322,7 @@ def delete(self, permanent: bool | None = None) -> None:
 
 
 # docstring handled through attach_func_to_class_method
-def save(self, transfer_labels: bool = False, using: str | None = None) -> None:
+def save(self, using: str | None = None) -> None:
     if self.artifact is not None:
         self.artifact.save()
     # we don't need to save feature sets again
@@ -344,10 +344,6 @@ def save(self, transfer_labels: bool = False, using: str | None = None) -> None:
     save_feature_set_links(self)
     if using is not None:
         logger.warning("using argument is ignored")
-    if transfer_labels:
-        if hasattr(self, "_artifacts"):
-            for artifact in self._artifacts:
-                self.labels.add_from(artifact)
 
 
 # docstring handled through attach_func_to_class_method

--- a/lamindb/_feature_set.py
+++ b/lamindb/_feature_set.py
@@ -73,7 +73,7 @@ def __init__(self, *args, **kwargs):
     features_hash = hash_set({feature.uid for feature in features})
     feature_set = FeatureSet.filter(hash=features_hash).one_or_none()
     if feature_set is not None:
-        logger.success(f"loaded: {feature_set}")
+        logger.debug(f"loaded: {feature_set}")
         init_self_from_db(self, feature_set)
         return None
     else:

--- a/lamindb/_filter.py
+++ b/lamindb/_filter.py
@@ -14,7 +14,11 @@ def filter(Registry: type[Registry], **expressions) -> QuerySet:
         _using_key = expressions.pop("_using_key")
     if Registry in {Artifact, Collection}:
         # visibility is set to 0 unless expressions contains id or uid equality
-        if not ("id" in expressions or "uid" in expressions):
+        if not (
+            "id" in expressions
+            or "uid" in expressions
+            or "uid__startswith" in expressions
+        ):
             visibility = "visibility"
             if not any(e.startswith(visibility) for e in expressions):
                 expressions[

--- a/lamindb/_from_values.py
+++ b/lamindb/_from_values.py
@@ -18,12 +18,16 @@ def get_or_create_records(
     iterable: ListLike,
     field: StrField,
     *,
+    create: bool = False,
     from_public: bool = False,
     organism: Registry | str | None = None,
     public_source: Registry | None = None,
     mute: bool = False,
 ) -> list[Registry]:
     """Get or create records from iterables."""
+    Registry = field.field.model
+    if create:
+        return [Registry(**{field.field.name: value}) for value in iterable]
     upon_create_search_names = settings.upon_create_search_names
     feature: Feature = None
     organism = _get_organism_record(field, organism)
@@ -34,7 +38,6 @@ def get_or_create_records(
         kwargs["public_source"] = public_source
     settings.upon_create_search_names = False
     try:
-        Registry = field.field.model
         iterable_idx = index_iterable(iterable)
 
         # returns existing records & non-existing values

--- a/lamindb/_registry.py
+++ b/lamindb/_registry.py
@@ -99,8 +99,7 @@ def __init__(orm: Registry, *args, **kwargs):
                 if existing_record is not None:
                     logger.important(
                         f"returning existing {orm.__class__.__name__} record with same"
-                        f" name{version_comment}: '{kwargs['name']}' "
-                        "(disable via setting upon_create_search_names)"
+                        f" name{version_comment}: '{kwargs['name']}'"
                     )
                     init_self_from_db(orm, existing_record)
                     return None
@@ -121,11 +120,14 @@ def from_values(
     field: StrField | None = None,
     organism: Registry | str | None = None,
     public_source: Registry | None = None,
+    create: bool = False,
     mute: bool = False,
 ) -> list[Registry]:
     """{}."""
     from_public = True if cls.__module__.startswith("lnschema_bionty.") else False
     field_str = get_default_str_field(cls, field=field)
+    if create:
+        return [cls(**{field_str: value}) for value in values]
     return get_or_create_records(
         iterable=values,
         field=getattr(cls, field_str),

--- a/lamindb/_registry.py
+++ b/lamindb/_registry.py
@@ -126,6 +126,7 @@ def from_values(
     return get_or_create_records(
         iterable=values,
         field=getattr(cls, field_str),
+        create=create,
         from_public=from_public,
         organism=organism,
         public_source=public_source,
@@ -187,9 +188,11 @@ def _search(
             return word
 
     decomposed_string = string.split()
+    # add the entire string back
+    decomposed_string += string
     for word in decomposed_string:
-        # will not search against words with 2 or fewer characters
-        if len(word) <= 2:
+        # will not search against words with 3 or fewer characters
+        if len(word) <= 3:
             decomposed_string.remove(word)
     if truncate_words:
         decomposed_string = [truncate_word(word) for word in decomposed_string]

--- a/lamindb/_registry.py
+++ b/lamindb/_registry.py
@@ -430,7 +430,7 @@ def transfer_to_default_db(
         record_on_default = registry.objects.filter(uid=record.uid).one_or_none()
         if record_on_default is not None:
             logger.important(
-                f"returning existing {record.__class__.__name__} with uid='{record.uid}' on default database"
+                f"returning existing {record.__class__.__name__}(uid='{record.uid}') on default database"
             )
             return record_on_default
         if not mute:

--- a/lamindb/_registry.py
+++ b/lamindb/_registry.py
@@ -189,7 +189,7 @@ def _search(
 
     decomposed_string = string.split()
     # add the entire string back
-    decomposed_string += string
+    decomposed_string += [string]
     for word in decomposed_string:
         # will not search against words with 3 or fewer characters
         if len(word) <= 3:

--- a/lamindb/_registry.py
+++ b/lamindb/_registry.py
@@ -60,19 +60,16 @@ def suggest_records_with_similar_names(record: Registry, kwargs) -> bool:
     for alternative_record in queryset:
         if alternative_record.name == kwargs["name"]:
             return True
-        else:
-            s, it, nots = (
-                ("", "it", "s") if len(queryset) == 1 else ("s", "one of them", "")
-            )
-            msg = f"record{s} with similar name{s} exist{nots}! did you mean to load {it}?"
-            if IPYTHON:
-                from IPython.display import display
+    s, it, nots = ("", "it", "s") if len(queryset) == 1 else ("s", "one of them", "")
+    msg = f"record{s} with similar name{s} exist{nots}! did you mean to load {it}?"
+    if IPYTHON:
+        from IPython.display import display
 
-                logger.warning(f"{msg}")
-                if settings._verbosity_int >= 1:
-                    display(queryset.df())
-            else:
-                logger.warning(f"{msg}\n{queryset}")
+        logger.warning(f"{msg}")
+        if settings._verbosity_int >= 1:
+            display(queryset.df())
+    else:
+        logger.warning(f"{msg}\n{queryset}")
     return False
 
 
@@ -126,8 +123,6 @@ def from_values(
     """{}."""
     from_public = True if cls.__module__.startswith("lnschema_bionty.") else False
     field_str = get_default_str_field(cls, field=field)
-    if create:
-        return [cls(**{field_str: value}) for value in values]
     return get_or_create_records(
         iterable=values,
         field=getattr(cls, field_str),
@@ -192,6 +187,10 @@ def _search(
             return word
 
     decomposed_string = string.split()
+    for word in decomposed_string:
+        # will not search against words with 2 or fewer characters
+        if len(word) <= 2:
+            decomposed_string.remove(word)
     if truncate_words:
         decomposed_string = [truncate_word(word) for word in decomposed_string]
     # construct the query

--- a/lamindb/_registry.py
+++ b/lamindb/_registry.py
@@ -406,11 +406,9 @@ def update_fk_to_default_db(
 FKBULK = [
     "organism",
     "public_source",
-    "initial_version",
     "latest_report",  # Transform
     "source_code",  # Transform
     "report",  # Run
-    "file",  # Collection
 ]
 
 
@@ -431,8 +429,8 @@ def transfer_to_default_db(
         registry = record.__class__
         record_on_default = registry.objects.filter(uid=record.uid).one_or_none()
         if record_on_default is not None:
-            logger.warning(
-                f"record with {record.uid} already exists on default database: {record}"
+            logger.important(
+                f"returning existing {record.__class__.__name__} with uid='{record.uid}' on default database"
             )
             return record_on_default
         if not mute:
@@ -522,9 +520,9 @@ def save(self, *args, **kwargs) -> Registry:
             except ImportError:
                 parents = kwargs.get("parents", True)
             add_from_kwargs = {"parents": parents}
-            logger.info("transfer features")
+            logger.debug("transfer features")
             self.features._add_from(self_on_db, **add_from_kwargs)
-            logger.info("transfer labels")
+            logger.debug("transfer labels")
             self.labels.add_from(self_on_db, **add_from_kwargs)
     return self
 

--- a/lamindb/_registry.py
+++ b/lamindb/_registry.py
@@ -115,9 +115,9 @@ def from_values(
     cls,
     values: ListLike,
     field: StrField | None = None,
+    create: bool = False,
     organism: Registry | str | None = None,
     public_source: Registry | None = None,
-    create: bool = False,
     mute: bool = False,
 ) -> list[Registry]:
     """{}."""

--- a/lamindb/_ulabel.py
+++ b/lamindb/_ulabel.py
@@ -41,20 +41,8 @@ def __init__(self, *args, **kwargs):
     )
 
 
-@classmethod  # type:ignore
-@doc_args(ULabel.from_values.__doc__)
-def from_values(cls, values: ListLike, **kwargs) -> list[ULabel]:
-    """{}."""
-    records = get_or_create_records(
-        iterable=values,
-        field=ULabel.name,
-    )
-    return records
-
-
 METHOD_NAMES = [
     "__init__",
-    "from_values",
 ]
 
 if ln_setup._TESTING:

--- a/lamindb/_ulabel.py
+++ b/lamindb/_ulabel.py
@@ -8,8 +8,6 @@ from lnschema_core import ULabel
 
 from lamindb._utils import attach_func_to_class_method
 
-from ._from_values import get_or_create_records
-
 if TYPE_CHECKING:
     from lnschema_core.types import ListLike
 

--- a/lamindb/core/_data.py
+++ b/lamindb/core/_data.py
@@ -95,19 +95,6 @@ def save_feature_set_links(self: Artifact | Collection) -> None:
         bulk_create(links, ignore_conflicts=True)
 
 
-def format_repr(
-    record: Registry, exclude_field_names: str | list[str] | None = None
-) -> str:
-    if isinstance(exclude_field_names, str):
-        exclude_field_names = [exclude_field_names]
-    exclude_field_names_init = ["id", "created_at", "updated_at"]
-    if exclude_field_names is not None:
-        exclude_field_names_init += exclude_field_names
-    return record.__repr__(
-        include_foreign_keys=False, exclude_field_names=exclude_field_names_init
-    )
-
-
 @doc_args(Data.describe.__doc__)
 def describe(self: Data, print_types: bool = False):
     """{}."""

--- a/lamindb/core/_data.py
+++ b/lamindb/core/_data.py
@@ -319,21 +319,15 @@ def add_labels(
             if "Feature" == feature_set.registry
         }
         for registry_name, _ in records_by_registry.items():
-            msg = ""
-            if (
-                not feature.dtype.startswith("cat[")
-                or registry_name not in feature.dtype
-            ):
-                if len(msg) > 0:
-                    msg += ", "
-                msg += f"linked feature '{feature.name}' to registry '{registry_name}'"
+            if registry_name not in feature.dtype:
+                logger.debug(
+                    f"updated categorical feature '{feature.name}' type with registry '{registry_name}'"
+                )
                 if not feature.dtype.startswith("cat["):
                     feature.dtype = f"cat[{registry_name}]"
                 elif registry_name not in feature.dtype:
                     feature.dtype = feature.dtype.rstrip("]") + f"|{registry_name}]"
                 feature.save()
-            if len(msg) > 0:
-                logger.save(msg)
 
 
 def _track_run_input(

--- a/lamindb/core/_data.py
+++ b/lamindb/core/_data.py
@@ -391,7 +391,7 @@ def _track_run_input(
                                 f" {input_data[0].transform.id}"
                             )
                     logger.info(
-                        f"adding {data_class_name} {input_data_ids} as input for run"
+                        f"adding {data_class_name} ids {input_data_ids} as inputs for run"
                         f" {run.id}{transform_note}"
                     )
                     track_run_input = True

--- a/lamindb/core/_data.py
+++ b/lamindb/core/_data.py
@@ -20,6 +20,7 @@ from lnschema_core.models import (
 
 from lamindb._parents import view_lineage
 from lamindb._query_set import QuerySet
+from lamindb._registry import get_default_str_field
 from lamindb.core._settings import settings
 
 from ._feature_manager import (
@@ -94,21 +95,17 @@ def save_feature_set_links(self: Artifact | Collection) -> None:
         bulk_create(links, ignore_conflicts=True)
 
 
-def format_repr(value: Registry, exclude: list[str] | str | None = None) -> str:
-    if isinstance(exclude, str):
-        exclude = [exclude]
-    exclude_fields = set() if exclude is None else set(exclude)
-    exclude_fields.update(["created_at", "updated_at"])
-
-    fields = [
-        f
-        for f in value.__repr__(include_foreign_keys=False).split(", ")
-        if not any(f"{excluded_field}=" in f for excluded_field in exclude_fields)
-    ]
-    repr = ", ".join(fields)
-    if not repr.endswith(")"):
-        repr += ")"
-    return repr
+def format_repr(
+    record: Registry, exclude_field_names: str | list[str] | None = None
+) -> str:
+    if isinstance(exclude_field_names, str):
+        exclude_field_names = [exclude_field_names]
+    exclude_field_names_init = ["id", "created_at", "updated_at"]
+    if exclude_field_names is not None:
+        exclude_field_names_init += exclude_field_names
+    return record.__repr__(
+        include_foreign_keys=False, exclude_field_names=exclude_field_names_init
+    )
 
 
 @doc_args(Data.describe.__doc__)
@@ -152,25 +149,23 @@ def describe(self: Data):
     # provenance
     if len(foreign_key_fields) > 0:  # always True for Artifact and Collection
         record_msg = f"{colors.green(model_name)}{__repr__(self, include_foreign_keys=False).lstrip(model_name)}"
-        msg += f"{record_msg}\n\n"
-
-        msg += f"{colors.green('Provenance')}:\n  "
+        msg += f"{record_msg}\n"
+        fields_values = [(field, getattr(self, field)) for field in foreign_key_fields]
         related_msg = "".join(
             [
-                f"📎 {field}: {format_repr(self.__getattribute__(field))}\n  "
-                for field in foreign_key_fields
-                if self.__getattribute__(field) is not None
+                f"  {field_name}: {attr.__class__.__get_name_with_schema__()} = '{getattr(attr, get_default_str_field(attr))}'\n"
+                for (field_name, attr) in fields_values
+                if attr is not None
             ]
         )
         msg += related_msg
     # input of
     if self.id is not None and self.input_of.exists():
         values = [format_field_value(i.started_at) for i in self.input_of.all()]
-        msg += f"📎 input_of ({colors.italic('core.Run')}): {values}\n    "
+        msg += f"  input_of: Run = {values}\n"
     msg = msg.rstrip(" ")  # do not use removesuffix as we need to remove 2 or 4 spaces
-    msg += print_features(self)
     msg += print_labels(self)
-
+    msg += print_features(self)
     logger.print(msg)
 
 
@@ -316,7 +311,7 @@ def add_labels(
         feature_set_ids = [link.featureset_id for link in feature_set_links.all()]
         # get all linked features of type Feature
         feature_sets = FeatureSet.filter(id__in=feature_set_ids).all()
-        linked_features_by_slot = {
+        {
             feature_set_links.filter(featureset_id=feature_set.id)
             .one()
             .slot: feature_set.features.all()
@@ -339,43 +334,6 @@ def add_labels(
                 feature.save()
             if len(msg) > 0:
                 logger.save(msg)
-            # check whether we have to update the feature set that manages labels
-            # (Feature) to account for a new feature
-            found_feature = False
-            for _, linked_features in linked_features_by_slot.items():
-                if feature in linked_features:
-                    found_feature = True
-            if not found_feature:
-                if "external" in linked_features_by_slot:
-                    feature_set = self.features.feature_set_by_slot["external"]
-                    features_list = feature_set.features.list()
-                else:
-                    features_list = []
-                features_list.append(feature)
-                feature_set = FeatureSet(features_list)
-                feature_set.save()
-                if "external" in linked_features_by_slot:
-                    old_feature_set_link = feature_set_links.filter(
-                        slot="external"
-                    ).one()
-                    old_feature_set_link.delete()
-                    remaining_links = self.feature_sets.through.objects.filter(
-                        featureset_id=feature_set.id
-                    ).all()
-                    if len(remaining_links) == 0:
-                        old_feature_set = FeatureSet.filter(
-                            id=old_feature_set_link.featureset_id
-                        ).one()
-                        logger.info(
-                            "nothing links to it anymore, deleting feature set"
-                            f" {old_feature_set}"
-                        )
-                        old_feature_set.delete()
-                self.features.add_feature_set(feature_set, slot="external")
-                logger.save(
-                    f"linked new feature '{feature.name}' together with new feature set"
-                    f" {feature_set}"
-                )
 
 
 def _track_run_input(

--- a/lamindb/core/_data.py
+++ b/lamindb/core/_data.py
@@ -153,7 +153,7 @@ def describe(self: Data):
         fields_values = [(field, getattr(self, field)) for field in foreign_key_fields]
         related_msg = "".join(
             [
-                f"  {field_name}: {attr.__class__.__get_name_with_schema__()} = '{getattr(attr, get_default_str_field(attr))}'\n"
+                f"  {field_name}: {attr.__class__.__get_name_with_schema__()} = {format_field_value(getattr(attr, get_default_str_field(attr)))}\n"
                 for (field_name, attr) in fields_values
                 if attr is not None
             ]

--- a/lamindb/core/_feature_manager.py
+++ b/lamindb/core/_feature_manager.py
@@ -518,9 +518,9 @@ class FeatureManager:
 
     def _add_from(self, data: Data, parents: bool = True):
         """Transfer features from a artifact or collection."""
+        # This only covers feature sets, though.
         using_key = settings._using_key
         for slot, feature_set in data.features.feature_set_by_slot.items():
-            print(slot)
             members = feature_set.members
             if len(members) == 0:
                 continue

--- a/lamindb/core/_feature_manager.py
+++ b/lamindb/core/_feature_manager.py
@@ -367,7 +367,7 @@ class FeatureManager:
                     if validated.sum() != len(values):
                         not_validated_keys = values_array[~validated]
                         hint = (
-                            f"  ulabels = ln.ULabel.from_values({not_validated_keys}, create=True)"
+                            f"  ulabels = ln.ULabel.from_values({not_validated_keys}, create=True)\n"
                             f"  ln.save(ulabels)"
                         )
                         msg = (

--- a/lamindb/core/_label_manager.py
+++ b/lamindb/core/_label_manager.py
@@ -254,14 +254,16 @@ class LabelManager:
                             key = link.feature.name
                         else:
                             key = None
-                    transfer_to_default_db(
+                    label_returned = transfer_to_default_db(
                         label,
                         using_key,
                         mute=True,
                         transfer_fk=False,
                         save=True,
                     )
-                    assert label.id is not None
+                    # TODO: refactor return value of transfer to default db
+                    if label_returned is not None:
+                        label = label_returned
                     labels_by_features[key].append(label)
                 # treat features
                 _, new_features = validate_labels(features)

--- a/lamindb/core/_label_manager.py
+++ b/lamindb/core/_label_manager.py
@@ -32,6 +32,7 @@ def get_labels_as_dict(self: Data, links: bool = False):
         "report_of",
         "environment_of",
         "collection_links",
+        "artifact_links",
         "feature_set_links",
         "previous_runs",
         "feature_values",

--- a/lamindb/core/_label_manager.py
+++ b/lamindb/core/_label_manager.py
@@ -254,14 +254,15 @@ class LabelManager:
                             key = link.feature.name
                         else:
                             key = None
-                    transfered_label = transfer_to_default_db(
+                    transfer_to_default_db(
                         label,
                         using_key,
                         mute=True,
                         transfer_fk=False,
                         save=True,
                     )
-                    labels_by_features[key].append(transfered_label)
+                    assert label.id is not None
+                    labels_by_features[key].append(label)
                 # treat features
                 _, new_features = validate_labels(features)
                 if len(new_features) > 0:

--- a/lamindb/core/_label_manager.py
+++ b/lamindb/core/_label_manager.py
@@ -50,9 +50,7 @@ def get_labels_as_dict(self: Data, links: bool = False):
     return labels
 
 
-def print_labels(
-    self: Data, field: str = "name", ignore_labels_with_feature: bool = True
-):
+def print_labels(self: Data, field: str = "name", print_types: bool = False):
     labels_msg = ""
     for related_name, (related_model, labels) in get_labels_as_dict(self).items():
         # there is a try except block here to deal with schema inconsistencies
@@ -62,10 +60,15 @@ def print_labels(
             if len(labels_list) > 0:
                 get_default_str_field(labels)
                 print_values = _print_values(labels_list, n=10)
-                labels_msg += f"  {related_name}: {related_model} = {print_values}\n"
+                type_str = f": {related_model}" if print_types else ""
+                labels_msg += f"    .{related_name}{type_str} = {print_values}\n"
         except Exception:
             continue
-    return labels_msg
+    msg = ""
+    if labels_msg:
+        msg += f"  {colors.italic('Labels')}\n"
+        msg += labels_msg
+    return msg
 
 
 def transfer_add_labels(labels, features_lookup_self, self, row, parents: bool = True):

--- a/lamindb/core/_label_manager.py
+++ b/lamindb/core/_label_manager.py
@@ -255,11 +255,14 @@ class LabelManager:
                         else:
                             key = None
                     transfered_label = transfer_to_default_db(
-                        label, using_key, mute=True, transfer_fk=False
+                        label,
+                        using_key,
+                        mute=True,
+                        transfer_fk=False,
+                        save=True,
                     )
                     labels_by_features[key].append(transfered_label)
                 # treat features
-                save(new_labels, parents=parents)
                 _, new_features = validate_labels(features)
                 if len(new_features) > 0:
                     transfer_fk_to_default_db_bulk(new_features, using_key)

--- a/lamindb/core/_run_context.py
+++ b/lamindb/core/_run_context.py
@@ -259,7 +259,7 @@ class run_context:
         transform: Transform | None = None,
         new_run: bool | None = None,
         path: str | None = None,
-    ) -> None:
+    ) -> Run:
         """Track notebook or script run.
 
         Creates or loads a global :class:`~lamindb.Run` that enables data
@@ -386,7 +386,7 @@ class run_context:
         from ._track_environment import track_environment
 
         track_environment(run)
-        return None
+        return run
 
     @classmethod
     def _track_script(

--- a/lamindb/core/_sync_git.py
+++ b/lamindb/core/_sync_git.py
@@ -20,7 +20,9 @@ def get_git_repo_from_remote() -> Path:
     if repo_dir.exists():
         logger.warning(f"git repo {repo_dir} already exists locally")
         return repo_dir
-    logger.important(f"cloning {repo_url} into {repo_dir}")
+    logger.important(
+        f"running outside of synched git repo, cloning {repo_url} into {repo_dir}"
+    )
     result = subprocess.run(
         f"git clone --depth 10 {repo_url}.git",
         shell=True,
@@ -48,8 +50,7 @@ def check_local_git_repo() -> bool:
             # running-in-correct-git-repo
             return True
         else:
-            # running-in-wrong-git-repo
-            logger.warning("running in wrong git repo")
+            # running-outside-of-correct-git-repo
             return False
 
 

--- a/lamindb/core/exceptions.py
+++ b/lamindb/core/exceptions.py
@@ -10,7 +10,7 @@ The registry base class:
 """
 
 
-class ValidationError(Exception):
+class ValidationError(SystemExit):
     """Validation error: not mapped in registry."""
 
     pass

--- a/tests/test_feature_manager.py
+++ b/tests/test_feature_manager.py
@@ -218,11 +218,8 @@ def test_add_labels_using_anndata(adata):
         registry="Feature", artifact_links__slot="obs"
     ).one()
     assert feature_set_obs.n == 4
-    feature_set_ext = artifact.feature_sets.filter(
-        registry="Feature", artifact_links__slot="external"
-    ).one()
-    assert feature_set_ext.n == 1
-    assert "organism" in feature_set_ext.features.list("name")
+    # TODO, write a test that queries the organism feature
+    # assert "organism" in feature_set_ext.features.list("name")
 
     # now we add cell types & tissues and run checks
     ln.Feature(name="cell_type", dtype="cat").save()
@@ -259,12 +256,13 @@ def test_add_labels_using_anndata(adata):
     ln.Feature(name="experiment", dtype="cat").save()
     features = ln.Feature.lookup()
     artifact.labels.add(experiment_1, feature=features.experiment)
-    df = artifact.features["external"].df()
-    assert set(df["name"]) == {
-        "organism",
-        "experiment",
-    }
-    assert set(df["dtype"]) == {"cat[bionty.Organism]", "cat[ULabel]"}
+    # TODO: replace the following with an updated test
+    # df = artifact.features["external"].df()
+    # assert set(df["name"]) == {
+    #     "organism",
+    #     "experiment",
+    # }
+    # assert set(df["dtype"]) == {"cat[bionty.Organism]", "cat[ULabel]"}
 
     assert set(artifact.labels.get(features.experiment).list("name")) == {
         "experiment_1"
@@ -307,8 +305,6 @@ def test_add_labels_using_anndata(adata):
         "hematopoietic stem cell",
         "B cell",
     }
-
-    assert set(df["dtype"]) == {"cat[bionty.Organism]", "cat[ULabel]"}
     assert experiment_1 in artifact.ulabels.all()
 
     # call describe
@@ -338,7 +334,7 @@ def test_labels_get():
     feature_set = ln.FeatureSet(features=[feature_name_feature])
     feature_set.save()
     artifact.save()
-    assert str(artifact.features) == "no linked features"
+    assert str(artifact.features) == ""
     artifact.features.add_feature_set(feature_set, slot="random")
     assert artifact.feature_sets.first() == feature_set
     artifact.delete(permanent=True, storage=True)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -46,7 +46,7 @@ def prepare_cell_type_registry():
 
 def test_search_synonyms(prepare_cell_type_registry):
     result = bt.CellType.search("P cell").df()
-    assert set(result.name) == {"nodal myocyte", "PP cell"}
+    assert set(result.name[:2]) == {"nodal myocyte", "PP cell"}
 
 
 def test_search_limit(prepare_cell_type_registry):
@@ -55,8 +55,6 @@ def test_search_limit(prepare_cell_type_registry):
 
 
 def test_search_case_sensitive(prepare_cell_type_registry):
-    result = bt.CellType.search("b cell", case_sensitive=True).df()
-    assert len(result) == 0
-
     result = bt.CellType.search("b cell", case_sensitive=False).df()
-    assert len(result) == 1
+    print(result.name)
+    assert result.name[0] == "B cell"

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -46,7 +46,7 @@ def prepare_cell_type_registry():
 
 def test_search_synonyms(prepare_cell_type_registry):
     result = bt.CellType.search("P cell").df()
-    assert set(result.name[:2]) == {"nodal myocyte", "PP cell"}
+    assert set(result.name.iloc[:2]) == {"nodal myocyte", "PP cell"}
 
 
 def test_search_limit(prepare_cell_type_registry):
@@ -56,5 +56,4 @@ def test_search_limit(prepare_cell_type_registry):
 
 def test_search_case_sensitive(prepare_cell_type_registry):
     result = bt.CellType.search("b cell", case_sensitive=False).df()
-    print(result.name)
-    assert result.name[0] == "B cell"
+    assert result.name.iloc[0] == "B cell"


### PR DESCRIPTION
- `ln.track()` returns `run`
- better duplicate detection and search
- prettier `.describe()`
- feature values decoupled from feature sets
- more interactivity in `lamin save`
- `create` flag in `.from_values()`
- reorder fields in dataframe & record representations
- auto-detect feature types in dict-style assignment & raise better validation errors