### PR TITLE
🐛 Reload transform upon passing same uid

### DIFF
--- a/docs/arrays.ipynb
+++ b/docs/arrays.ipynb
@@ -20,7 +20,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We saw how LaminDB allows to query & search across artifacts & collections using registries: {doc}`records`.\n",
+    "We saw how LaminDB allows to query & search across artifacts & collections using registries: {doc}`registries`.\n",
     "\n",
     "Let us now look at the following case:\n",
     "\n",

--- a/docs/registries.ipynb
+++ b/docs/registries.ipynb
@@ -160,7 +160,7 @@
    "id": "ba40b102",
    "metadata": {},
    "source": [
-    "{class}`~lamindb.Record.get` errors if more than one matching records are found."
+    "{class}`~lamindb.core.Record.get` errors if more than one matching records are found."
    ]
   },
   {

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -582,7 +582,7 @@
     "* `name__startswith=\"Martha\"`: `name` starts with `\"Martha`\n",
     "* `name__in=[\"Martha\", \"John\"]`: `name` is `\"John\"` or `\"Martha\"`\n",
     "\n",
-    "For more info, see: {doc}`records`.\n",
+    "For more info, see: {doc}`registries`.\n",
     "\n",
     ":::\n",
     "\n",
@@ -644,7 +644,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more info, see: {doc}`records`."
+    "For more info, see: {doc}`registries`."
    ]
   },
   {

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -497,13 +497,6 @@ def _check_accessor_artifact(data: Any, accessor: str | None = None):
     return accessor
 
 
-def update_attributes(data: Artifact, attributes: Mapping[str, str]):
-    for key, value in attributes.items():
-        if getattr(data, key) != value:
-            logger.warning(f"updated {key} from {getattr(data, key)} to {value}")
-            setattr(data, key, value)
-
-
 def __init__(artifact: Artifact, *args, **kwargs):
     artifact.features = FeatureManager(artifact)
     artifact.params = ParamManager(artifact)
@@ -608,7 +601,7 @@ def __init__(artifact: Artifact, *args, **kwargs):
 
     # an object with the same hash already exists
     if isinstance(kwargs_or_artifact, Artifact):
-        from ._record import init_self_from_db
+        from ._record import init_self_from_db, update_attributes
 
         init_self_from_db(artifact, kwargs_or_artifact)
         # adding "key" here is dangerous because key might be auto-populated

--- a/lamindb/_collection.py
+++ b/lamindb/_collection.py
@@ -21,14 +21,13 @@ from lnschema_core.models import (
 )
 from lnschema_core.types import VisibilityChoice
 
-from lamindb._artifact import update_attributes
 from lamindb._utils import attach_func_to_class_method
 from lamindb.core._data import _track_run_input, describe, view_lineage
 from lamindb.core._mapped_collection import MappedCollection
 from lamindb.core.versioning import process_revises
 
 from . import Artifact, Run
-from ._record import init_self_from_db
+from ._record import init_self_from_db, update_attributes
 from .core._data import (
     add_transform_to_kwargs,
     get_run,

--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -36,6 +36,13 @@ def init_self_from_db(self: Record, existing_record: Record):
     self._state.db = "default"
 
 
+def update_attributes(record: Record, attributes: dict[str, str]):
+    for key, value in attributes.items():
+        if getattr(record, key) != value:
+            logger.warning(f"updated {key} from {getattr(record, key)} to {value}")
+            setattr(record, key, value)
+
+
 def validate_required_fields(record: Record, kwargs):
     required_fields = {
         k.name for k in record._meta.fields if not k.null and k.default is None

--- a/lamindb/_transform.py
+++ b/lamindb/_transform.py
@@ -44,12 +44,18 @@ def __init__(transform: Transform, *args, **kwargs):
                 .order_by("-created_at")
                 .first()
             )
-        elif uid is not None and not uid.endswith("0000"):
+        elif uid is not None:
             revises = (
                 Transform.filter(uid__startswith=uid[:-4], is_latest=True)
                 .order_by("-created_at")
                 .first()
             )
+    if revises is not None and uid is not None and uid == revises.uid:
+        from ._record import init_self_from_db, update_attributes
+
+        init_self_from_db(transform, revises)
+        update_attributes(transform, {"name": name})
+        return None
     if revises is not None and key is not None and revises.key != key:
         note = message_update_key_in_version_family(
             suid=revises.stem_uid,

--- a/lamindb/integrations/_vitessce.py
+++ b/lamindb/integrations/_vitessce.py
@@ -80,8 +80,7 @@ def save_vitessce_config(
             name="save_vitessce_config",
             type="function",
             version="2",
-        )
-        transform.save()
+        ).save()
     run = Run(transform=transform).save()
     if len(dataset_artifacts) > 1:
         # if we have more datasets, we should create a collection

--- a/tests/core/test_transform.py
+++ b/tests/core/test_transform.py
@@ -23,6 +23,11 @@ def test_revises_versioned_transform():
 
     transform.save()
 
+    # try to reload the same transform with the same uid
+    transform_reload = ln.Transform(uid=transform.uid, name="My transform updated name")
+    assert transform_reload.id == transform.id
+    assert transform_reload.name == "My transform updated name"
+
     # create new transform from old transform
     transform_r2 = ln.Transform(name="My 2nd transform", is_new_version_of=transform)
     assert transform_r2.uid != transform.uid


### PR DESCRIPTION
For `Transform`, we want to be able to pass a `uid`. If this uid exists, we want to reload the existing record from the database.

We might want to also allow this behavior for other records, but so far we haven't needed it.