### PR TITLE
🐛 Fix categoricals and sources being checked

### DIFF
--- a/lamindb/_curate.py
+++ b/lamindb/_curate.py
@@ -87,6 +87,19 @@ class CurateLookup:
 class BaseCurator:
     """Curate a dataset."""
 
+    def _check_keys_in_obs(
+        self, df: pd.DataFrame, categoricals: dict, sources: dict
+    ) -> None:
+        missing_keys = [
+            key
+            for key in list(categoricals.keys()) + list(sources.keys())
+            if key not in df.columns
+        ]
+        if missing_keys:
+            raise KeyError(
+                f"The following keys were passed as categoricals or sources but are missing in the columns: {missing_keys}."
+            )
+
     def validate(self) -> bool:
         """Validate dataset.
 
@@ -146,6 +159,9 @@ class DataFrameCurator(BaseCurator):
         exclude: dict | None = None,
     ) -> None:
         from lamindb.core._settings import settings
+
+        super().__init__()
+        self._check_keys_in_obs(df, categoricals or {}, sources or {})
 
         self._df = df
         self._fields = categoricals or {}

--- a/lamindb/_curate.py
+++ b/lamindb/_curate.py
@@ -201,7 +201,7 @@ class DataFrameCurator(BaseCurator):
             if key not in df.columns
         ]
         if missing_keys:
-            raise KeyError(
+            raise ValueError(
                 f"The following keys were passed as categoricals or sources but are missing in the columns: {missing_keys}."
             )
 

--- a/lamindb/_curate.py
+++ b/lamindb/_curate.py
@@ -193,7 +193,10 @@ class DataFrameCurator(BaseCurator):
         )
 
     def _check_categoricals_sources_in_cols(
-        self, df: pd.DataFrame, categoricals: dict, sources: dict
+        self,
+        df: pd.DataFrame,
+        categoricals: dict[str, FieldAttr],
+        sources: dict[str, Record],
     ) -> None:
         missing_categoricals = [
             key for key in categoricals.keys() if key not in df.columns

--- a/lamindb/_curate.py
+++ b/lamindb/_curate.py
@@ -158,7 +158,7 @@ class DataFrameCurator(BaseCurator):
         self._kwargs = {"organism": organism} if organism else {}
         if sources is None:
             sources = {}
-        self._check_categoricals_sources_in_cols(df, categoricals, sources)
+        self._check_categoricals_sources_in_cols(df, self._fields, sources)
         self._sources = sources
         if exclude is None:
             exclude = {}

--- a/lamindb/_curate.py
+++ b/lamindb/_curate.py
@@ -195,24 +195,23 @@ class DataFrameCurator(BaseCurator):
     def _check_categoricals_sources_in_cols(
         self, df: pd.DataFrame, categoricals: dict, sources: dict
     ) -> None:
-        missing_keys = [
-            key
-            for key in list(categoricals.keys()) + list(sources.keys())
-            if key not in df.columns
+        missing_categoricals = [
+            key for key in categoricals.keys() if key not in df.columns
         ]
-        if missing_keys:
+        missing_sources = [key for key in sources.keys() if key not in df.columns]
+
+        if missing_categoricals:
             raise ValueError(
-                f"The following keys were passed as categoricals or sources but are missing in the columns: {missing_keys}."
+                f"The following keys were passed as categoricals but are missing in the columns: {missing_categoricals}."
+            )
+
+        if missing_sources:
+            raise ValueError(
+                f"The following keys were passed as sources but are missing in the columns: {missing_sources}."
             )
 
     def _save_columns(self, validated_only: bool = True, **kwargs) -> None:
         """Save column name records."""
-        missing_columns = set(self.fields.keys()) - set(self._df.columns)
-        if missing_columns:
-            raise ValueError(
-                f"Columns {missing_columns} are not found in the data object!"
-            )
-
         # Always save features specified as the fields keys
         update_registry(
             values=list(self.fields.keys()),

--- a/tests/core/test_curate.py
+++ b/tests/core/test_curate.py
@@ -113,14 +113,6 @@ def test_custom_using_invalid_field_lookup(curate_lookup):
     )
 
 
-def test_missing_columns(df):
-    with pytest.raises(ValueError) as error:
-        ln.Curator.from_df(df, categoricals={"missing_column": "some_registry_field"})
-    assert "Columns {'missing_column'} are not found in the data object!" in str(
-        error.value
-    )
-
-
 def test_additional_args_with_all_key(df, categoricals):
     curate = ln.Curator.from_df(df, categoricals=categoricals)
     with pytest.raises(ValueError) as error:
@@ -228,10 +220,10 @@ def test_categorical_key_not_present(df):
     )
 
 
-def test_source_key_not_present(df, categoricals):
+def test_source_key_not_present(adata, categoricals):
     with pytest.raises(ValueError) as error:
-        ln.Curator.from_df(
-            df,
+        ln.Curator.from_anndata(
+            adata,
             categoricals=categoricals,
             sources={"not_present": None},
             organism="human",

--- a/tests/core/test_curate.py
+++ b/tests/core/test_curate.py
@@ -216,7 +216,7 @@ def test_categorical_key_not_present(df):
         )
 
     assert (
-        "The following keys were passed as categoricals or sources but are missing in the columns"
+        "The following keys were passed as categoricals but are missing in the columns"
         in str(error.value)
     )
 
@@ -231,7 +231,7 @@ def test_source_key_not_present(adata, categoricals):
             organism="human",
         )
     assert (
-        "The following keys were passed as categoricals or sources but are missing in the columns"
+        "The following keys were passed as sources but are missing in the columns"
         in str(error.value)
     )
 

--- a/tests/core/test_curate.py
+++ b/tests/core/test_curate.py
@@ -206,9 +206,10 @@ def test_no_categoricals(adata):
 
 def test_anndata_annotator_wrong_type(df, categoricals):
     with pytest.raises(ValueError) as error:
-        ln.Curator.from_df(
+        ln.Curator.from_anndata(
             df,
             categoricals=categoricals,
+            var_index=bt.Gene.symbol,
             organism="human",
         )
     assert "data has to be an AnnData object" in str(error.value)
@@ -229,10 +230,9 @@ def test_categorical_key_not_present(df):
 
 def test_source_key_not_present(df, categoricals):
     with pytest.raises(ValueError) as error:
-        ln.Curator.from_anndata(
+        ln.Curator.from_df(
             df,
             categoricals=categoricals,
-            var_index=bt.Gene.symbol,
             sources={"not_present": None},
             organism="human",
         )

--- a/tests/core/test_curate.py
+++ b/tests/core/test_curate.py
@@ -209,7 +209,6 @@ def test_anndata_annotator_wrong_type(df, categoricals):
         ln.Curator.from_df(
             df,
             categoricals=categoricals,
-            var_index=bt.Gene.symbol,
             organism="human",
         )
     assert "data has to be an AnnData object" in str(error.value)
@@ -220,7 +219,6 @@ def test_categorical_key_not_present(df):
         ln.Curator.from_df(
             df,
             categoricals={"not present": None},
-            var_index=bt.Gene.symbol,
             organism="human",
         )
     assert (

--- a/tests/core/test_curate.py
+++ b/tests/core/test_curate.py
@@ -226,6 +226,7 @@ def test_source_key_not_present(adata, categoricals):
         ln.Curator.from_anndata(
             adata,
             categoricals=categoricals,
+            var_index=bt.Gene.symbol,
             sources={"not_present": None},
             organism="human",
         )

--- a/tests/core/test_curate.py
+++ b/tests/core/test_curate.py
@@ -214,8 +214,9 @@ def test_categorical_key_not_present(df):
             categoricals={"not present": None},
             organism="human",
         )
+
     assert (
-        "The following keys were passed as categoricals or source but are missing in the columns"
+        "The following keys were passed as categoricals or sources but are missing in the columns"
         in str(error.value)
     )
 

--- a/tests/core/test_curate.py
+++ b/tests/core/test_curate.py
@@ -231,7 +231,7 @@ def test_source_key_not_present(adata, categoricals):
             organism="human",
         )
     assert (
-        "The following keys were passed as categoricals or source but are missing in the columns"
+        "The following keys were passed as categoricals or sources but are missing in the columns"
         in str(error.value)
     )
 

--- a/tests/core/test_curate.py
+++ b/tests/core/test_curate.py
@@ -206,7 +206,7 @@ def test_no_categoricals(adata):
 
 def test_anndata_annotator_wrong_type(df, categoricals):
     with pytest.raises(ValueError) as error:
-        ln.Curator.from_anndata(
+        ln.Curator.from_df(
             df,
             categoricals=categoricals,
             var_index=bt.Gene.symbol,
@@ -217,7 +217,7 @@ def test_anndata_annotator_wrong_type(df, categoricals):
 
 def test_categorical_key_not_present(df):
     with pytest.raises(ValueError) as error:
-        ln.Curator.from_anndata(
+        ln.Curator.from_df(
             df,
             categoricals={"not present": None},
             var_index=bt.Gene.symbol,

--- a/tests/core/test_curate.py
+++ b/tests/core/test_curate.py
@@ -215,6 +215,35 @@ def test_anndata_annotator_wrong_type(df, categoricals):
     assert "data has to be an AnnData object" in str(error.value)
 
 
+def test_categorical_key_not_present(df):
+    with pytest.raises(ValueError) as error:
+        ln.Curator.from_anndata(
+            df,
+            categoricals={"not present": None},
+            var_index=bt.Gene.symbol,
+            organism="human",
+        )
+    assert (
+        "The following keys were passed as categoricals or source but are missing in the columns"
+        in str(error.value)
+    )
+
+
+def test_source_key_not_present(df, categoricals):
+    with pytest.raises(ValueError) as error:
+        ln.Curator.from_anndata(
+            df,
+            categoricals=categoricals,
+            var_index=bt.Gene.symbol,
+            sources={"not_present": None},
+            organism="human",
+        )
+    assert (
+        "The following keys were passed as categoricals or source but are missing in the columns"
+        in str(error.value)
+    )
+
+
 def test_unvalidated_adata_object(adata, categoricals):
     curate = ln.Curator.from_anndata(
         adata,


### PR DESCRIPTION
Fixes https://github.com/laminlabs/lamindb/issues/1833

- Now raising a `ValueError` when categoricals or sources are passed that do not exist in the columns of the DataFrame.
- We could have added this to the `BaseCurator` but since all implementations currently use the `DataFrameCurator` it's fine like this.
