### PR TITLE
🩹 Fix anndata io `read_zarr` warning

### DIFF
--- a/lamindb/core/storage/_zarr.py
+++ b/lamindb/core/storage/_zarr.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 import scipy.sparse as sparse
 import zarr
-from anndata._io import read_zarr
+from anndata.io import read_zarr
 from anndata._io.specs import write_elem
 from anndata._io.specs.registry import get_spec
 from fsspec.implementations.local import LocalFileSystem

--- a/lamindb/core/storage/_zarr.py
+++ b/lamindb/core/storage/_zarr.py
@@ -5,9 +5,9 @@ from typing import TYPE_CHECKING
 
 import scipy.sparse as sparse
 import zarr
-from anndata.io import read_zarr
 from anndata._io.specs import write_elem
 from anndata._io.specs.registry import get_spec
+from anndata.io import read_zarr
 from fsspec.implementations.local import LocalFileSystem
 from lamindb_setup.core.upath import create_mapper, infer_filesystem
 


### PR DESCRIPTION
```
anndata/_io/__init__.py:12: FutureWarning: Importing read_zarr from `anndata._io` is deprecated. Please use anndata.io instead.
  warnings.warn(
```

