### PR TITLE
🚸 Simplify CLI commands

### DIFF
--- a/docs/signup-login.md
+++ b/docs/signup-login.md
@@ -32,5 +32,5 @@ lamin login <email> --key <API-key>
 Log out:
 
 ```
-lamin logout
+lamin login --logout
 ```

--- a/noxfile.py
+++ b/noxfile.py
@@ -209,9 +209,11 @@ def docs(session):
             names = name.split(" ")
             section = ""
             if len(names) != 1:
-                section = (
-                    "```\n\n" + "#" * len(names) + " " + " ".join(("lamin", *names[1:]))
-                )
+                if len(names) == 2:
+                    separator = "#" * len(names) + " " + " ".join(("lamin", *names[1:]))
+                else:
+                    separator = ""
+                section = "```\n\n" + separator
 
             help_string = help_dict["help"].replace("Usage: main", "Usage: lamin")
             help_docstring = help_dict["docstring"]

--- a/noxfile.py
+++ b/noxfile.py
@@ -155,7 +155,7 @@ def build(session, group):
     elif group == "unit-storage":
         run(session, f"pytest {coverage_args} ./tests/storage --durations=50")
     elif group == "tutorial":
-        run(session, "lamin logout")
+        run(session, "lamin login --logout")
         run(
             session, f"pytest -s {coverage_args} ./docs/test_notebooks.py::test_{group}"
         )


### PR DESCRIPTION
- Integrate `close` as `--unload` into `load`
- Integrate `logout` as `--logout` into `login`
- Integrate `schema view` as `info view` into `info`

Before | After
--- | ---
<img width="1008" alt="image" src="https://github.com/user-attachments/assets/ac8c829d-3a8f-4fff-b2d3-a88958292724"> | <img width="963" alt="image" src="https://github.com/user-attachments/assets/f11ff15e-59ea-44e1-95cc-e68078925912">

Before | After
--- | ---
<img width="415" alt="image" src="https://github.com/user-attachments/assets/016d53ce-3d89-4adc-97b1-7055c2f71d52"> | <img width="418" alt="image" src="https://github.com/user-attachments/assets/7e0545b0-efd0-468f-83c4-76fc5e9e73b2">

In `lamin-cli`

- https://github.com/laminlabs/lamin-cli/pull/72