### PR TITLE
🚸 Improve `lamin load` UX for notebooks & scripts

### DIFF
--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -75,13 +75,21 @@ def notebook_to_script(
     script_path.write_text(py_content)
 
 
-def script_to_notebook(transform: Transform, notebook_path: Path) -> None:
+def script_to_notebook(
+    transform: Transform, notebook_path: Path, bump_revision: bool = False
+) -> None:
     import jupytext
 
-    # get title back
+    from .core.versioning import increment_base62
+
     py_content = transform.source_code.replace(
         "# # transform.name", f"# # {transform.name}"
     )
+    if bump_revision:
+        uid = transform.uid
+        new_uid = f"{uid[:-4]}{increment_base62(uid[-4:])}"
+        py_content = py_content.replace(uid, new_uid)
+        logger.important(f"updated uid: {uid} → {new_uid}")
     notebook = jupytext.reads(py_content, fmt="py:percent")
     jupytext.write(notebook, notebook_path)
 

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -86,9 +86,7 @@ def raise_missing_context(transform_type: str, key: str) -> bool:
         message = f'to track this {transform_type}, copy & paste `ln.track("{new_uid}")` and re-run'
     else:
         uid = transform.uid
-        suid, vuid = uid[: Transform._len_stem_uid], uid[Transform._len_stem_uid :]
-        new_vuid = increment_base62(vuid)
-        new_uid = f"{suid}{new_vuid}"
+        new_uid = f"{uid[:-4]}{increment_base62(uid[-4:])}"
         message = f"you already have a transform with key '{key}' ('{transform.uid}')\n  - to make a revision, call `ln.track('{new_uid}')`\n  - to create a new transform, rename your file and run: `ln.track()`"
     if transform_type == "notebook":
         print(f"→ {message}")

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -476,11 +476,11 @@ class Context:
                     "updated transform name, "  # white space on purpose
                 )
             elif (
-                transform.created_by != ln_setup.settings.user.id
+                transform.created_by_id != ln_setup.settings.user.id
                 and not transform_was_saved
             ):
                 raise UpdateContext(
-                    f'{transform.created_by.name} ({transform.created_by.handle}) already works on this draft notebook.\n\nPlease create a revision via `ln.track("{uid[:-4]}{increment_base62(uid[-4:])}")` or a new transform with a *different* filename and `ln.track("{ids.base62_12()}0000")`.'
+                    f'{transform.created_by.name} ({transform.created_by.handle}) already works on this draft {transform.type}.\n\nPlease create a revision via `ln.track("{uid[:-4]}{increment_base62(uid[-4:])}")` or a new transform with a *different* filename and `ln.track("{ids.base62_12()}0000")`.'
                 )
             # check whether transform source code was already saved
             if transform_was_saved:

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -20,7 +20,6 @@ from .exceptions import (
     InconsistentKey,
     MissingContextUID,
     NotebookNotSaved,
-    NotebookNotSavedError,
     NoTitleError,
     TrackNotCalled,
     UpdateContext,
@@ -392,7 +391,7 @@ class Context:
             try:
                 nbproject_title = nbproject.meta.live.title
             except IndexError:
-                raise NotebookNotSavedError(
+                raise NotebookNotSaved(
                     "The notebook is not saved, please save the notebook and"
                     " rerun ``"
                 ) from None

--- a/lamindb/core/exceptions.py
+++ b/lamindb/core/exceptions.py
@@ -51,6 +51,12 @@ class DoesNotExist(Exception):
     pass
 
 
+class InconsistentKey(Exception):
+    """Inconsistent transform or artifact `key`."""
+
+    pass
+
+
 # -------------------------------------------------------------------------------------
 # run context
 # -------------------------------------------------------------------------------------

--- a/lamindb/core/exceptions.py
+++ b/lamindb/core/exceptions.py
@@ -6,7 +6,7 @@
    InvalidArgument
    DoesNotExist
    ValidationError
-   NotebookNotSavedError
+   NotebookNotSaved
    NoTitleError
    MissingContextUID
    UpdateContext
@@ -68,12 +68,6 @@ class IntegrityError(Exception):
     For instance, it's not allowed to delete artifacts outside managed storage
     locations.
     """
-
-    pass
-
-
-class NotebookNotSavedError(Exception):
-    """Notebook wasn't saved."""
 
     pass
 

--- a/lamindb/core/versioning.py
+++ b/lamindb/core/versioning.py
@@ -18,7 +18,7 @@ def message_update_key_in_version_family(
     registry: str,
     new_key: str,
 ) -> str:
-    return f'Or update key "{existing_key}" to "{new_key}":\n\nln.{registry}.filter(uid__startswith="{suid}").update(key="{new_key}")\n'
+    return f'Or update key "{existing_key}" to "{new_key}" for all previous versions:\n\nln.{registry}.filter(uid__startswith="{suid}").update(key="{new_key}")\n'
 
 
 def increment_base62(s: str) -> str:

--- a/noxfile.py
+++ b/noxfile.py
@@ -176,7 +176,7 @@ def build(session, group):
     elif group == "storage":
         run(session, f"pytest -s {coverage_args} ./docs/storage")
     elif group == "cli":
-        run(session, f"pytest -vv {coverage_args} ./sub/lamin-cli/tests")
+        run(session, f"pytest {coverage_args} ./sub/lamin-cli/tests --durations=50")
     # move artifacts into right place
     if group in {"tutorial", "guide", "biology"}:
         target_dir = Path(f"./docs/{group}")


### PR DESCRIPTION
## Avoid accidental overwrites

Adds a user prompt in case the target file exists to avoid accidental overwrites.

```
! demo.ipynb exists: replace? (y/n)
```

## Auto-bumping uid for revising notebooks

Upon revising a notebook a user so far runs into an error that tells them to manually update the `uid`. To avoid this, the `uid` is now automatically updated upon `lamin load`.

Before:
```
% lamin load https://lamin.ai/laminlabs/lamindata/transform/3qIZOmDUVBwc0000
→ demo.ipynb
```

After:
```
% lamin load https://lamin.ai/laminlabs/lamindata/transform/3qIZOmDUVBwc0000
! demo.ipynb exists: replace? (y/n)y
→ updated uid: 3qIZOmDUVBwc0000 → 3qIZOmDUVBwc0001
→ notebook is here: demo.ipynb
```

The `uid` is only updated for notebooks, not for other transform types and not for artifacts. Only notebooks are essentially guaranteed to be revised once a user loads them. A script, for instance, is equally likely to be run with the exact same source code hash it had before a user loading it.

There is an edge case in which a user might want to re-run the exact same saved notebook with the same `uid` to inspect whether it reproduces the same outputs. This edge case is *not yet* supported.

## Avoid conflicts for two user working on the same draft transform

Before:
```
→ loaded Transform('3qIZOmDU'), started new Run('Q6dM7cRs') at 2024-09-29 10:03:05 UTC
```

After:
```
UpdateContext: Alex Wolf (falexwolf) already works on this draft notebook.

Please create a revision via `ln.track("3qIZOmDUVBwc0002")` or a new transform with a *different* filename and `ln.track("1fFD29wCRmGY0000")`.
```

## Slightly more logging for the downloaded local asset

Before:
```
→ demo.ipynb
```

After:
```
→ notebook is here: demo.ipynb
```

## Fixes integrity issue

Before this PR, it was possible to run `ln.track()` with a bumped `uid` on a notebook with a different filename/key without running into the below error. The error was only raised upon finding an exact match of the `uid`. Now it's also raised upon finding a match on the stem uid.

```
UpdateContext: Filename "demo1.ipynb" clashes with the existing key "demo.ipynb" for uid "3qIZOmDUVBwc...."

Either init a new transform with a new uid:

ln.track("BQjjSpMoyidv0000)"

Or update key "demo.ipynb" to "demo1.ipynb" for all previous versions:

ln.Transform.filter(uid__startswith="3qIZOmDUVBwc").update(key="demo1.ipynb")
```

## Notes

Needs:

- https://github.com/laminlabs/lamin-cli/pull/83

Resolves:

- https://github.com/laminlabs/lamindb/issues/1980
- https://github.com/laminlabs/lamindb/issues/1996