### PR TITLE
🐛 Fix marking latest transform as `is_latest`

### DIFF
--- a/lamindb/_transform.py
+++ b/lamindb/_transform.py
@@ -37,8 +37,7 @@ def __init__(transform: Transform, *args, **kwargs):
             "Only name, key, version, type, revises, reference, "
             f"reference_type can be passed, but you passed: {kwargs}"
         )
-    # Transform allows passing a uid, all others don't
-    if uid is None and key is not None:
+    if revises is None and key is not None:
         revises = Transform.filter(key=key).order_by("-created_at").first()
     if revises is not None and key is not None and revises.key != key:
         note = message_update_key_in_version_family(

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -414,6 +414,10 @@ class Context:
         if transform is None:
             if uid is None:
                 uid = f"{stem_uid}{get_uid_ext(version)}"
+            # note that here we're not passing revises because we're not querying it
+            # hence, we need to do a revision family lookup based on key
+            # hence, we need key to be not None
+            assert key is not None  # noqa: S101
             transform = Transform(
                 uid=uid,
                 version=version,
@@ -422,8 +426,7 @@ class Context:
                 reference=transform_ref,
                 reference_type=transform_ref_type,
                 type=transform_type,
-            )
-            transform.save()
+            ).save()
             self._logging_message += f"created Transform('{transform.uid}')"
         else:
             uid = transform.uid

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -91,7 +91,7 @@ def test_invalid_transform_type():
     ln.context._run = None
 
 
-def test_create_or_load_transform(monkeypatch):
+def test_create_or_load_transform():
     title = "title"
     stem_uid = "NJvdsWWbJlZS"
     version = "0"
@@ -102,6 +102,7 @@ def test_create_or_load_transform(monkeypatch):
         stem_uid=stem_uid,
         version=version,
         name=title,
+        key="my-test-transform-create-or-load",
         transform_type="notebook",
     )
     assert context._transform.uid == uid
@@ -111,6 +112,7 @@ def test_create_or_load_transform(monkeypatch):
         uid=None,
         transform=context._transform,
         stem_uid=stem_uid,
+        key="my-test-transform-create-or-load",
         version=version,
         name=title,
     )
@@ -125,6 +127,7 @@ def test_create_or_load_transform(monkeypatch):
         stem_uid=stem_uid,
         version=version,
         name="updated title",
+        key="my-test-transform-create-or-load",
     )
     assert context._transform.uid == uid
     assert context._transform.version == version
@@ -180,6 +183,8 @@ def test_run_scripts_for_versioning():
         "created Transform('Ro1gl7n8YrdH0001') & created Run('"
         in result.stdout.decode()
     )
+    assert not ln.Transform.get("Ro1gl7n8YrdH0000").is_latest
+    assert ln.Transform.get("Ro1gl7n8YrdH0001").is_latest
 
     # inconsistent version
     result = subprocess.run(  # noqa: S602


### PR DESCRIPTION
The bug was introduced 2 weeks ago: https://docs.lamin.ai/changelog/2024#db-0-76-2

It leads to all previous transform revisions to be displayed in the UI. 