### PR TITLE
✨ Improve runtime formatting

### DIFF
--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -233,9 +233,9 @@ def save_context_core(
 
     # finalize
     if not from_cli:
-        run_time = (
-            run.finished_at - run.started_at.split(".")[0]
-        )  # Discard digits after seconds
+        run_time = str(run.finished_at - run.started_at).split(".")[
+            0
+        ]  # Discard digits after seconds
         formatted_run_time = f"{int(run_time.split(':')[0])}h {int(run_time.split(':')[1])}m {int(run_time.split(':')[2])}s"
         logger.important(
             f"finished Run('{run.uid[:8]}') after {formatted_run_time} at {format_field_value(run.finished_at)}"

--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -233,7 +233,7 @@ def save_context_core(
 
     # finalize
     if not from_cli:
-        run_time = run.finished_at - run.started_at
+        run_time = run.finished_at - run.started_at.split(".")[0]
         logger.important(
             f"finished Run('{run.uid[:8]}') after {run_time} at {format_field_value(run.finished_at)}"
         )

--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -234,8 +234,9 @@ def save_context_core(
     # finalize
     if not from_cli:
         run_time = run.finished_at - run.started_at.split(".")[0]
+        formatted_run_time = f"{int(run_time.split(':')[0])}h {int(run_time.split(':')[1])}m {int(run_time.split(':')[2])}s"
         logger.important(
-            f"finished Run('{run.uid[:8]}') after {run_time.replace(':', 'h ', 1).replace(':', 'm ', 1)}s at {format_field_value(run.finished_at)}"
+            f"finished Run('{run.uid[:8]}') after {formatted_run_time} at {format_field_value(run.finished_at)}"
         )
     if ln_setup.settings.instance.is_on_hub:
         identifier = ln_setup.settings.instance.slug

--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -235,7 +235,7 @@ def save_context_core(
     if not from_cli:
         run_time = run.finished_at - run.started_at.split(".")[0]
         logger.important(
-            f"finished Run('{run.uid[:8]}') after {run_time} at {format_field_value(run.finished_at)}"
+            f"finished Run('{run.uid[:8]}') after {run_time.replace(':', 'h ', 1).replace(':', 'm ', 1)}s at {format_field_value(run.finished_at)}"
         )
     if ln_setup.settings.instance.is_on_hub:
         identifier = ln_setup.settings.instance.slug

--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -233,7 +233,9 @@ def save_context_core(
 
     # finalize
     if not from_cli:
-        run_time = run.finished_at - run.started_at.split(".")[0]
+        run_time = (
+            run.finished_at - run.started_at.split(".")[0]
+        )  # Discard digits after seconds
         formatted_run_time = f"{int(run_time.split(':')[0])}h {int(run_time.split(':')[1])}m {int(run_time.split(':')[2])}s"
         logger.important(
             f"finished Run('{run.uid[:8]}') after {formatted_run_time} at {format_field_value(run.finished_at)}"


### PR DESCRIPTION
Before:
`→ finished Run('7xgSkdkp') after 0:10:06.762290 at 2024-11-12 12:14:24 UTC`

After:
`→ finished Run('7xgSkdkp') after 0h 10m 06s at 2024-11-12 12:14:24 UTC`

We can hyperoptimize this by removing leading 0s but I think this is fine.
