### PR TITLE
🚸 Improve search

### DIFF
--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import builtins
-from itertools import combinations
 from typing import TYPE_CHECKING, NamedTuple
 
 import dj_database_url
 import lamindb_setup as ln_setup
 from django.db import connections, transaction
-from django.db.models import Case, IntegerField, Manager, Q, QuerySet, Value, When
+from django.db.models import IntegerField, Manager, Q, QuerySet, Value
 from django.db.models.functions import Length
 from lamin_utils import colors, logger
 from lamin_utils._lookup import Lookup

--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -301,7 +301,7 @@ def _search(
     exact_matches = input_queryset.filter(exact_expression).annotate(
         **{
             "ordering": Value(1, output_field=IntegerField()),
-            "name_length": Length(name_field),
+            "name_length": Value(1, output_field=IntegerField()),
         }
     )
 


### PR DESCRIPTION
Key improvements:
- prioritize `startswith` and isolated phrases (e.g. "naive B cell", "B cell, ..." over "club cell" when searching "b cell")
- sort by shorter names first

Note: `centrocyte` appears in the "b cell" search because there's a perfect match of "B cell" in the description, same for "t cell" results.

LaminDB Before|LaminDB After |Hub
---|---|---
<img width="335" alt="Screenshot 2024-11-07 at 12 24 25" src="https://github.com/user-attachments/assets/2acb0259-a743-4c10-a36c-889c1ad8e577">|<img width="338" alt="Screenshot 2024-11-07 at 12 42 48" src="https://github.com/user-attachments/assets/680d08cb-a12d-49d4-8e15-76121e4d1bf7">|<img width="392" alt="Screenshot 2024-11-07 at 12 21 23" src="https://github.com/user-attachments/assets/41fc0e0f-2fba-4cdd-b089-71c5d9f59a75">
<img width="333" alt="Screenshot 2024-11-07 at 12 24 31" src="https://github.com/user-attachments/assets/5155c65e-3c81-4978-ab98-70da0321a505">|<img width="332" alt="Screenshot 2024-11-07 at 12 43 10" src="https://github.com/user-attachments/assets/145e1c7a-8718-4117-8cb6-67aee1a8b44a">|<img width="392" alt="Screenshot 2024-11-07 at 12 22 12" src="https://github.com/user-attachments/assets/b6f4e40c-d44c-490c-ab39-84e77243e1f1">
<img width="330" alt="Screenshot 2024-11-07 at 12 24 17" src="https://github.com/user-attachments/assets/bfb732a4-512f-48de-adb2-e8e02f5175ad">|<img width="349" alt="Screenshot 2024-11-07 at 12 43 18" src="https://github.com/user-attachments/assets/c822dca8-d7b0-49ab-866b-32f8874695f7">|<img width="385" alt="Screenshot 2024-11-07 at 12 22 34" src="https://github.com/user-attachments/assets/fd72c85f-4842-4410-b063-1eac2e91e797">
<img width="362" alt="Screenshot 2024-11-07 at 13 10 44" src="https://github.com/user-attachments/assets/96b159ba-357a-4f8c-8c5b-4e6c54155ea0">|<img width="394" alt="Screenshot 2024-11-07 at 13 10 15" src="https://github.com/user-attachments/assets/a1244fba-7946-4017-97c8-01d9a12b7bc2">|<img width="393" alt="Screenshot 2024-11-07 at 13 11 40" src="https://github.com/user-attachments/assets/8785a3a9-56d0-4da6-8b53-a4febaf831a7">
<img width="831" alt="Screenshot 2024-11-07 at 16 06 53" src="https://github.com/user-attachments/assets/01e61f01-cd14-4d07-8a43-6c643374e216">|<img width="369" alt="Screenshot 2024-11-07 at 21 43 05" src="https://github.com/user-attachments/assets/124d22b0-f9a5-4e39-a63b-5f004af302f2">|<img width="693" alt="Screenshot 2024-11-07 at 16 11 32" src="https://github.com/user-attachments/assets/42edbe5e-3940-4a1b-af3e-7d6e58c45bbe">
<img width="519" alt="Screenshot 2024-11-07 at 16 09 37" src="https://github.com/user-attachments/assets/407530a0-f1a6-45eb-9751-4639e617d7c6">|<img width="403" alt="Screenshot 2024-11-07 at 21 43 25" src="https://github.com/user-attachments/assets/95a77c0b-e451-4982-b5d3-b3fa987b9db6">|<img width="687" alt="Screenshot 2024-11-07 at 16 11 58" src="https://github.com/user-attachments/assets/bb17740a-afc1-4dde-8a17-53cf6119f996">
