### PR TITLE
🐛 Return include fields when one of them is empty

### DIFF
--- a/lamindb/_query_set.py
+++ b/lamindb/_query_set.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, NamedTuple
 import pandas as pd
 from django.db import models
 from django.db.models import F
-from lamin_utils import logger
+from lamin_utils import colors, logger
 from lamindb_setup.core._docs import doc_args
 from lnschema_core.models import (
     Artifact,
@@ -223,7 +223,10 @@ class QuerySet(models.QuerySet):
                         )
                     )
                     if link_df.shape[0] == 0:
-                        return df
+                        logger.warning(
+                            f"{colors.yellow(expression)} is not shown because no values are found"
+                        )
+                        continue
                     link_groupby = link_df.groupby(left_side_link_model)[
                         values_expression
                     ].apply(list)


### PR DESCRIPTION
Print warning for no-value columns in df include:
<img width="582" alt="Screenshot 2024-10-11 at 14 21 25" src="https://github.com/user-attachments/assets/f6b6c005-0815-48b6-9871-b20463390911">
