### PR TITLE
✅ Add another test for running with tracked params, logging cosmetics

### DIFF
--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -158,7 +158,7 @@ def save_context_core(
         if hash != ref_hash:
             response = input(
                 f"You are about to overwrite existing source code (hash '{ref_hash}') for Transform('{transform.uid}')."
-                f"Proceed? (y/n)"
+                f" Proceed? (y/n)"
             )
             if response == "y":
                 transform.source_code = source_code_path.read_text()

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -91,7 +91,7 @@ def raise_missing_context(transform_type: str, key: str) -> bool:
         new_uid = f"{suid}{new_vuid}"
         message = f"you already have a transform with key '{key}' ('{transform.uid}')\n  - to make a revision, call `ln.track('{new_uid}')`\n  - to create a new transform, rename your file and run: `ln.track()`"
     if transform_type == "notebook":
-        print(f"→ {message}\n")
+        print(f"→ {message}")
         response = input("→ Ready to re-run? (y/n)")
         if response == "y":
             logger.important(

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -83,7 +83,7 @@ def raise_missing_context(transform_type: str, key: str) -> bool:
     transform = Transform.filter(key=key).latest_version().first()
     if transform is None:
         new_uid = f"{base62_12()}0000"
-        message = f'To track this {transform_type}, copy & paste `ln.track("{new_uid}")` into the current cell and re-run it\n\n'
+        message = f'to track this {transform_type}, copy & paste `ln.track("{new_uid}")` and re-run'
     else:
         uid = transform.uid
         suid, vuid = uid[: Transform._len_stem_uid], uid[Transform._len_stem_uid :]
@@ -100,7 +100,7 @@ def raise_missing_context(transform_type: str, key: str) -> bool:
             return True
         raise MissingContextUID("Please follow the instructions.")
     else:
-        raise MissingContextUID(message)
+        raise MissingContextUID(f"✗ {message}")
     return False
 
 
@@ -305,10 +305,10 @@ class Context:
                 transform_exists = Transform.filter(id=transform.id).first()
             if transform_exists is None:
                 transform.save()
-                self._logging_message += f"created Transform(uid='{transform.uid}')"
+                self._logging_message += f"created Transform('{transform.uid[:8]}')"
                 transform_exists = transform
             else:
-                self._logging_message += f"loaded Transform(uid='{transform.uid}')"
+                self._logging_message += f"loaded Transform('{transform.uid[:8]}')"
             self._transform = transform_exists
 
         if new_run is None:  # for notebooks, default to loading latest runs
@@ -323,9 +323,7 @@ class Context:
             )
             if run is not None:  # loaded latest run
                 run.started_at = datetime.now(timezone.utc)  # update run time
-                self._logging_message += (
-                    f" & loaded Run(started_at={format_field_value(run.started_at)})"
-                )
+                self._logging_message += f" & loaded Run('{run.uid[:8]}', started_at={format_field_value(run.started_at)})"
 
         if run is None:  # create new run
             run = Run(
@@ -333,9 +331,7 @@ class Context:
                 params=params,
             )
             run.started_at = datetime.now(timezone.utc)
-            self._logging_message += (
-                f" & created Run(started_at={format_field_value(run.started_at)})"
-            )
+            self._logging_message += f" & created Run('{run.uid[:8]}', started_at={format_field_value(run.started_at)})"
         # can only determine at ln.finish() if run was consecutive in
         # interactive session, otherwise, is consecutive
         run.is_consecutive = True if is_run_from_ipython else None
@@ -343,6 +339,9 @@ class Context:
         run.save()
         if params is not None:
             run.params.add_values(params)
+            self._logging_message += " with params: " + " ".join(
+                f"{key}='{value}'" for key, value in params.items()
+            )
         self._run = run
         track_environment(run)
         logger.important(self._logging_message)
@@ -448,7 +447,7 @@ class Context:
                 reference_type=transform_ref_type,
                 type=transform_type,
             ).save()
