### PR TITLE
📝 Add hide-output for some cells & links to storage engines

### DIFF
--- a/docs/arrays.ipynb
+++ b/docs/arrays.ipynb
@@ -391,7 +391,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This returns a [pyarrow](https://arrow.apache.org/docs/python/index.html) [dataset](https://arrow.apache.org/docs/python/dataset.html)."
+    "This returns a [pyarrow dataset](https://arrow.apache.org/docs/python/dataset.html)."
    ]
   },
   {

--- a/docs/arrays.ipynb
+++ b/docs/arrays.ipynb
@@ -33,7 +33,9 @@
     "\n",
     "Because the artifact was validated, querying the `DataFrame` is guaranteed to succeed!\n",
     "\n",
-    "Such within-collection queries are also possible for cloud-backed collections using DuckDB, TileDB, zarr, HDF5, parquet, and other storage backends.\n",
+    "Such within-collection queries are also possible for cloud-backed collections using [DuckDB](https://duckdb.org),\n",
+    "[TileDB](https://tiledb.com), [zarr](https://zarr.readthedocs.io/en/stable), [HDF5](https://docs.h5py.org/en/stable),\n",
+    "[parquet](https://parquet.apache.org), and other storage backends.\n",
     "\n",
     "- For a use case with TileDB, see: {doc}`docs:cellxgene`\n",
     "- For a use case with DuckDB, see: {doc}`docs:rxrx`\n",
@@ -59,7 +61,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "import lamindb as ln"
@@ -150,7 +156,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "adata = artifact.open()"
@@ -293,7 +303,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "backed = artifact.open()"
@@ -363,7 +377,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "backed = artifact.open()"
@@ -373,7 +391,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This returns `pyarrow` `Dataset`, see [here](https://arrow.apache.org/docs/python/dataset.html)."
+    "This returns a [pyarrow](https://arrow.apache.org/docs/python/index.html) [dataset](https://arrow.apache.org/docs/python/dataset.html)."
    ]
   },
   {


### PR DESCRIPTION
Fixes https://github.com/laminlabs/lamindb/issues/2150

- Adds hide-output to cells that emit the "run input was not tracked" warning. At this point, `ln.track()` has not been introduced so we are not using it in the tutorials
- Adds hyperlinks to storage engines that have not been introduced at this point. I am convinced that most users have no idea what they are and just dropping them doesn't work and leaves readers confused. Maybe we need to introduce them in a drop down in 1-2 sentences each while also explaining what a storage engine in general is. For now, I've added hyperlinks that come at the risk of being outdated. However, these URLs should be fairly stable.