### PR TITLE
📝 Refactor docs, including annotate guide

### DIFF
--- a/docs/annotate-flexible.ipynb
+++ b/docs/annotate-flexible.ipynb
@@ -4,14 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Validate, standardize & annotate data of flexible formats"
+    "# Validate, standardize & annotate data of any format"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Our [previous guide](./annotate) explained how to validate, standardize & annotate `DataFrame` and `AnnData`. In this guide, we'll dive into how to use the basic APIs that let you work with any format of data."
+    "Our [previous guide](./annotate) explained how to validate, standardize & annotate `DataFrame` and `AnnData`. In this guide, we'll walk through the basic API that lets you work with any format of data."
    ]
   },
   {
@@ -20,32 +20,13 @@
    "source": [
     ":::{dropdown} How do I validate based on a public ontology?\n",
     "\n",
-    "LaminDB makes it easy to validate categorical variables based on registries ({class}`~lamindb.core.CanValidate`).\n",
+    "LaminDB makes it easy to validate categorical variables based on registries that inherit from {class}`~lamindb.core.CanValidate`.\n",
     "\n",
     "{class}`~lamindb.core.CanValidate` methods validate against the registries in your LaminDB instance.\n",
     "In {doc}`./bio-registries`, you'll see how to extend standard validation to validation against _public references_ using a `ReferenceTable` ontology object: `public = Record.public()`.\n",
     "By default, {meth}`~lamindb.core.Record.from_values` considers a match in a public reference a validated value for any {mod}`bionty` entity.\n",
     "\n",
-    ":::\n",
-    "\n",
-    ":::{dropdown} What to do for non-validated values?\n",
-    "\n",
-    "Be aware when you are working with a _freshly initialized instance_: nothing is validated as no records have yet been registered.\n",
-    "Run `inspect` to get instructions of how to register non-validated values. You may need to standardize your values, fix typos or simply register them.\n",
-    "\n",
     ":::"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Setup\n",
-    "\n",
-    "Install the `lamindb` Python package:\n",
-    "```shell\n",
-    "pip install 'lamindb[bionty]'\n",
-    "```"
    ]
   },
   {
@@ -58,6 +39,7 @@
    },
    "outputs": [],
    "source": [
+    "# !pip install 'lamindb[bionty,zarr]'\n",
     "!lamin init --storage ./test-annotate-flexible --schema bionty"
    ]
   },
@@ -69,16 +51,6 @@
    "source": [
     "import lamindb as ln\n",
     "import bionty as bt\n",
-    "\n",
-    "ln.settings.verbosity = \"info\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import zarr\n",
     "import numpy as np\n",
     "\n",
@@ -93,7 +65,7 @@
    "source": [
     "## Define validation criteria\n",
     "\n",
-    "Any entity that doesn't have its dedicated registry (\"is not typed\") can be validated & registered using {class}`~lamindb.ULabel`:"
+    "Entities that don't have a dedicated registry (\"are not typed\") can be validated & registered using {class}`~lamindb.ULabel`:"
    ]
   },
   {
@@ -182,7 +154,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Repeat the process for another labels:"
+    "Repeat the process for more labels:"
    ]
   },
   {
@@ -194,7 +166,7 @@
     "projects = ln.ULabel.from_values(\n",
     "    [\"Project A\", \"Project B\"], \n",
     "    field=ln.ULabel.name, \n",
-    "    create=True, # create non-existing labels\n",
+    "    create=True, # create non-existing labels rather than attempting to load them from the database\n",
     ")\n",
     "ln.save(projects)"
    ]
