### PR TITLE
noxfile: fix "install" session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -57,7 +57,7 @@ def install(session):
         "./sub/bionty",
     ]
     top_deps = [
-        "./sub/lamindb[aws,bionty,jupyter]",
+        ".[aws,bionty,jupyter]",
     ]
     cmds = [
         f"uv pip install {'--system' if CI else ''} --no-cache-dir {' '.join(base_deps)}",


### PR DESCRIPTION
Hello Lamins,

When following the contribution guide, it is suggested to run `nox -s install`, which fails because the lamindb repo is not under `sub/lamindb`. This change aligns the install sessions behavior with the install_ci sessions behavior used in CI.

Cheers,
Andreas 😃 