### PR TITLE
📝 Document how to query by nested run parameters

### DIFF
--- a/docs/scripts/run-track-with-params.py
+++ b/docs/scripts/run-track-with-params.py
@@ -10,12 +10,11 @@ if __name__ == "__main__":
     params = {
         "input_dir": args.input_dir,
         "learning_rate": args.learning_rate,
-        "downsample": args.downsample,
         "preprocess_params": {
-            "normalization": "nice",
-            "subset_features": True,
+            "downsample": args.downsample,
+            "normalization": "the_good_one",
         },
     }
-    ln.track("JjRF4mACd9m00000", params=params)
+    ln.track("JjRF4mACd9m00001", params=params)
     # your code
     ln.finish()

--- a/docs/scripts/run-track-with-params.py
+++ b/docs/scripts/run-track-with-params.py
@@ -11,6 +11,10 @@ if __name__ == "__main__":
         "input_dir": args.input_dir,
         "learning_rate": args.learning_rate,
         "downsample": args.downsample,
+        "preprocess_params": {
+            "normalization": "nice",
+            "subset_features": True,
+        },
     }
     ln.track("JjRF4mACd9m00000", params=params)
     # your code

--- a/docs/track.ipynb
+++ b/docs/track.ipynb
@@ -304,7 +304,7 @@
    },
    "outputs": [],
    "source": [
-    "assert run.params.get_values() == {'downsample': True, 'input_dir': './mydataset', 'learning_rate': 0.01}\n",
+    "assert run.params.get_values() == {'input_dir': './mydataset', 'learning_rate': 0.01, 'preprocess_params': {'downsample': True, 'normalization': 'the_good_one'}}\n",
     "\n",
     "# clean up test instance\n",
     "!rm -r ./test-track\n",

--- a/docs/track.ipynb
+++ b/docs/track.ipynb
@@ -230,14 +230,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that above, `preprocess_params__downsample` traverses the dictionary-like parameter `preprocess_params`."
+    "Note that:\n",
+    "\n",
+    "* `preprocess_params__downsample=True` traverses the dictionary `preprocess_params` to find the key `\"downsample\"` and match it to `True`\n",
+    "* nested keys like `\"downsample\"` in a dictionary do not appear in `Param` and hence, do not get validated"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Look at the parameter values that were used for a given run."
+    "Below is how you get the parameter values that were used for a given run."
    ]
   },
   {
@@ -252,6 +255,31 @@
    "source": [
     "run = ln.Run.params.filter(learning_rate=0.01).order_by(\"-started_at\").first()\n",
     "run.params.get_values()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or [on the hub](https://lamin.ai/laminlabs/lamindata/transform/JjRF4mACd9m00001).\n",
+    "\n",
+    "<img width=\"400\" alt=\"image\" src=\"https://github.com/user-attachments/assets/d8a5df37-d585-4940-b6f0-91f99b6c436c\">"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you want to query all parameter values across all runs, use {class}`~lamindb.core.ParamValue`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln.core.ParamValue.df(include=[\"param__name\", \"created_by__handle\"])"
    ]
   },
   {

--- a/docs/track.ipynb
+++ b/docs/track.ipynb
@@ -165,7 +165,6 @@
     "\n",
     "ln.Param(name=\"input_dir\", dtype=\"str\").save()\n",
     "ln.Param(name=\"learning_rate\", dtype=\"float\").save()\n",
-    "ln.Param(name=\"downsample\", dtype=\"bool\").save()\n",
     "ln.Param(name=\"preprocess_params\", dtype=\"dict\").save()"
    ]
   },
@@ -224,7 +223,14 @@
    },
    "outputs": [],
    "source": [
-    "ln.Run.params.filter(learning_rate=0.01, input_dir=\"./mydataset\").df()"
+    "ln.Run.params.filter(learning_rate=0.01, input_dir=\"./mydataset\", preprocess_params__downsample=True).df()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that above, `preprocess_params__downsample` traverses the dictionary-like parameter `preprocess_params`."
    ]
   },
   {

--- a/docs/track.ipynb
+++ b/docs/track.ipynb
@@ -165,7 +165,8 @@
     "\n",
     "ln.Param(name=\"input_dir\", dtype=\"str\").save()\n",
     "ln.Param(name=\"learning_rate\", dtype=\"float\").save()\n",
-    "ln.Param(name=\"downsample\", dtype=\"bool\").save()"
+    "ln.Param(name=\"downsample\", dtype=\"bool\").save()\n",
+    "ln.Param(name=\"preprocess_params\", dtype=\"dict\").save()"
    ]
   },
   {

--- a/docs/track.ipynb
+++ b/docs/track.ipynb
@@ -265,7 +265,7 @@
    "source": [
     "Or [on the hub](https://lamin.ai/laminlabs/lamindata/transform/JjRF4mACd9m00001).\n",
     "\n",
-    "<img width=\"400\" alt=\"image\" src=\"https://github.com/user-attachments/assets/d8a5df37-d585-4940-b6f0-91f99b6c436c\">"
+    "<img width=\"500\" alt=\"image\" src=\"https://github.com/user-attachments/assets/d8a5df37-d585-4940-b6f0-91f99b6c436c\">"
    ]
   },
   {
@@ -278,7 +278,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "ln.core.ParamValue.df(include=[\"param__name\", \"created_by__handle\"])"

--- a/docs/track.ipynb
+++ b/docs/track.ipynb
@@ -141,6 +141,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "(track-run-parameters)=\n",
+    "\n",
     "## Track run parameters"
    ]
   },


### PR DESCRIPTION
Before, we didn't have documentation on how to query dictionary-like parameters. Now it's part of the `track` guide: 
<img width="600" alt="image" src="https://github.com/user-attachments/assets/cf4aed3d-2726-4678-8249-136c65d197d6">

The `lamindb.Run` page cross-links this section: https://github.com/laminlabs/lnschema-core/commit/7d14d949f6b295c900bd4a161f4e0794356b7ae4
<img width="350" alt="image" src="https://github.com/user-attachments/assets/b2cde063-f14b-49c9-8505-8bc8a2f75402">


We also show how run params look on the hub: https://lamin.ai/laminlabs/lamindata/transform/JjRF4mACd9m00001
<img width="500" alt="image" src="https://github.com/user-attachments/assets/d8a5df37-d585-4940-b6f0-91f99b6c436c">

