### PR TITLE
📝 Document how to work with run parameters

### DIFF
--- a/docs/scripts/run-track-with-params.py
+++ b/docs/scripts/run-track-with-params.py
@@ -7,15 +7,11 @@ if __name__ == "__main__":
     p.add_argument("--downsample", action="store_true")
     p.add_argument("--learning-rate", type=float)
     args = p.parse_args()
-
     params = {
         "input_dir": args.input_dir,
         "learning_rate": args.learning_rate,
         "downsample": args.downsample,
     }
-
     ln.track("JjRF4mACd9m00000", params=params)
-
-    # actual code
-
+    # your code
     ln.finish()

--- a/docs/scripts/run-track-with-params.py
+++ b/docs/scripts/run-track-with-params.py
@@ -1,0 +1,21 @@
+import argparse
+import lamindb as ln
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--input-dir", type=str)
+    p.add_argument("--downsample", action="store_true")
+    p.add_argument("--learning-rate", type=float)
+    args = p.parse_args()
+
+    params = {
+        "input_dir": args.input_dir,
+        "learning_rate": args.learning_rate,
+        "downsample": args.downsample,
+    }
+
+    ln.track("JjRF4mACd9m00000", params=params)
+
+    # actual code
+
+    ln.finish()

--- a/docs/scripts/synced-with-git.py
+++ b/docs/scripts/synced-with-git.py
@@ -1,0 +1,6 @@
+import lamindb as ln
+
+ln.settings.sync_git_repo = "https://github.com/..."
+ln.track()
+# your code
+ln.finish()

--- a/docs/scripts/synched-script.py
+++ b/docs/scripts/synched-script.py
@@ -1,9 +1,0 @@
-import lamindb as ln
-
-ln.settings.sync_git_repo = "https://github.com/..."
-
-ln.track("8a12ar0hoE5u0000")
-df = ln.Artifact.get(...).load()
-df_processed = df / 2
-ln.Artifact.from_df(df_processed, ...).save()
-ln.finish()

--- a/docs/scripts/synched-script.py
+++ b/docs/scripts/synched-script.py
@@ -1,0 +1,9 @@
+import lamindb as ln
+
+ln.settings.sync_git_repo = "https://github.com/..."
+
+ln.track("8a12ar0hoE5u0000")
+df = ln.Artifact.get(...).load()
+df_processed = df / 2
+ln.Artifact.from_df(df_processed, ...).save()
+ln.finish()

--- a/docs/track.ipynb
+++ b/docs/track.ipynb
@@ -6,12 +6,9 @@
    "source": [
     "# Track notebooks & scripts\n",
     "\n",
-    "Call {meth}`~lamindb.core.Context.track` to track code along with its inputs and outputs.\n",
+    "This guide explains how to use {meth}`~lamindb.track` & {meth}`~lamindb.finish` to track notebook & scripts along with their inputs and outputs.\n",
     "\n",
-    "```{note}\n",
-    "\n",
-    "Tracking of notebooks & scripts is analogous to tracking data transformations through pipelines, functions & UI, see {doc}`docs:project-flow`.\n",
-    "```"
+    "For tracking data lineage in pipelines, see {doc}`docs:pipelines`."
    ]
   },
   {
@@ -39,7 +36,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Call {meth}`~lamindb.track` to register a data transformation and start tracking inputs & outputs of a run. You will find your notebook in the {class}`~lamindb.Transform` registry along with scripts, pipelines & functions. {class}`~lamindb.Run` stores executions."
+    "Call {meth}`~lamindb.track` to register a data transformation and start tracking inputs & outputs of a run. You will find your notebook or script in the {class}`~lamindb.Transform` registry along with pipelines & functions. {class}`~lamindb.Run` stores executions."
    ]
   },
   {
@@ -63,7 +60,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "LaminDB now automatically tracks all input and output data and saved the run environment in a `requirements.txt`."
+    "LaminDB now automatically tracks all input and output data of the current run.\n",
+    "\n",
+    "Note: You can access a `requirments.txt` via `ln.context.run.environment`."
    ]
   },
   {
@@ -97,7 +96,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Query for a notebook or script"
+    "## Query & load a notebook or script"
    ]
   },
   {
@@ -119,7 +118,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "On the hub, use the search or filter in the `Transform` view."
+    "On the hub, search or filter the `transform` page and then load a script or notebook on the CLI. For example,\n",
+    "\n",
+    "```bash\n",
+    "lamin load https://lamin.ai/laminlabs/lamindata/transform/13VINnFk89PE0004\n",
+    "```"
    ]
   },
   {

--- a/docs/track.ipynb
+++ b/docs/track.ipynb
@@ -88,7 +88,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is how a notebook with run report looks on the hub:\n",
+    "Below is how a notebook with run report looks on the hub.\n",
     "\n",
     "<img src=\"https://lamin-site-assets.s3.amazonaws.com/.lamindb/RGXj5wcAf7EAc6J8dJfH.png\" width=\"900px\">"
    ]
