### PR TITLE
🚸 Better logging during transfer, describe, track() and raise an error if transferring outdated artifact

### DIFF
--- a/docs/transfer.ipynb
+++ b/docs/transfer.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here, we'll show how to transfer data from another instance into the current instance."
+    "This guide shows how to transfer data from a source database instance into the current default database instance."
    ]
   },
   {
@@ -48,7 +48,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "All artifacts in the `laminlabs/lamindata` clone of CZ CELLxGENE (for more info, see [cellxgene](inv:docs#cellxgene)):"
+    "Query all artifacts in the `laminlabs/lamindata` instance and filter them to their latest versions."
    ]
   },
   {
@@ -61,7 +61,10 @@
    },
    "outputs": [],
    "source": [
-    "artifacts = ln.Artifact.using(\"laminlabs/lamindata\")\n",
+    "# query all latest artifact versions \n",
+    "artifacts = ln.Artifact.using(\"laminlabs/lamindata\").filter(is_latest=True)\n",
+    "\n",
+    "# convert the QuerySet to a DataFrame and show the latest 5 versions\n",
     "artifacts.df().head()"
    ]
   },
@@ -69,7 +72,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Query or search the queryset:"
+    "You can now further subset or search the {class}`~lamindb.core.QuerySet`. Here we query by whether the description contains \"tabula sapiens\"."
    ]
   },
   {
@@ -82,7 +85,7 @@
    },
    "outputs": [],
    "source": [
-    "artifact = artifacts.filter(description__icontains=\"tabula sapiens\").first()\n",
+    "artifact = artifacts.filter(description__contains=\"Tabula Sapiens\").first()\n",
     "artifact"
    ]
   },
@@ -90,7 +93,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Save the artifact to the default instance:"
+    "By saving the artifact record that's currently attached to the source database instance, you transfer it to the default database instance."
    ]
   },
   {
@@ -110,7 +113,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "All features & labels have been transferred, the data itself is still on CZ's S3:"
+    "```{dropdown} How do I know if a record is saved in the default database instance or not?\n",
+    "\n",
+    "Every record has an attribute `._state.db` which can take the following values:\n",
+    "\n",
+    "- `None`: the record has not yet been saved to any database\n",
+    "- `\"default\"`: the record is saved on the default database instance\n",
+    "- `\"account/name\"`: the record is save on a non-default database instance referenced by `account/name` (e.g., `laminlabs/lamindata`)\n",
+    "\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The artifact record and all other feature & label records have been transferred. The data itself however in the original storage location. This means that transferring an artifact does *not* copy the data."
    ]
   },
   {

--- a/docs/transfer.ipynb
+++ b/docs/transfer.ipynb
@@ -86,7 +86,7 @@
    "outputs": [],
    "source": [
     "artifact = artifacts.filter(description__contains=\"Tabula Sapiens\").first()\n",
-    "artifact"
+    "artifact.describe()"
    ]
   },
   {
@@ -128,7 +128,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The artifact record and all other feature & label records have been transferred. The data itself however in the original storage location. This means that transferring an artifact does *not* copy the data."
+    "The artifact record and all other feature & label records have been transferred to the current database."
    ]
   },
   {
@@ -148,7 +148,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The database is populated correspondingly."
+    "You see that the data itself remained in the original storage location, which has been added to the current instance's storage location as a read-only location."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "ln.Storage.df()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "See the state of the database."
    ]
   },
   {

--- a/docs/transfer.ipynb
+++ b/docs/transfer.ipynb
@@ -195,8 +195,7 @@
    "outputs": [],
    "source": [
     "# clean up test instance\n",
-    "!lamin delete --force test-transfer\n",
-    "!rm -r test-transfer"
+    "!lamin delete --force test-transfer"
    ]
   }
  ],

--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -480,7 +480,7 @@ def transfer_to_default_db(
 ) -> Record | None:
     registry = record.__class__
     record_on_default = registry.objects.filter(uid=record.uid).one_or_none()
-    record_str = f"r{record.__class__.__name__}(uid='{record.uid}')"
+    record_str = f"{record.__class__.__name__}(uid='{record.uid}')"
     if record_on_default is not None:
         transfer_logs["mapped"].append(record_str)
         return record_on_default

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -293,10 +293,10 @@ class Context:
                 transform_exists = Transform.filter(id=transform.id).first()
             if transform_exists is None:
                 transform.save()
