### PR TITLE
✨ New features for MappedCollection

### DIFF
--- a/lamindb/core/_mapped_collection.py
+++ b/lamindb/core/_mapped_collection.py
@@ -374,7 +374,7 @@ class MappedCollection:
             label = label.decode("utf-8")
         return label
 
-    def get_label_weights(self, obs_keys: str | list[str]):
+    def get_label_weights(self, obs_keys: str | list[str], scaler: float | None = None):
         """Get all weights for the given label keys."""
         if isinstance(obs_keys, str):
             obs_keys = [obs_keys]
@@ -386,8 +386,12 @@ class MappedCollection:
             labels = ["__".join(labels_obs) for labels_obs in zip(*labels_list)]
         else:
             labels = labels_list[0]
-        counter = Counter(labels)  # type: ignore
-        weights = 1.0 / np.array([counter[label] for label in labels])
+        counter = Counter(labels)
+        counts = np.array([counter[label] for label in labels])
+        if scaler is None:
+            weights = 1.0 / counts
+        else:
+            weights = scaler / (counts + scaler)
         return weights
 
     def get_merged_labels(self, label_key: str):

--- a/lamindb/core/_mapped_collection.py
+++ b/lamindb/core/_mapped_collection.py
@@ -383,7 +383,7 @@ class MappedCollection:
             labels_to_str = self.get_merged_labels(label_key).astype(str).astype("O")
             labels_list.append(labels_to_str)
         if len(labels_list) > 1:
-            labels = map("__".join, zip(*labels_list))
+            labels = ["__".join(labels_obs) for labels_obs in zip(*labels_list)]
         else:
             labels = labels_list[0]
         counter = Counter(labels)  # type: ignore

--- a/lamindb/core/_mapped_collection.py
+++ b/lamindb/core/_mapped_collection.py
@@ -271,7 +271,11 @@ class MappedCollection:
         return all(vrs_sort_status)
 
     def check_vars_non_aligned(self, vars: pd.Index | list) -> list[int]:
-        """Returns indices of objects with non-aligned variables."""
+        """Returns indices of objects with non-aligned variables.
+
+        Args:
+            vars: Check alignment against these variables.
+        """
         if self.var_list is None:
             self._read_vars()
         vars = pd.Index(vars)

--- a/lamindb/core/_mapped_collection.py
+++ b/lamindb/core/_mapped_collection.py
@@ -383,10 +383,9 @@ class MappedCollection:
             labels_to_str = self.get_merged_labels(label_key).astype(str).astype("O")
             labels_list.append(labels_to_str)
         if len(labels_list) > 1:
-            labels = reduce(lambda a, b: a + b, labels_list)
+            labels = map("__".join, zip(*labels_list))
         else:
             labels = labels_list[0]
-        labels = self.get_merged_labels(label_key)
         counter = Counter(labels)  # type: ignore
         weights = 1.0 / np.array([counter[label] for label in labels])
         return weights

--- a/lamindb/core/_mapped_collection.py
+++ b/lamindb/core/_mapped_collection.py
@@ -378,7 +378,7 @@ class MappedCollection:
         self,
         obs_keys: str | list[str],
         scaler: float | None = None,
-        return_cats: bool = False,
+        return_categories: bool = False,
     ):
         """Get all weights for the given label keys."""
         if isinstance(obs_keys, str):
@@ -392,7 +392,7 @@ class MappedCollection:
         else:
             labels = labels_list[0]
         counter = Counter(labels)