@@ -145,9 +145,9 @@
    "metadata": {},
    "source": [
     "```{eval-rst}\n",
-    ".. literalinclude:: ../sub/lamin-cli/tests/scripts/run-track-with-params.py\n",
+    ".. literalinclude:: scripts/synced-with-git.py\n",
     "   :language: python\n",
-    "   :caption: run-track-with-params.py\n",
+    "   :caption: synced-with-git.py\n",
     "```"
    ]
   },
@@ -155,7 +155,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You'll now see the GitHub emoji clickable on the hub:\n",
+    "You'll now see the GitHub emoji clickable on the hub.\n",
     "\n",
     "<img src=\"https://lamin-site-assets.s3.amazonaws.com/.lamindb/IpV8Kiq4xUbgXhzlUYT7.png\" width=\"900px\">\n",
     "<br>"
@@ -172,7 +172,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "LaminDB's validation dialogue auto-generates code for run parameters. Here is an example."
+    "LaminDB's validation dialogue auto-generates code for run parameters. Here is an example:"
    ]
   },
   {
@@ -195,7 +195,7 @@
    "metadata": {},
    "source": [
     "```{eval-rst}\n",
-    ".. literalinclude:: ./scripts/run-track-with-params.py\n",
+    ".. literalinclude:: scripts/run-track-with-params.py\n",
     "   :language: python\n",
     "   :caption: run-track-with-params.py\n",
     "```"
@@ -225,14 +225,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "So how did we generate the `Param` definitions? If the parameters hadn't yet been defined, you'd have gotten a validation error suggesting to define parameters."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Query by run parameters"
+    "## Query by run parameters"
    ]
   },
   {
@@ -245,7 +238,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "ln.Run.params.filter(learning_rate=0.01, input_dir=\"./mydataset\").df()"
@@ -325,6 +322,7 @@
     "assert run.params.get_values() == {'downsample': True, 'input_dir': './mydataset', 'learning_rate': 0.01}\n",
     "\n",
     "# clean up test instance\n",
+    "!rm -r ./test-track\n",
     "!lamin delete --force test-track"
    ]
   }

--- a/docs/track.ipynb
+++ b/docs/track.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Manage notebooks & scripts\n",
+    "# Track notebooks & scripts\n",
     "\n",
     "Call {meth}`~lamindb.core.Context.track` to track code along with its inputs and outputs.\n",
     "\n",
@@ -63,14 +63,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "LaminDB now automatically tracks all input and output data."
+    "LaminDB now automatically tracks all input and output data and saved the run environment in a `requirements.txt`."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Save run report, environment & source code"
+    "## Track run report & source code"
    ]
   },
   {
@@ -107,7 +107,6 @@
     "In the API, filter {class}`~lamindb.Transform` to obtain a transform record:\n",
     "\n",
     "```python\n",
-    "\n",
     "transform = ln.Transform.get(name=\"Track notebooks & scripts\")\n",
     "transform.source_code  # source code\n",
     "transform.latest_run.report  # report of latest run\n",
@@ -145,28 +144,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A tracked Python script could look like this:\n",
-    "\n",
-    "```python\n",
-    "# my_script.py\n",
-    "\n",
-    "import lamindb as ln\n",
-    "\n",
-    "# set this setting in the script or on laminhub\n",
-    "ln.settings.sync_git_repo = \"https://github.com/...\"\n",
-    "\n",
-    "# initiate tracking\n",
-    "ln.track(\"8a12ar0hoE5u0000\")\n",
-    "\n",
-    "\n",
-    "# load input artifacts\n",
-    "data = ln.Artifact.get(...).load()\n",
-    "\n",
-    "# save output artifacts\n",
-    "ln.Artifact(output_data, ...).save()\n",
-    "\n",
-    "# save the script as transform.source_code\n",
-    "ln.finish()\n",
+    "```{eval-rst}\n",
+    ".. literalinclude:: ../sub/lamin-cli/tests/scripts/run-track-with-params.py\n",
+    "   :language: python\n",
+    "   :caption: run-track-with-params.py\n",
     "```"
    ]
   },