@@ -244,13 +216,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Link the artifact to validated labels through features:"
+    "Link the artifact to validated labels. You could directly do this, e.g., via `artifact.ulabels.add(projects)` or `artifact.diseases.add(diseases)`.\n",
+    "\n",
+    "However, often, you want to track the features that measured labels. Hence, let's try to associate our labels with features:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "from lamindb.core.exceptions import ValidationError\n",
@@ -265,34 +243,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Follow the suggestion to register new features:"
+    "This errored because we hadn't yet registered features. After copy and paste from the error message, things work out:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "ln.Feature(name='project', dtype='cat[ULabel]').save()\n",
-    "ln.Feature(name='disease', dtype='cat[bionty.Disease]').save();"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "artifact.features.add_values({\"project\": projects, \"disease\": diseases})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "ln.Feature(name='disease', dtype='cat[bionty.Disease]').save()\n",
+    "artifact.features.add_values({\"project\": projects, \"disease\": diseases})\n",
     "artifact.features"
    ]
   },
@@ -306,28 +272,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "feature_set = ln.FeatureSet(genes)\n",
-    "feature_set.save()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "artifact.features.add_feature_set(feature_set, slot=\"gene\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "feature_set.save()\n",
+    "artifact.features.add_feature_set(feature_set, slot=\"genes\")\n",
     "artifact.describe()"
    ]
   },
@@ -343,7 +297,6 @@
    "source": [
     "# clean up test instance\n",
     "!lamin delete --force test-annotate-flexible\n",
-    "!rm -r test-annotate-flexible\n",
     "!rm -r data.zarr"
    ]
   }

--- a/docs/annotate.ipynb
+++ b/docs/annotate.ipynb
@@ -7,38 +7,25 @@
    "source": [
     "# Validate, standardize & annotate\n",
     "\n",
-    "This guide focuses on three crucial aspects of data management:\n",
+    "This guide focuses on three aspects of data management:\n",
     "\n",
-    "1. Validation: Ensuring your data meets predefined criteria\n",
-    "2. Standardization: Conforming data to consistent formats and terminologies\n",
-    "3. Annotation: Enriching data with metadata for improved organization and analysis\n",
+    "1. Validation: Ensuring your datasets meets predefined criteria\n",
+    "2. Standardization: Transforming datasets so that they meet validation criteria, e.g., by fixing typos or using standardized identifiers\n",
+    "3. Annotation: Linking datasets against metadata records\n",
+    "\n",
+    "While this guide focuses on validating DataFrame and AnnData objects, {doc}`annotate-flexible` explains how to curate arbitrary artifacts.\n",
     "\n",
     "## Key Concepts\n",
     "\n",
-    "- **Registries**: In LaminDB, registries are collections of validated metadata. They serve as the \"source of truth\" for your data annotations. For instance, if \"Experiment 1\" has been registered as the `name` of a `ULabel` record, it is a validated value for field `ULabel.name`.\n",
+    "- **Registries** store valid metadata records. For instance, if the string `\"Experiment 1\"` was registered as the `name` of a `ULabel` record, it's going to pass validation against `ULabel.name`.\n",
     "\n",
-    "- **Artifacts**: These are the data objects that you manage with LaminDB. Artifacts can be annotated with validated metadata from registries.\n",
-    "\n",
-    "- **Annotation**: The process of attaching metadata to your data objects, enhancing their context and searchability.\n",
-    "\n",
-    "In this guide, we'll walk you through the following flow for `DataFrame` and `AnnData`: \n",
+    "- **Artifacts**: These are the data objects that you manage with LaminDB. Artifacts can be validated & annotated with metadata records from registries.\n",
     "\n",
     "```{toctree}\n",
     ":maxdepth: 1\n",
     ":hidden:\n",
     "\n",
     "annotate-flexible\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c47f2b20",
-   "metadata": {},
-   "source": [
-    "Install the `lamindb` Python package:\n",
-    "```shell\n",
-    "pip install 'lamindb[bionty]'\n",
     "```"
    ]
   },
@@ -53,6 +40,7 @@
    },
    "outputs": [],
    "source": [
+    "#! pip install 'lamindb[bionty]'\n",
     "!lamin init --storage ./test-annotate --schema bionty"
    ]
   },
