### PR TITLE
🚸 Enable versioning artifacts based on `key` akin to the AWS S3 behavior

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,14 +37,14 @@ jobs:
         with:
           python-version: "3.11"
       - name: cache pre-commit
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: cache postgres
         if: ${{ matrix.group == 'faq' || matrix.group == 'unit' }}
         id: cache-postgres
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/postgres.tar
           key: cache-postgres-0
@@ -64,7 +64,7 @@ jobs:
       - run: nox -s lint
         if: ${{ matrix.group == 'tutorial' }} # choose a fast-running a group
       - run: nox -s "install_ci(group='${{ matrix.group }}')"
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -97,7 +97,7 @@ jobs:
           ssh-key: ${{ secrets.READ_LNDOCS }}
           path: lndocs
           ref: main
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           - "faq"
           - "storage"
           - "cli"
-    timeout-minutes: 10
+    timeout-minutes: 11
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/introduction.ipynb
+++ b/docs/introduction.ipynb
@@ -169,26 +169,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "View data lineage."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "artifact.view_lineage()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Load an artifact."
    ]
   },
@@ -209,7 +189,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Revise an artifact."
+    "Create a new version of an artifact."
    ]
   },
   {
@@ -258,22 +238,45 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "View data lineage."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "artifact_v2.view_lineage()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     ":::{dropdown} How does this look for a file or folder?\n",
     "\n",
-    "Local:\n",
+    "Source path is local:\n",
     "\n",
     "```python\n",
     "ln.Artifact(\"./my_data.fcs\", description=\"my flow cytometry file\")\n",
     "ln.Artifact(\"./my_images/\", description=\"my folder of images\")\n",
     "```\n",
+    "<br>\n",
     "\n",
-    "Remote:\n",
+    "Upon `artifact.save()`, the source path will be copied (uploaded) into your default storage.\n",
+    "\n",
+    "If the source path is remote, `artifact.save()` won't trigger data duplication but register the existing path.\n",
     "\n",
     "```python\n",
     "ln.Artifact(\"s3://my-bucket/my_data.fcs\", description=\"my flow cytometry file\")\n",
     "ln.Artifact(\"s3://my-bucket/my_images/\", description=\"my folder of images\")\n",
     "```\n",
-    "\n",
+    "<br>\n",
     "You can also use other remote file systems supported by `fsspec`.\n",
     "\n",
     ":::\n",

--- a/docs/introduction.ipynb
+++ b/docs/introduction.ipynb
@@ -974,7 +974,7 @@
    "metadata": {},
    "source": [
     "```\n",
-    "ln.finish()\n",
+    "ln.context.finish()\n",
     "```"
    ]
   },

--- a/docs/introduction.ipynb
+++ b/docs/introduction.ipynb
@@ -116,9 +116,9 @@
     "\n",
     "git, by comparison, identifies code by its content hash & file name. If you rename a notebook or script file and change the content, you lose the identity of the file. Notebook platforms like Google Colab and DeepNote support renaming and changing content of a given notebook, but they do not support versioning in a simple queryable way: every notebook version comes with the same [notebook id](https://lamin.ai/blog/nbproject#metadata-tracking).\n",
     "\n",
-    "To enable versioning, LaminDB auto-generates `uid` values so that different versions of a transform are grouped by a random \"stem uid\" `suid`: the 12 initial characters of the `uid`. The remaining 4 characters of the `uid` encode the version in a `vuid`, hence, `uid = f\"{suid}{vuid}\"`. You can optionally label any given version with a tag via the `transform.version` field.\n",
+    "To enable versioning, LaminDB auto-generates `uid = f\"{suid}{vuid}\"` so that different versions of a transform are grouped by a random \"stem uid\" `suid` (the first part of the `uid`) while the last **four** characters encode a version in a `vuid` (an auto-incrementing base62 number). You can optionally tag a version using the `.version` field.\n",
     "\n",
-    "Datasets and all other versioned entities in lamindb are versioned in the same way.\n",
+    "All versioned entities in lamindb are versioned in this way, including artifacts and collections.\n",
     "\n",
     ":::"
    ]
@@ -152,7 +152,7 @@
     "# a sample dataset\n",
     "df = pd.DataFrame(\n",
     "    {\"CD8A\": [1, 2, 3], \"CD4\": [3, 4, 5], \"CD14\": [5, 6, 7], \"perturbation\": [\"DMSO\", \"IFNG\", \"DMSO\"]},\n",
-    "    index=[\"observation1\", \"observation2\", \"observation3\"],\n",
+    "    index=[\"sample1\", \"sample2\", \"sample3\"],\n",
     ")\n",
     "\n",
     "# create an artifact from a DataFrame\n",
@@ -169,7 +169,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "View data lineage:"
+    "View data lineage."
    ]
   },
   {
@@ -189,7 +189,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Load an artifact:"
+    "Load an artifact."
    ]
   },
   {
@@ -203,6 +203,55 @@
    "outputs": [],
    "source": [
     "artifact.load()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Revise an artifact."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# update the dataframe\n",
+    "df.loc[\"sample2\", \"perturbation\"] = \"IL-12\"\n",
+    "\n",
+    "# create a new version of `artifact`\n",
+    "artifact_v2 = ln.Artifact.from_df(df, revises=artifact).save()\n",
+    "\n",
+    "# see all versions of an artifact\n",
+    "artifact_v2.versions.df()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Similar to git, you can tag a version."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "artifact_v2.version = \"1.0\"\n",
+    "artifact_v2.save()\n",
+    "artifact_v2.versions.df()"
    ]
   },
   {
@@ -266,22 +315,6 @@
     "```\n",
     "\n",
     "You can open large artifacts for slicing from the cloud or load small artifacts directly into memory.\n",
-    "\n",
-    ":::\n",
-    "\n",
-    ":::{dropdown} How to version artifacts?\n",
-    "\n",
-    "Every artifact is auto-versioned by its `hash` and the last for characters of the `uid`.\n",
-    "\n",
-    "You can optionally pass a human-readable `version` field when you create new versions via:\n",
-    "\n",
-    "```python\n",
-    "artifact_v2 = ln.Artifact(\"my_path\", revises=artifact_v1)\n",
-    "```\n",
-    "\n",
-    "Artifacts of the same version family share the same uid stem (the first 16 characters of the `uid`).\n",
-    "\n",
-    "You can see all versions of an artifact via `artifact.versions`.\n",
     "\n",
     ":::"
    ]
@@ -857,7 +890,7 @@
     "        \"CD38\": [4, 2, 3],\n",
     "        \"perturbation\": [\"DMSO\", \"IFNG\", \"IFNG\"]\n",
     "    },\n",
-    "    index=[\"observation4\", \"observation5\", \"observation6\"],\n",
+    "    index=[\"sample4\", \"sample5\", \"sample6\"],\n",
     ")\n",
     "adata = ad.AnnData(df[[\"CD8A\", \"CD4\", \"CD38\"]], obs=df[[\"perturbation\"]])\n",
     "\n",

--- a/docs/introduction.ipynb
+++ b/docs/introduction.ipynb
@@ -155,14 +155,11 @@
     "    index=[\"sample1\", \"sample2\", \"sample3\"],\n",
     ")\n",
     "\n",
-    "# create an artifact from a DataFrame\n",
-    "artifact = ln.Artifact.from_df(df, description=\"my RNA-seq\")\n",
+    "# create & save an artifact from a DataFrame\n",
+    "artifact = ln.Artifact.from_df(df, description=\"my RNA-seq\").save()\n",
     "\n",
     "# artifacts come with typed, relational metadata\n",
-    "artifact.describe()\n",
-    "\n",
-    "# save data & metadata in one operation\n",
-    "artifact.save()"
+    "artifact.describe()"
    ]
   },
   {

--- a/docs/introduction.ipynb
+++ b/docs/introduction.ipynb
@@ -116,7 +116,7 @@
     "\n",
     "git, by comparison, identifies code by its content hash & file name. If you rename a notebook or script file and change the content, you lose the identity of the file. Notebook platforms like Google Colab and DeepNote support renaming and changing content of a given notebook, but they do not support versioning in a simple queryable way: every notebook version comes with the same [notebook id](https://lamin.ai/blog/nbproject#metadata-tracking).\n",
     "\n",
-    "To enable versioning, LaminDB auto-generates `uid` values so that different versions of a transform are grouped by a random \"stem uid\" `suid`, consisting in the same first 12 characters of the `uid`. The remaining 4 characters encode a revision in a `ruid`, hence, `uid = f\"{suid}{ruid}\"`. You can optionally label any given version with a semantic tag via the `transform.version` field.\n",
+    "To enable versioning, LaminDB auto-generates `uid` values so that different versions of a transform are grouped by a random \"stem uid\" `suid`: the 12 initial characters of the `uid`. The remaining 4 characters of the `uid` encode the version in a `vuid`, hence, `uid = f\"{suid}{vuid}\"`. You can optionally label any given version with a tag via the `transform.version` field.\n",
     "\n",
     "Datasets and all other versioned entities in lamindb are versioned in the same way.\n",
     "\n",

--- a/docs/introduction.ipynb
+++ b/docs/introduction.ipynb
@@ -156,7 +156,7 @@
     ")\n",
     "\n",
     "# create an artifact from a DataFrame\n",
-    "artifact = ln.Artifact.from_df(df, description=\"my RNA-seq\", version=\"1\")\n",
+    "artifact = ln.Artifact.from_df(df, description=\"my RNA-seq\")\n",
     "\n",
     "# artifacts come with typed, relational metadata\n",
     "artifact.describe()\n",
@@ -644,7 +644,7 @@
     "curate.validate()\n",
     "\n",
     "# save curated artifact\n",
-    "artifact = curate.save_artifact(description=\"my RNA-seq\", version=\"1\")\n",
+    "artifact = curate.save_artifact(description=\"my RNA-seq\")\n",
     "artifact.describe()"
    ]
   },
