### PR TITLE
📝 Document inherited class members

### DIFF
--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -1,7 +1,6 @@
 """A data framework for biology.
 
-Records
-=======
+Core registries.
 
 .. autosummary::
    :toctree: .
@@ -17,8 +16,7 @@ Records
    FeatureSet
    Param
 
-Key functionality
-=================
+Key functionality.
 
 .. autosummary::
    :toctree: .
@@ -29,8 +27,7 @@ Key functionality
    view
    save
 
-Modules & settings
-==================
+Modules and settings.
 
 .. autosummary::
    :toctree: .

--- a/lamindb/_query_set.py
+++ b/lamindb/_query_set.py
@@ -132,7 +132,7 @@ class RecordsList(UserList):
         return one_helper(self)
 
 
-class QuerySet(models.QuerySet, CanValidate):
+class QuerySet(models.QuerySet):
     """Sets of records returned by queries.
 
     See Also:
@@ -301,42 +301,50 @@ class QuerySet(models.QuerySet, CanValidate):
         else:
             raise ValueError("Record isn't subclass of `lamindb.core.IsVersioned`")
 
-    @doc_args(Record.search.__doc__)
-    def search(self, string: str, **kwargs):
-        """{}"""  # noqa: D415
-        from ._record import _search
 
-        return _search(cls=self, string=string, **kwargs)
+# -------------------------------------------------------------------------------------
+# CanValidate
+# -------------------------------------------------------------------------------------
 
-    @doc_args(Record.lookup.__doc__)
-    def lookup(self, field: StrField | None = None, **kwargs) -> NamedTuple:
-        """{}"""  # noqa: D415
-        from ._record import _lookup
 
-        return _lookup(cls=self, field=field, **kwargs)
+@doc_args(Record.search.__doc__)
+def search(self, string: str, **kwargs):
+    """{}"""  # noqa: D415
+    from ._record import _search
 
-    @doc_args(CanValidate.validate.__doc__)
-    def validate(self, values: ListLike, field: str | StrField | None = None, **kwargs):
-        """{}"""  # noqa: D415
-        from ._can_validate import _validate
+    return _search(cls=self, string=string, **kwargs)
 
-        return _validate(cls=self, values=values, field=field, **kwargs)
 
-    @doc_args(CanValidate.inspect.__doc__)
-    def inspect(self, values: ListLike, field: str | StrField | None = None, **kwargs):
-        """{}"""  # noqa: D415
-        from ._can_validate import _inspect
+@doc_args(Record.lookup.__doc__)
+def lookup(self, field: StrField | None = None, **kwargs) -> NamedTuple:
+    """{}"""  # noqa: D415
+    from ._record import _lookup
 
-        return _inspect(cls=self, values=values, field=field, **kwargs)
+    return _lookup(cls=self, field=field, **kwargs)
 
-    @doc_args(CanValidate.standardize.__doc__)
-    def standardize(
-        self, values: Iterable, field: str | StrField | None = None, **kwargs
-    ):
-        """{}"""  # noqa: D415
-        from ._can_validate import _standardize
 
-        return _standardize(cls=self, values=values, field=field, **kwargs)
+@doc_args(CanValidate.validate.__doc__)
+def validate(self, values: ListLike, field: str | StrField | None = None, **kwargs):
+    """{}"""  # noqa: D415
+    from ._can_validate import _validate
+
+    return _validate(cls=self, values=values, field=field, **kwargs)
+
+
+@doc_args(CanValidate.inspect.__doc__)
+def inspect(self, values: ListLike, field: str | StrField | None = None, **kwargs):
+    """{}"""  # noqa: D415
+    from ._can_validate import _inspect
+
+    return _inspect(cls=self, values=values, field=field, **kwargs)
+
+
+@doc_args(CanValidate.standardize.__doc__)
+def standardize(self, values: Iterable, field: str | StrField | None = None, **kwargs):
+    """{}"""  # noqa: D415
+    from ._can_validate import _standardize
+
+    return _standardize(cls=self, values=values, field=field, **kwargs)
 
 
 models.QuerySet.df = QuerySet.df
@@ -345,10 +353,10 @@ models.QuerySet.first = QuerySet.first
 models.QuerySet.one = QuerySet.one
 models.QuerySet.one_or_none = QuerySet.one_or_none
 models.QuerySet.latest_version = QuerySet.latest_version
-models.QuerySet.search = QuerySet.search
-models.QuerySet.lookup = QuerySet.lookup
-models.QuerySet.validate = QuerySet.validate
-models.QuerySet.inspect = QuerySet.inspect
-models.QuerySet.standardize = QuerySet.standardize
+models.QuerySet.search = search
+models.QuerySet.lookup = lookup
+models.QuerySet.validate = validate
+models.QuerySet.inspect = inspect
+models.QuerySet.standardize = standardize
 models.QuerySet._delete_base_class = models.QuerySet.delete
 models.QuerySet.delete = QuerySet.delete

--- a/lamindb/core/__init__.py
+++ b/lamindb/core/__init__.py
@@ -10,8 +10,6 @@ Registries:
    QuerySet
    QueryManager
    RecordsList
-   HasFeatures
-   HasParams
    FeatureManager
    ParamManager
    LabelManager


### PR DESCRIPTION
While it's more verbose to document inherited class members, it turned out that users get confused if they don't see all available members.

Also, it reminds developers to be as careful as possible with using inheritance: the docs immediately give feedback if an API becomes bloated.

See also:

- https://github.com/laminlabs/lndocs/pull/99