### PR TITLE
✨ Track transfers as transforms

### DIFF
--- a/docs/transfer.ipynb
+++ b/docs/transfer.ipynb
@@ -257,6 +257,10 @@
    },
    "outputs": [],
    "source": [
+    "# test the last 3 cells here\n",
+    "assert artifact.transform.name == \"Transfer from `laminlabs/lamindata`\"\n",
+    "assert artifact.transform.key == \"transfers/4XIuR0tvaiXM\"\n",
+    "assert artifact.run.parent.transform.name == \"Transfer data\"\n",
     "# clean up test instance\n",
     "!lamin delete --force test-transfer"
    ]

--- a/docs/transfer.ipynb
+++ b/docs/transfer.ipynb
@@ -98,15 +98,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ln.Run.df()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {
     "tags": [
      "hide-output"

--- a/docs/transfer.ipynb
+++ b/docs/transfer.ipynb
@@ -40,7 +40,7 @@
    "source": [
     "import lamindb as ln\n",
     "\n",
-    "ln.track(\"ITeOtm7bhtdq0000\")\n"
+    "ln.track(\"ITeOtm7bhtdq0000\")"
    ]
   },
   {
@@ -93,6 +93,15 @@
    "metadata": {},
    "source": [
     "By saving the artifact record that's currently attached to the source database instance, you transfer it to the default database instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln.Run.df()"
    ]
   },
   {
@@ -181,6 +190,70 @@
    "outputs": [],
    "source": [
     "ln.view()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "View lineage:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact.view_lineage()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The transferred dataset is linked to a special type of transform that stores the slug and uid of the source instance:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact.transform.name"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The transform key has shape `f\"transfers/{source_instance.uid}\"`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact.transform.key"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The current notebook run is linked as the parent of the \"transfer run\":"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact.run.parent.transform"
    ]
   },
   {

--- a/docs/transfer.ipynb
+++ b/docs/transfer.ipynb
@@ -260,7 +260,9 @@
     "# test the last 3 cells here\n",
     "assert artifact.transform.name == \"Transfer from `laminlabs/lamindata`\"\n",
     "assert artifact.transform.key == \"transfers/4XIuR0tvaiXM\"\n",
+    "assert artifact.transform.uid == \"4XIuR0tvaiXM0000\"\n",
     "assert artifact.run.parent.transform.name == \"Transfer data\"\n",
+    "\n",
     "# clean up test instance\n",
     "!lamin delete --force test-transfer"
    ]

--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -477,14 +477,20 @@ def transfer_fk_to_default_db_bulk(
 
 
 def get_transfer_run(record) -> Run:
+    from lamindb_setup import settings as setup_settings
+
     from lamindb.core._context import context
     from lamindb.core._data import WARNING_RUN_TRANSFORM
 
     slug = record._state.db
     owner, name = get_owner_name_from_identifier(slug)
     settings_file = instance_settings_file(name, owner)
-    isettings = load_instance_settings(settings_file)
-    key = f"transfers/{isettings.uid}"
+    print(settings_file)
+    if not settings_file.exists():
+        print("settings file does not exit, re-connect")
+        connect_instance(owner=owner, name=name)  # write settings file
+    instance_uid = load_instance_settings(settings_file).uid
+    key = f"transfers/{instance_uid}"
     transform = Transform.filter(key=key).one_or_none()
     if transform is None:
         search_names = settings.creation.search_names

--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -480,9 +480,8 @@ def get_transfer_run(record) -> Run:
     from lamindb.core._context import context
     from lamindb.core._data import WARNING_RUN_TRANSFORM
 
-    assert "/" in record._state.db  # noqa: S101
     slug = record._state.db
-    owner, name = slug.split("/")
+    owner, name = get_owner_name_from_identifier(slug)
     settings_file = instance_settings_file(name, owner)
     isettings = load_instance_settings(settings_file)
     key = f"transfers/{isettings.uid}"

--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -516,7 +516,7 @@ def transfer_to_default_db(
     save: bool = False,
     transfer_fk: bool = True,
 ) -> Record | None:
-    if record.state._db is None or record.state._db == "default":
+    if record._state.db is None or record._state.db == "default":
         return None
     registry = record.__class__
     record_on_default = registry.objects.filter(uid=record.uid).one_or_none()

--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -505,7 +505,6 @@ def get_transfer_run(record) -> Run:
     if run is None:
         run = Run(transform=transform, parent=parent).save()
         run.parent = parent  # so that it's available in memory
-    print(Run.df())
     return run
 
 
@@ -517,6 +516,8 @@ def transfer_to_default_db(
     save: bool = False,
     transfer_fk: bool = True,
 ) -> Record | None:
+    if record.state._db is None or record.state._db == "default":
+        return None
     registry = record.__class__
     record_on_default = registry.objects.filter(uid=record.uid).one_or_none()
     record_str = f"{record.__class__.__name__}(uid='{record.uid}')"

--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -496,12 +496,13 @@ def get_transfer_run(record) -> Run:
         raise SystemExit("Need to call .using() before")
     instance_uid = cache_filepath.read_text()
     key = f"transfers/{instance_uid}"
-    transform = Transform.filter(key=key).one_or_none()
+    uid = instance_uid + "0000"
+    transform = Transform.filter(uid=uid).one_or_none()
     if transform is None:
         search_names = settings.creation.search_names
         settings.creation.search_names = False
         transform = Transform(
-            name=f"Transfer from `{slug}`", key=key, type="function"
+            uid=uid, name=f"Transfer from `{slug}`", key=key, type="function"
         ).save()
         settings.creation.search_names = search_names
     # use the global run context to get the parent run id

--- a/lamindb/_run.py
+++ b/lamindb/_run.py
@@ -18,13 +18,16 @@ def __init__(run: Run, *args, **kwargs):
     reference_type: str | None = (
         kwargs.pop("reference_type") if "reference_type" in kwargs else None
     )
+    parent: Run | None = kwargs.pop("parent", None)
     if transform is None:
         raise TypeError("Pass transform parameter")
     if transform._state.adding:
         raise ValueError("Please save transform record before creating a run")
+
     super(Run, run).__init__(
         transform=transform,
         reference=reference,
+        parent=parent,
         reference_type=reference_type,
     )
 

--- a/lamindb/core/_feature_manager.py
+++ b/lamindb/core/_feature_manager.py
@@ -917,7 +917,7 @@ def _add_from(self, data: Artifact | Collection, transfer_logs: dict = None):
     """Transfer features from a artifact or collection."""
     # This only covers feature sets
     if transfer_logs is None:
-        transfer_logs = {"mapped": [], "transferred": []}
+        transfer_logs = {"mapped": [], "transferred": [], "run": None}
     using_key = settings._using_key
     for slot, feature_set in data.features._feature_set_by_slot.items():
         members = feature_set.members

--- a/lamindb/core/_label_manager.py
+++ b/lamindb/core/_label_manager.py
@@ -212,7 +212,7 @@ class LabelManager:
         from django.db.utils import ProgrammingError
 
         if transfer_logs is None:
-            transfer_logs = {"mapped": [], "transferred": []}
+            transfer_logs = {"mapped": [], "transferred": [], "run": None}
         using_key = settings._using_key
         for related_name, (_, labels) in get_labels_as_dict(data).items():
             labels = labels.all()


### PR DESCRIPTION
Any transferred artifact now has a special "Transfer" transform as its data source which identifies the source LaminDB instance and the fact that the artifact is transferred.

Before | After
--- | ---
<img width="805" alt="image" src="https://github.com/user-attachments/assets/34fb4b7f-1961-47f9-b150-ee88b7173f2d"> | <img width="804" alt="image" src="https://github.com/user-attachments/assets/729f6d54-215f-459e-b24d-e4fd03e1c649">

The PR also enables tracking transferred artifacts as inputs without explicitly saving them in a given transform run. This means the following call will now lead to a trace in data lineage:
```
input_artifact = ln.Artifact.using("laminlabs/lamindata").get(description="exemplar-001")
input_artifact.load()
```

Before this PR, it was silently ignored.