@@ -755,7 +755,7 @@
     "curate.validate()\n",
     "\n",
     "# save curated artifact\n",
-    "artifact = curate.save_artifact(description=\"my RNA-seq\", version=\"1\")\n",
+    "artifact = curate.save_artifact(description=\"my RNA-seq\")\n",
     "artifact.describe()"
    ]
   },
@@ -896,7 +896,7 @@
    },
    "outputs": [],
    "source": [
-    "collection = ln.Collection([artifact, artifact2], name=\"my RNA-seq collection\", version=\"1\")\n",
+    "collection = ln.Collection([artifact, artifact2], name=\"my RNA-seq collection\")\n",
     "collection.save()\n",
     "collection.describe()\n",
     "collection.view_lineage()"

--- a/docs/introduction.ipynb
+++ b/docs/introduction.ipynb
@@ -151,7 +151,7 @@
     "\n",
     "# a sample dataset\n",
     "df = pd.DataFrame(\n",
-    "    {\"CD8A\": [1, 2, 3], \"CD4\": [3, 4, 5], \"CD14\": [5, 6, 7], \"perturbation\": [\"DMSO\", \"IFNG\", \"DMSO\"]},\n",
+    "    {\"CD8A\": [1, 2, 3], \"CD4\": [3, 4, 5], \"CD14\": [5, 6, 7], \"perturbation\": [\"DMSO\", \"IL-12\", \"DMSO\"]},\n",
     "    index=[\"sample1\", \"sample2\", \"sample3\"],\n",
     ")\n",
     "\n",
@@ -223,7 +223,7 @@
    "outputs": [],
    "source": [
     "# update the dataframe\n",
-    "df.loc[\"sample2\", \"perturbation\"] = \"IL-12\"\n",
+    "df.loc[\"sample2\", \"perturbation\"] = \"IFNG\"\n",
     "\n",
     "# create a new version of `artifact`\n",
     "artifact_v2 = ln.Artifact.from_df(df, revises=artifact).save()\n",

--- a/docs/introduction.ipynb
+++ b/docs/introduction.ipynb
@@ -118,7 +118,7 @@
     "\n",
     "To enable versioning, LaminDB auto-generates `uid = f\"{suid}{vuid}\"` so that different versions of a transform are grouped by a random \"stem uid\" `suid` (the first part of the `uid`) while the last **four** characters encode a version in a `vuid` (an auto-incrementing base62 number). You can optionally tag a version using the `.version` field.\n",
     "\n",
-    "All versioned entities in lamindb are versioned in this way, including artifacts and collections.\n",
+    "All versioned entities in LaminDB are versioned in this way, including artifacts and collections.\n",
     "\n",
     ":::"
    ]
@@ -166,7 +166,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Load an artifact."
+    "Load the dataset into memory."
    ]
   },
   {
@@ -179,6 +179,7 @@
    },
    "outputs": [],
    "source": [
+    "# returns a dataframe\n",
     "artifact.load()"
    ]
   },
@@ -186,7 +187,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create a new version of an artifact."
+    "Create a new version of the dataset."
    ]
   },
   {
@@ -213,7 +214,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Similar to git, you can tag a version."
+    "Similar to tagging a git commit, you can label a version."
    ]
   },
   {
@@ -249,6 +250,27 @@
    "outputs": [],
    "source": [
     "artifact_v2.view_lineage()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ":::{dropdown} I'd rather control versioning through a key or file path like on S3.\n",
+    "\n",
+    "That works, too, and you won't need to pass an old version via `revises`:\n",
+    "\n",
+    "```python\n",
+    "artifact_v1 = ln.Artifact.from_df(df, key=\"my_datasets/my_study1.parquet\").save()\n",
+    "# below automatically creates a new version of artifact_v1 because the `key` matches\n",
+    "artifact_v2 = ln.Artifact.from_df(df_updated, key=\"my_datasets/my_study1.parquet\").save()\n",
+    "```\n",
+    "\n",
+    "<br>\n",
+    "\n",
+    "The good thing about passing `revises: Artifact` is that it works for entities that don't come with a file path and you don't need to worry about coming up with naming conventions for paths. You'll see that LaminDB makes it easy to organize data by entities, rather than file paths.\n",
+    "\n",
+    ":::"
    ]
   },
   {

--- a/docs/introduction.ipynb
+++ b/docs/introduction.ipynb
@@ -276,7 +276,7 @@
     "You can optionally pass a human-readable `version` field when you create new versions via:\n",
     "\n",
     "```python\n",
-    "artifact_v2 = ln.Artifact(\"my_path\", is_new_version_of=artifact_v1)\n",
+    "artifact_v2 = ln.Artifact(\"my_path\", revises=artifact_v1)\n",
     "```\n",
     "\n",
     "Artifacts of the same version family share the same uid stem (the first 16 characters of the `uid`).\n",

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -710,11 +710,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you'd like to version an artifact or transform, either provide the `version` parameter when creating it or create new versions through `is_new_version_of`.\n",
+    "If you'd like to version an artifact or transform, either provide the `version` parameter when creating it or create new versions through `revises`.\n",
     "\n",
     "For instance:\n",
     "```\n",
-    "new_artifact = ln.Artifact(data, is_new_version_of=old_artifact)\n",
+    "new_artifact = ln.Artifact(data, revises=old_artifact)\n",
     "```"
    ]
   },
@@ -786,7 +786,7 @@
     "    artifacts.append(new_artifact)\n",
     "    # create a new version of the collection\n",
     "    collection = ln.Collection(\n",
-    "        artifacts, is_new_version_of=collection, description=f\"Now includes {folder_name}\"\n",
+    "        artifacts, revises=collection, description=f\"Now includes {folder_name}\"\n",
     "    )\n",
     "    collection.save()"
    ]

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -166,7 +166,8 @@
     ":::{dropdown} How do I track a pipeline instead of a notebook?\n",
     "\n",
     "```python\n",
-    "transform = ln.Transform(name=\"My pipeline\", version=\"1.2.0\")\n",
+    "transform = ln.Transform(name=\"My pipeline\")\n",
+    "transform.version = \"1.2.0\"  # tag the version\n",
     "ln.context.track(transform)\n",
     "```\n",
     "\n",
@@ -710,12 +711,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you'd like to version an artifact or transform, either provide the `version` parameter when creating it or create new versions through `revises`.\n",
+    "You can create new versions of artifacts, collections & transforms when you pass an older version to `revises`.\n",
     "\n",
-    "For instance:\n",
     "```\n",
     "new_artifact = ln.Artifact(data, revises=old_artifact)\n",
-    "```"
+    "```\n",
+    "\n",
+    "Alternatively, you can set a `key` to append to a version family in the same way you'd do it on AWS S3."
    ]
   },
   {
@@ -754,7 +756,6 @@
     "collection = ln.Collection(\n",
     "    artifact,\n",
     "    name=\"Iris collection\",\n",
-    "    version=\"1\",\n",
     "    description=\"Iris study 0\",\n",
     ")\n",
     "collection.save()"

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -557,6 +557,9 @@ def __init__(artifact: Artifact, *args, **kwargs):
     )
     accessor = kwargs.pop("_accessor") if "_accessor" in kwargs else None
     accessor = _check_accessor_artifact(data=data, accessor=accessor)
