### PR TITLE
🚸 `lamin load` → `lamin connect` & `lamin get` → `lamin load`

### DIFF
--- a/docs/faq/setup.ipynb
+++ b/docs/faq/setup.ipynb
@@ -19,7 +19,7 @@
    },
    "outputs": [],
    "source": [
-    "!lamin load --unload"
+    "!lamin disconnect"
    ]
   },
   {

--- a/docs/setup.ipynb
+++ b/docs/setup.ipynb
@@ -111,16 +111,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Load an instance"
+    "## Connecting to an instance"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Load your own instance:\n",
+    "Connect to your own instance:\n",
     "```\n",
-    "lamin load <instance_name>\n",
+    "lamin connect <instance_name>\n",
     "````"
    ]
   },
@@ -128,9 +128,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Load somebody else's instance:\n",
+    "Connect to somebody else's instance:\n",
     "```\n",
-    "lamin load <account_handle/instance_name>\n",
+    "lamin connect <account_handle/instance_name>\n",
     "```"
    ]
   },
@@ -170,7 +170,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!lamin info"
+    "!lamin settings"
    ]
   },
   {
@@ -225,25 +225,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Update default storage"
+    "## Update the default storage"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It's easiest to see and update default storage in the Python API using {attr}`~lamindb.core.Settings.storage`:\n",
+    "It's easiest to see and update the default storage for the current Python session in the Python API using {attr}`~lamindb.core.Settings.storage`:\n",
     "\n",
     "```python\n",
     "import lamindb as ln\n",
     "ln.settings.storage  # set via ln.settings.storage = \"s3://other-bucket\"\n",
     "#> s3://default-bucket\n",
-    "```\n",
-    "\n",
-    "You can also change it using the CLI via\n",
-    "\n",
-    "```\n",
-    "lamin set --storage s3://other-bucket\n",
     "```"
    ]
   },
@@ -291,18 +285,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Close an instance"
+    "## Dsiconnect from an instance"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Loading an instance means loading an environment for managing your datasets.\n",
+    "Connecting to an instance means loading an environment for managing your datasets.\n",
     "\n",
-    "When loading a new instance, you automatically _close_ the previously loaded old instance.\n",
+    "When connecting to a new instance, you automatically _disconnect_ from the previously connected instance.\n",
     "\n",
-    "If you want to close the instance without loading a new instance, use `lamin load --unload`"
+    "If you want to disconnect from the instance without connecting to a new instance, use `lamin disconnect`"
    ]
   },
   {
@@ -330,7 +324,7 @@
     "Here is an example:\n",
     "\n",
     "```\n",
-    "% lamin load testdb\n",
+    "% lamin connect testdb\n",
     "🔶 \n",
     "\n",
     "Your database is not up to date with your installed Python library.\n",
@@ -343,7 +337,7 @@
     "\n",
     "Otherwise, downgrade your Python library to match the database!\n",
     "\n",
-    "✅ loaded instance: testuser1/testdb\n",
+    "✅ connected lamindb: testuser1/testdb\n",
     "```\n",
     ":::"
    ]

--- a/docs/setup.ipynb
+++ b/docs/setup.ipynb
@@ -292,7 +292,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Connecting to an instance means loading an environment for managing your datasets.\n",
+    "Connecting to an instance means loading an environment for managing your data.\n",
     "\n",
     "When connecting to a new instance, you automatically _disconnect_ from the previously connected instance.\n",
     "\n",

--- a/docs/signup-login.md
+++ b/docs/signup-login.md
@@ -32,5 +32,5 @@ lamin login <email> --key <API-key>
 Log out:
 
 ```
-lamin login --logout
+lamin logout
 ```

--- a/docs/storage/prepare-transfer-local-to-cloud.ipynb
+++ b/docs/storage/prepare-transfer-local-to-cloud.ipynb
@@ -13,7 +13,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!lamin set auto-connect false"
+    "!lamin settings set auto-connect false"
    ]
   },
   {

--- a/docs/track.ipynb
+++ b/docs/track.ipynb
@@ -191,10 +191,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A notebook acts like a template upon using `lamin get` to load it. Consider you run:\n",
+    "A notebook acts like a template upon using `lamin load` to load it. Consider you run:\n",
     "\n",
     "```bash\n",
-    "lamin get https://lamin.ai/account/instance/transform/Akd7gx7Y9oVO0000\n",
+    "lamin load https://lamin.ai/account/instance/transform/Akd7gx7Y9oVO0000\n",
     "```\n",
     "\n",
     "Upon running the returned notebook, you'll automatically create a new version and be able to browse it via the version dropdown on the UI.\n",
@@ -237,7 +237,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py39",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -251,7 +251,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.9.17"
   },
   "nbproject": {
    "id": "9priar0hoE5u",

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -10,7 +10,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -18,7 +17,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -35,7 +33,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -92,7 +89,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -100,7 +96,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -127,7 +122,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -135,7 +129,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -177,7 +170,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -216,7 +208,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -224,7 +215,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -285,7 +275,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -348,7 +337,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -409,7 +397,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -457,7 +444,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -477,7 +463,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -505,7 +490,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -853,7 +837,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -912,7 +895,7 @@
     "If you want to cache a notebook or script, call:\n",
     "\n",
     "```\n",
-    "lamin get https://lamin.ai/laminlabs/lamindata/transform/PtTXoc0RbOIq65cN\n",
+    "lamin load https://lamin.ai/laminlabs/lamindata/transform/PtTXoc0RbOIq65cN\n",
     "```\n"
    ]
   },