@@ -178,6 +159,117 @@
     "\n",
     "<img src=\"https://lamin-site-assets.s3.amazonaws.com/.lamindb/IpV8Kiq4xUbgXhzlUYT7.png\" width=\"900px\">\n",
     "<br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Track run parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "LaminDB's validation dialogue auto-generates code for run parameters. Here is an example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "ln.Param(name=\"input_dir\", dtype=\"str\").save()\n",
+    "ln.Param(name=\"learning_rate\", dtype=\"float\").save()\n",
+    "ln.Param(name=\"downsample\", dtype=\"bool\").save()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{eval-rst}\n",
+    ".. literalinclude:: ../sub/lamin-cli/tests/scripts/run-track-with-params.py\n",
+    "   :language: python\n",
+    "   :caption: run-track-with-params.py\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run the script."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "!python scripts/run-track-with-params.py  --input-dir ./mydataset --learning-rate 0.01 --downsample"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So how did we generate the `Param` definitions? If the parameters hadn't yet been defined, you'd have gotten a validation error suggesting to define parameters."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Query by run parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Query for all runs that match a certain parameters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln.Run.params.filter(learning_rate=0.01, input_dir=\"./mydataset\").df()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Look at the parameter values that were used for a given run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "run = ln.Run.params.filter(learning_rate=0.01).order_by(\"-started_at\").first()\n",
+    "run.params.get_values()"
    ]
   },
   {
@@ -230,6 +322,8 @@
    },
    "outputs": [],
    "source": [
+    "assert run.params.get_values() == {'downsample': True, 'input_dir': './mydataset', 'learning_rate': 0.01}\n",
+    "\n",
     "# clean up test instance\n",
     "!lamin delete --force test-track"
    ]
