### PR TITLE
✨ Add extra groups for all schemas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,24 @@ fcs = [
 erdiagram = [
     "django-schema-graph",
 ]
+wetlab = [
+    "wetlab"
+]
+findrefs = [
+    "findrefs"
+]
+clinicore = [
+    "clinicore"
+]
+cellregistry = [
+    "cellregistry"
+]
+omop = [
+    "omop"
+]
+ourprojects = [
+    "ourprojects"
+]
 dev = [
     # basic test
     "line_profiler",


### PR DESCRIPTION
Context: https://laminlabs.slack.com/archives/C04FPE8V01W/p1729586056058489

We have seen repeatedly that users and developers were trying to install lamindb with additional schemas as extras. This PR adds all lamin schemas as extra dependency groups. This enables the installation of the schemas like:

```pip install lamindb[wetlab]``` just it works for bionty.