### PR TITLE
✨ var index support

### DIFF
--- a/lamindb/_curate.py
+++ b/lamindb/_curate.py
@@ -425,7 +425,7 @@ class AnnDataCurator(DataFrameCurator):
     def __init__(
         self,
         data: ad.AnnData | UPathStr,
-        var_index: FieldAttr,
+        var_index: FieldAttr | str,
         categoricals: dict[str, FieldAttr] | None = None,
         obs_columns: FieldAttr = Feature.name,
         using_key: str = "default",
@@ -452,6 +452,11 @@ class AnnDataCurator(DataFrameCurator):
             self._adata = backed_access(upath.create_path(data))
 
         self._data = data
+
+        if isinstance(var_index, str):
+            import bionty as bt
+
+            var_index = getattr(bt.Gene, var_index)
         self._var_field = var_index
         super().__init__(
             df=self._adata.obs,

--- a/tests/core/test_curate.py
+++ b/tests/core/test_curate.py
@@ -244,6 +244,16 @@ def test_anndata_annotator(adata, categoricals, to_add):
     bt.CellType.filter().delete()
 
 
+def test_str_var_index(adata):
+    curate = ln.Curate.from_anndata(
+        adata,
+        var_index="symbol",
+        organism="human",
+    )
+    validated = curate.validate()
+    assert validated
+
+
 def test_no_categoricals(adata):
     curate = ln.Curate.from_anndata(
         adata,
@@ -291,14 +301,14 @@ def test_source_key_not_present(adata, categoricals):
 
 
 def test_unvalidated_adata_object(adata, categoricals):
-    curate = ln.Curator.from_anndata(
+    curator = ln.Curator.from_anndata(
         adata,
         categoricals=categoricals,
         var_index=bt.Gene.symbol,
         organism="human",
     )
     with pytest.raises(ValidationError) as error:
-        curate.save_artifact()
+        curator.save_artifact()
     assert "Dataset does not validate. Please curate." in str(error.value)
 
 
@@ -312,16 +322,16 @@ def test_mudata_annotator(mdata):
         "rna_2:donor": ln.ULabel.name,
     }
 
-    curate = ln.Curator.from_mudata(
+    curator = ln.Curator.from_mudata(
         mdata,
         categoricals=categoricals,
         var_index={"rna": bt.Gene.symbol, "rna_2": bt.Gene.symbol},
         organism="human",
     )
-    curate.add_new_from("donor", modality="rna")
-    validated = curate.validate()
+    curator.add_new_from("donor", modality="rna")
+    validated = curator.validate()
     assert validated
-    artifact = curate.save_artifact(description="test MuData")
+    artifact = curator.save_artifact(description="test MuData")
 
     # clean up
     artifact.delete(permanent=True)


### PR DESCRIPTION
Fixes https://github.com/laminlabs/lamindb/issues/2091

- Adds support for str in `var_index`. However, this currently assumes that the `var_index` is `Gene`. I am not sure whether this is the right way to go about it. Maybe we should actually just not do this.

WDYT @sunnyosun ?