-                self._logging_message += f"created Transform('{transform.uid}')"
+                self._logging_message += f"created Transform(uid='{transform.uid}')"
                 transform_exists = transform
             else:
-                self._logging_message += f"loaded Transform('{transform.uid}')"
+                self._logging_message += f"loaded Transform(uid='{transform.uid}')"
             self._transform = transform_exists
 
         if new_run is None:  # for notebooks, default to loading latest runs
@@ -312,7 +312,7 @@ class Context:
             if run is not None:  # loaded latest run
                 run.started_at = datetime.now(timezone.utc)  # update run time
                 self._logging_message += (
-                    f" & loaded Run('{format_field_value(run.started_at)}')"
+                    f" & loaded Run(started_at={format_field_value(run.started_at)})"
                 )
 
         if run is None:  # create new run
@@ -322,7 +322,7 @@ class Context:
             )
             run.started_at = datetime.now(timezone.utc)
             self._logging_message += (
-                f" & created Run('{format_field_value(run.started_at)}')"
+                f" & created Run(started_at={format_field_value(run.started_at)})"
             )
         # can only determine at ln.finish() if run was consecutive in
         # interactive session, otherwise, is consecutive
@@ -436,7 +436,7 @@ class Context:
                 reference_type=transform_ref_type,
                 type=transform_type,
             ).save()
-            self._logging_message += f"created Transform('{transform.uid}')"
+            self._logging_message += f"created Transform(uid='{transform.uid}')"
         else:
             uid = transform.uid
             # check whether the transform file has been renamed
@@ -477,7 +477,9 @@ class Context:
                     if condition:
                         bump_revision = True
                     else:
-                        self._logging_message += f"loaded Transform('{transform.uid}')"
+                        self._logging_message += (
+                            f"loaded Transform(uid='{transform.uid}')"
+                        )
                 if bump_revision:
                     change_type = (
                         "Re-running saved notebook"
@@ -494,7 +496,7 @@ class Context:
                         f'ln.context.uid = "{suid}{new_vuid}"'
                     )
             else:
-                self._logging_message += f"loaded Transform('{transform.uid}')"
+                self._logging_message += f"loaded Transform(uid='{transform.uid}')"
         self._transform = transform
 
     def finish(self, ignore_non_consecutive: None | bool = None) -> None:

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -242,7 +242,7 @@ class Context:
                     ):
                         better_version = bump_version_function(self.version)
                         raise SystemExit(
-                            f"Version '{self.version}' is already taken by Transform('{transform.uid}'); please set another version, e.g., ln.context.version = '{better_version}'"
+                            f"Version '{self.version}' is already taken by Transform(uid='{transform.uid}'); please set another version, e.g., ln.context.version = '{better_version}'"
                         )
             elif transform_settings_are_set:
                 stem_uid, self.version = (

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import builtins
 import hashlib
-import os
 from datetime import datetime, timezone
 from pathlib import Path, PurePath
 from typing import TYPE_CHECKING
@@ -12,6 +11,7 @@ from lamin_utils import logger
 from lamindb_setup.core.hashing import hash_file
 from lnschema_core import Run, Transform, ids
 from lnschema_core.ids import base62_12
+from lnschema_core.models import format_field_value
 from lnschema_core.users import current_user_id
 
 from ._settings import settings
@@ -311,7 +311,9 @@ class Context:
             )
             if run is not None:  # loaded latest run
                 run.started_at = datetime.now(timezone.utc)  # update run time
-                self._logging_message += f" & loaded Run('{run.started_at}')"
+                self._logging_message += (
+                    f" & loaded Run('{format_field_value(run.started_at)}')"
+                )
 
         if run is None:  # create new run
             run = Run(
@@ -319,7 +321,9 @@ class Context:
                 params=params,
             )
             run.started_at = datetime.now(timezone.utc)
-            self._logging_message += f" & created Run('{run.started_at}')"
+            self._logging_message += (
+                f" & created Run('{format_field_value(run.started_at)}')"
+            )
         # can only determine at ln.finish() if run was consecutive in
         # interactive session, otherwise, is consecutive
         run.is_consecutive = True if is_run_from_ipython else None

--- a/lamindb/core/_data.py
+++ b/lamindb/core/_data.py
@@ -98,6 +98,11 @@ def save_feature_set_links(self: Artifact | Collection) -> None:
 @doc_args(Artifact.describe.__doc__)
 def describe(self: Artifact, print_types: bool = False):
     """{}"""  # noqa: D415
