### PR TITLE
:sparkles: Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/.config.yml
+++ b/.github/ISSUE_TEMPLATE/.config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: LaminHub issues
+    url: https://github.com/laminlabs/laminhub-public
+    about: If you have issues with LaminHub, please report them here.
+  - name: Enterprise support
+    url: https://lamin.ai/contact
+    about: If you have non-technical queries, please contact us directly.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,94 @@
+name: Bug report
+description: Report something that is broken or incorrect
+labels: bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Note**: This is a public repository! Do not reveal any internal information.
+        Please read [this guide](https://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports) detailing how to provide the necessary information for us to reproduce your bug.
+        In brief:
+          * Please provide exact steps how to reproduce the bug in a clean Python environment if possible.
+
+  - type: textarea
+    id: report
+    attributes:
+      label: Report
+      description: A clear and concise description of what the bug is.
+      placeholder: |
+        This is a public repository!
+        Do not reveal any internal information.
+    validations:
+      required: true
+
+  - type: textarea
+    id: versions
+    attributes:
+      label: Version information
+      description: |
+        Please paste below the output of
+
+        ```bash
+        pip install session-info
+        ```
+
+        ```python
+        import session_info
+        session_info.show(html=False, dependencies=True)
+        ```
+      placeholder: |
+        -----
+        anndata             0.8.0rc2.dev27+ge524389
+        session_info        1.0.0
+        -----
+        asttokens           NA
+        awkward             1.8.0
+        backcall            0.2.0
+        cython_runtime      NA
+        dateutil            2.8.2
+        debugpy             1.6.0
+        decorator           5.1.1
+        entrypoints         0.4
+        executing           0.8.3
+        h5py                3.7.0
+        ipykernel           6.15.0
+        jedi                0.18.1
+        mpl_toolkits        NA
+        natsort             8.1.0
+        numpy               1.22.4
+        packaging           21.3
+        pandas              1.4.2
+        parso               0.8.3
+        pexpect             4.8.0
+        pickleshare         0.7.5
+        pkg_resources       NA
+        prompt_toolkit      3.0.29
+        psutil              5.9.1
+        ptyprocess          0.7.0
+        pure_eval           0.2.2
+        pydev_ipython       NA
+        pydevconsole        NA
+        pydevd              2.8.0
+        pydevd_file_utils   NA
+        pydevd_plugins      NA
+        pydevd_tracing      NA
+        pygments            2.12.0
+        pytz                2022.1
+        scipy               1.8.1
+        setuptools          62.5.0
+        setuptools_scm      NA
+        six                 1.16.0
+        stack_data          0.3.0
+        tornado             6.1
+        traitlets           5.3.0
+        wcwidth             0.2.5
+        zmq                 23.1.0
+        -----
+        IPython             8.4.0
+        jupyter_client      7.3.4
+        jupyter_core        4.10.0
+        -----
+        Python 3.9.13 | packaged by conda-forge | (main, May 27 2022, 16:58:50) [GCC 10.3.0]
+        Linux-5.18.6-arch1-1-x86_64-with-glibc2.35
+        -----
+        Session information updated at 2022-07-07 17:55

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,19 @@
+name: Feature request
+description: Propose a new feature for lamindb
+labels: enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Note**: This is a public repository! Do not reveal any internal information.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description of feature
+      description: Please describe your suggestion for a new feature. It might help to describe a problem or use case, plus any alternatives that you have considered.
+      placeholder: |
+        This is a public repository!
+        Do not reveal any internal information.
+    validations:
+      required: true


### PR DESCRIPTION
- Adds issue templates for bugs and features
- Adds buttons to report laminhub issues and to contact us

Should work and look similarly to https://github.com/laminlabs/laminhub-public/issues/new/choose

It's somewhat important to me to encourage people to report their used dependency versions because it's hella difficult to diagnose many issues without it.

Can't test it before merging, but it should be good. 