### PR TITLE
✨ Python 3.12 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/setup-python@v5
         if: ${{ matrix.group != 'storage' }}
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: cache pre-commit
         uses: actions/cache@v4
         with:
@@ -134,7 +134,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - run: |
           python -m pip install -U uv
           uv pip install --system coverage[toml]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
           aws-region: us-east-1
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12" # use 3.10 because 3.11+ give issues
+          python-version: "3.10" # use 3.10 because 3.11+ give issues (ablog lacks 3.12 support)
       - run: pip install "laminci@git+https://x-access-token:${{ secrets.LAMIN_BUILD_DOCS }}@github.com/laminlabs/laminci"
       - run: nox -s "install_ci(group='docs')"
       - uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
           aws-region: us-east-1
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10" # use 3.10, 3.8 and 3.11 give issues
+          python-version: "3.12" # use 3.10 because 3.11+ give issues
       - run: pip install "laminci@git+https://x-access-token:${{ secrets.LAMIN_BUILD_DOCS }}@github.com/laminlabs/laminci"
       - run: nox -s "install_ci(group='docs')"
       - uses: actions/download-artifact@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "lamindb"
-requires-python = ">=3.9"
+requires-python = ">=3.9,<3.13"
 authors = [{name = "Lamin Labs", email = "open-source@lamin.ai"}]
 readme = "README.md"
 dynamic = ["version", "description"]
@@ -12,6 +12,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     # Lamin PINNED packages


### PR DESCRIPTION
- Uses 3.12 instead of 3.11 in the CI
- Specifies 3.12 support in our classifiers
- Removes support for Python 3.13

Docs don't build with 3.12:

```
Extension error:
Could not import extension ablog (exception: No module named 'pkg_resources')
```

See https://github.com/laminlabs/lndocs/issues/105