-            self._logging_message += f"created Transform(uid='{transform.uid}')"
+            self._logging_message += f"created Transform('{transform.uid[:8]}')"
         else:
             uid = transform.uid
             # check whether the transform.key is consistent
@@ -490,7 +489,7 @@ class Context:
                         bump_revision = True
                     else:
                         self._logging_message += (
-                            f"loaded Transform(uid='{transform.uid}')"
+                            f"loaded Transform('{transform.uid[:8]}')"
                         )
                 if bump_revision:
                     change_type = (
@@ -508,7 +507,7 @@ class Context:
                         f'ln.track("{suid}{new_vuid}")'
                     )
             else:
-                self._logging_message += f"loaded Transform(uid='{transform.uid}')"
+                self._logging_message += f"loaded Transform('{transform.uid[:8]}')"
         self._transform = transform
 
     def finish(self, ignore_non_consecutive: None | bool = None) -> None:

--- a/tests/core/notebooks/not-initialized.ipynb
+++ b/tests/core/notebooks/not-initialized.ipynb
@@ -20,7 +20,7 @@
     "from io import StringIO\n",
     "from contextlib import redirect_stdout\n",
     "\n",
-    "EXPECTED_OUTPUT = \"→ To track this notebook, copy & paste\"\n",
+    "EXPECTED_OUTPUT = \"→ to track this notebook, copy & paste\"\n",
     "output = StringIO()\n",
     "\n",
     "# user input is `n`\n",

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -143,10 +143,7 @@ def test_run_scripts_for_versioning():
     )
     # print(result.stdout.decode())
     assert result.returncode == 0
-    assert (
-        "created Transform(uid='Ro1gl7n8') & created Run('lmj2lyGD', started_at='"
-        in result.stdout.decode()
-    )
+    assert "created Transform(uid='Ro1gl7n8') & created Run(" in result.stdout.decode()
 
     # updated key (filename change)
     result = subprocess.run(  # noqa: S602

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -144,7 +144,7 @@ def test_run_scripts_for_versioning():
     # print(result.stdout.decode())
     assert result.returncode == 0
     assert (
-        "created Transform(uid='Ro1gl7n8YrdH0000') & created Run(started_at='"
+        "created Transform(uid='Ro1gl7n8') & created Run('lmj2lyGD', started_at='"
         in result.stdout.decode()
     )
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -143,7 +143,7 @@ def test_run_scripts_for_versioning():
     )
     # print(result.stdout.decode())
     assert result.returncode == 0
-    assert "created Transform(uid='Ro1gl7n8') & created Run(" in result.stdout.decode()
+    assert "created Transform('Ro1gl7n8') & created Run(" in result.stdout.decode()
 
     # updated key (filename change)
     result = subprocess.run(  # noqa: S602
@@ -176,10 +176,7 @@ def test_run_scripts_for_versioning():
     )
     # print(result.stdout.decode())
     assert result.returncode == 0
-    assert (
-        "created Transform(uid='Ro1gl7n8YrdH0001') & created Run(started_at="
-        in result.stdout.decode()
-    )
+    assert "created Transform('Ro1gl7n8') & created Run(" in result.stdout.decode()
     assert not ln.Transform.get("Ro1gl7n8YrdH0000").is_latest
     assert ln.Transform.get("Ro1gl7n8YrdH0001").is_latest
 


### PR DESCRIPTION
Main contribution: The new test & example in the PR below:

- https://github.com/laminlabs/lamin-cli/pull/80

Logging:

I meanwhile think that adopting the hub’s truncated 8-char uids in LaminDB can work by omitting the `uid=` prefix in record representations like so:
```
Transform('JjRF4mAC')
Run('DWqJ1af7')
```

This makes the logs much less noisy in parts, makes it easier to talk about a transform or a run, and can be used in `Record.get(truncated_uid)`.

Compare this with the below:
```
Transform(uid='JjRF4mACd9m00000')
Run(uid='DWqJ1af7W8q4tFz5pxQd')
```