### PR TITLE
✨ Add an artifact loader for `.yaml`

### DIFF
--- a/lamindb/core/loaders.py
+++ b/lamindb/core/loaders.py
@@ -109,7 +109,7 @@ def load_json(path: UPathStr) -> dict:
 
 
 def load_image(path: UPathStr):
-    """Display `.svg` in ipython, otherwise return path."""
+    """Display `.jpg`, `.png` or `.gif` in ipython, otherwise return path."""
     if is_run_from_ipython:
         from IPython.display import Image, display
 
@@ -141,6 +141,7 @@ FILE_LOADERS = {
     ".h5mu": load_h5mu,
     ".jpg": load_image,
     ".png": load_image,
+    ".gif": load_image,
     ".svg": load_svg,
 }
 

--- a/lamindb/core/loaders.py
+++ b/lamindb/core/loaders.py
@@ -10,6 +10,7 @@
    load_h5mu
    load_html
    load_json
+   load_yaml
    load_image
    load_svg
 
@@ -107,6 +108,14 @@ def load_json(path: UPathStr) -> dict:
         data = json.load(f)
     return data
 
+def load_yaml(path: UPathStr) -> dict:
+    """Load `.yaml` to `dict`."""
+    import yaml
+
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    return data
+
 
 def load_image(path: UPathStr):
     """Display `.jpg`, `.png` or `.gif` in ipython, otherwise return path."""
@@ -138,6 +147,7 @@ FILE_LOADERS = {
     ".zarr": load_anndata_zarr,
     ".html": load_html,
     ".json": load_json,
+    ".yaml": load_yaml,
     ".h5mu": load_h5mu,
     ".jpg": load_image,
     ".png": load_image,


### PR DESCRIPTION
* Fix incorrect documentation for `load_image`
* Add loaders for `.gif` and `.yaml`.

In addition, we could add a data loader for `.rds`, which when called, produces an error message that you should use laminr for loading `.rds` files. WDYT?