### PR TITLE
🚸 Query with typed labels through `.features`

### DIFF
--- a/lamindb/core/_feature_manager.py
+++ b/lamindb/core/_feature_manager.py
@@ -509,9 +509,9 @@ def filter_base(cls, **expression):
             expression = {feature_param: feature, f"value{comparator}": value}
             feature_value = value_model.filter(**expression)
             new_expression[f"_{feature_param}_values__in"] = feature_value
-        else:
+        elif isinstance(value, (str, Record)):
             if isinstance(value, str):
-                expression = {f"name{comparator}": value}
+                expression = {"name": value}
                 value = ULabel.get(**expression)
             accessor_name = (
                 value.__class__.artifacts.through.artifact.field._related_name
@@ -520,6 +520,8 @@ def filter_base(cls, **expression):
             new_expression[f"{accessor_name}__{value.__class__.__name__.lower()}"] = (
                 value
             )
+        else:
+            raise NotImplementedError
     if cls == FeatureManager or cls == ParamManagerArtifact:
         return Artifact.filter(**new_expression)
     elif cls == ParamManagerRun:

--- a/tests/core/test_feature_manager.py
+++ b/tests/core/test_feature_manager.py
@@ -203,6 +203,9 @@ Here is how to create ulabels for them:
     ln.Artifact.features.filter(
         temperature=100.0, project="project_1", donor="U0123"
     ).one()
+    # for bionty
+    assert artifact == ln.Artifact.features.filter(disease=diseases[0]).one()
+
     # test comparator
     assert ln.Artifact.features.filter(temperature__lt=21).one_or_none() is None
     assert len(ln.Artifact.features.filter(temperature__gt=21).all()) >= 1


### PR DESCRIPTION
**Before**

You could only query categorical features with string representations of `ULabel`, e.g.,:

```python
ln.Artifact.features.filter(scientist="Barbara McClintock")
```

**After**

Given a categorical feature `"cell_type_by_expert"` with type `cat[bionty.CellType]`, you can now do:

```python
tcell = bt.CellType.get(name="T cell")
artifacts = ln.Artifact.features.filter(cell_type_by_expert=t_cell)
```

Note: The above is a shortcut for the equivalent query:
```python
artifacts = ln.Artifact.filter(links_cell_type__feature__name="cell_type_by_expert", links_cell_type__celltype=t_cell)
```