+    if "is_new_version_of" in kwargs:
+        logger.warning("`is_new_version_of` will be removed soon, please use `revises`")
+        revises = kwargs.pop("is_new_version_of")
     if not len(kwargs) == 0:
         raise ValueError(
             "Only data, key, run, description, version, revises, visibility"

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -199,7 +199,7 @@ def get_stat_or_artifact(
 ) -> tuple[int, str | None, str | None, int | None, Artifact | None] | Artifact:
     n_objects = None
     if settings.creation.artifact_skip_size_hash:
-        return None, None, None, n_objects
+        return None, None, None, n_objects, None
     stat = path.stat()  # one network request
     if not isinstance(path, LocalPathClasses):
         size, hash, hash_type = None, None, None
@@ -221,10 +221,10 @@ def get_stat_or_artifact(
             size = stat.st_size
     if not check_hash:
         return size, hash, hash_type, n_objects, None
+    previous_artifact_version = None
     if key is None:
         result = Artifact.objects.using(instance).filter(hash=hash).all()
         artifact_with_same_hash_exists = len(result) > 0
-        previous_artifact_version = None
     else:
         storage_id = settings.storage.id
         result = (

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -565,20 +565,16 @@ def __init__(artifact: Artifact, *args, **kwargs):
             "Only data, key, run, description, version, revises, visibility"
             f" can be passed, you passed: {kwargs}"
         )
-    if revises is not None:
-        if key is not None:
-            if revises.key != key:
-                note = message_update_key_in_version_family(
-                    suid=revises.stem_uid,
-                    existing_key=revises.key,
-                    new_key=key,
-                    registry="Artifact",
-                )
-                raise ValueError(
-                    f"`key` is {key}, but `revises.key` is '{revises.key}'\n\n Either do *not* pass `key`.\n\n{note}"
-                )
-        else:
-            key = revises.key
+    if revises is not None and key is not None and revises.key != key:
+        note = message_update_key_in_version_family(
+            suid=revises.stem_uid,
+            existing_key=revises.key,
+            new_key=key,
+            registry="Artifact",
+        )
+        raise ValueError(
+            f"`key` is {key}, but `revises.key` is '{revises.key}'\n\n Either do *not* pass `key`.\n\n{note}"
+        )
 
     if revises is None:
         provisional_uid = init_uid(version=version, n_full_id=20)
@@ -615,6 +611,9 @@ def __init__(artifact: Artifact, *args, **kwargs):
     else:
         kwargs = kwargs_or_artifact
 
+    # only set key now so that we don't do a look-up on it in case revises is passed
+    if revises is not None:
+        kwargs["key"] = revises.key
     # in case we have a new version of a folder with a different hash, print a
     # warning that the old version can't be recovered
     if revises is not None and revises.n_objects is not None and revises.n_objects > 1:

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -569,7 +569,7 @@ def __init__(artifact: Artifact, *args, **kwargs):
         provisional_uid = init_uid(version=version, n_full_id=20)
     else:
         if not isinstance(revises, Artifact):
-            raise TypeError("revises has to be of type ln.Artifact")
+            raise TypeError("`revises` has to be of type `Artifact`")
         provisional_uid, version = get_uid_from_old_version(revises, version, using_key)
         if description is None:
             description = revises.description

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -235,7 +235,7 @@ def get_stat_or_artifact(
         )
         artifact_with_same_hash_exists = len(result.filter(hash=hash).all()) > 0
         if not artifact_with_same_hash_exists and len(result) > 0:
-            previous_artifact_version = result
+            previous_artifact_version = result[0]
     if artifact_with_same_hash_exists:
         if settings.creation.artifact_if_hash_exists == "error":
             msg = f"artifact with same hash exists: {result[0]}"
@@ -556,7 +556,10 @@ def __init__(artifact: Artifact, *args, **kwargs):
             f" can be passed, you passed: {kwargs}"
         )
     if revises is not None and key is not None:
-        raise ValueError("One of revises or key has to be None.")
+        if revises.key != key:
+            raise ValueError(
+                f"`key` needs to be consistent, but `revises.key`: '{revises.key}' != `key`: '{key}'\nHint: Either pass `key` or `revises`"
+            )
 
     if revises is None:
         provisional_uid = init_uid(version=version, n_full_id=20)

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -212,7 +212,7 @@ def get_stat_or_artifact(
                 size, hash, hash_type, n_objects = get_stat_dir_cloud(path)
         if hash is None:
             logger.warning(f"did not add hash for {path}")
-            return size, hash, hash_type, n_objects
+            return size, hash, hash_type, n_objects, None
     else:
         if path.is_dir():
             size, hash, hash_type, n_objects = hash_dir(path)
@@ -220,7 +220,7 @@ def get_stat_or_artifact(
             hash, hash_type = hash_file(path)
             size = stat.st_size
     if not check_hash:
-        return size, hash, hash_type, n_objects
+        return size, hash, hash_type, n_objects, None
     if key is None:
         result = Artifact.objects.using(instance).filter(hash=hash).all()
         artifact_with_same_hash_exists = len(result) > 0
@@ -249,7 +249,7 @@ def get_stat_or_artifact(
                 "creating new Artifact object despite existing artifact with same hash:"
                 f" {result[0]}"
             )
-            return size, hash, hash_type, n_objects
+            return size, hash, hash_type, n_objects, None
         else:
             if result[0].visibility == -1:
                 raise FileExistsError(

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -241,7 +241,7 @@ def get_stat_or_artifact(
         artifact_with_same_hash_exists = len(result.filter(hash=hash).all()) > 0
         if not artifact_with_same_hash_exists and len(result) > 0:
             logger.important(
-                f"creating new artifact revision for key='{key}' (storage: '{settings.storage.root_as_str}')"
+                f"creating new artifact version for key='{key}' (storage: '{settings.storage.root_as_str}')"
             )
             previous_artifact_version = result[0]
     if artifact_with_same_hash_exists:

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -703,7 +703,6 @@ def from_mudata(
     key: str | None = None,
     description: str | None = None,
     run: Run | None = None,
-    version: str | None = None,
     revises: Artifact | None = None,
     **kwargs,
 ) -> Artifact:
@@ -713,7 +712,6 @@ def from_mudata(
         key=key,
         run=run,
         description=description,
-        version=version,
         revises=revises,
         _accessor="MuData",
         type="dataset",

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -240,7 +240,9 @@ def get_stat_or_artifact(
         )
         artifact_with_same_hash_exists = len(result.filter(hash=hash).all()) > 0
         if not artifact_with_same_hash_exists and len(result) > 0:
-            logger.important(f"creating new artifact revision for {key}")
+            logger.important(
+                f"creating new artifact revision for key='{key}' (storage: '{settings.storage.root_as_str}')"
+            )
             previous_artifact_version = result[0]
     if artifact_with_same_hash_exists:
         if settings.creation.artifact_if_hash_exists == "error":

--- a/lamindb/_collection.py
+++ b/lamindb/_collection.py
@@ -11,7 +11,6 @@ from typing import (
 import anndata as ad
 import lamindb_setup as ln_setup
 import pandas as pd
-from anndata import AnnData
 from lamin_utils import logger
 from lamindb_setup.core._docs import doc_args
 from lamindb_setup.core.hashing import hash_set
@@ -37,10 +36,10 @@ from .core._data import (
     save_feature_set_links,
     save_feature_sets,
 )
+from .core._settings import settings
 
 if TYPE_CHECKING:
     from lamindb.core.storage import UPath
-    from lamindb.core.storage._backed_access import AnnDataAccessor, BackedAccessor
 
     from ._query_set import QuerySet
 
@@ -90,7 +89,7 @@ def __init__(
         provisional_uid = init_uid(version=version, n_full_id=20)
     else:
         if not isinstance(revises, Collection):
-            raise TypeError("revises has to be of type ln.Collection")
+            raise TypeError("`revises` has to be of type `Collection`")
         provisional_uid, version = get_uid_from_old_version(revises, version)
         if name is None:
             name = revises.name
@@ -145,6 +144,9 @@ def __init__(
     else:
         kwargs = {}
         add_transform_to_kwargs(kwargs, run)
+        search_names_setting = settings.creation.search_names
+        if revises is not None and name == revises.name:
+            settings.creation.search_names = False
         super(Collection, collection).__init__(
             uid=provisional_uid,
             name=name,
@@ -159,6 +161,7 @@ def __init__(
             revises=revises,
             **kwargs,
         )
+        settings.creation.search_names = search_names_setting
     collection._artifacts = artifacts
     collection._feature_sets = feature_sets
     # register provenance

--- a/lamindb/_collection.py
+++ b/lamindb/_collection.py
@@ -26,7 +26,7 @@ from lamindb._artifact import update_attributes
 from lamindb._utils import attach_func_to_class_method
 from lamindb.core._data import _track_run_input
 from lamindb.core._mapped_collection import MappedCollection
-from lamindb.core.versioning import get_uid_from_old_version, init_uid
+from lamindb.core.versioning import get_uid_from_old_version, init_uid, process_revises
 
 from . import Artifact, Run
 from ._record import init_self_from_db
@@ -85,14 +85,7 @@ def __init__(
         raise ValueError(
             f"Only artifacts, name, run, description, reference, reference_type, visibility can be passed, you passed: {kwargs}"
         )
-    if revises is None:
-        provisional_uid = init_uid(version=version, n_full_id=20)
-    else:
-        if not isinstance(revises, Collection):
-            raise TypeError("`revises` has to be of type `Collection`")
-        provisional_uid, version = get_uid_from_old_version(revises, version)
-        if name is None:
-            name = revises.name
+    provisional_uid, version, name = process_revises(revises, version, name, Collection)
     run = get_run(run)
     if isinstance(artifacts, Artifact):
         artifacts = [artifacts]

--- a/lamindb/_collection.py
+++ b/lamindb/_collection.py
@@ -26,7 +26,7 @@ from lamindb._artifact import update_attributes
 from lamindb._utils import attach_func_to_class_method
 from lamindb.core._data import _track_run_input
 from lamindb.core._mapped_collection import MappedCollection
-from lamindb.core.versioning import get_uid_from_old_version, init_uid, process_revises
+from lamindb.core.versioning import process_revises
 
 from . import Artifact, Run
 from ._record import init_self_from_db
@@ -85,7 +85,9 @@ def __init__(
         raise ValueError(
             f"Only artifacts, name, run, description, reference, reference_type, visibility can be passed, you passed: {kwargs}"
         )
-    provisional_uid, version, name = process_revises(revises, version, name, Collection)
+    provisional_uid, version, name, revises = process_revises(
+        revises, version, name, Collection
+    )
     run = get_run(run)
     if isinstance(artifacts, Artifact):
         artifacts = [artifacts]

--- a/lamindb/_collection.py
+++ b/lamindb/_collection.py
@@ -81,6 +81,9 @@ def __init__(
     feature_sets: dict[str, FeatureSet] = (
         kwargs.pop("feature_sets") if "feature_sets" in kwargs else {}
     )
+    if "is_new_version_of" in kwargs:
+        logger.warning("`is_new_version_of` will be removed soon, please use `revises`")
+        revises = kwargs.pop("is_new_version_of")
     if not len(kwargs) == 0:
         raise ValueError(
             f"Only artifacts, name, run, description, reference, reference_type, visibility can be passed, you passed: {kwargs}"

--- a/lamindb/_collection.py
+++ b/lamindb/_collection.py
@@ -72,9 +72,7 @@ def __init__(
         kwargs.pop("reference_type") if "reference_type" in kwargs else None
     )
     run: Run | None = kwargs.pop("run") if "run" in kwargs else None
-    is_new_version_of: Collection | None = (
-        kwargs.pop("is_new_version_of") if "is_new_version_of" in kwargs else None
-    )
+    revises: Collection | None = kwargs.pop("revises") if "revises" in kwargs else None
     version: str | None = kwargs.pop("version") if "version" in kwargs else None
     visibility: int | None = (
         kwargs.pop("visibility")
@@ -88,14 +86,14 @@ def __init__(
         raise ValueError(
             f"Only artifacts, name, run, description, reference, reference_type, visibility can be passed, you passed: {kwargs}"
         )
-    if is_new_version_of is None:
+    if revises is None:
         provisional_uid = init_uid(version=version, n_full_id=20)
     else:
-        if not isinstance(is_new_version_of, Collection):
-            raise TypeError("is_new_version_of has to be of type ln.Collection")
-        provisional_uid, version = get_uid_from_old_version(is_new_version_of, version)
+        if not isinstance(revises, Collection):
+            raise TypeError("revises has to be of type ln.Collection")
+        provisional_uid, version = get_uid_from_old_version(revises, version)
         if name is None:
-            name = is_new_version_of.name
+            name = revises.name
     run = get_run(run)
     if isinstance(artifacts, Artifact):
         artifacts = [artifacts]
@@ -158,14 +156,14 @@ def __init__(
             run=run,
             version=version,
             visibility=visibility,
-            is_new_version_of=is_new_version_of,
+            revises=revises,
             **kwargs,
         )
     collection._artifacts = artifacts
     collection._feature_sets = feature_sets
     # register provenance
-    if is_new_version_of is not None:
-        _track_run_input(is_new_version_of, run=run)
+    if revises is not None:
+        _track_run_input(revises, run=run)
     _track_run_input(artifacts, run=run)
 
 

--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -148,7 +148,7 @@ def save_context_core(
             _source_code_artifact_path,
             description=f"Source of transform {transform.uid}",
             version=transform.version,
-            is_new_version_of=prev_source,
+            revises=prev_source,
             visibility=0,  # hidden file
             run=False,
         )
@@ -211,7 +211,7 @@ def save_context_core(
             report_file = ln.Artifact(
                 report_path,
                 description=f"Report of run {run.uid}",
-                is_new_version_of=prev_report,
+                revises=prev_report,
                 visibility=0,  # hidden file
                 run=False,
             )

--- a/lamindb/_is_versioned.py
+++ b/lamindb/_is_versioned.py
@@ -7,13 +7,13 @@ from lnschema_core.models import IsVersioned
 
 from lamindb._utils import attach_func_to_class_method
 
-from .core.versioning import get_new_path_from_uid, get_uid_from_old_version
+from .core.versioning import create_uid, get_new_path_from_uid
 
 
 # docstring handled through attach_func_to_class_method
 def _add_to_version_family(self, revises: IsVersioned, version: str | None = None):
     old_uid = self.uid
-    new_uid, version = get_uid_from_old_version(revises, version)
+    new_uid, revises = create_uid(revises=revises, version=version)
     if self.__class__.__name__ == "Artifact" and self._key_is_virtual:
         old_path = self.path
         new_path = get_new_path_from_uid(

--- a/lamindb/_is_versioned.py
+++ b/lamindb/_is_versioned.py
@@ -11,11 +11,9 @@ from .core.versioning import get_new_path_from_uid, get_uid_from_old_version
 
 
 # docstring handled through attach_func_to_class_method
-def _add_to_version_family(
-    self, is_new_version_of: IsVersioned, version: str | None = None
-):
+def _add_to_version_family(self, revises: IsVersioned, version: str | None = None):
     old_uid = self.uid
-    new_uid, version = get_uid_from_old_version(is_new_version_of, version)
+    new_uid, version = get_uid_from_old_version(revises, version)
     if self.__class__.__name__ == "Artifact" and self._key_is_virtual:
         old_path = self.path
         new_path = get_new_path_from_uid(

--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -381,9 +381,11 @@ def add_db_connection(db: str, using: str):
 @doc_args(Record.using.__doc__)
 def using(
     cls,
-    instance: str,
+    instance: str | None,
 ) -> QuerySet:
     """{}"""  # noqa: D415
+    if instance is None:
+        return QuerySet(model=cls, using=None)
     from lamindb_setup._connect_instance import (
         load_instance_settings,
         update_db_using_local,

--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -548,6 +548,7 @@ def save(self, *args, **kwargs) -> Record:
                 revises._revises = None  # ensure we don't start a recursion
                 revises.save()
                 super(Record, self).save(*args, **kwargs)
+            self._revises = None
         # save unversioned record
         else:
             super(Record, self).save(*args, **kwargs)

--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -12,7 +12,7 @@ from lamin_utils._lookup import Lookup
 from lamindb_setup._connect_instance import get_owner_name_from_identifier
 from lamindb_setup.core._docs import doc_args
 from lamindb_setup.core._hub_core import connect_instance
-from lnschema_core.models import IsVersioned, Record
+from lnschema_core.models import Collection, IsVersioned, Record
 
 from lamindb._utils import attach_func_to_class_method
 from lamindb.core._settings import settings

--- a/lamindb/_transform.py
+++ b/lamindb/_transform.py
@@ -46,7 +46,7 @@ def __init__(transform: Transform, *args, **kwargs):
         raise ValueError(
             f"`key` is {key}, but `revises.key` is '{revises.key}'\n\n Either do *not* pass `key`.\n\n{note}"
         )
-    new_uid, version, name = process_revises(revises, version, name, Transform)
+    new_uid, version, name, revises = process_revises(revises, version, name, Transform)
     # this is only because the user-facing constructor allows passing a uid
     # most others don't
     if uid is None:

--- a/lamindb/_transform.py
+++ b/lamindb/_transform.py
@@ -7,7 +7,7 @@ from lnschema_core.models import Run, Transform
 
 from ._parents import _view_parents
 from ._run import delete_run_artifacts
-from .core.versioning import process_is_new_version_of
+from .core.versioning import process_revises
 
 if TYPE_CHECKING:
     from lnschema_core.types import TransformType
@@ -19,9 +19,7 @@ def __init__(transform: Transform, *args, **kwargs):
         return None
     name: str | None = kwargs.pop("name") if "name" in kwargs else None
     key: str | None = kwargs.pop("key") if "key" in kwargs else None
-    is_new_version_of: Transform | None = (
-        kwargs.pop("is_new_version_of") if "is_new_version_of" in kwargs else None
-    )
+    revises: Transform | None = kwargs.pop("revises") if "revises" in kwargs else None
     version: str | None = kwargs.pop("version") if "version" in kwargs else None
     type: TransformType | None = kwargs.pop("type") if "type" in kwargs else "pipeline"
     reference: str | None = kwargs.pop("reference") if "reference" in kwargs else None
@@ -32,12 +30,10 @@ def __init__(transform: Transform, *args, **kwargs):
     uid: str | None = kwargs.pop("uid") if "uid" in kwargs else None
     if not len(kwargs) == 0:
         raise ValueError(
-            "Only name, key, version, type, is_new_version_of, reference, "
+            "Only name, key, version, type, revises, reference, "
             f"reference_type can be passed, but you passed: {kwargs}"
         )
-    new_uid, version, name = process_is_new_version_of(
-        is_new_version_of, version, name, Transform
-    )
+    new_uid, version, name = process_revises(revises, version, name, Transform)
     # this is only because the user-facing constructor allows passing an id
     # most others don't
     if uid is None:
@@ -54,7 +50,7 @@ def __init__(transform: Transform, *args, **kwargs):
         reference=reference,
         reference_type=reference_type,
         _has_consciously_provided_uid=has_consciously_provided_uid,
-        is_new_version_of=is_new_version_of,
+        revises=revises,
     )
 
 

--- a/lamindb/_transform.py
+++ b/lamindb/_transform.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from lamin_utils import logger
 from lamindb_setup.core._docs import doc_args
 from lnschema_core.models import Run, Transform
 
@@ -26,6 +27,9 @@ def __init__(transform: Transform, *args, **kwargs):
     reference_type: str | None = (
         kwargs.pop("reference_type") if "reference_type" in kwargs else None
     )
+    if "is_new_version_of" in kwargs:
+        logger.warning("`is_new_version_of` will be removed soon, please use `revises`")
+        revises = kwargs.pop("is_new_version_of")
     # below is internal use that we'll hopefully be able to eliminate
     uid: str | None = kwargs.pop("uid") if "uid" in kwargs else None
     if not len(kwargs) == 0:

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -26,7 +26,7 @@ from .exceptions import (
 )
 from .subsettings._transform_settings import transform_settings
 from .versioning import bump_version as bump_version_function
-from .versioning import increment_base62
+from .versioning import increment_base62, message_update_key_in_version_family
 
 if TYPE_CHECKING:
     from lamindb_setup.core.types import UPathStr
@@ -432,7 +432,12 @@ class Context:
                 suid = transform.stem_uid
                 new_suid = ids.base62_12()
                 transform_type = "Notebook" if is_run_from_ipython else "Script"
-                note = f'Or update key "{transform.key}" in your existing family:\n\nln.Transform.filter(uid__startswith="{suid}").update(key="{key}")'
+                note = message_update_key_in_version_family(
+                    suid=suid,
+                    existing_key=transform.key,
+                    new_key=key,
+                    registry="Transform",
+                )
                 raise UpdateContext(
                     f"{transform_type} filename changed.\n\nEither init a new transform family by setting:\n\n"
                     f'ln.context.uid = "{new_suid}0000"\n\n{note}'

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -87,9 +87,9 @@ def raise_missing_context(transform_type: str, key: str) -> None:
         message = f"To track this {transform_type}, set\n\n"
     else:
         uid = transform.uid
-        suid, ruid = uid[: Transform._len_stem_uid], uid[Transform._len_stem_uid :]
-        new_ruid = increment_base62(ruid)
-        new_uid = f"{suid}{new_ruid}"
+        suid, vuid = uid[: Transform._len_stem_uid], uid[Transform._len_stem_uid :]
+        new_vuid = increment_base62(vuid)
+        new_uid = f"{suid}{new_vuid}"
         message = f"You already have a {transform_type} version family with key '{key}', suid '{transform.stem_uid}' & name '{transform.name}'.\n\n- to create a new {transform_type} version family, rename your file and rerun: ln.context.track()\n- to bump the version, set: "
     message += f'ln.context.uid = "{new_uid}"'
     if transform_type == "notebook":
@@ -224,7 +224,7 @@ class Context:
                             f"Please pass consistent version: ln.context.version = '{transform.version}'"
                         )
                     # test whether version was already used for another member of the family
-                    suid, ruid = (
+                    suid, vuid = (
                         self.uid[: Transform._len_stem_uid],
                         self.uid[Transform._len_stem_uid :],
                     )
@@ -233,7 +233,7 @@ class Context:
                     ).one_or_none()
                     if (
                         transform is not None
-                        and ruid != transform.uid[Transform._len_stem_uid :]
+                        and vuid != transform.uid[Transform._len_stem_uid :]
                     ):
                         better_version = bump_version_function(self.version)
                         raise SystemExit(
@@ -465,14 +465,14 @@ class Context:
                         if is_run_from_ipython
                         else "Source code changed"
                     )
-                    suid, ruid = (
+                    suid, vuid = (
                         uid[: Transform._len_stem_uid],
                         uid[Transform._len_stem_uid :],
                     )
-                    new_ruid = increment_base62(ruid)
+                    new_vuid = increment_base62(vuid)
                     raise UpdateContext(
                         f"{change_type}, bump version by setting:\n\n"
-                        f'ln.context.uid = "{suid}{new_ruid}"'
+                        f'ln.context.uid = "{suid}{new_vuid}"'
                     )
             else:
                 self._logging_message += f"loaded Transform('{transform.uid}')"

--- a/lamindb/core/storage/_tiledbsoma.py
+++ b/lamindb/core/storage/_tiledbsoma.py
@@ -202,10 +202,10 @@ def write_tiledbsoma_store(
     if add_run_uid:
         del adata.obs["lamin_run_uid"]
 
-    is_new_version_of = None
+    revises = None
     if appending:
         if store_is_artifact:
-            is_new_version_of = store
+            revises = store
         else:
             from lamindb._artifact import (
                 check_path_in_existing_storage,
@@ -217,15 +217,13 @@ def write_tiledbsoma_store(
                 search_by_key = get_relative_path_to_directory(
                     path=storepath, directory=UPath(storage.root)
                 ).as_posix()
-                is_new_version_of = Artifact.filter(
+                revises = Artifact.filter(
                     key=search_by_key, is_latest=True, _key_is_virtual=False
                 ).one_or_none()
-                if is_new_version_of is not None:
-                    logger.info(f"Assuming it is a new version of {is_new_version_of}.")
+                if revises is not None:
+                    logger.info(f"Assuming it is a new version of {revises}.")
 
-    if is_new_version_of is None:
+    if revises is None:
         return Artifact(storepath, run=run, **artifact_kwargs)
     else:
-        return Artifact(
-            storepath, run=run, is_new_version_of=is_new_version_of, **artifact_kwargs
-        )
+        return Artifact(storepath, run=run, revises=revises, **artifact_kwargs)

--- a/lamindb/core/versioning.py
+++ b/lamindb/core/versioning.py
@@ -89,10 +89,10 @@ def init_uid(
     *,
     version: str | None = None,
     n_full_id: int = 20,
-    is_new_version_of: IsVersioned | None = None,
+    revises: IsVersioned | None = None,
 ) -> str:
-    if is_new_version_of is not None:
-        stem_uid = is_new_version_of.stem_uid
+    if revises is not None:
+        stem_uid = revises.stem_uid
     else:
         stem_uid = ids.base62(n_full_id - 4)
     if version is not None:
@@ -105,27 +105,27 @@ def init_uid(
 
 
 def get_uid_from_old_version(
-    is_new_version_of: IsVersioned,
+    revises: IsVersioned,
     version: str | None = None,
     using_key: str | None = None,
 ) -> tuple[str, str]:
     """{}"""  # noqa: D415
     msg = ""
-    if is_new_version_of.version is None:
+    if revises.version is None:
         previous_version = "1"
         msg = f"setting previous version to '{previous_version}'"
     else:
-        previous_version = is_new_version_of.version
+        previous_version = revises.version
     version = set_version(version, previous_version)
     new_uid = init_uid(
         version=version,
-        n_full_id=is_new_version_of._len_full_uid,
-        is_new_version_of=is_new_version_of,
+        n_full_id=revises._len_full_uid,
+        revises=revises,
     )
     # the following covers the edge case where the old file was unversioned
-    if is_new_version_of.version is None:
-        is_new_version_of.version = previous_version
-        is_new_version_of.save(using=using_key)
+    if revises.version is None:
+        revises.version = previous_version
+        revises.save(using=using_key)
         if msg != "":
             msg += f"& new version to '{version}'"
     return new_uid, version
@@ -141,18 +141,18 @@ def get_new_path_from_uid(old_path: UPath, old_uid: str, new_uid: str):
     return new_path
 
 
-def process_is_new_version_of(
-    is_new_version_of: IsVersioned,
+def process_revises(
+    revises: IsVersioned,
     version: str | None,
     name: str | None,
     type: type[IsVersioned],
 ) -> tuple[str, str, str]:
-    if is_new_version_of is not None and not isinstance(is_new_version_of, type):
-        raise TypeError(f"is_new_version_of has to be of type {type.__name__}")
-    if is_new_version_of is None:
+    if revises is not None and not isinstance(revises, type):
+        raise TypeError(f"revises has to be of type {type.__name__}")
+    if revises is None:
         uid = init_uid(version=version, n_full_id=type._len_full_uid)
     else:
-        uid, version = get_uid_from_old_version(is_new_version_of, version)
+        uid, version = get_uid_from_old_version(revises, version)
         if name is None:
-            name = is_new_version_of.name
+            name = revises.name
     return uid, version, name

--- a/lamindb/core/versioning.py
+++ b/lamindb/core/versioning.py
@@ -11,6 +11,16 @@ if TYPE_CHECKING:
     from lnschema_core.models import IsVersioned
 
 
+def message_update_key_in_version_family(
+    *,
+    suid: str,
+    existing_key: str,
+    registry: str,
+    new_key: str,
+) -> str:
+    return f'Or update key "{existing_key}" in your existing family:\n\nln.{registry}.filter(uid__startswith="{suid}").update(key="{new_key}")'
+
+
 def increment_base62(s: str) -> str:
     # we don't need to throw an error for zzzz because uids are enforced to be unique
     # on the db level and have an enforced maximum length
@@ -112,7 +122,6 @@ def init_uid(
 def get_uid_from_old_version(
     revises: IsVersioned,
     version: str | None = None,
-    using_key: str | None = None,
 ) -> tuple[str, str]:
     """{}"""  # noqa: D415
     new_uid = init_uid(

--- a/lamindb/core/versioning.py
+++ b/lamindb/core/versioning.py
@@ -143,13 +143,13 @@ def get_new_path_from_uid(old_path: UPath, old_uid: str, new_uid: str):
 
 
 def process_revises(
-    revises: IsVersioned,
+    revises: IsVersioned | None,
     version: str | None,
     name: str | None,
     type: type[IsVersioned],
 ) -> tuple[str, str, str]:
     if revises is not None and not isinstance(revises, type):
-        raise TypeError(f"revises has to be of type {type.__name__}")
+        raise TypeError(f"`revises` has to be of type `{type.__name__}`")
     if revises is None:
         uid = init_uid(version=version, n_full_id=type._len_full_uid)
     else:

--- a/lamindb/core/versioning.py
+++ b/lamindb/core/versioning.py
@@ -101,10 +101,10 @@ def init_uid(
 ) -> str:
     if revises is not None:
         suid = revises.stem_uid
-        ruid = increment_base62(revises.uid[-4:])
+        vuid = increment_base62(revises.uid[-4:])
     else:
         suid = ids.base62(n_full_id - 4)
-        ruid = "0000"
+        vuid = "0000"
     if version is not None:
         if not isinstance(version, str):
             raise ValueError(
@@ -116,7 +116,7 @@ def init_uid(
                 raise ValueError(
                     f"Please increment the previous version: '{revises.version}'"
                 )
-    return suid + ruid
+    return suid + vuid
 
 
 def get_uid_from_old_version(

--- a/tests/test_artifact.py
+++ b/tests/test_artifact.py
@@ -37,7 +37,6 @@ from lamindb_setup.core.upath import (
     CloudPath,
     LocalPathClasses,
     UPath,
-    extract_suffix_from_path,
 )
 
 # how do we properly abstract out the default storage variable?
@@ -134,7 +133,25 @@ def test_data_is_anndata_paths():
     assert not data_is_anndata("s3://somewhere/something.zarr")
 
 
-def test_revises_versioned_file(df, adata):
+def test_basic_validation():
+    # extra kwargs
+    with pytest.raises(ValueError):
+        ln.Artifact("testpath.csv", description="test1b", extra_kwarg="extra")
+
+    # > 1 args
+    with pytest.raises(ValueError) as error:
+        ln.Artifact("testpath.csv", "testpath.csv")
+    assert error.exconly() == "ValueError: Only one non-keyword arg allowed: data"
+
+
+# comment out for now
+# AUTO_KEY_PREFIX
+#    with pytest.raises(ValueError) as error:
+#        ln.Artifact.from_df(df, key=".lamindb/test_df.parquet")
+#    assert error.exconly() == "ValueError: Key cannot start with .lamindb/"
+
+
+def test_revise_file(df, adata):
     # attempt to create a file with an invalid version
     with pytest.raises(ValueError) as error:
         artifact = ln.Artifact.from_df(df, description="test", version=0)
@@ -153,53 +170,36 @@ def test_revises_versioned_file(df, adata):
     assert artifact.path.exists()
 
     with pytest.raises(ValueError) as error:
-        artifact_v2 = ln.Artifact.from_anndata(adata, revises=artifact, version="1")
+        artifact_r2 = ln.Artifact.from_anndata(adata, revises=artifact, version="1")
     assert error.exconly() == "ValueError: Please increment the previous version: '1'"
 
     # create new file from old file
-    artifact_v2 = ln.Artifact.from_anndata(adata, revises=artifact)
+    artifact_r2 = ln.Artifact.from_anndata(adata, revises=artifact)
     assert artifact.version == "1"
-    assert artifact_v2.stem_uid == artifact.stem_uid
-    assert artifact_v2.version == "2"
-    assert artifact_v2.key is None
-    assert artifact_v2.description == "test"
+    assert artifact_r2.stem_uid == artifact.stem_uid
+    assert artifact_r2.version is None
+    assert artifact_r2.key is None
+    assert artifact_r2.description == "test"
 
-    artifact_v2.save()
-    assert artifact_v2.path.exists()
+    artifact_r2.save()
+    assert artifact_r2.path.exists()
 
     # create new file from newly versioned file
-    df.iloc[0, 0] = 0
-    file_v3 = ln.Artifact.from_df(df, description="test1", revises=artifact_v2)
-    assert file_v3.stem_uid == artifact.stem_uid
-    assert file_v3.version == "3"
-    assert file_v3.description == "test1"
+    df.iloc[0, 0] = 0  # mutate dataframe so that hash lookup doesn't trigger
+    file_r3 = ln.Artifact.from_df(
+        df, description="test1", revises=artifact_r2, version="2"
+    )
+    assert file_r3.stem_uid == artifact.stem_uid
+    assert file_r3.version == "2"
+    assert file_r3.description == "test1"
 
     with pytest.raises(TypeError) as error:
         ln.Artifact.from_df(df, description="test1a", revises=ln.Transform())
-    assert error.exconly() == "TypeError: revises has to be of type ln.Artifact"
+    assert error.exconly() == "TypeError: `revises` has to be of type `Artifact`"
 
-    # test that reference file cannot be deleted
-    artifact_v2.delete(permanent=True, storage=True)
+    artifact_r2.delete(permanent=True, storage=True)
     artifact.delete(permanent=True, storage=True)
 
-    # extra kwargs
-    with pytest.raises(ValueError):
-        ln.Artifact.from_df(df, description="test1b", extra_kwarg="extra")
-
-    # > 1 args
-    with pytest.raises(ValueError) as error:
-        ln.Artifact(df, df)
-    assert error.exconly() == "ValueError: Only one non-keyword arg allowed: data"
-
-
-# comment out for now
-# AUTO_KEY_PREFIX
-#    with pytest.raises(ValueError) as error:
-#        ln.Artifact.from_df(df, key=".lamindb/test_df.parquet")
-#    assert error.exconly() == "ValueError: Key cannot start with .lamindb/"
-
-
-def test_revises_unversioned_file(df, adata):
     # unversioned file
     artifact = ln.Artifact.from_df(df, description="test2")
     assert artifact.version is None
@@ -210,9 +210,9 @@ def test_revises_unversioned_file(df, adata):
 
     # create new file from old file
     new_artifact = ln.Artifact.from_anndata(adata, revises=artifact)
-    assert artifact.version == "1"
+    assert artifact.version is None
     assert new_artifact.stem_uid == artifact.stem_uid
-    assert new_artifact.version == "2"
+    assert new_artifact.version is None
     assert new_artifact.description == artifact.description
 
     artifact.delete(permanent=True, storage=True)

--- a/tests/test_artifact.py
+++ b/tests/test_artifact.py
@@ -181,9 +181,10 @@ def test_revise_artifact(df, adata):
     assert artifact_r2.version is None
     assert artifact_r2.key is None
     assert artifact_r2.description == "test"
-
+    assert artifact_r2._revises is not None
     artifact_r2.save()
     assert artifact_r2.path.exists()
+    assert artifact_r2._revises is None
 
     # create new file from newly versioned file
     df.iloc[0, 0] = 0  # mutate dataframe so that hash lookup doesn't trigger

--- a/tests/test_artifact.py
+++ b/tests/test_artifact.py
@@ -175,6 +175,11 @@ def test_revise_artifact(df, adata):
     assert error.exconly() == "ValueError: Please increment the previous version: '1'"
 
     # create new file from old file
+    artifact_r2 = ln.Artifact.from_anndata(
+        adata, is_new_version_of=artifact
+    )  # backward compat
+    assert artifact_r2.stem_uid == artifact.stem_uid
+    assert artifact_r2.uid.endswith("0001")
     artifact_r2 = ln.Artifact.from_anndata(adata, revises=artifact)
     assert artifact_r2.uid.endswith("0001")
     assert artifact_r2.stem_uid == artifact.stem_uid

--- a/tests/test_artifact.py
+++ b/tests/test_artifact.py
@@ -195,6 +195,21 @@ def test_revise_artifact(df, adata):
     assert artifact_r3.version == "2"
     assert artifact_r3.description == "test1"
 
+    # revise by matching on `key`
+    key = "my-test-dataset.parquet"
+    artifact_r2.key = key
+    artifact_r2.save()
+    artifact_r3 = ln.Artifact.from_df(df, description="test1", key=key, version="2")
+    assert artifact_r3.uid.endswith("0002")
+    assert artifact_r3.stem_uid == artifact.stem_uid
+    assert artifact_r3.key == key
+    assert artifact_r3.version == "2"
+    assert artifact_r3.description == "test1"
+
+    artifact_r3 = ln.Artifact.from_df(
+        df, description="test1", key="my-test-dataset1.parquet", version="2"
+    )
+
     with pytest.raises(TypeError) as error:
         ln.Artifact.from_df(df, description="test1a", revises=ln.Transform())
     assert error.exconly() == "TypeError: `revises` has to be of type `Artifact`"

--- a/tests/test_artifact_folders.py
+++ b/tests/test_artifact_folders.py
@@ -46,7 +46,7 @@ def test_folder_like_artifact(get_test_filepaths, key):
     # create a first file
     test_filepath_added = test_dirpath / "my_file_added.txt"
     test_filepath_added.write_text("2")
-    artifact3 = ln.Artifact(test_dirpath, key=key, is_new_version_of=artifact1)
+    artifact3 = ln.Artifact(test_dirpath, key=key, revises=artifact1)
     assert artifact3.n_objects == 4
     assert artifact3.hash != hash_test_dir
     assert artifact3._state.adding

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -349,11 +349,13 @@ def test_revise_collection(df, adata):
         ln.Collection(adata, revises="wrong-type")
 
     # create new collection from old collection
-    collection_r2 = ln.Collection(artifact, revises=collection)
-    assert collection.version == "1"
+    collection_r2 = ln.Collection(artifact, is_new_version_of=collection)
     assert collection_r2.stem_uid == collection.stem_uid
-    assert collection_r2.version is None
     assert collection_r2.uid.endswith("0001")
+    collection_r2 = ln.Collection(artifact, revises=collection)
+    assert collection_r2.stem_uid == collection.stem_uid
+    assert collection_r2.uid.endswith("0001")
+    assert collection_r2.version is None
     assert collection_r2.name == "test"
 
     collection_r2.save()

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -329,7 +329,7 @@ def test_collection_mapped(adata, adata2):
     artifact3.delete(permanent=True)
 
 
-def test_is_new_version_of_versioned_collection(df, adata):
+def test_revises_versioned_collection(df, adata):
     # create a versioned collection
     artifact = ln.Artifact.from_df(df, description="test")
     artifact.save()
@@ -341,13 +341,11 @@ def test_is_new_version_of_versioned_collection(df, adata):
     artifact.save()
 
     with pytest.raises(ValueError) as error:
-        collection_v2 = ln.Collection(
-            artifact, is_new_version_of=collection, version="1"
-        )
+        collection_v2 = ln.Collection(artifact, revises=collection, version="1")
     assert error.exconly() == "ValueError: Please increment the previous version: '1'"
 
     # create new collection from old collection
-    collection_v2 = ln.Collection(artifact, is_new_version_of=collection)
+    collection_v2 = ln.Collection(artifact, revises=collection)
     assert collection.version == "1"
     assert collection_v2.stem_uid == collection.stem_uid
     assert collection_v2.version == "2"
@@ -359,9 +357,7 @@ def test_is_new_version_of_versioned_collection(df, adata):
     df.iloc[0, 0] = 0
     artifact = ln.Artifact.from_df(df, description="test")
     artifact.save()
-    collection_v3 = ln.Collection(
-        artifact, name="test1", is_new_version_of=collection_v2
-    )
+    collection_v3 = ln.Collection(artifact, name="test1", revises=collection_v2)
     assert collection_v3.stem_uid == collection.stem_uid
     assert collection_v3.version == "3"
     assert collection_v3.name == "test1"
@@ -374,7 +370,7 @@ def test_is_new_version_of_versioned_collection(df, adata):
     artifacts.delete(permanent=True)
 
 
-def test_is_new_version_of_unversioned_collection(df, adata):
+def test_revises_unversioned_collection(df, adata):
     # unversioned collection
     artifact = ln.Artifact.from_df(df, description="test")
     artifact.save()
@@ -386,13 +382,13 @@ def test_is_new_version_of_unversioned_collection(df, adata):
     collection.save()
 
     with pytest.raises(TypeError):
-        ln.Collection(adata, is_new_version_of="wrong-type")
+        ln.Collection(adata, revises="wrong-type")
 
     artifact2 = ln.Artifact.from_anndata(adata, description="test")
     artifact2.save()
 
     # create new collection from old collection
-    new_collection = ln.Collection(artifact2, is_new_version_of=collection)
+    new_collection = ln.Collection(artifact2, revises=collection)
     assert collection.version == "1"
     assert new_collection.stem_uid == collection.stem_uid
     assert new_collection.version == "2"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -284,7 +284,7 @@ def test_write_read_tiledbsoma(storage):
             matrix_data=np.ones((n_obs, 2)),
         )
     assert artifact_soma.hash != hash_before_changes
-    assert artifact_soma.version == "2"
+    assert artifact_soma.uid.endswith("0001")
     if storage is not None:
         # cache should be ignored and deleted after the changes
         assert not cache_path.exists()
@@ -319,7 +319,7 @@ def test_write_read_tiledbsoma(storage):
         registration_mapping=mapping,
     )
     artifact_soma_append.save()
-    assert artifact_soma_append.version == "3"
+    assert artifact_soma_append.uid.endswith("0002")
 
     # append with path, should pull the artifact
     artifact_soma_append = write_tiledbsoma_store(
@@ -330,7 +330,7 @@ def test_write_read_tiledbsoma(storage):
         registration_mapping=mapping,
     )
     artifact_soma_append.save()
-    assert artifact_soma_append.version == "4"
+    assert artifact_soma_append.uid.endswith("0003")
 
     # try to append without registration mapping
     with pytest.raises(ValueError):

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -42,6 +42,16 @@ def test_revises_versioned_transform():
     transform_r3 = ln.Transform(revises=transform_r2)
     assert transform_r3.name == transform_r2.name
 
+    # revise by matching on `key`
+    key = "my-notebook.ipynb"
+    transform_r2.key = key
+    transform_r2.save()
+    transform_r3 = ln.Transform(name="My transform", key=key, version="2")
+    assert transform_r3.uid.endswith("0002")
+    assert transform_r3.stem_uid == transform_r2.stem_uid
+    assert transform_r3.key == key
+    assert transform_r3.version == "2"
+
     # wrong transform type
     with pytest.raises(TypeError) as error:
         ln.Transform(revises=ln.ULabel(name="x"))

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -24,22 +24,23 @@ def test_revises_versioned_transform():
     transform.save()
 
     # create new transform from old transform
-    transform_v2 = ln.Transform(name="My 2nd transform", revises=transform)
+    transform_r2 = ln.Transform(name="My 2nd transform", revises=transform)
     assert transform.version == "1"
-    assert transform_v2.uid != transform.uid
-    assert transform_v2.stem_uid == transform.stem_uid
-    assert transform_v2.version == "2"
+    assert transform_r2.uid != transform.uid
+    assert transform_r2.endswith("0001")
+    assert transform_r2.stem_uid == transform.stem_uid
+    assert transform_r2.version is None
 
-    transform_v2.save()
+    transform_r2.save()
 
     # create new transform from newly versioned transform
-    transform_v3 = ln.Transform(name="My transform", revises=transform_v2)
-    assert transform_v3.stem_uid == transform.stem_uid
-    assert transform_v3.version == "3"
+    transform_r3 = ln.Transform(name="My transform", revises=transform_r2, version="2")
+    assert transform_r3.stem_uid == transform.stem_uid
+    assert transform_r3.version == "2"
 
     # default name
-    transform_v3 = ln.Transform(revises=transform_v2)
-    assert transform_v3.name == transform_v2.name
+    transform_r3 = ln.Transform(revises=transform_r2)
+    assert transform_r3.name == transform_r2.name
 
     # wrong transform type
     with pytest.raises(TypeError) as error:
@@ -55,7 +56,7 @@ def test_revises_versioned_transform():
     )
 
     # test that reference transform cannot be deleted
-    transform_v2.delete()
+    transform_r2.delete()
     transform.delete()
 
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -5,7 +5,7 @@ import pytest
 from django.db.models.deletion import ProtectedError
 
 
-def test_is_new_version_of_versioned_transform():
+def test_revises_versioned_transform():
     # attempt to create a transform with an invalid version
     with pytest.raises(ValueError) as error:
         transform = ln.Transform(name="My transform", version=0)
@@ -24,7 +24,7 @@ def test_is_new_version_of_versioned_transform():
     transform.save()
 
     # create new transform from old transform
-    transform_v2 = ln.Transform(name="My 2nd transform", is_new_version_of=transform)
+    transform_v2 = ln.Transform(name="My 2nd transform", revises=transform)
     assert transform.version == "1"
     assert transform_v2.uid != transform.uid
     assert transform_v2.stem_uid == transform.stem_uid
@@ -33,27 +33,24 @@ def test_is_new_version_of_versioned_transform():
     transform_v2.save()
 
     # create new transform from newly versioned transform
-    transform_v3 = ln.Transform(name="My transform", is_new_version_of=transform_v2)
+    transform_v3 = ln.Transform(name="My transform", revises=transform_v2)
     assert transform_v3.stem_uid == transform.stem_uid
     assert transform_v3.version == "3"
 
     # default name
-    transform_v3 = ln.Transform(is_new_version_of=transform_v2)
+    transform_v3 = ln.Transform(revises=transform_v2)
     assert transform_v3.name == transform_v2.name
 
     # wrong transform type
     with pytest.raises(TypeError) as error:
-        ln.Transform(is_new_version_of=ln.ULabel(name="x"))
-    assert error.exconly().startswith(
-        "TypeError: is_new_version_of has to be of type Transform"
-    )
+        ln.Transform(revises=ln.ULabel(name="x"))
+    assert error.exconly().startswith("TypeError: revises has to be of type Transform")
 
     # wrong kwargs
     with pytest.raises(ValueError) as error:
         ln.Transform(x=1)
     assert (
-        error.exconly()
-        == "ValueError: Only name, key, version, type, is_new_version_of,"
+        error.exconly() == "ValueError: Only name, key, version, type, revises,"
         " reference, reference_type can be passed, but you passed: {'x': 1}"
     )
 
@@ -62,7 +59,7 @@ def test_is_new_version_of_versioned_transform():
     transform.delete()
 
 
-def test_is_new_version_of_unversioned_transform():
+def test_revises_unversioned_transform():
     # unversioned transform
     transform = ln.Transform(name="My transform")
     assert transform.version is None
@@ -72,7 +69,7 @@ def test_is_new_version_of_unversioned_transform():
     transform.save()
 
     # create new transform from old transform
-    new_transform = ln.Transform(name="My new transform", is_new_version_of=transform)
+    new_transform = ln.Transform(name="My new transform", revises=transform)
     assert transform.version == "1"
     assert new_transform.stem_uid == transform.stem_uid
     assert new_transform.version == "2"

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -24,8 +24,10 @@ def test_revises_versioned_transform():
     transform.save()
 
     # create new transform from old transform
+    transform_r2 = ln.Transform(name="My 2nd transform", is_new_version_of=transform)
+    assert transform_r2.uid != transform.uid
+    assert transform_r2.uid.endswith("0001")
     transform_r2 = ln.Transform(name="My 2nd transform", revises=transform)
-    assert transform.version == "1"
     assert transform_r2.uid != transform.uid
     assert transform_r2.uid.endswith("0001")
     assert transform_r2.stem_uid == transform.stem_uid

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -55,7 +55,9 @@ def test_revises_versioned_transform():
     # wrong transform type
     with pytest.raises(TypeError) as error:
         ln.Transform(revises=ln.ULabel(name="x"))
-    assert error.exconly().startswith("TypeError: revises has to be of type Transform")
+    assert error.exconly().startswith(
+        "TypeError: `revises` has to be of type `Transform`"
+    )
 
     # wrong kwargs
     with pytest.raises(ValueError) as error:

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -27,7 +27,7 @@ def test_revises_versioned_transform():
     transform_r2 = ln.Transform(name="My 2nd transform", revises=transform)
     assert transform.version == "1"
     assert transform_r2.uid != transform.uid
-    assert transform_r2.endswith("0001")
+    assert transform_r2.uid.endswith("0001")
     assert transform_r2.stem_uid == transform.stem_uid
     assert transform_r2.version is None
 
@@ -59,8 +59,6 @@ def test_revises_versioned_transform():
     transform_r2.delete()
     transform.delete()
 
-
-def test_revises_unversioned_transform():
     # unversioned transform
     transform = ln.Transform(name="My transform")
     assert transform.version is None
@@ -71,9 +69,10 @@ def test_revises_unversioned_transform():
 
     # create new transform from old transform
     new_transform = ln.Transform(name="My new transform", revises=transform)
-    assert transform.version == "1"
+    assert transform.version is None
     assert new_transform.stem_uid == transform.stem_uid
-    assert new_transform.version == "2"
+    assert new_transform.uid.endswith("0001")
+    assert new_transform.version is None
 
     transform.delete()
 

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -105,14 +105,18 @@ def test_latest_version_and_get():
     assert transform_v1.is_latest
     assert transform_v1.version is None
     # pass the latest version, also vary the name for the fun of it
-    transform_v2 = ln.Transform(name="Introduction v2", revises=transform_v1)
+    transform_v2 = ln.Transform(
+        name="Introduction v2", revises=transform_v1, version="2"
+    )
     transform_v2.save()
     assert not transform_v1.is_latest
     assert transform_v2.is_latest
     assert transform_v2.uid.endswith("0001")
-    # do not pass the latest version to revises
+    # consciosuly *not* pass the latest version to revises but the previous
+    # it automatically retrieves the latest version
     transform_v3 = ln.Transform(name="Introduction", revises=transform_v1)
     transform_v3.save()
+    assert transform_v3.uid.endswith("0002")
     assert not ln.Transform.objects.get(name="Introduction v2", version="2").is_latest
     assert transform_v3.is_latest
     transform_v4 = ln.Transform(name="Introduction")

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -112,7 +112,7 @@ def test_latest_version_and_get():
     assert not transform_v1.is_latest
     assert transform_v2.is_latest
     assert transform_v2.uid.endswith("0001")
-    # consciosuly *not* pass the latest version to revises but the previous
+    # consciously *not* pass the latest version to revises but the previous
     # it automatically retrieves the latest version
     transform_v3 = ln.Transform(name="Introduction", revises=transform_v1)
     transform_v3.save()
@@ -127,7 +127,7 @@ def test_latest_version_and_get():
     assert len(ln.Transform.filter(name="Introduction").all()) == 3
     assert len(ln.Transform.filter(name="Introduction").latest_version()) == 2
     transform_v4.delete()
-    with pytest.raises(Exception):  # # noqa: B017 should be MultipleResultsFound
+    with pytest.raises(Exception):  # noqa: B017 should be MultipleResultsFound
         ln.Transform.get(name="Introduction")
     assert (
         ln.Transform.filter(name="Introduction").latest_version().one() == transform_v3

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -109,7 +109,7 @@ def test_latest_version_and_get():
     transform_v2.save()
     assert not transform_v1.is_latest
     assert transform_v2.is_latest
-    assert transform_v2.version == "2"
+    assert transform_v2.uid.endswith("0001")
     # do not pass the latest version to revises
     transform_v3 = ln.Transform(name="Introduction", revises=transform_v1)
     transform_v3.save()

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -105,13 +105,13 @@ def test_latest_version_and_get():
     assert transform_v1.is_latest
     assert transform_v1.version is None
     # pass the latest version, also vary the name for the fun of it
-    transform_v2 = ln.Transform(name="Introduction v2", is_new_version_of=transform_v1)
+    transform_v2 = ln.Transform(name="Introduction v2", revises=transform_v1)
     transform_v2.save()
     assert not transform_v1.is_latest
     assert transform_v2.is_latest
     assert transform_v2.version == "2"
-    # do not pass the latest version to is_new_version_of
-    transform_v3 = ln.Transform(name="Introduction", is_new_version_of=transform_v1)
+    # do not pass the latest version to revises
+    transform_v3 = ln.Transform(name="Introduction", revises=transform_v1)
     transform_v3.save()
     assert not ln.Transform.objects.get(name="Introduction v2", version="2").is_latest
     assert transform_v3.is_latest


### PR DESCRIPTION
For `Artifact`, you can now also create revisions by passing the `key` argument.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/afa66d49-697e-4520-bc2a-1bf00495d823">

We're no longer auto-creating "semantic versions", but make labeling with the semantic version optional.

<img width="650" alt="image" src="https://github.com/user-attachments/assets/f91fd1cf-d00f-4f57-8c90-5717110e4754">

Technical changes:

- 🚚 Deprecate the `is_new_version_of` argument in favor of `revises`
- Deprecate passing `version` to constructors; rather set `.version` after creating records
- [♻️ Remove auto-incrementing the semantic `version` tag, auto-increment the `ruid` instead](https://github.com/laminlabs/lamindb/pull/1839/commits/91576e78c58ae1224ac851c2b8895b33ac829746)
- https://github.com/laminlabs/lnschema-core/pull/423