+    model_name = self.__class__.__name__
+    msg = f"{colors.green(model_name)}{record_repr(self, include_foreign_keys=False).lstrip(model_name)}\n"
+    if self._state.db is not None and self._state.db != "default":
+        msg += f"  {colors.italic('Database instance')}\n"
+        msg += f"    slug: {self._state.db}\n"
     # prefetch all many-to-many relationships
     # doesn't work for describing using artifact
     # self = (
@@ -108,10 +113,7 @@ def describe(self: Artifact, print_types: bool = False):
     #     .get(id=self.id)
     # )
 
-    model_name = self.__class__.__name__
-    msg = f"{colors.green(model_name)}{record_repr(self, include_foreign_keys=False).lstrip(model_name)}\n"
     prov_msg = ""
-
     fields = self._meta.fields
     direct_fields = []
     foreign_key_fields = []

--- a/lamindb/core/_data.py
+++ b/lamindb/core/_data.py
@@ -148,15 +148,24 @@ def describe(self: Artifact, print_types: bool = False):
             ]
         )
         prov_msg += related_msg
-    # input of
-    if self.id is not None and self.input_of_runs.exists():
-        values = [format_field_value(i.started_at) for i in self.input_of_runs.all()]
-        type_str = ": Run" if print_types else ""  # type: ignore
-        prov_msg += f"    .input_of_runs{type_str} = {values}\n"
     if prov_msg:
         msg += f"  {colors.italic('Provenance')}\n"
         msg += prov_msg
+
+    # input of runs
+    input_of_message = ""
+    if self.id is not None and self.input_of_runs.exists():
+        values = [format_field_value(i.started_at) for i in self.input_of_runs.all()]
+        type_str = ": Run" if print_types else ""  # type: ignore
+        input_of_message += f"    .input_of_runs{type_str} = {', '.join(values)}\n"
+    if input_of_message:
+        msg += f"  {colors.italic('Usage')}\n"
+        msg += input_of_message
+
+    # labels
     msg += print_labels(self, print_types=print_types)