-        if return_cats:
+        if return_categories:
             return {
                 k: 1.0 / v if scaler is None else scaler / (v + scaler)
                 for k, v in counter.items()

--- a/lamindb/core/_mapped_collection.py
+++ b/lamindb/core/_mapped_collection.py
@@ -149,7 +149,7 @@ class MappedCollection:
         self.storages = []  # type: ignore
         self.conns = []  # type: ignore
         self.parallel = parallel
-        self._path_list = path_list
+        self.path_list = path_list
         self._make_connections(path_list, parallel)
 
         self.n_obs_list = []
@@ -165,11 +165,12 @@ class MappedCollection:
         self.indices = np.hstack([np.arange(n_obs) for n_obs in self.n_obs_list])
         self.storage_idx = np.repeat(np.arange(len(self.storages)), self.n_obs_list)
 
-        self.join_vars = join
-        self.var_indices = None
-        self.var_joint = None
-        self.n_vars_list = None
-        self.n_vars = None
+        self.join_vars: Literal["inner", "outer"] | None = join
+        self.var_indices: list | None = None
+        self.var_joint: pd.Index | None = None
+        self.n_vars_list: list | None = None
+        self.var_list: list | None = None
+        self.n_vars: int | None = None
         if self.join_vars is not None:
             self._make_join_vars()
             self.n_vars = len(self.var_joint)
@@ -225,43 +226,67 @@ class MappedCollection:
             encoder.update({cat: i for i, cat in enumerate(cats)})
             self.encoders[label] = encoder
 
-    def _make_join_vars(self):
-        var_list = []
+    def _read_vars(self):
+        self.var_list = []
         self.n_vars_list = []
         for storage in self.storages:
             with _Connect(storage) as store:
                 vars = _safer_read_index(store["var"])
-                var_list.append(vars)
+                self.var_list.append(vars)
                 self.n_vars_list.append(len(vars))
 
-        vars_eq = all(var_list[0].equals(vrs) for vrs in var_list[1:])
+    def _make_join_vars(self):
+        if self.var_list is None:
+            self._read_vars()
+        vars_eq = all(self.var_list[0].equals(vrs) for vrs in self.var_list[1:])
         if vars_eq:
             self.join_vars = None
-            self.var_joint = var_list[0]
+            self.var_joint = self.var_list[0]
             return
 
         if self.join_vars == "inner":
-            self.var_joint = reduce(pd.Index.intersection, var_list)
+            self.var_joint = reduce(pd.Index.intersection, self.var_list)
             if len(self.var_joint) == 0:
                 raise ValueError(
                     "The provided AnnData objects don't have shared varibales.\n"
                     "Use join='outer'."
                 )
-            self.var_indices = [vrs.get_indexer(self.var_joint) for vrs in var_list]
+            self.var_indices = [
+                vrs.get_indexer(self.var_joint) for vrs in self.var_list
+            ]
         elif self.join_vars == "outer":
-            self.var_joint = reduce(pd.Index.union, var_list)
-            self.var_indices = [self.var_joint.get_indexer(vrs) for vrs in var_list]
+            self.var_joint = reduce(pd.Index.union, self.var_list)
+            self.var_indices = [
+                self.var_joint.get_indexer(vrs) for vrs in self.var_list
+            ]
+
+    def check_vars_sorted(self, ascending: bool = True) -> bool:
+        """Returns `True` if all variables are sorted in all objects."""
+        if self.var_list is None:
+            self._read_vars()
+        if ascending:
+            vrs_sort_status = (vrs.is_monotonic_increasing for vrs in self.var_list)
+        else:
+            vrs_sort_status = (vrs.is_monotonic_decreasing for vrs in self.var_list)
+        return all(vrs_sort_status)
+
+    def check_vars_non_aligned(self, vars: pd.Index | list) -> list[int]:
+        """Returns indices of objects with non-aligned variables."""
+        if self.var_list is None:
+            self._read_vars()
+        vars = pd.Index(vars)
+        return [i for i, vrs in enumerate(self.var_list) if not vrs.equals(vars)]
 
     def __len__(self):
         return self.n_obs
 
     @property
-    def shape(self):
+    def shape(self) -> tuple[int, int]:
         """Shape of the (virtually aligned) dataset."""
         return (self.n_obs, self.n_vars)
 
     @property
-    def original_shapes(self):
+    def original_shapes(self) -> list[tuple[int, int]]:
         """Shapes of the underlying AnnData objects."""
         if self.n_vars_list is None:
             n_vars_list = [None] * len(self.n_obs_list)
@@ -510,7 +535,7 @@ class MappedCollection:
         self._closed = True
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         """Check if connections to array streaming backend are closed.
 
         Does not matter if `parallel=True`.
@@ -535,4 +560,4 @@ class MappedCollection:
         mapped.parallel = False
         mapped.storages = []
         mapped.conns = []
-        mapped._make_connections(mapped._path_list, parallel=False)
+        mapped._make_connections(mapped.path_list, parallel=False)

--- a/lamindb/core/_mapped_collection.py
+++ b/lamindb/core/_mapped_collection.py
@@ -380,7 +380,21 @@ class MappedCollection:
         scaler: float | None = None,
         return_categories: bool = False,
     ):
-        """Get all weights for the given label keys."""
+        """Get all weights for the given label keys.
+
+        This counts the number of labels for each label and returns
+        weights for each obs label accoding to the formula `1 / num of this label in the data`.
+        If `scaler` is provided, then `scaler / (scaler + num of this label in the data)`.
+
+        Args:
+            obs_keys: A key in the ``.obs`` slots or a list of keys. If a list is provided,
+                the labels from the obs keys will be concatenated with ``"__"`` delimeter
+            scaler: Use this number to scale the provided weights.
+            return_categories: If `False`, returns weights for each observation,
+                can be directly passed to a sampler. If `True`, returns a dictionary with
+                unique categories for labels (concatenated if `obs_keys` is a list)
+                and their weights.
+        """
         if isinstance(obs_keys, str):
             obs_keys = [obs_keys]
         labels_list = []

--- a/lamindb/core/_mapped_collection.py
+++ b/lamindb/core/_mapped_collection.py
@@ -426,7 +426,7 @@ class MappedCollection:
                     codes = self._get_codes(store, label_key)
                     codes = decode(codes) if isinstance(codes[0], bytes) else codes
                     cats_merge.update(codes)
-        return cats_merge
+        return sorted(cats_merge)
 
     def _get_categories(self, storage: StorageType, label_key: str):  # type: ignore
         """Get categories."""

--- a/lamindb/core/_mapped_collection.py
+++ b/lamindb/core/_mapped_collection.py
@@ -374,7 +374,12 @@ class MappedCollection:
             label = label.decode("utf-8")
         return label
 
-    def get_label_weights(self, obs_keys: str | list[str], scaler: float | None = None):
+    def get_label_weights(
+        self,
+        obs_keys: str | list[str],
+        scaler: float | None = None,
+        return_cats: bool = False,
+    ):
         """Get all weights for the given label keys."""
         if isinstance(obs_keys, str):
             obs_keys = [obs_keys]
@@ -387,6 +392,11 @@ class MappedCollection:
         else:
             labels = labels_list[0]
         counter = Counter(labels)
+        if return_cats:
+            return {
+                k: 1.0 / v if scaler is None else scaler / (v + scaler)
+                for k, v in counter.items()
+            }
         counts = np.array([counter[label] for label in labels])
         if scaler is None:
             weights = 1.0 / counts

--- a/lamindb/core/storage/_valid_suffixes.py
+++ b/lamindb/core/storage/_valid_suffixes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from lamindb_setup.core.upath import VALID_COMPOSITE_SUFFIXES, VALID_SIMPLE_SUFFIXES
 
 # add new composite suffixes like so

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -243,8 +243,10 @@ def test_collection_mapped(adata, adata2):
     assert len(ls_ds[0]["X"]) == 3
     assert np.array_equal(ls_ds[2]["X"], np.array([1, 2, 5]))
     weights = ls_ds.get_label_weights("feat1")
+    assert len(weights) == 4
     assert all(weights[1:] == weights[0])
     weights = ls_ds.get_label_weights(["feat1", "feat2"])
+    assert len(weights) == 4
     assert all(weights[1:] == weights[0])
     ls_ds.close()
     assert ls_ds.closed

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -215,12 +215,11 @@ def test_collection_mapped(adata, adata2):
     ) as ls_ds:
         assert ls_ds.encoders["feat1"]["A"] == -1
         assert ls_ds.encoders["feat1"]["B"] == 0
-        # can't predict order of elements in set
+        # categories in the encoder are sorted
         A_enc = ls_ds.encoders["feat2"]["A"]
+        assert A_enc == 0
         B_enc = ls_ds.encoders["feat2"]["B"]
-        assert A_enc in (0, 1)
-        assert B_enc in (0, 1)
-        assert A_enc != B_enc
+        assert B_enc == 1
         assert ls_ds[0]["feat1"] == -1
         assert ls_ds[1]["feat1"] == 0
         assert ls_ds[0]["feat2"] == A_enc

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -244,10 +244,12 @@ def test_collection_mapped(adata, adata2):
     assert np.array_equal(ls_ds[2]["X"], np.array([1, 2, 5]))
     weights = ls_ds.get_label_weights("feat1")
     assert len(weights) == 4
-    assert all(weights[1:] == weights[0])
+    assert all(weights == 0.5)
     weights = ls_ds.get_label_weights(["feat1", "feat2"])
     assert len(weights) == 4
-    assert all(weights[1:] == weights[0])
+    assert all(weights == 0.5)
+    weights = ls_ds.get_label_weights(["feat1", "feat2"], scaler=1.0)
+    assert all(weights == 1.0 / 3.0)
     ls_ds.close()
     assert ls_ds.closed
     del ls_ds

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -259,9 +259,9 @@ def test_collection_mapped(adata, adata2):
     assert not ls_ds.check_vars_sorted(ascending=True)
     assert not ls_ds.check_vars_sorted(ascending=False)
     assert ls_ds.check_vars_non_aligned(["MYC", "TCF7", "GATA1"]) == []
-    ls_ds.vars_list = None
+    ls_ds.var_list = None
     assert not ls_ds.check_vars_sorted()
-    ls_ds.vars_list = None
+    ls_ds.var_list = None
     assert ls_ds.check_vars_non_aligned(["MYC", "TCF7", "GATA1"]) == []
 
     ls_ds.close()

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -255,6 +255,15 @@ def test_collection_mapped(adata, adata2):
     )
     assert weights["A__A"] == 1.0 / 3.0
     assert weights["B__B"] == 1.0 / 3.0
+
+    assert not ls_ds.check_vars_sorted(ascending=True)
+    assert not ls_ds.check_vars_sorted(ascending=False)
+    assert ls_ds.check_vars_non_aligned(["MYC", "TCF7", "GATA1"]) == []
+    ls_ds.vars_list = None
+    assert not ls_ds.check_vars_sorted()
+    ls_ds.vars_list = None
+    assert ls_ds.check_vars_non_aligned(["MYC", "TCF7", "GATA1"]) == []
+
     ls_ds.close()
     assert ls_ds.closed
     del ls_ds
@@ -307,6 +316,8 @@ def test_collection_mapped(adata, adata2):
         assert np.issubdtype(ls_ds[2]["X"].dtype, np.integer)
         assert np.issubdtype(ls_ds[4]["X"].dtype, np.integer)
         assert np.array_equal(ls_ds[3]["obsm_X_pca"], np.array([3, 4]))
+        assert ls_ds.check_vars_non_aligned(["MYC", "TCF7", "GATA1"]) == [2]
+        assert not ls_ds.check_vars_sorted()
 
     with collection_outer.mapped(layers_keys="layer1", join="outer") as ls_ds:
         assert np.array_equal(ls_ds[0]["layer1"], np.array([0, 0, 0, 3, 0, 2]))

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -250,7 +250,9 @@ def test_collection_mapped(adata, adata2):
     assert all(weights == 0.5)
     weights = ls_ds.get_label_weights(["feat1", "feat2"], scaler=1.0)
     assert all(weights == 1.0 / 3.0)
-    weights = ls_ds.get_label_weights(["feat1", "feat2"], scaler=1.0, return_cats=True)
+    weights = ls_ds.get_label_weights(
+        ["feat1", "feat2"], scaler=1.0, return_categories=True
+    )
     assert weights["A__A"] == 1.0 / 3.0
     assert weights["B__B"] == 1.0 / 3.0
     ls_ds.close()

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -250,6 +250,9 @@ def test_collection_mapped(adata, adata2):
     assert all(weights == 0.5)
     weights = ls_ds.get_label_weights(["feat1", "feat2"], scaler=1.0)
     assert all(weights == 1.0 / 3.0)
+    weights = ls_ds.get_label_weights(["feat1", "feat2"], scaler=1.0, return_cats=True)
+    assert weights["A__A"] == 1.0 / 3.0
+    assert weights["B__B"] == 1.0 / 3.0
     ls_ds.close()
     assert ls_ds.closed
     del ls_ds


### PR DESCRIPTION
https://github.com/laminlabs/lamindb/pull/1809
This add the features requested by @jkobject 

>checking variables are aligned across datasets

I have added a function `check_vars_non_aligned` that returns a list of objects' indices that are not aligned with the provided variables list.
```
mapped = MappedCollection(...)
mapped.check_vars_non_aligned(var_list) # returns a list of indices of objects with non-aligned variables
```
I haven't added this check by default because in general it is not needed when `join="inner"` or `"outer"` is used, but i think it is fine to have as a separate function.

>checking that variables are sorted across datasets

I have added `check_vars_sorted`
```
mapped.check_vars_sorted(ascending=True) # returns True if sorted in ascending order
mapped.check_vars_sorted(ascending=False) # descending
```

>allowing for a weight scaler and outputting the different elements we are weighting on

I see that `get_label_weights` didn't work properly before with several obs keys. Now i have fixed that and added proper tests. It concatenates labels from several keys and computes weight based on the number of these concatenated label categories.
I have added the scaler. It is `None` by default.
I have also added  `return_categories` argument, it is `False` by default, but if `True`, the function returns a dictionary with categories and their weight. It is more convenient in my opinion to have it `False` by default because than weight can be provided directly to a sampler.
```
mapped.get_label_weights(obs_keys=["key1", "key2"], scaler=10.) # returns weights for each observation
mapped.get_label_weights(obs_keys=["key1", "key2"], scaler=10., return_categories=True) # returns a dict with categories and their weights.
```
Also improved the docstring of this function.

>sorting the categories otherwise the encoder will change everytime it is used

Done.
