### PR TITLE
👷 Add a contributing guide, make installation from GitHub easier

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         run: sudo apt-get -y install graphviz
       - run: nox -s lint
         if: ${{ matrix.group == 'tutorial' }} # choose a fast-running a group
-      - run: nox -s "install(group='${{ matrix.group }}')"
+      - run: nox -s "install_ci(group='${{ matrix.group }}')"
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
         with:
           python-version: "3.10" # use 3.10, 3.8 and 3.11 give issues
       - run: pip install -U laminci
-      - run: nox -s "install(group='docs')"
+      - run: nox -s "install_ci(group='docs')"
       - uses: actions/download-artifact@v2
       - run: nox -s docs
       - uses: nwtgck/actions-netlify@v1.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,3 +19,10 @@ Running tests requires the Docker daemon up, then run at the root of the reposit
 ```
 pytest
 ```
+
+We use `pre-commit` and `gitmoji`. At the root of your repo, please call
+
+```
+gitmoji -i
+pre-commit install
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+Contributions are generally welcome. Please make an issue to discuss proposals.
+
+For installation from PyPI, see [docs.lamin.ai/setup](https://docs.lamin.ai/setup).
+
+For installation from GitHub, call:
+
+```
+git clone --recursive https://github.com/laminlabs/lamindb
+pip install laminci
+nox -s install
+```
+
+This will install a few dependencies from the git submodules linked [here](https://github.com/laminlabs/lamindb/tree/main/sub).
+
+Running tests requires the Docker daemon up, then run at the root of the repository:
+
+```
+pytest
+```

--- a/docs/includes/installation.md
+++ b/docs/includes/installation.md
@@ -27,4 +27,6 @@ zarr      # store & stream arrays with zarr
 erdiagram # display schema graphs
 ```
 
+If you'd like to install from GitHub, see [here](https://github.com/laminlabs/lamindb/blob/main/README.md).
+
 If you'd like a docker container, here is a way: [github.com/laminlabs/lamindb-docker](https://github.com/laminlabs/lamindb-docker).

--- a/docs/setup.ipynb
+++ b/docs/setup.ipynb
@@ -14,7 +14,7 @@
    "source": [
     "## Installation\n",
     "\n",
-    "```{include} installation.md\n",
+    "```{include} includes/installation.md\n",
     "\n",
     "```"
    ]


### PR DESCRIPTION
It's now pleasant to use: 
```
nox -s install
```

There is a contributing guide at `CONTRIBUTING.md` at the root of the repo, linked from the installation section in the docs.