@@ -251,7 +345,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.17"
+   "version": "3.10.13"
   },
   "nbproject": {
    "id": "9priar0hoE5u",

--- a/docs/track.ipynb
+++ b/docs/track.ipynb
@@ -195,7 +195,7 @@
    "metadata": {},
    "source": [
     "```{eval-rst}\n",
-    ".. literalinclude:: ../sub/lamin-cli/tests/scripts/run-track-with-params.py\n",
+    ".. literalinclude:: ./scripts/run-track-with-params.py\n",
     "   :language: python\n",
     "   :caption: run-track-with-params.py\n",
     "```"

--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 import lamindb_setup as ln_setup
 from lamin_utils import logger
 from lamindb_setup.core.hashing import hash_file
-from lnschema_core.models import format_field_value
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -96,6 +95,10 @@ def save_context_core(
     ignore_non_consecutive: bool | None = None,
     from_cli: bool = False,
 ) -> str | None:
+    from lnschema_core.models import (
+        format_field_value,  # needs to come after lamindb was imported because of CLI use
+    )
+
     import lamindb as ln
 
     from .core._context import context, is_run_from_ipython

--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-import os
 import re
-import shutil
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 import lamindb_setup as ln_setup
 from lamin_utils import logger
 from lamindb_setup.core.hashing import hash_file
+from lnschema_core.models import format_field_value
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -234,6 +233,11 @@ def save_context_core(
     transform.save()
 
     # finalize
+    if not from_cli:
+        run_time = run.finished_at - run.started_at
+        logger.important(
+            f"finished Run('{run.uid[:8]}') after {run_time} at {format_field_value(run.finished_at)}"
+        )
     if ln_setup.settings.instance.is_on_hub:
         identifier = ln_setup.settings.instance.slug
         logger.important(

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -323,7 +323,7 @@ class Context:
             )
             if run is not None:  # loaded latest run
                 run.started_at = datetime.now(timezone.utc)  # update run time
-                self._logging_message += f" & loaded Run('{run.uid[:8]}', started_at={format_field_value(run.started_at)})"
+                self._logging_message += f", started Run('{run.uid[:8]}') at {format_field_value(run.started_at)}"
 
         if run is None:  # create new run
             run = Run(
@@ -331,7 +331,7 @@ class Context:
                 params=params,
             )
             run.started_at = datetime.now(timezone.utc)
-            self._logging_message += f" & created Run('{run.uid[:8]}', started_at={format_field_value(run.started_at)})"
+            self._logging_message += f", started new Run('{run.uid[:8]}') at {format_field_value(run.started_at)}"
         # can only determine at ln.finish() if run was consecutive in
         # interactive session, otherwise, is consecutive
         run.is_consecutive = True if is_run_from_ipython else None
@@ -339,7 +339,7 @@ class Context:
         run.save()
         if params is not None:
             run.params.add_values(params)
-            self._logging_message += " with params: " + " ".join(
+            self._logging_message += "\n→ params: " + " ".join(
                 f"{key}='{value}'" for key, value in params.items()
             )
         self._run = run

--- a/lamindb/core/_feature_manager.py
+++ b/lamindb/core/_feature_manager.py
@@ -497,6 +497,7 @@ def filter_base(cls, **expression):
         )
     new_expression = {}
     features = model.filter(name__in=keys_normalized).all().distinct()
+    feature_param = "param" if model is Param else "feature"
     for key, value in expression.items():
         split_key = key.split("__")
         normalized_key = split_key[0]
@@ -505,9 +506,9 @@ def filter_base(cls, **expression):
             comparator = f"__{split_key[1]}"
         feature = features.get(name=normalized_key)
         if not feature.dtype.startswith("cat"):
-            expression = {"feature": feature, f"value{comparator}": value}
+            expression = {feature_param: feature, f"value{comparator}": value}
             feature_value = value_model.filter(**expression)
-            new_expression["_feature_values__in"] = feature_value
+            new_expression[f"_{feature_param}_values__in"] = feature_value
         else:
             if isinstance(value, str):
                 expression = {f"name{comparator}": value}
@@ -990,3 +991,4 @@ FeatureManager.filter = filter
 FeatureManager.get = get
 ParamManager.add_values = add_values_params
 ParamManager.get_values = get_values
+ParamManager.filter = filter

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -143,7 +143,7 @@ def test_run_scripts_for_versioning():
     )
     # print(result.stdout.decode())
     assert result.returncode == 0
-    assert "created Transform('Ro1gl7n8') & created Run(" in result.stdout.decode()
+    assert "created Transform('Ro1gl7n8'), started new Run(" in result.stdout.decode()
 
     # updated key (filename change)
     result = subprocess.run(  # noqa: S602
@@ -176,7 +176,7 @@ def test_run_scripts_for_versioning():
     )
     # print(result.stdout.decode())
     assert result.returncode == 0
-    assert "created Transform('Ro1gl7n8') & created Run(" in result.stdout.decode()
+    assert "created Transform('Ro1gl7n8'), started new Run(" in result.stdout.decode()
     assert not ln.Transform.get("Ro1gl7n8YrdH0000").is_latest
     assert ln.Transform.get("Ro1gl7n8YrdH0001").is_latest
 
@@ -206,7 +206,7 @@ def test_run_external_script():
     print(result.stderr.decode())
     assert result.returncode == 0
     assert "created Transform" in result.stdout.decode()
-    assert "created Run" in result.stdout.decode()
+    assert "started new Run" in result.stdout.decode()
     transform = ln.Transform.get(key="run-track-and-finish-sync-git.py")
     # the algorithm currently picks different commits depending on the state of the repo
     # any of these commits are valid


### PR DESCRIPTION
This adds two new sections about tracking and querying run parameters to https://docs.lamin.ai/track

## Track run params

<img width="600" alt="image" src="https://github.com/user-attachments/assets/7733db4e-46d8-4dae-898d-b98164693c40">

## Query by run params

<img width="500" alt="image" src="https://github.com/user-attachments/assets/47a6cba4-fa98-445e-b773-4d1e0d33e5c2">

## More comprehensive run context logging

Before: 

```bash
→ created Transform(uid='JjRF4mAC8qbE0000') & created Run(started_at='2024-09-26 19:51:58 UTC')`
```

After:

```bash
→ created Transform('JjRF4mAC'), started new Run('O45bXStj') at 2024-09-28 14:26:31 UTC
→ params: input_dir='./mydataset' learning_rate='0.01' downsample='True'
→ finished Run('O45bXStj') after 0:00:00.709727 at 2024-09-28 14:26:31 UTC
```

## Simplified GitHub syncing section

Before | After
--- | ---
<img width="617" alt="image" src="https://github.com/user-attachments/assets/73e949ec-36b6-4bf8-ba76-ad21cff07e68"> | <img width="579" alt="image" src="https://github.com/user-attachments/assets/e9a37d49-6c74-458d-95de-36462466052d">

## Notes

Tracking run parameters has been supported since https://docs.lamin.ai/changelog/2024#db-0-72-0 but has never properly documented.

Needs:

- https://github.com/laminlabs/lamin-cli/pull/82