### PR TITLE
🐛 Fix `using_key` for source and organism

### DIFF
--- a/lamindb/_can_validate.py
+++ b/lamindb/_can_validate.py
@@ -60,6 +60,25 @@ def validate(
     )
 
 
+def _check_source_db(source: Record, using_key: str | None):
+    """Check if the source is from the DB."""
+    if using_key is not None and using_key != "default":
+        if source._state.db != using_key:
+            raise ValueError(
+                f"source must be a bionty.Source record from instance '{using_key}'!"
+            )
+
+
+def _check_organism_db(organism: Record, using_key: str | None):
+    """Check if the organism is from the DB."""
+    if isinstance(organism, Record):
+        if using_key is not None and using_key != "default":
+            if organism._state.db != using_key:
+                raise ValueError(
+                    f"organism must be a bionty.Organism record from instance '{using_key}'!"
+                )
+
+
 def _inspect(
     cls,
     values: ListLike,
@@ -78,8 +97,11 @@ def _inspect(
 
     field = get_name_field(cls, field=field)
     queryset = _queryset(cls, using_key)
-    if isinstance(source, Record) and hasattr(cls, "source_id"):
+    using_key = queryset.db
+    if isinstance(source, Record):
+        _check_source_db(source, using_key)
         queryset = queryset.filter(source=source).all()
+    _check_organism_db(organism, using_key)
     orm = queryset.model
     model_name = orm._meta.model.__name__
 
@@ -166,8 +188,11 @@ def _validate(
     field = get_name_field(cls, field=field)
 
     queryset = _queryset(cls, using_key)
-    if isinstance(source, Record) and hasattr(cls, "source_id"):
+    using_key = queryset.db
+    if isinstance(source, Record):
+        _check_source_db(source, using_key)
         queryset = queryset.filter(source=source).all()
+    _check_organism_db(organism, using_key)
     field_values = pd.Series(
         _filter_query_based_on_organism(
             queryset=queryset,
@@ -296,8 +321,11 @@ def _standardize(
         cls, field=field if return_field is None else return_field
     )
     queryset = _queryset(cls, using_key)
-    if isinstance(source, Record) and hasattr(cls, "source_id"):
+    using_key = queryset.db
+    if isinstance(source, Record):
+        _check_source_db(source, using_key)
         queryset = queryset.filter(source=source).all()
+    _check_organism_db(organism, using_key)
     orm = queryset.model
 
     if _has_organism_field(orm):

--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -360,7 +360,7 @@ def get_name_field(
 def _queryset(cls: Record | QuerySet | Manager, using_key: str) -> QuerySet:
     if isinstance(cls, (QuerySet, Manager)):
         return cls.all()
-    elif using_key is None:
+    elif using_key is None or using_key == "default":
         return cls.objects.all()
     else:
         # using must be called on cls, otherwise the connection isn't found

--- a/tests/test_curate.py
+++ b/tests/test_curate.py
@@ -68,7 +68,7 @@ def categoricals():
 
 @pytest.fixture
 def curate_lookup(categoricals):
-    return CurateLookup(categoricals=categoricals, using="undefined")
+    return CurateLookup(categoricals=categoricals, using_key="undefined")
 
 
 @pytest.fixture


### PR DESCRIPTION
Now raise error if the instance of `source` or `organism` record doesn't match the using instance.