@@ -964,7 +947,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.9.17"
   },
   "vscode": {
    "interpreter": {

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import os
 import shutil
+from collections.abc import Mapping
 from pathlib import Path, PurePath, PurePosixPath
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import TYPE_CHECKING, Any
 
 import fsspec
 import lamindb_setup as ln_setup

--- a/lamindb/_collection.py
+++ b/lamindb/_collection.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 from typing import (
     TYPE_CHECKING,
     Any,
-    Iterable,
     Literal,
 )
 
@@ -37,6 +36,8 @@ from .core._data import (
 from .core._settings import settings
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from lamindb.core.storage import UPath
 
     from ._query_set import QuerySet

--- a/lamindb/_curate.py
+++ b/lamindb/_curate.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import copy
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
 
 import anndata as ad
 import lamindb_setup as ln_setup
@@ -19,6 +19,8 @@ from lnschema_core import (
 from .core.exceptions import ValidationError
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from lamindb_setup.core.types import UPathStr
     from lnschema_core.types import FieldAttr
     from mudata import MuData

--- a/lamindb/_feature_set.py
+++ b/lamindb/_feature_set.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterable, Type
+from typing import TYPE_CHECKING
 
 import lamindb_setup as ln_setup
 import numpy as np
@@ -21,6 +21,8 @@ from .core.schema import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     import pandas as pd
 
     from ._query_set import QuerySet

--- a/lamindb/_from_values.py
+++ b/lamindb/_from_values.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
 
 import pandas as pd
 from django.core.exceptions import FieldDoesNotExist
@@ -10,6 +10,8 @@ from lnschema_core.models import Feature, Record, ULabel
 from .core._settings import settings
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from lnschema_core.types import ListLike, StrField
 
 

--- a/lamindb/_query_set.py
+++ b/lamindb/_query_set.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import UserList
-from typing import TYPE_CHECKING, Iterable, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 import pandas as pd
 from django.db import models
@@ -23,6 +23,8 @@ from lnschema_core.models import (
 from lamindb.core.exceptions import DoesNotExist
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from lnschema_core.types import ListLike, StrField
 
 

--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import builtins
-from typing import TYPE_CHECKING, List, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 import dj_database_url
 import lamindb_setup as ln_setup
@@ -443,7 +443,7 @@ def update_fk_to_default_db(
     using_key: str | None,
     transfer_logs: dict,
 ):
-    record = records[0] if isinstance(records, (List, QuerySet)) else records
+    record = records[0] if isinstance(records, (list, QuerySet)) else records
     if hasattr(record, f"{fk}_id") and getattr(record, f"{fk}_id") is not None:
         fk_record = getattr(record, fk)
         field = REGISTRY_UNIQUE_FIELD.get(fk, "uid")
@@ -457,7 +457,7 @@ def update_fk_to_default_db(
             transfer_to_default_db(
                 fk_record_default, using_key, save=True, transfer_logs=transfer_logs
             )
-        if isinstance(records, (List, QuerySet)):
+        if isinstance(records, (list, QuerySet)):
             for r in records:
                 setattr(r, f"{fk}", None)
                 setattr(r, f"{fk}_id", fk_record_default.id)

--- a/lamindb/_save.py
+++ b/lamindb/_save.py
@@ -6,7 +6,7 @@ import traceback
 from collections import defaultdict
 from datetime import datetime
 from functools import partial
-from typing import TYPE_CHECKING, Iterable, overload
+from typing import TYPE_CHECKING, overload
 
 import lamindb_setup
 from django.db import IntegrityError, transaction
@@ -25,6 +25,8 @@ from lamindb.core.storage.paths import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from lamindb_setup.core.upath import UPath
 
 

--- a/lamindb/core/_data.py
+++ b/lamindb/core/_data.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Iterable, List
+from typing import TYPE_CHECKING, Any
 
 from django.db import connections
 from lamin_utils import colors, logger
@@ -39,6 +39,8 @@ from .schema import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from lnschema_core.types import StrField
 
 
@@ -312,7 +314,7 @@ def add_labels(
         records = records.list()
     if isinstance(records, (str, Record)):
         records = [records]
-    if not isinstance(records, List):  # avoids warning for pd Series
+    if not isinstance(records, list):  # avoids warning for pd Series
         records = list(records)
     # create records from values
     if len(records) == 0:

--- a/lamindb/core/_django.py
+++ b/lamindb/core/_django.py
@@ -78,7 +78,7 @@ def get_artifact_with_related(
         link_model = getattr(model, link).rel.related_model
         if not hasattr(link_model, "feature"):
             continue
-        label_field = link.removeprefix("links_").replace("_", "")
+        label_field = link.removeprefix("links_").replace("_", "")  # type: ignore
         annotations[f"linkfield_{link}"] = Subquery(
             link_model.objects.filter(artifact=OuterRef("pk"))
             .annotate(

--- a/lamindb/core/_django.py
+++ b/lamindb/core/_django.py
@@ -78,7 +78,7 @@ def get_artifact_with_related(
         link_model = getattr(model, link).rel.related_model
         if not hasattr(link_model, "feature"):
             continue
-        label_field = link.removeprefix("links_").replace("_", "")  # type: ignore
+        label_field = link.removeprefix("links_").replace("_", "")
         annotations[f"linkfield_{link}"] = Subquery(
             link_model.objects.filter(artifact=OuterRef("pk"))
             .annotate(

--- a/lamindb/core/_label_manager.py
+++ b/lamindb/core/_label_manager.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING
 
 import numpy as np
 from django.db import connections
@@ -139,7 +139,7 @@ def validate_labels(labels: QuerySet | list | dict):
         new_labels = [labels[int(i)] for i in np.argwhere(~validated).flatten()]
         return validated_labels, new_labels
 
-    if isinstance(labels, Dict):
+    if isinstance(labels, dict):
         result = {}
         for registry, labels_registry in labels.items():
             result[registry] = validate_labels_registry(labels_registry)

--- a/lamindb/core/_mapped_collection.py
+++ b/lamindb/core/_mapped_collection.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import Counter
 from functools import reduce
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import pandas as pd

--- a/lamindb/core/_settings.py
+++ b/lamindb/core/_settings.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Literal, Mapping
+from typing import TYPE_CHECKING, Literal
 
 import lamindb_setup as ln_setup
 from lamin_utils import logger
@@ -13,6 +13,7 @@ from .subsettings._creation_settings import CreationSettings, creation_settings
 from .subsettings._transform_settings import TransformSettings, transform_settings
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
     from lamindb_setup.core._settings_storage import StorageSettings

--- a/lamindb/core/storage/_anndata_accessor.py
+++ b/lamindb/core/storage/_anndata_accessor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 from functools import cached_property
 from itertools import chain
-from typing import TYPE_CHECKING, Callable, Literal, Mapping, Union
+from typing import TYPE_CHECKING, Callable, Literal, Union
 
 import h5py
 import numpy as np
@@ -21,6 +21,7 @@ from lamindb_setup.core.upath import UPath, create_mapper, infer_filesystem
 from packaging import version
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
     from fsspec.core import OpenFile

--- a/noxfile.py
+++ b/noxfile.py
@@ -148,7 +148,7 @@ def build(session, group):
 
     login_testuser2(session)
     login_testuser1(session)
-    run(session, "lamin set private-django-api true")
+    run(session, "lamin settings set private-django-api true")
     coverage_args = "--cov=lamindb --cov-config=pyproject.toml --cov-append --cov-report=term-missing"
     if group == "unit-core":
         run(session, f"pytest {coverage_args} ./tests/core --durations=50")

--- a/noxfile.py
+++ b/noxfile.py
@@ -155,7 +155,7 @@ def build(session, group):
     elif group == "unit-storage":
         run(session, f"pytest {coverage_args} ./tests/storage --durations=50")
     elif group == "tutorial":
-        run(session, "lamin login --logout")
+        run(session, "lamin logout")
         run(
             session, f"pytest -s {coverage_args} ./docs/test_notebooks.py::test_{group}"
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,11 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "lamindb"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [{name = "Lamin Labs", email = "open-source@lamin.ai"}]
 readme = "README.md"
 dynamic = ["version", "description"]
 classifiers = [
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
This PR implements @ap--'s suggestions to improve the command name consistency of the CLI.

It's backward compatible.

Before | After
--- | ---
<img width="412" alt="image" src="https://github.com/user-attachments/assets/65daaafd-aa3b-49a9-bb9c-5beea5fcfdc0"> | <img width="427" alt="image" src="https://github.com/user-attachments/assets/4d6b972c-7c26-4dd4-ae4a-fa330341aa35">

Based on the below issue:

- https://github.com/laminlabs/pfizer-lamin-usage/issues/25

Needs:

- https://github.com/laminlabs/lamin-cli/pull/79