### PR TITLE
🚚 Deprecate `Curate` in favor of `Curator` and make `CuratorBase` the base class of `DataFrameCurator`

### DIFF
--- a/docs/curate-df.ipynb
+++ b/docs/curate-df.ipynb
@@ -117,7 +117,7 @@
    "id": "804ae191",
    "metadata": {},
    "source": [
-    "The {meth}`~lamindb.Curator.validate` method checks our data against the defined criteria. It identifies which values are already validated (exist in our registries) and which are potentially problematic (do not yet exist in our registries)."
+    "The {meth}`~lamindb.core.BaseCurator.validate` method checks our data against the defined criteria. It identifies which values are already validated (exist in our registries) and which are potentially problematic (do not yet exist in our registries)."
    ]
   },
   {
@@ -143,7 +143,7 @@
     "\n",
     "If you see \"non-validated\" values, you'll need to decide whether to add them to your registries or \"fix\" them in your dataset.\n",
     "\n",
-    "Because our current registries are still empty, we'll start by populating our {class}`~lamindb.CellType` registry with values from a public ontology."
+    "Because our current registries are still empty, we'll start by populating our {class}`~bionty.CellType` registry with values from a public ontology."
    ]
   },
   {

--- a/docs/curate-df.ipynb
+++ b/docs/curate-df.ipynb
@@ -117,7 +117,7 @@
    "id": "804ae191",
    "metadata": {},
    "source": [
-    "The {meth}`~lamindb.core.DataFrameCurator.validate` method checks our data against the defined criteria. It identifies which values are already validated (exist in our registries) and which are potentially problematic (do not yet exist in our registries)."
+    "The {meth}`~lamindb.Curator.validate` method checks our data against the defined criteria. It identifies which values are already validated (exist in our registries) and which are potentially problematic (do not yet exist in our registries)."
    ]
   },
   {

--- a/docs/curate-df.ipynb
+++ b/docs/curate-df.ipynb
@@ -117,7 +117,7 @@
    "id": "804ae191",
    "metadata": {},
    "source": [
-    "The {meth}`~lamindb.Curate.validate` method checks our data against the defined criteria. It identifies which values are already validated (exist in our registries) and which are potentially problematic (do not yet exist in our registries)."
+    "The {meth}`~lamindb.core.DataFrameCurator.validate` method checks our data against the defined criteria. It identifies which values are already validated (exist in our registries) and which are potentially problematic (do not yet exist in our registries)."
    ]
   },
   {

--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -25,7 +25,7 @@ Key functionality
 
    context
    connect
-   Curate
+   Curator
    view
    save
 
@@ -94,7 +94,7 @@ if _check_instance_setup(from_lamindb=True):
         _ulabel,
         integrations,
     )
-    from ._curate import Curate
+    from ._curate import Curator
     from ._save import save
     from ._view import view
     from .core._context import context
@@ -110,6 +110,7 @@ if _check_instance_setup(from_lamindb=True):
 
     track = context.track  # backward compat
     finish = context.finish  # backward compat
+    Curate = Curator  # backward compat
     settings.__doc__ = """Global :class:`~lamindb.core.Settings`."""
     context.__doc__ = """Global :class:`~lamindb.core.Context`."""
     from django.db.models import Q

--- a/lamindb/_curate.py
+++ b/lamindb/_curate.py
@@ -111,7 +111,7 @@ class BaseCurator:
 class DataFrameCurator(BaseCurator):
     """Curation flow for a DataFrame object.
 
-    See also :class:`~lamindb.Curate`.
+    See also :class:`~lamindb.Curator`.
 
     Args:
         df: The DataFrame object to curate.
@@ -354,7 +354,7 @@ class DataFrameCurator(BaseCurator):
 class AnnDataCurator(DataFrameCurator):
     """Curation flow for ``AnnData``.
 
-    See also :class:`~lamindb.Curate`.
+    See also :class:`~lamindb.Curator`.
 
     Note that if genes are removed from the AnnData object, the object should be recreated using :meth:`~lamindb.Curate.from_anndata`.
 
@@ -562,7 +562,7 @@ class AnnDataCurator(DataFrameCurator):
 class MuDataCurator:
     """Curation flow for a ``MuData`` object.
 
-    See also :class:`~lamindb.Curate`.
+    See also :class:`~lamindb.Curator`.
 
     Note that if genes or other measurements are removed from the MuData object,
     the object should be recreated using :meth:`~lamindb.Curate.from_mudata`.
@@ -880,7 +880,7 @@ class Curator(BaseCurator):
 
     The curation flow has several steps:
 
-    1. Create a :class:`Curate` object corresponding to the object type that you want to curate:
+    1. Instantiate `Curator` from one of the following dataset objects:
 
     - :meth:`~lamindb.Curate.from_df`
     - :meth:`~lamindb.Curate.from_anndata`
@@ -893,7 +893,7 @@ class Curator(BaseCurator):
     - Values that can successfully validated and already exist in the registry.
     - Values which are new and not yet validated or potentially problematic values.
 
-    3. Determine how to handle validated and unvalidated values:
+    3. Determine how to handle validated and non-validated values:
 
     - Validated values not yet in the registry can be automatically registered using :meth:`~lamindb.core.DataFrameCurator.add_validated_from`.
     - Valid and new values can be registered using :meth:`~lamindb.core.DataFrameCurator.add_new_from`.

--- a/lamindb/_curate.py
+++ b/lamindb/_curate.py
@@ -84,7 +84,31 @@ class CurateLookup:
             return colors.warning("No fields are found!")
 
 
-class DataFrameCurator:
+class BaseCurator:
+    """Curate a dataset."""
+
+    def validate(self) -> bool:
+        """Validate dataset.
+
+        Returns:
+            Boolean indicating whether the dataset is validated.
+        """
+        pass
+
+    def save_artifact(self, description: str | None = None, **kwargs) -> Artifact:
+        """Save the dataset as artifact.
+
+        Args:
+            description: Description of the DataFrame object.
+            **kwargs: Object level metadata.
+
+        Returns:
+            A saved artifact record.
+        """
+        pass
+
+
+class DataFrameCurator(BaseCurator):
     """Curation flow for a DataFrame object.
 
     See also :class:`~lamindb.Curate`.
@@ -848,8 +872,8 @@ class MuDataCurator:
         return self._artifact
 
 
-class Curate:
-    """Curation flow.
+class Curator(BaseCurator):
+    """Dataset curator.
 
     Data curation entails accurately labeling datasets with standardized metadata
     to facilitate data integration, interpretation and analysis.
@@ -1521,3 +1545,6 @@ def _save_organism(name: str):  # pragma: no cover
             )
         organism.save()
     return organism
+
+
+Curate = Curator  # backward compat

--- a/lamindb/core/__init__.py
+++ b/lamindb/core/__init__.py
@@ -30,6 +30,7 @@ Curators:
 .. autosummary::
    :toctree: .
 
+   BaseCurator
    DataFrameCurator
    AnnDataCurator
    MuDataCurator
@@ -80,6 +81,7 @@ from lnschema_core.models import (
 
 from lamindb._curate import (
     AnnDataCurator,
+    BaseCurator,
     CurateLookup,
     DataFrameCurator,
     MuDataCurator,


### PR DESCRIPTION
Addresses:

- https://github.com/laminlabs/lamindb/issues/1861

A follow-up PR will address below issue:
- https://github.com/laminlabs/lamindb/issues/1860