+
+    # features
     msg += print_features(  # type: ignore
         self,
         print_types=print_types,

--- a/lamindb/core/_feature_manager.py
+++ b/lamindb/core/_feature_manager.py
@@ -792,7 +792,7 @@ def _add_from(self, data: Artifact | Collection, transfer_logs: dict = None):
     """Transfer features from a artifact or collection."""
     # This only covers feature sets
     if transfer_logs is None:
-        transfer_logs = {}
+        transfer_logs = {"mapped": [], "new": []}
     using_key = settings._using_key
     for slot, feature_set in data.features._feature_set_by_slot.items():
         members = feature_set.members

--- a/lamindb/core/_feature_manager.py
+++ b/lamindb/core/_feature_manager.py
@@ -792,7 +792,7 @@ def _add_from(self, data: Artifact | Collection, transfer_logs: dict = None):
     """Transfer features from a artifact or collection."""
     # This only covers feature sets
     if transfer_logs is None:
-        transfer_logs = {"mapped": [], "new": []}
+        transfer_logs = {"mapped": [], "transferred": []}
     using_key = settings._using_key
     for slot, feature_set in data.features._feature_set_by_slot.items():
         members = feature_set.members

--- a/lamindb/core/_label_manager.py
+++ b/lamindb/core/_label_manager.py
@@ -184,7 +184,7 @@ class LabelManager:
         from django.db.utils import ProgrammingError
 
         if transfer_logs is None:
-            transfer_logs = {}
+            transfer_logs = {"mapped": [], "new": []}
         using_key = settings._using_key
         for related_name, (_, labels) in get_labels_as_dict(data).items():
             labels = labels.all()

--- a/lamindb/core/_label_manager.py
+++ b/lamindb/core/_label_manager.py
@@ -184,7 +184,7 @@ class LabelManager:
         from django.db.utils import ProgrammingError
 
         if transfer_logs is None:
-            transfer_logs = {"mapped": [], "new": []}
+            transfer_logs = {"mapped": [], "transferred": []}
         using_key = settings._using_key
         for related_name, (_, labels) in get_labels_as_dict(data).items():
             labels = labels.all()

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -3,13 +3,15 @@ from pathlib import Path
 from subprocess import DEVNULL, run
 from time import perf_counter
 
-import lamindb as ln
 import lamindb_setup as ln_setup
 import pytest
 from lamin_utils import logger
 from laminci.db import setup_local_test_postgres
 
-AUTO_CONNECT = ln.setup.settings.auto_connect
+AUTO_CONNECT = ln_setup.settings.auto_connect
+ln_setup.settings.auto_connect = False
+
+import lamindb as ln
 
 
 def pytest_sessionstart():

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -167,7 +167,7 @@ def test_run_scripts_for_versioning():
     # print(result.stderr.decode())
     assert result.returncode == 1
     assert (
-        "Version '1' is already taken by Transform('Ro1gl7n8YrdH0000'); please set another version, e.g., ln.context.version = '1.1'"
+        "Version '1' is already taken by Transform(uid='Ro1gl7n8YrdH0000'); please set another version, e.g., ln.context.version = '1.1'"
         in result.stderr.decode()
     )
 
@@ -180,7 +180,7 @@ def test_run_scripts_for_versioning():
     # print(result.stdout.decode())
     assert result.returncode == 0
     assert (
-        "created Transform('Ro1gl7n8YrdH0001') & created Run('"
+        "created Transform(uid='Ro1gl7n8YrdH0001') & created Run('"
         in result.stdout.decode()
     )
     assert not ln.Transform.get("Ro1gl7n8YrdH0000").is_latest

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -144,7 +144,7 @@ def test_run_scripts_for_versioning():
     # print(result.stdout.decode())
     assert result.returncode == 0
     assert (
-        "created Transform('Ro1gl7n8YrdH0000') & created Run('"
+        "created Transform(uid='Ro1gl7n8YrdH0000') & created Run('"
         in result.stdout.decode()
     )
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -144,7 +144,7 @@ def test_run_scripts_for_versioning():
     # print(result.stdout.decode())
     assert result.returncode == 0
     assert (
-        "created Transform(uid='Ro1gl7n8YrdH0000') & created Run('"
+        "created Transform(uid='Ro1gl7n8YrdH0000') & created Run(started_at='"
         in result.stdout.decode()
     )
 
@@ -180,7 +180,7 @@ def test_run_scripts_for_versioning():
     # print(result.stdout.decode())
     assert result.returncode == 0
     assert (
-        "created Transform(uid='Ro1gl7n8YrdH0001') & created Run('"
+        "created Transform(uid='Ro1gl7n8YrdH0001') & created Run(started_at='"
         in result.stdout.decode()
     )
     assert not ln.Transform.get("Ro1gl7n8YrdH0000").is_latest

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -3,13 +3,15 @@ from pathlib import Path
 from subprocess import DEVNULL, run
 from time import perf_counter
 
-import lamindb as ln
 import lamindb_setup as ln_setup
 import pytest
 from lamin_utils import logger
 from laminci.db import setup_local_test_postgres
 
-AUTO_CONNECT = ln.setup.settings.auto_connect
+AUTO_CONNECT = ln_setup.settings.auto_connect
+ln_setup.settings.auto_connect = False
+
+import lamindb as ln
 
 
 def pytest_sessionstart():


### PR DESCRIPTION
## Data integrity and docs

- 🚸 Now raises an error if `is_latest=False` in the to-be-transferred record.
- 📝 Polished the transfer guide.

## Logs during `record.save()` during transfer

before | after
--- | ---
<img width="400" alt="image" src="https://github.com/user-attachments/assets/324e228c-3ae7-4de1-a25c-68ee7cc688a8"> |  <img width="400" alt="image" src="https://github.com/user-attachments/assets/28c57de7-d96b-4a39-b694-80c6416acc8e">

## Logs during  `artifact.describe()`

before | after
--- | ---
<img width="808" alt="image" src="https://github.com/user-attachments/assets/c958e1fc-8b5e-496a-bb82-eedb2e1b8cf2"> | <img width="790" alt="image" src="https://github.com/user-attachments/assets/1d93727d-1427-4984-956e-060aaf4d6469">

## Logs during  `context.track()`

before | after
--- | ---
<img width="778" alt="image" src="https://github.com/user-attachments/assets/f0dcf4e3-70f0-4ed5-a6a8-9ada02c4d7b6"> | <img width="799" alt="image" src="https://github.com/user-attachments/assets/dcfde092-2b37-41e5-830e-db4f59266fdc">