@@ -89,7 +77,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6e313088",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "df = pd.DataFrame({\n",
@@ -113,11 +105,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cfb3492d",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "# define validation criteria for categorical variables\n",
-    "# each key is a column name, and each value is the registry field to validate against\n",
+    "# in the dictionary, each key is a column name of the dataframe, and each value is a registry field onto which values are mapped\n",
     "categoricals = {\n",
     "    \"cell_type\": bt.CellType.name,\n",
     "    \"assay_ontology_id\": bt.ExperimentalFactor.ontology_id,\n",
@@ -141,7 +137,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1132efd8",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "annotate.validate()"
@@ -154,9 +154,9 @@
    "source": [
     "## Curate and register new metadata labels\n",
     "\n",
-    "If you see any \"non-validated\" entries, you'll need to decide whether to add them to your registries or correct them in your data.\n",
+    "If you see any \"non-validated\" values, you'll need to decide whether to add them to your registries or correct them in your data.\n",
     "\n",
-    "Our current database instance is empty. Once you populated its registries, saving new labels will only rarely be needed. You'll mostly use your lamindb instance to validate any incoming new data and annotate it."
+    "Because our current database instance is empty, here, we'll add values to the registries defined in the validation criteria."
    ]
   },
   {
@@ -166,30 +166,37 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# this adds assays that were validated via the public ontology\n",
+    "# this adds assays that were validated (via a public ontology)\n",
     "annotate.add_validated_from(\"assay_ontology_id\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "943e0e7a",
-   "metadata": {},
+   "id": "bcb388d8",
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# this adds cell types that were validated via the public ontology\n",
-    "annotate.add_validated_from(\"cell_type\")"
+    "# this adds cell types that were _not_ validated\n",
+    "annotate.add_new_from(\"cell_type\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "ea6b82b8",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
-    "# use a lookup object to get the correct spelling of categories from public reference\n",
-    "# pass \"public\" to use the public reference\n",
+    "# use a lookup object to get the correct spelling of categories from a public reference\n",
     "lookup = annotate.lookup(\"public\")\n",
     "lookup"
    ]
@@ -198,7 +205,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4c98914a",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "cell_types = lookup[df.cell_type.name]\n",
@@ -209,7 +220,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b06c7875",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "# curate the cell type\n",
@@ -222,7 +237,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "13cec5d4",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "# register non-validated donors\n",
@@ -233,7 +252,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1a90599b",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "# validate again\n",
@@ -255,7 +278,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "15d7b858",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "df.index = [\"obs1\", \"obs2\", \"obs3\"]\n",
@@ -270,7 +297,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "19e7b8ca",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "annotate = ln.Annotate.from_anndata(\n",
@@ -285,7 +316,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e8d8cee5",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "annotate.validate()"
@@ -295,7 +330,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7877c058",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "annotate.add_validated_from(\"all\")"
@@ -305,7 +344,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0e139bda",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "annotate.validate()"
@@ -331,7 +374,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f12ec345",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "artifact = annotate.save_artifact(description=\"test AnnData\")"
@@ -349,7 +396,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5e901343",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "artifact.describe()"
@@ -360,16 +411,16 @@
    "id": "c00b51c4",
    "metadata": {},
    "source": [
-    "We've walked through the process of validating, standardizing, and annotating data using LaminDB. Key steps include:\n",
+    "We've walked through the process of validating, standardizing, and annotating data going through these key steps:\n",
     "\n",
     "1. Defining validation criteria\n",
     "2. Validating data against existing registries\n",
     "3. Adding new validated entries to registries\n",
-    "4. Annotating data objects (Artifacts) with validated metadata\n",
+    "4. Annotating artifacts with validated metadata\n",
     "\n",
-    "By following these steps, you can ensure your data is clean, standardized, and well-annotated, setting a strong foundation for further analysis and collaboration.\n",
+    "By following these steps, you can ensure your data is standardized and well-annotated.\n",
     "\n",
-    "If you have datasets with other formats, please check out [Validate, standardize & annotate data of flexible formats](./annotate-flexible)."
+    "If you have datasets that aren't DataFrame-like or AnnData-like, read: {doc}`annotate-flexible`"
    ]
   }
  ],

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,4 +1,4 @@
-# Reference
+# API
 
 <meta http-equiv="Refresh" content="0; url=./lamindb.html" />
 

--- a/docs/arrays.ipynb
+++ b/docs/arrays.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![Jupyter Notebook](https://img.shields.io/badge/Source%20on%20GitHub-orange)](https://github.com/laminlabs/lamindb/blob/main/docs/data.ipynb)"
+    "[![Jupyter Notebook](https://img.shields.io/badge/Source%20on%20GitHub-orange)](https://github.com/laminlabs/lamindb/blob/main/docs/arrays.ipynb)"
    ]
   },
   {
@@ -20,7 +20,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We saw how LaminDB allows to query & search across artifacts & collections using registries: {doc}`meta`.\n",
+    "We saw how LaminDB allows to query & search across artifacts & collections using registries: {doc}`records`.\n",
     "\n",
     "Let us now look at the following case:\n",
     "\n",

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,6 @@
 :hidden:
 
 guide
-reference
+api
 changelog
 ```

--- a/docs/introduction.ipynb
+++ b/docs/introduction.ipynb
@@ -1149,7 +1149,7 @@
     "\n",
     "<img src=\"https://lamin-site-assets.s3.amazonaws.com/.lamindb/XoTQFCmmj2uU4d2xyj9t.png\" width=\"350px\" style=\"background: transparent\" align=\"right\">\n",
     "\n",
-    "LaminDB provides a SQL schema for common entities: {class}`~lamindb.Artifact`, {class}`~lamindb.Collection`, {class}`~lamindb.Transform`, {class}`~lamindb.Feature`, {class}`~lamindb.ULabel` etc. - see the [API reference](/reference) or the [source code](https://github.com/laminlabs/lnschema-core/blob/main/lnschema_core/models.py).\n",
+    "LaminDB provides a SQL schema for common entities: {class}`~lamindb.Artifact`, {class}`~lamindb.Collection`, {class}`~lamindb.Transform`, {class}`~lamindb.Feature`, {class}`~lamindb.ULabel` etc. - see the [API reference](/api) or the [source code](https://github.com/laminlabs/lnschema-core/blob/main/lnschema_core/models.py).\n",
     "\n",
     "The core schema is extendable through plugins (see blue vs. red entities in **graphic**), e.g., with basic biological ({class}`~bionty.Gene`, {class}`~bionty.Protein`, {class}`~bionty.CellLine`, etc.) & operational entities (`Biosample`, `Techsample`, `Treatment`, etc.).\n",
     "\n",

--- a/docs/introduction.ipynb
+++ b/docs/introduction.ipynb
@@ -453,7 +453,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "ln.Artifact"

--- a/docs/introduction.ipynb
+++ b/docs/introduction.ipynb
@@ -75,7 +75,7 @@
    "source": [
     "# store artifacts in a local directory `./lamin-intro`\n",
     "!lamin init --storage ./lamin-intro --schema bionty\n",
-    "# disable django's unnecessary functionality for a clean API\n",
+    "# make django's unnecessary functionality private for clean auto-complete\n",
     "!lamin set private-django-api true"
    ]
   },

--- a/docs/introduction.ipynb
+++ b/docs/introduction.ipynb
@@ -345,7 +345,7 @@
    },
    "outputs": [],
    "source": [
-    "# create & save a label\n",
+    "# create & save a ulabel record\n",
     "candidate_marker_study = ln.ULabel(name=\"Candidate marker study\").save()\n",
     "\n",
     "# label an artifact\n",
@@ -357,22 +357,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Registries"
+    "### Registries & records"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "LaminDB's central classes are registries that manage metadata.\n",
+    "LaminDB's central classes are registries that manage metadata in form of related records. They all inherit from {class}`~lamindb.core.Record`.\n",
     "\n",
-    "The easiest way to see what's in a registry is to call `.df()`."
+    "We've already seen how to create _new_ `artifact`, `transform` and `ulabel` records by instantiating {class}`~lamindb.core.Record`.\n",
+    "\n",
+    "The easiest way to see all _existing_ records of a given type is to call the _class method_ {class}`~lamindb.core.Record.df`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "ln.Artifact.df()"
@@ -381,7 +387,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "ln.Transform.df()"
@@ -390,7 +400,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "ln.ULabel.df() "
@@ -402,7 +416,7 @@
    "source": [
     "### Queries\n",
     "\n",
-    "You can write arbitrary relational queries using Django's query syntax."
+    "You can write arbitrary relational queries using the class methods {class}`~lamindb.core.Record.get` and {class}`~lamindb.core.Record.filter`."
    ]
   },
   {
@@ -431,7 +445,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The syntax here is Django's query syntax.\n",
+    "\n",
+    "If you want to see what you can query for, just type the class:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln.Artifact"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Search"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The class methods {class}`~lamindb.core.Record.search` and {class}`~lamindb.core.Record.lookup` help finding sets of approximately matching records."
    ]
   },
   {
@@ -462,14 +501,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Features"
+    "### Dataset features"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can annotate artifacts with features & values."
+    "You can annotate dataset-like artifacts with features."
    ]
   },
   {
@@ -496,7 +535,7 @@
    "source": [
     "LaminDB validates all user input against its registries. As the `temperature` feature didn't exist, we got an error.\n",
     "\n",
-    "Let's follow the hint in the error message:"
+    "Following the hint in the error message:"
    ]
   },
   {
@@ -548,7 +587,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Features provide a way to bucket labels beyond their type/registry."
+    "Features provide a way to \"bucket\" labels independent of their registry."
    ]
   },
   {
@@ -564,14 +603,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Validate"
+    "### Validate a DataFrame"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's use the high-level {class}`~lamindb.Annotate`class to validate a `DataFrame`:"
+    "Let's use the high-level {class}`~lamindb.Annotate` class to validate a `DataFrame`:"
    ]
   },
   {

--- a/docs/query-search.md
+++ b/docs/query-search.md
@@ -3,6 +3,6 @@
 ```{toctree}
 :maxdepth: 1
 
-meta
-data
+records
+arrays
 ```

--- a/docs/records.ipynb
+++ b/docs/records.ipynb
@@ -10,23 +10,6 @@
    ]
   },
   {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "1e640c6f",
-   "metadata": {},
-   "source": [
-    "Find & access data using registries."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5ccd1a6b",
-   "metadata": {},
-   "source": [
-    "## Setup"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "03242699",
@@ -44,26 +27,6 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3ba53765",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import lamindb as ln\n",
-    "\n",
-    "ln.settings.verbosity = \"info\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d832785f",
-   "metadata": {},
-   "source": [
-    "We'll need some toy data:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e980e41d",
    "metadata": {
     "tags": [
      "hide-output"
@@ -71,6 +34,9 @@
    },
    "outputs": [],
    "source": [
+    "import lamindb as ln\n",
+    "\n",
+    "# create toy data\n",
     "ln.Artifact(ln.core.datasets.file_jpg_paradisi05(), description=\"My image\").save()\n",
     "ln.Artifact.from_df(ln.core.datasets.df_iris(), description=\"The iris collection\").save()\n",
     "ln.Artifact(ln.core.datasets.file_fastq(), description=\"My fastq\").save()"
@@ -122,34 +88,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "user = users.testuser1"
+    "user = users.testuser1\n",
+    "user"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf7e1415",
+   "metadata": {},
+   "source": [
+    "You can also get a dictionary, if you prefer:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b19ac180",
+   "id": "04130d47",
    "metadata": {},
    "outputs": [],
    "source": [
-    "user"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "196ffb27",
-   "metadata": {},
-   "source": [
-    ":::{note}\n",
-    "\n",
-    "You can also auto-complete in a dictionary:\n",
-    "\n",
-    "```python\n",
-    "users_dict = ln.User.lookup().dict()\n",
-    "```\n",
-    "\n",
-    ":::"
+    "users_dict = ln.User.lookup().dict()"
    ]
   },
   {
@@ -188,9 +146,8 @@
    "source": [
     "To access the results encoded in a filter statement, execute its return value with one of:\n",
     "\n",
-    "- `.df()`: A pandas `DataFrame` with each record stored as a row.\n",
-    "- `.all()`: An indexable django `QuerySet`.\n",
-    "- `.list()`: A list of records.\n",
+    "- `.df()`: A pandas `DataFrame` with each record in a row.\n",
+    "- `.all()`: A {class}`~lamindb.core.QuerySet`.\n",
     "- `.one()`: Exactly one record. Will raise an error if there is none.\n",
     "- `.one_or_none()`: Either one record or `None` if there is no query result."
    ]
@@ -226,7 +183,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7ccda1e1",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "ln.Artifact.search(\"iris\").df()"
@@ -248,12 +209,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.save(\n",
-    "    [\n",
-    "        ln.Transform(name=title, type=\"notebook\")\n",
-    "        for title in ln.core.datasets.fake_bio_notebook_titles(n=500)\n",
-    "    ]\n",
-    ")"
+    "transforms = [ln.Transform(name=title, type=\"notebook\") for title in ln.core.datasets.fake_bio_notebook_titles(n=500)]\n",
+    "ln.save(transforms)"
    ]
   },
   {
@@ -269,7 +226,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4b0b0c0c",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "ln.Transform.search(\"intestine\").df().head()"
@@ -299,10 +260,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7f9ce71b",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
-    "ln.Artifact.filter(run__created_by__handle__startswith=\"testuse\").df()"
+    "ln.Artifact.filter(run__created_by__handle__startswith=\"testuse\").df()  "
    ]
   },
   {
@@ -313,7 +278,7 @@
    "source": [
     "The filter selects all artifacts based on the users who ran the generating notebook.\n",
     "\n",
-    "(Under the hood, in the SQL database, it's joining the artifact table with the run and the user table.)\n",
+    "Under the hood, in the SQL database, it's joining the artifact table with the run and the user table.\n",
     "\n"
    ]
   },
@@ -323,9 +288,7 @@
    "id": "28710b83",
    "metadata": {},
    "source": [
-    "Beyond `__startswith`, Django supports about [two dozen field comparators](https://docs.djangoproject.com/en/stable/ref/models/querysets/#field-lookups) `field__comparator=value`.\n",
-    "\n",
-    "Here are some of them."
+    "Beyond `__startswith`, Django supports about [two dozen field comparators](https://docs.djangoproject.com/en/stable/ref/models/querysets/#field-lookups) `field__comparator=value`. Below follow some of them."
    ]
   },
   {
@@ -341,7 +304,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5b6ec3ca-bea4-4097-897b-94322a64506a",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "ln.Artifact.filter(suffix=\".jpg\", created_by=user).df()"
@@ -362,14 +329,18 @@
    "id": "fdd61cf1-d3c7-4bfb-a0b2-14e81201db03",
    "metadata": {},
    "source": [
-    "Or subset to artifacts greater than 10kB. Here, we can't use keyword arguments, but need an explicit where statement."
+    "Or subset to artifacts smaller than 10kB. Here, we can't use keyword arguments, but need an explicit where statement."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "a7f73e99-614d-443b-b8a1-f1acea0f1538",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "ln.Artifact.filter(created_by=user, size__lt=1e4).df()"
@@ -388,12 +359,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0d1b9a73",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
-    "from django.db.models import Q\n",
-    "\n",
-    "ln.Artifact.filter().filter(Q(suffix=\".jpg\") | Q(suffix=\".fastq.gz\")).df()"
+    "ln.Artifact.filter().filter(ln.Q(suffix=\".jpg\") | ln.Q(suffix=\".fastq.gz\")).df()"
    ]
   },
   {
@@ -409,7 +382,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "fd26b709",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "ln.Artifact.filter(suffix__in=[\".jpg\", \".fastq.gz\"]).df()"
@@ -428,7 +405,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b87bec42",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "ln.Artifact.filter().order_by(\"-updated_at\").df()"
@@ -447,7 +428,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "214b9a56",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "ln.Transform.filter(name__contains=\"search\").df().head(10)"
@@ -465,7 +450,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "36d300b1",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "ln.Transform.filter(name__icontains=\"Search\").df().head(10)"
@@ -484,7 +473,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "32fc9bd7",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "ln.Transform.filter(name__startswith=\"Research\").df()"

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -77,9 +77,7 @@
    },
    "outputs": [],
    "source": [
-    "import lamindb as ln\n",
-    "\n",
-    "ln.settings.verbosity = \"hint\""
+    "import lamindb as ln"
    ]
   },
   {
@@ -476,7 +474,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If the data is large, you'll likely want to query it via {meth}`~lamindb.Artifact.open` or shard the adata across many array-like artifacts. For more on this, see: {doc}`data`.\n",
+    "If the data is large, you'll likely want to query it via {meth}`~lamindb.Artifact.open` or shard the adata across many array-like artifacts. For more on this, see: {doc}`arrays`.\n",
     "\n",
     ":::{dropdown} How do I update an artifact?\n",
     "\n",
@@ -587,7 +585,7 @@
     "* `name__startswith=\"Martha\"`: `name` starts with `\"Martha`\n",
     "* `name__in=[\"Martha\", \"John\"]`: `name` is `\"John\"` or `\"Martha\"`\n",
     "\n",
-    "For more info, see: {doc}`meta`.\n",
+    "For more info, see: {doc}`records`.\n",
     "\n",
     ":::\n",
     "\n",
@@ -649,7 +647,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more info, see: {doc}`meta`."
+    "For more info, see: {doc}`records`."
    ]
   },
   {

--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -109,3 +109,4 @@ if _check_instance_setup(from_lamindb=True):
 
     track = _run_context._track
     settings.__doc__ = """Global :class:`~lamindb.core.Settings`."""
+    from django.db.models import Q

--- a/noxfile.py
+++ b/noxfile.py
@@ -29,8 +29,8 @@ GROUPS["tutorial"] = [
     "transfer.ipynb",
 ]
 GROUPS["guide"] = [
-    "data.ipynb",
-    "meta.ipynb",
+    "arrays.ipynb",
+    "records.ipynb",
     "track.ipynb",
     "annotate.ipynb",
     "annotate-flexible.ipynb",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ classifiers = [
 ]
 dependencies = [
     # Lamin PINNED packages
-    "lnschema_core==0.70.2",
-    "lamindb_setup==0.74.0",
+    "lnschema_core==0.70.4",
+    "lamindb_setup==0.74.1",
     "lamin_utils==0.13.2",
     "lamin_cli==0.15.0",
     # others
@@ -39,7 +39,7 @@ Home = "https://github.com/laminlabs/lamindb"
 
 [project.optional-dependencies]
 bionty = [
-    "bionty==0.44.1",
+    "bionty==0.44.2",
 ]
 aws = [
     "lamindb_setup[aws]",


### PR DESCRIPTION
Also: 

- Rename meta.ipynb to records.ipynb and data.ipynb to arrays.ipynb
- Expose django.db.models.Q as lamindb.Q
- Rename docs section `reference` to `API`