### PR TITLE
🚸 Transfer: Warn about inconsistencies between source & target instances

### DIFF
--- a/docs/bio-registries.ipynb
+++ b/docs/bio-registries.ipynb
@@ -275,7 +275,7 @@
    "source": [
     "We'd like to load the corresponding records in our in-house registry to annotate a dataset.\n",
     "\n",
-    "To this end, you'll typically use {class}`~lamindb.core.Record.from_values`, which will both validate & retrieve records that match the values."
+    "To this end, you'll typically use {class}`~lamindb.core.CanValidate.from_values`, which will both validate & retrieve records that match the values."
    ]
   },
   {

--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -389,17 +389,19 @@ def using(
             raise RuntimeError(
                 f"Failed to load instance {instance}, please check your permissions!"
             )
-        instance, _ = result
-        source_schema = {schema for schema in instance["schema_str"] if schema != ""}  # type: ignore
+        iresult, _ = result
+        source_schema = {
+            schema for schema in iresult["schema_str"].split(",") if schema != ""
+        }  # type: ignore
         target_schema = ln_setup.settings.instance.schema
         if not source_schema.issubset(target_schema):
             missing_members = source_schema - target_schema
             logger.warning(
                 f"source schema has additional modules: {missing_members}\nconsider mounting these schema modules to not encounter errors"
             )
-        cache_filepath.write_text(instance["lnid"])  # type: ignore
+        cache_filepath.write_text(iresult["lnid"])  # type: ignore
         settings_file = instance_settings_file(name, owner)
-        db = update_db_using_local(instance, settings_file)
+        db = update_db_using_local(iresult, settings_file)
     else:
         isettings = load_instance_settings(settings_file)
         db = isettings.db

--- a/lamindb/core/_label_manager.py
+++ b/lamindb/core/_label_manager.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from django.db import connections
-from lamin_utils import colors
+from lamin_utils import colors, logger
 from lnschema_core.models import Feature
 
 from lamindb._from_values import _print_values
@@ -277,4 +277,7 @@ class LabelManager:
                         )
             # ProgrammingError is raised when schemas don't match between source and target instances
             except ProgrammingError:
+                logger.warning(
+                    f"{related_name} labels cannot be transferred because schema module does not exist in target instance: {labels}"
+                )
                 continue

--- a/tests/core/test_record.py
+++ b/tests/core/test_record.py
@@ -16,7 +16,7 @@ def test_signatures():
         pass
 
     # class methods
-    class_methods = ["filter", "get", "df", "search", "lookup", "from_values", "using"]
+    class_methods = ["filter", "get", "df", "search", "lookup", "using"]
     for name in class_methods:
         setattr(Mock, name, getattr(_record, name))
         assert signature(getattr(Mock, name)) == _record.SIGS.pop(name)


### PR DESCRIPTION
This PR adds warnings about:

- inconsistent lamindb versions (greater than minor)
- missing schema modules in the target instance
- in-ability of transferring given labels who don't have a registry in the target instance

Check for version inconsistency was added here:

- https://github.com/laminlabs/lamindb-setup/pull/869

A previous PR silently excepted errors when target registries didn't exist.

- https://github.com/laminlabs/lamindb/pull/1654

Addresses:

- https://github.com/laminlabs/lamindb/issues/1990