### PR TITLE
♻️ Only apply exact length uid constraint for internal entities

### DIFF
--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -72,7 +72,7 @@ def validate_required_fields(record: Record, kwargs):
     if missing_fields:
         raise TypeError(f"{missing_fields} are required.")
     # ensure the exact length of the internal uid for core entities
-    if record.__class__ in {
+    if "uid" in kwargs and record.__class__ in {
         Artifact,
         Collection,
         Transform,


### PR DESCRIPTION
It turned out that in some use cases, it's meaningful to populate the `uid` field with an external id; e.g. from an ELN system.

Hence, we're only validating the internal ids.

Storage and users are exceptions because we might want to change the length at some point in the future (we changed the Storage uid length about 1 year ago from 8 to 12 chars).