### PR TITLE
✨ Error when renaming internal features and labels

### DIFF
--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -586,13 +586,13 @@ def save(self, *args, **kwargs) -> Record:
             with transaction.atomic():
                 revises._revises = None  # ensure we don't start a recursion
                 revises.save()
-                name_changed_warning(self)
+                check_name_change(self)
                 super(Record, self).save(*args, **kwargs)
                 _store_record_old_name(self)
             self._revises = None
         # save unversioned record
         else:
-            name_changed_warning(self)
+            check_name_change(self)
             super(Record, self).save(*args, **kwargs)
             _store_record_old_name(self)
     # perform transfer of many-to-many fields
@@ -628,7 +628,7 @@ def _store_record_old_name(record: Record):
         record._name = getattr(record, record._name_field)
 
 
-def name_changed_warning(record: Record):
+def check_name_change(record: Record):
     """Warns if a record's name has changed."""
     if (
         not record.pk

--- a/lamindb/core/_data.py
+++ b/lamindb/core/_data.py
@@ -67,11 +67,17 @@ def add_transform_to_kwargs(kwargs: dict[str, Any], run: Run):
 
 def save_feature_sets(self: Artifact | Collection) -> None:
     if hasattr(self, "_feature_sets"):
+        from lamindb.core._feature_manager import get_feature_set_by_slot_
+
+        existing_feature_sets = get_feature_set_by_slot_(self)
         saved_feature_sets = {}
         for key, feature_set in self._feature_sets.items():
             if isinstance(feature_set, FeatureSet) and feature_set._state.adding:
                 feature_set.save()
                 saved_feature_sets[key] = feature_set
+            if key in existing_feature_sets:
+                # remove existing feature set on the same slot
+                self.feature_sets.remove(existing_feature_sets[key])
         if len(saved_feature_sets) > 0:
             s = "s" if len(saved_feature_sets) > 1 else ""
             display_feature_set_keys = ",".join(

--- a/lamindb/core/_label_manager.py
+++ b/lamindb/core/_label_manager.py
@@ -274,6 +274,13 @@ class LabelManager:
         registry = label.__class__
         related_name = d.get(registry.__get_name_with_schema__())
         link_model = getattr(self._host, related_name).through
-        link_model.filter(
+        link_records = link_model.filter(
             artifact_id=self._host.id, **{f"{registry.__name__.lower()}_id": label.id}
-        ).update(feature_id=None, feature_ref_is_name=None)
+        )
+        features = link_records.values_list("feature__name", flat=True).distinct()
+        s = "s" if len(features) > 1 else ""
+        link_records.update(feature_id=None, feature_ref_is_name=None)
+        logger.warning(
+            f'{registry.__name__} "{getattr(label, label._name_field)}" is no longer associated with the following feature{s}:\n'
+            f"{list(features)}"
+        )

--- a/lamindb/core/_label_manager.py
+++ b/lamindb/core/_label_manager.py
@@ -263,3 +263,17 @@ class LabelManager:
                     getattr(self._host, related_name).add(
                         *labels, through_defaults={"feature_id": feature_id}
                     )
+
+    def make_external(self, label: Record):
+        """Make a label external, aka dissociate label from internal features.
+
+        Args:
+            label: Label record to make external.
+        """
+        d = dict_related_model_to_related_name(self._host)
+        registry = label.__class__
+        related_name = d.get(registry.__get_name_with_schema__())
+        link_model = getattr(self._host, related_name).through
+        link_model.filter(
+            artifact_id=self._host.id, **{f"{registry.__name__.lower()}_id": label.id}
+        ).update(feature_id=None, feature_ref_is_name=None)

--- a/lamindb/core/exceptions.py
+++ b/lamindb/core/exceptions.py
@@ -11,6 +11,7 @@
    MissingContextUID
    UpdateContext
    IntegrityError
+   RecordNameChangeIntegrityError
 
 """
 
@@ -53,6 +54,12 @@ class DoesNotExist(SystemExit):
 
 class InconsistentKey(Exception):
     """Inconsistent transform or artifact `key`."""
+
+    pass
+
+
+class RecordNameChangeIntegrityError(SystemExit):
+    """Custom exception for name change errors."""
 
     pass
 

--- a/tests/core/test_data.py
+++ b/tests/core/test_data.py
@@ -1,4 +1,5 @@
 import lamindb as ln
+import pytest
 from lamindb.core._data import add_transform_to_kwargs
 
 
@@ -9,3 +10,66 @@ def test_add_transform_to_kwargs():
     run = ln.Run(transform)
     add_transform_to_kwargs(kwargs, run)
     assert kwargs["transform"] == transform
+
+
+def test_rename():
+    import bionty as bt
+    import pandas as pd
+    from lamindb.core.exceptions import RecordNameChangeIntegrityError
+
+    df = pd.DataFrame(
+        {
+            "feature_to_rename": [
+                "label-to-rename",
+                "label-to-rename",
+                "label-not-to-rename",
+            ],
+            "cell_type": ["T cell", "B cell", "neuron"],
+        }
+    )
+
+    curator = ln.Curator.from_df(
+        df,
+        categoricals={
+            "feature_to_rename": ln.ULabel.name,
+            "cell_type": bt.CellType.name,
+        },
+    )
+    curator.add_new_from("feature_to_rename")
+    artifact = curator.save_artifact(description="test-rename")
+    assert artifact.ulabels.through.objects.filter(
+        feature__name="feature_to_rename", ulabel__name="label-to-rename"
+    ).exists()
+    assert ln.Artifact.filter(feature_sets__features__name="feature_to_rename").exists()
+
+    # rename label
+    ulabel = ln.ULabel.get(name="label-to-rename")
+    with pytest.raises(RecordNameChangeIntegrityError):
+        ulabel.name = "label-renamed"
+        ulabel.save()
+
+    artifact.labels.make_external(ulabel)
+    assert not artifact.ulabels.through.objects.filter(
+        feature__name="feature_to_rename"
+    ).exists()
+    ulabel.name = "label-renamed"
+    ulabel.save()
+
+    # rename feature
+    feature = ln.Feature.get(name="feature_to_rename")
+    with pytest.raises(RecordNameChangeIntegrityError):
+        feature.name = "feature_renamed"
+        feature.save()
+
+    artifact.features.make_external(feature)
+    assert not ln.Artifact.filter(
+        feature_sets__features__name="feature_to_rename"
+    ).exists()
+    feature.name = "feature_renamed"
+    feature.save()
+
+    # clean up
+    artifact.delete()
+    ln.FeatureSet.filter().delete()
+    ln.ULabel.filter().delete()
+    ln.Feature.filter().delete()

--- a/tests/core/test_data.py
+++ b/tests/core/test_data.py
@@ -13,7 +13,6 @@ def test_add_transform_to_kwargs():
 
 
 def test_rename():
-    import bionty as bt
     import pandas as pd
     from lamindb.core.exceptions import RecordNameChangeIntegrityError
 
@@ -24,7 +23,6 @@ def test_rename():
                 "label-to-rename",
                 "label-not-to-rename",
             ],
-            "cell_type": ["T cell", "B cell", "neuron"],
         }
     )
 
@@ -32,7 +30,6 @@ def test_rename():
         df,
         categoricals={
             "feature_to_rename": ln.ULabel.name,
-            "cell_type": bt.CellType.name,
         },
     )
     curator.add_new_from("feature_to_rename")

--- a/tests/core/test_data.py
+++ b/tests/core/test_data.py
@@ -81,7 +81,7 @@ def test_rename():
     assert artifact.feature_sets.count() == 0
 
     # clean up
-    artifact.delete()
+    artifact.delete(permanent=True)
     ln.FeatureSet.filter().delete()
     ln.ULabel.filter().delete()
     ln.Feature.filter().delete()


### PR DESCRIPTION
When to error:
1. If a feature is an internal feature, aka it is a member of a featureset.
    <img width="689" alt="Screenshot 2024-10-18 at 15 55 42" src="https://github.com/user-attachments/assets/93958001-e93e-489f-a415-ddd7f9f08741">
2. If a label is an internal label, aka it is associated with an internal feature.
    <img width="695" alt="Screenshot 2024-10-18 at 15 55 33" src="https://github.com/user-attachments/assets/fd0004f7-01e4-4566-a65e-efebd3af67f2">

To bypass the renaming error:
1. `artifact.features.make_external(feature)`: remove feature from all featuresets.
2. `artifact.labels.make_external(label)`: keep the label associated with artifacts, but remove set `feature=None` in the link tables. This label will no longer associated with any internal faetures.

Full renaming UX:
https://lamin.ai/laminlabs/lamindata/transform/u1s4bAB3sliY0000




