### PR TITLE
🚸 Make source code searchable

### DIFF
--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -66,7 +66,7 @@ def notebook_to_script(
     import jupytext
 
     notebook = jupytext.read(notebook_path)
-    py_format = jupytext.formats.get_format_implementation("py:percent")
+    py_format = jupytext.formats.get_format_implementation("py", "percent")
     script = py_format.writes(notebook, notebook_metadata={}, cell_metadata={})
     script.replace(f"# {transform.name}", "# Transform.name")
     script_path.write_text(script)
@@ -75,7 +75,7 @@ def notebook_to_script(
 def script_to_notebook(transform: Transform, notebook_path: Path) -> None:
     import jupytext
 
-    py_format = jupytext.formats.get_format_implementation("py:percent")
+    py_format = jupytext.formats.get_format_implementation("py", "percent")
     # script content won't have title
     script = transform.source_code.replace("# Transform.name", f"# {transform.name}")
     notebook = py_format.reads(script)

--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -121,8 +121,8 @@ def save_context_core(
         report_path = ln_setup.settings.storage.cache_dir / filepath.name
         notebook_to_ipynb(filepath, report_path)
         # write the source code
-        source_code_path = ln_setup.settings.storage.cache_dir / filepath.with_suffix(
-            ".py"
+        source_code_path = ln_setup.settings.storage.cache_dir / filepath.name.replace(
+            ".ipynb", ".py"
         )
         notebook_to_script(transform, filepath, source_code_path)
     ln.settings.creation.artifact_silence_missing_run_warning = True

--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -149,21 +149,7 @@ def save_context_core(
         # representation
         source_code_path = ln_setup.settings.storage.cache_dir / filepath.name
         notebook_to_script(filepath, source_code_path)
-    # find initial versions of source codes and html reports
-    prev_report = None
-    if transform_family is None:
-        transform_family = transform.versions
-    if len(transform_family) > 0:
-        for prev_transform in transform_family.order_by("-created_at"):
-            if (
-                prev_transform.latest_run is not None
-                and prev_transform.latest_run.report_id is not None
-            ):
-                prev_report = prev_transform.latest_run.report
-            if prev_transform._source_code_artifact_id is not None:
-                pass
     ln.settings.creation.artifact_silence_missing_run_warning = True
-
     # track source code
     hash, _ = hash_file(source_code_path)  # ignore hash_type for now
     if (
@@ -252,7 +238,6 @@ def save_context_core(
             report_file = ln.Artifact(
                 report_path,
                 description=f"Report of run {run.uid}",
-                revises=prev_report,
                 visibility=0,  # hidden file
                 run=False,
             )

--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -73,7 +73,7 @@ def notebook_to_script(
     # remove global metadata header
     py_content = re.sub(r"^# ---\n.*?# ---\n\n", "", py_content, flags=re.DOTALL)
     # replace title
-    py_content = py_content.replace(f"# # {transform.name}", "# # Transform.name")
+    py_content = py_content.replace(f"# # {transform.name}", "# # transform.name")
     script_path.write_text(py_content)
 
 
@@ -82,7 +82,7 @@ def script_to_notebook(transform: Transform, notebook_path: Path) -> None:
 
     # get title back
     py_content = transform.source_code.replace(
-        "# # Transform.name", f"# # {transform.name}"
+        "# # transform.name", f"# # {transform.name}"
     )
     notebook = jupytext.reads(py_content, fmt="py:percent")
     jupytext.write(notebook, notebook_path)

--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -79,6 +79,8 @@ def notebook_to_script(notebook_path: Path, script_path: Path) -> None:
         notebook, replace_title="Transform.name", remove_cell_metadata=True
     )
     jupytext.write(notebook, script_path, fmt="py:percent")
+    print(script_path.read_text())
+    quit()
 
 
 def script_to_notebook(transform: Transform, notebook_path: Path) -> None:
@@ -94,7 +96,6 @@ def save_context_core(
     run: Run,
     transform: Transform,
     filepath: Path,
-    transform_family: QuerySet | None = None,
     finished_at: bool = False,
     from_cli: bool = False,
 ) -> str | None:

--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -61,15 +61,18 @@ def notebook_to_script(
     # remove global metadata header
     py_content = re.sub(r"^# ---\n.*?# ---\n\n", "", py_content, flags=re.DOTALL)
     # replace title
-    py_content = py_content.replace(f"# {transform.name}", "# Transform.name")
+    py_content = py_content.replace(f"# # {transform.name}", "# # Transform.name")
     script_path.write_text(py_content)
 
 
 def script_to_notebook(transform: Transform, notebook_path: Path) -> None:
     import jupytext
 
-    notebook = jupytext.reads(transform.source_code, fmt="py:percent")
-    prepare_notebook(notebook)
+    # get title back
+    py_content = transform.source_code.replace(
+        "# # Transform.name", f"# # {transform.name}"
+    )
+    notebook = jupytext.reads(py_content, fmt="py:percent")
     jupytext.write(notebook, notebook_path)
 
 

--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -118,7 +118,9 @@ def save_context_core(
         report_path = ln_setup.settings.storage.cache_dir / filepath.name
         notebook_to_ipynb(filepath, report_path)
         # write the source code
-        source_code_path = ln_setup.settings.storage.cache_dir / filepath.name
+        source_code_path = ln_setup.settings.storage.cache_dir / filepath.with_suffix(
+            ".py"
+        )
         notebook_to_script(transform, filepath, source_code_path)
     ln.settings.creation.artifact_silence_missing_run_warning = True
     # track source code

--- a/noxfile.py
+++ b/noxfile.py
@@ -177,7 +177,7 @@ def build(session, group):
     elif group == "storage":
         run(session, f"pytest -s {coverage_args} ./docs/storage")
     elif group == "cli":
-        run(session, f"pytest {coverage_args} ./sub/lamin-cli/tests")
+        run(session, f"pytest -vv {coverage_args} ./sub/lamin-cli/tests")
     # move artifacts into right place
     if group in {"tutorial", "guide", "biology"}:
         target_dir = Path(f"./docs/{group}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "lnschema_core==0.73.4",
     "lamindb_setup==0.76.8",
     "lamin_utils==0.13.4",
-    "lamin_cli==0.16.2",
+    "lamin_cli==0.16.3",
     # others
     "rapidfuzz",
     "pyarrow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ gcp = [
 ]
 jupyter = [
     "nbproject==0.10.4",  # keep pinning
-    "nbstripout==0.6.1", # 0.7.0 seems to be broken, 0.6.2 incompatible with orjson
+    "jupytext",
     "nbconvert",
 ]
 zarr = [

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -223,9 +223,8 @@ def test_run_external_script():
     # ensure that the source code is not saved as an output artifact
     assert transform.latest_run.output_artifacts.count() == 0
     assert transform.runs.count() == 1
-    assert transform._source_code_artifact.hash == "Cwk0OPOyUH5nzTiU2ISlDQ"
-    assert transform._source_code_artifact.transform is None
-    assert transform._source_code_artifact.run is None
+    assert transform.hash == "Cwk0OPOyUH5nzTiU2ISlDQ"
+    assert transform._source_code_artifact is None
 
 
 @pytest.mark.parametrize("type", ["notebook", "script"])


### PR DESCRIPTION
This change enables searchability of source code both on the hub and in lamindb by treating source code in the same way as metadata (say ontology descriptions). `transform.source_code` gets stored in a `Text` column in Postgres/SQLite. By all realistic calculations, this will never lead to scalability issues.

Also, we're now
- using the `jupytext` format for notebooks for a cleaner representation of `transform.source_code`
- stripping the notebook title both from run reports and source code to de-duplicate with the `transform.name` field, so that these can no longer get out-of-sync

Adjacent PRs:

- https://github.com/laminlabs/lamin-cli/pull/64
- https://github.com/laminlabs/laminhub/pull/1138

Internal [Slack discussion](https://laminlabs.slack.com/archives/C046F63LJJ2/p1721135617920409).