### PR TITLE
🔥 Remove deprecated `artifact.backed()`

### DIFF
--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -908,14 +908,6 @@ def replace(
     self._to_store = not check_path_in_storage
 
 
-# deprecated
-def backed(
-    self, mode: str = "r", is_run_input: bool | None = None
-) -> AnnDataAccessor | BackedAccessor | SOMACollection | SOMAExperiment:
-    logger.warning("`.backed()` is deprecated, use `.open()`!'")
-    return self.open(mode, is_run_input)
-
-
 # docstring handled through attach_func_to_class_method
 def open(
     self, mode: str = "r", is_run_input: bool | None = None
@@ -1185,6 +1177,5 @@ for name in METHOD_NAMES:
 Artifact._delete_skip_storage = _delete_skip_storage
 Artifact._save_skip_storage = _save_skip_storage
 Artifact.path = path
-Artifact.backed = backed
 Artifact.describe = describe
 Artifact.view_lineage = view_lineage

--- a/lamindb/core/_settings.py
+++ b/lamindb/core/_settings.py
@@ -52,7 +52,7 @@ class Settings:
         return creation_settings
 
     track_run_inputs: bool = True
-    """Track files as input upon `.load()`, `.cache()` and `.backed()`.
+    """Track files as input upon `.load()`, `.cache()` and `.open()`.
 
     Requires a global run context with :func:`~lamindb.core.Context.track` was created!
 

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -321,9 +321,8 @@ def test_write_read_tiledbsoma(storage):
     with pytest.raises(ValueError):
         artifact_soma_append.open(mode="p")
 
-    # run deprecated backed
-    # and test running without the context manager
-    store = artifact_soma_append.backed()
+    # test running without the context manager
+    store = artifact_soma_append.open()
     n_obs_final = adata.n_obs + sum(
         adt.n_obs for adt in [adata_to_append_1, adata_to_append_2]
     )


### PR DESCRIPTION
Was deprecated in favor of `open()` here: https://docs.lamin.ai/changelog/2024#db-0-74-2