### PR TITLE
🚸 No traceback for invalid arguments

### DIFF
--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -356,7 +356,7 @@ def get_artifact_kwargs_from_data(
             key = inferred_key
         else:
             if not key == inferred_key:
-                raise ValueError(
+                raise InvalidArgument(
                     f"The path '{data}' is already in registered storage"
                     f" '{storage.root}' with key '{inferred_key}'\nYou passed"
                     f" conflicting key '{key}': please move the file before"

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -30,7 +30,7 @@ from lnschema_core.types import (
 from lamindb._utils import attach_func_to_class_method
 from lamindb.core._data import _track_run_input, describe, view_lineage
 from lamindb.core._settings import settings
-from lamindb.core.exceptions import IntegrityError
+from lamindb.core.exceptions import IntegrityError, InvalidArgument
 from lamindb.core.loaders import load_to_memory
 from lamindb.core.storage import (
     LocalPathClasses,
@@ -175,7 +175,7 @@ def process_data(
             key_suffix = None
         suffix = infer_suffix(data, format)
         if key_suffix is not None and key_suffix != suffix:
-            raise ValueError(
+            raise InvalidArgument(
                 f"The suffix '{key_suffix}' of the provided key is incorrect, it should"
                 f" be '{suffix}'."
             )

--- a/lamindb/core/exceptions.py
+++ b/lamindb/core/exceptions.py
@@ -1,7 +1,5 @@
 """Exceptions.
 
-The registry base class:
-
 .. autosummary::
    :toctree: .
 
@@ -16,6 +14,10 @@ The registry base class:
 
 """
 
+# inheriting from SystemExit has the sole purpose of suppressing
+# the traceback - this isn't optimal but the current best solution
+# https://laminlabs.slack.com/archives/C04A0RMA0SC/p1726856875597489
+
 
 class InvalidArgument(SystemExit):
     """Invalid method or function argument."""
@@ -24,10 +26,14 @@ class InvalidArgument(SystemExit):
 
 
 class TrackNotCalled(SystemExit):
+    """ln.context.track() wasn't called."""
+
     pass
 
 
 class NotebookNotSaved(SystemExit):
+    """Notebook wasn't saved."""
+
     pass
 
 

--- a/lamindb/core/exceptions.py
+++ b/lamindb/core/exceptions.py
@@ -5,6 +5,7 @@ The registry base class:
 .. autosummary::
    :toctree: .
 
+   InvalidArgument
    DoesNotExist
    ValidationError
    NotebookNotSavedError
@@ -14,6 +15,12 @@ The registry base class:
    IntegrityError
 
 """
+
+
+class InvalidArgument(SystemExit):
+    """Invalid method or function argument."""
+
+    pass
 
 
 class TrackNotCalled(SystemExit):

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -23,7 +23,7 @@ from lamindb._artifact import (
     process_data,
 )
 from lamindb.core._settings import settings
-from lamindb.core.exceptions import IntegrityError
+from lamindb.core.exceptions import IntegrityError, InvalidArgument
 from lamindb.core.loaders import load_fcs, load_to_memory, load_tsv
 from lamindb.core.storage._zarr import write_adata_zarr, zarr_is_adata
 from lamindb.core.storage.paths import (
@@ -785,11 +785,11 @@ def test_df_suffix(df):
     artifact = ln.Artifact.from_df(df, key="test_.parquet")
     assert artifact.suffix == ".parquet"
 
-    with pytest.raises(ValueError) as error:
+    with pytest.raises(InvalidArgument) as error:
         artifact = ln.Artifact.from_df(df, key="test_.def")
     assert (
         error.exconly().partition(",")[0]
-        == "ValueError: The suffix '.def' of the provided key is incorrect"
+        == "lamindb.core.exceptions.InvalidArgument: The suffix '.def' of the provided key is incorrect"
     )
 
 
@@ -808,11 +808,11 @@ def test_adata_suffix(adata):
         == "ValueError: Error when specifying AnnData storage format"
     )
 
-    with pytest.raises(ValueError) as error:
+    with pytest.raises(InvalidArgument) as error:
         artifact = ln.Artifact.from_anndata(adata, key="test_")
     assert (
         error.exconly().partition(",")[0]
-        == "ValueError: The suffix '' of the provided key is incorrect"
+        == "lamindb.core.exceptions.InvalidArgument: The suffix '' of the provided key is incorrect"
     )
 
 

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -381,11 +381,11 @@ def test_create_from_local_filepath(
         inferred_key = get_relative_path_to_directory(
             path=test_filepath, directory=root_dir
         ).as_posix()
-        with pytest.raises(ValueError) as error:
+        with pytest.raises(InvalidArgument) as error:
             artifact = ln.Artifact(test_filepath, key=key, description=description)
         assert (
             error.exconly()
-            == f"ValueError: The path '{test_filepath}' is already in registered"
+            == f"lamindb.core.exceptions.InvalidArgument: The path '{test_filepath}' is already in registered"
             " storage"
             f" '{root_dir.resolve().as_posix()}' with key '{inferred_key}'\nYou"
             f" passed conflicting key '{key}': please move the file before"

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -458,10 +458,10 @@ def test_from_dir_many_artifacts(get_test_filepaths, key):
     test_dirpath = get_test_filepaths[2]
     # the directory contains 3 files, two of them are duplicated
     if key is not None and is_in_registered_storage:
-        with pytest.raises(ValueError) as error:
+        with pytest.raises(InvalidArgument) as error:
             ln.Artifact.from_dir(test_dirpath, key=key)
         assert error.exconly().startswith(
-            "ValueError: The path"  # The path {data} is already in registered storage
+            "lamindb.core.exceptions.InvalidArgument: The path"  # The path {data} is already in registered storage
         )
         return None
     else:

--- a/tests/core/test_artifact_folders.py
+++ b/tests/core/test_artifact_folders.py
@@ -1,5 +1,6 @@
 import lamindb as ln
 import pytest
+from lamindb.core.exceptions import InvalidArgument
 
 
 @pytest.mark.parametrize("key", [None, "my_new_folder"])
@@ -11,10 +12,10 @@ def test_folder_like_artifact(get_test_filepaths, key):
 
     # run tests on initial Artifact creation
     if key is not None and is_in_registered_storage:
-        with pytest.raises(ValueError) as error:
+        with pytest.raises(InvalidArgument) as error:
             ln.Artifact(test_dirpath, key=key)
         assert error.exconly().startswith(
-            "ValueError: The path"  # The path {data} is already in registered storage
+            "lamindb.core.exceptions.InvalidArgument: The path"  # The path {data} is already in registered storage
         )
         return None
     if key is None and not is_in_registered_storage:


### PR DESCRIPTION
Before | After
--- | ---
<img width="693" alt="image" src="https://github.com/user-attachments/assets/396077af-266a-45d8-9cad-d1926d2964c0"> | <img width="645" alt="image" src="https://github.com/user-attachments/assets/52b91f6d-cb2d-4a31-9906-cceb391110db">

Slack discussion: This could be [refined](https://laminlabs.slack.com/archives/C04A0RMA0SC/p1726856875597489).