### PR TITLE
🚸 Better dialogue upon clashing transform keys

### DIFF
--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -450,11 +450,11 @@ class Context:
             self._logging_message += f"created Transform(uid='{transform.uid}')"
         else:
             uid = transform.uid
-            # check whether the transform file has been renamed
+            # check whether the transform.key is consistent
             if transform.key != key:
                 suid = transform.stem_uid
                 new_suid = ids.base62_12()
-                transform_type = "Notebook" if is_run_from_ipython else "Script"
+                transform_type = "notebook" if is_run_from_ipython else "script"
                 note = message_update_key_in_version_family(
                     suid=suid,
                     existing_key=transform.key,
@@ -462,7 +462,7 @@ class Context:
                     registry="Transform",
                 )
                 raise UpdateContext(
-                    f"{transform_type} filename changed.\n\nEither init a new transform family by setting:\n\n"
+                    f'\n✗ Filename "{key}" clashes with the existing key "{transform.key}" for uid "{transform.uid[:-4]}...."\n\nEither init a new transform with a new uid:\n\n'
                     f'ln.context.uid = "{new_suid}0000"\n\n{note}'
                 )
             elif transform.name != name:

--- a/lamindb/core/versioning.py
+++ b/lamindb/core/versioning.py
@@ -18,7 +18,7 @@ def message_update_key_in_version_family(
     registry: str,
     new_key: str,
 ) -> str:
-    return f'Or update key "{existing_key}" in your existing family:\n\nln.{registry}.filter(uid__startswith="{suid}").update(key="{new_key}")'
+    return f'Or update key "{existing_key}" to "{new_key}":\n\nln.{registry}.filter(uid__startswith="{suid}").update(key="{new_key}")\n'
 
 
 def increment_base62(s: str) -> str:

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -156,7 +156,7 @@ def test_run_scripts_for_versioning():
     )
     # print(result.stderr.decode())
     assert result.returncode == 1
-    assert "Script filename changed." in result.stderr.decode()
+    assert "clashes with the existing key" in result.stderr.decode()
 
     # version already taken
     result = subprocess.run(  # noqa: S602


### PR DESCRIPTION
Before:

```
% python myscript.py  
→ connected lamindb: laminlabs/lamindata
Script filename changed.

Either init a new transform family by setting:

ln.context.uid = "BIck2BoL1HmT0000"

Or update key "mcfarland_2020_preparation.ipynb" in your existing family:

ln.Transform.filter(uid__startswith="13VINnFk89PE").update(key="myscript.py")
```

After:

```
% python myscript.py
→ connected lamindb: laminlabs/lamindata

✗ Filename "myscript.py" clashes with the existing key "mcfarland_2020_preparation.ipynb" for uid "13VINnFk89PE...."

Either init a new transform with a new uid:

ln.context.uid = "IEgwQyRtgI3o0000"

Or update key "mcfarland_2020_preparation.ipynb" to "myscript.py":

ln.Transform.filter(uid__startswith="13VINnFk89PE").update(key="myscript.py")

```

Addresses: 

- https://github.com/laminlabs/lamindb/issues/1971

Needs: https://github.com/laminlabs/lamin-cli/commit/a4127009cdb18173d032acfc3977f829b684f5c9