### PR TITLE
:sparkles: Support dict in add_values

### DIFF
--- a/lamindb/_from_values.py
+++ b/lamindb/_from_values.py
@@ -278,16 +278,26 @@ def index_iterable(iterable: Iterable) -> pd.Index:
 
 
 def _print_values(names: Iterable, n: int = 20, quotes: bool = True) -> str:
-    if isinstance(names, list):
-        return str(names)
-    names = (name for name in names if name != "None")
-    unique_names = list(dict.fromkeys(names))[:n]
-    if quotes:
-        print_values = ", ".join(f"'{name}'" for name in unique_names)
+    if isinstance(names, dict):
+        items = {
+            f"{key}: {value}": None
+            for key, value in names.items()
+            if key != "None" and value != "None"
+        }
     else:
-        print_values = ", ".join(f"{name}" for name in unique_names)
-    if len(unique_names) > n:
+        # Use a dictionary instead of a list to have unique values and preserve order
+        items = {str(name): None for name in names if name != "None"}
+
+    unique_items = list(items.keys())
+
+    if quotes:
+        unique_items = [f"'{item}'" for item in unique_items]
+
+    print_values = ", ".join(unique_items[:n])
+
+    if len(unique_items) > n:
         print_values += ", ..."
+
     return print_values
 
 

--- a/lamindb/_from_values.py
+++ b/lamindb/_from_values.py
@@ -278,6 +278,8 @@ def index_iterable(iterable: Iterable) -> pd.Index:
 
 
 def _print_values(names: Iterable, n: int = 20, quotes: bool = True) -> str:
+    if isinstance(names, list):
+        return str(names)
     names = (name for name in names if name != "None")
     unique_names = list(dict.fromkeys(names))[:n]
     if quotes:

--- a/lamindb/core/_feature_manager.py
+++ b/lamindb/core/_feature_manager.py
@@ -306,6 +306,8 @@ def infer_feature_type_convert_json(
             return convert_numpy_dtype_to_lamin_feature_type(
                 value.dtype, str_as_cat=str_as_ulabel
             ), list(value)
+        if isinstance(value, dict):
+            return "dict", value
         if len(value) > 0:  # type: ignore
             first_element_type = type(next(iter(value)))
             if all(isinstance(elem, first_element_type) for elem in value):


### PR DESCRIPTION
Discussed here: https://laminlabs.slack.com/archives/C04FPE8V01W/p1718821216654699

* Supports `dict` in `infer_feature_type_convert_json`. We expect users to attempt to set `Run.params(dict)` which was not supported before this change.
* Adapts `_print_values` to also support dictionaries