### PR TITLE
✨ Support saving R code including `.qmd` and `.Rmd`

### DIFF
--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -103,10 +103,10 @@ def save_context_core(
 
     # for scripts, things are easy
     is_consecutive = True
-    is_notebook = transform.type == "notebook"
+    is_ipynb = filepath.suffix == ".ipynb"
     source_code_path = filepath
     # for notebooks, we need more work
-    if is_notebook:
+    if is_ipynb:
         try:
             import jupytext
             from nbproject.dev import (
@@ -198,7 +198,7 @@ def save_context_core(
         run.finished_at = datetime.now(timezone.utc)
 
     # track report and set is_consecutive
-    if not is_notebook:
+    if not is_ipynb:
         run.is_consecutive = True
         run.save()
     else:
@@ -251,9 +251,7 @@ def save_context_core(
         )
         if not from_cli:
             thing, name = (
-                ("notebook", "notebook.ipynb")
-                if is_notebook
-                else ("script", "script.py")
+                ("notebook", "notebook.ipynb") if is_ipynb else ("script", "script.py")
             )
             logger.important(
                 f"if you want to update your {thing} without re-running it, use `lamin save {name}`"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     # Lamin PINNED packages
     "lnschema_core==0.76.1",
     "lamin_utils==0.13.7",
-    "lamin_cli==0.20.1",
+    "lamin_cli==0.21.0",
     # PINNED in lamin-cli
     "lamindb_setup",
     # others


### PR DESCRIPTION
You can now run any of

- `lamin save myscript.R`
- `lamin save myanalsyis.qmd`
- `lamin save myanalsyis.Rmd`

The latter two calls will error if the `lamin` CLI doesn't find a file `myanalysis.html` that the user manually created. If the `.html` file is present it will be saved & linked as the latest run report.

## Background

Even before this PR, lamindb worked fine with reticulate.

Executing the following script:
```R
library(reticulate)

# Import lamindb
ln <- import("lamindb")

ln$track("EPnfDtJz8qbE0000", path="test-laminr.R")   # <-- unique id for the script, script path

# Create a sample R dataframe
r_df <- data.frame(
  id = 1:5,
  value = c(10.5, 20.3, 15.7, 25.1, 30.2),
  category = c("A", "B", "A", "C", "B")
)

# Save the dataframe as RDS
storage_path <- "example_data.rds"
saveRDS(r_df, storage_path)

ln$Artifact(storage_path, description="Example dataframe")$save()  # save an artifact
ln$finish()  # mark the script run as finished
```
gives rise to these logs:
```bash
% Rscript test-laminr.R
→ connected lamindb: falexwolf/docsbuild
→ created Transform('EPnfDtJz'), started new Run('ZEauiBpc') at 2024-11-12 18:52:06 UTC
→ returning existing artifact with same hash: Artifact(uid='fkOF8rmyP06cA4lQ0000', is_latest=True, description='Example dataframe', suffix='.rds', size=227, hash='R94kXc7AXWPd2zJgkpHwpg', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, created_by_id=1, created_at=2024-11-12 18:49:24 UTC)
Artifact(uid='fkOF8rmyP06cA4lQ0000', is_latest=True, description='Example dataframe', suffix='.rds', size=227, hash='R94kXc7AXWPd2zJgkpHwpg', _hash_type='md5', visibility=1, _key_is_virtual=True, storage_id=1, transform_id=1, run_id=1, created_by_id=1, created_at=2024-11-12 18:49:24 UTC)
→ finished Run('ZEauiBpc') after 0h 0m 1s at 2024-11-12 18:52:08 UTC
```

In particular, the `transform.source_code` is populated via `ln#finish()` and does then *not* require running `lamin save`.  Working with a `.qmd` or `.Rmd` file, however, requires running `lamin save` to save & link the `.html` run report.

Comes along with:

- https://github.com/laminlabs/laminr/issues/76

Needs:

- https://github.com/laminlabs/lamin-cli/pull/95