### PR TITLE
✨ Warn if curating against gene symbols

### DIFF
--- a/lamindb/_curate.py
+++ b/lamindb/_curate.py
@@ -451,6 +451,11 @@ class AnnDataCurator(DataFrameCurator):
 
             self._adata = backed_access(upath.create_path(data))
 
+        if "symbol" in str(self.var_index):
+            logger.warning(
+                "Curating gene symbols is discouraged. See FAQ for more details."
+            )
+
         self._data = data
         self._var_field = var_index
         super().__init__(

--- a/lamindb/_curate.py
+++ b/lamindb/_curate.py
@@ -451,7 +451,7 @@ class AnnDataCurator(DataFrameCurator):
 
             self._adata = backed_access(upath.create_path(data))
 
-        if "symbol" in str(self.var_index):
+        if "symbol" in str(var_index):
             logger.warning(
                 "Curating gene symbols is discouraged. See FAQ for more details."
             )


### PR DESCRIPTION
Fixes https://github.com/laminlabs/bionty/issues/143

- Adds a warning if the `var_index` is `bt.Gene.symbol` to check out the FAQ for more details on why this is bad
- I decided against hard coding a URL because it can change.
- I decided against adding this warning in `curate()` because it would get triggered repeatedly which can be annoying