### PR TITLE
✨ Support Hugging Face paths

### DIFF
--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -119,11 +119,9 @@ def process_pathlike(
                     new_root = list(filepath.parents)[-1]
                 # do not register remote storage locations on hub if the current instance
                 # is not managed on the hub
-                print(new_root)
                 storage_settings, _ = init_storage(
                     new_root, prevent_register_hub=not setup_settings.instance.is_on_hub
                 )
-                print(storage_settings)
                 storage_record = register_storage_in_instance(storage_settings)
                 use_existing_storage_key = True
                 return storage_record, use_existing_storage_key

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -111,12 +111,19 @@ def process_pathlike(
             # for the storage root: the bucket
             if not isinstance(filepath, LocalPathClasses):
                 # for a cloud path, new_root is always the bucket name
-                new_root = list(filepath.parents)[-1]
+                if filepath.protocol == "hf":
+                    hf_path = filepath.fs.resolve_path(filepath.as_posix())
+                    hf_path.path_in_repo = ""
+                    new_root = "hf://" + hf_path.unresolve()
+                else:
+                    new_root = list(filepath.parents)[-1]
                 # do not register remote storage locations on hub if the current instance
                 # is not managed on the hub
+                print(new_root)
                 storage_settings, _ = init_storage(
                     new_root, prevent_register_hub=not setup_settings.instance.is_on_hub
                 )
+                print(storage_settings)
                 storage_record = register_storage_in_instance(storage_settings)
                 use_existing_storage_key = True
                 return storage_record, use_existing_storage_key

--- a/noxfile.py
+++ b/noxfile.py
@@ -109,7 +109,7 @@ def install_ci(session, group):
         )
         run(session, "uv pip install --system vitessce")
     elif group == "docs":
-        extras += "bionty"
+        extras += "bionty,zarr"
         run(session, "uv pip install --system mudata")
         run(
             session,
@@ -121,6 +121,8 @@ def install_ci(session, group):
     # on the release branch, do not use submodules but run with pypi install
     # only exception is the docs group which should always use the submodule
     # to push docs fixes fast
+    # installing this after lamindb to be sure that these packages won't be reinstaled
+    # during lamindb installation
     if IS_PR or group == "docs":
         cmd = "uv pip install --system --no-deps ./sub/lamindb-setup ./sub/lnschema-core ./sub/lamin-cli"
         run(session, cmd)

--- a/noxfile.py
+++ b/noxfile.py
@@ -93,10 +93,10 @@ def install_ci(session, group):
     extras = ""
     if group == "unit-core":
         extras += "bionty,aws,zarr,fcs,jupyter"
+        run(session, "uv pip install --system huggingface_hub")
     elif group == "unit-storage":
         extras += "aws,zarr,bionty"
         run(session, "uv pip install --system tiledbsoma")
-        run(session, "uv pip install --system huggingface_hub")
     elif group == "tutorial":
         extras += "aws,jupyter,bionty"
     elif group == "guide":

--- a/noxfile.py
+++ b/noxfile.py
@@ -96,6 +96,7 @@ def install_ci(session, group):
     elif group == "unit-storage":
         extras += "aws,zarr,bionty"
         run(session, "uv pip install --system tiledbsoma")
+        run(session, "uv pip install --system huggingface_hub")
     elif group == "tutorial":
         extras += "aws,jupyter,bionty"
     elif group == "guide":

--- a/noxfile.py
+++ b/noxfile.py
@@ -84,12 +84,6 @@ def install(session):
     ],
 )
 def install_ci(session, group):
-    # on the release branch, do not use submodules but run with pypi install
-    # only exception is the docs group which should always use the submodule
-    # to push docs fixes fast
-    if IS_PR or group == "docs":
-        cmd = "uv pip install --system --no-deps ./sub/lamindb-setup ./sub/lnschema-core ./sub/lamin-cli"
-        run(session, cmd)
     extras = ""
     if group == "unit-core":
         extras += "bionty,aws,zarr,fcs,jupyter"
@@ -123,12 +117,18 @@ def install_ci(session, group):
         )
     elif group == "cli":
         extras += "jupyter,aws,bionty"
-    if IS_PR and "bionty" in extras:
-        run(
-            session,
-            "uv pip install --system --no-deps ./sub/bionty",
-        )
     run(session, f"uv pip install --system -e .[dev,{extras}]")
+    # on the release branch, do not use submodules but run with pypi install
+    # only exception is the docs group which should always use the submodule
+    # to push docs fixes fast
+    if IS_PR or group == "docs":
+        cmd = "uv pip install --system --no-deps ./sub/lamindb-setup ./sub/lnschema-core ./sub/lamin-cli"
+        run(session, cmd)
+        if "bionty" in extras:
+            run(
+                session,
+                "uv pip install --system --no-deps ./sub/bionty",
+            )
 
 
 @nox.session

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -917,5 +917,5 @@ def test_huggingface_links():
     assert artifact_pq.cache().is_dir()
     shutil.rmtree(artifact_pq._cache_path)
 
-    artifact_adata.delete(permanent=True)
-    artifact_pq.delete(permanent=True)
+    artifact_adata.delete(permanent=True, storage=False)
+    artifact_pq.delete(permanent=True, storage=False)

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -897,3 +897,22 @@ def test_bulk_delete():
     assert not report_path.exists()
     assert not _source_code_artifact_path.exists()
     assert not environment_path.exists()
+
+
+def test_huggingface_links():
+    artifact_adata = ln.Artifact(
+        "hf://datasets/Koncopd/lamindb-test@main/anndata/pbmc68k_test.h5ad"
+    )
+    artifact_adata.save()
+    assert isinstance(artifact_adata.load(), ad.AnnData)
+    assert artifact_adata._cache_path.exists()
+    artifact_adata._cache_path.unlink()
+
+    artifact_pq = ln.Artifact("hf://datasets/Koncopd/lamindb-test/sharded_parquet")
+    artifact_pq.save()
+    assert len(artifact_pq.open().files) == 11
+    assert artifact_pq.cache().is_dir()
+    shutil.rmtree(artifact_pq._cache_path)
+
+    artifact_adata.delete(permanent=True)
+    artifact_pq.delete(permanent=True)

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -901,14 +901,17 @@ def test_bulk_delete():
 
 def test_huggingface_links():
     artifact_adata = ln.Artifact(
-        "hf://datasets/Koncopd/lamindb-test@main/anndata/pbmc68k_test.h5ad"
+        "hf://datasets/Koncopd/lamindb-test@main/anndata/pbmc68k_test.h5ad",
+        description="hf adata",
     )
     artifact_adata.save()
     assert isinstance(artifact_adata.load(), ad.AnnData)
     assert artifact_adata._cache_path.exists()
     artifact_adata._cache_path.unlink()
 
-    artifact_pq = ln.Artifact("hf://datasets/Koncopd/lamindb-test/sharded_parquet")
+    artifact_pq = ln.Artifact(
+        "hf://datasets/Koncopd/lamindb-test/sharded_parquet", description="hf parquet"
+    )
     artifact_pq.save()
     assert len(artifact_pq.open().files) == 11
     assert artifact_pq.cache().is_dir()


### PR DESCRIPTION
This PR enables to register paths in Hugging Face repos as Artifacts similar to s3 or gs paths.

Example:
```
import lamindb as ln
artifact = ln.Artifact("hf://datasets/Koncopd/lamindb-test/sharded_parquet").save()
artifact.open()
artifact.cache()
...
```
