### PR TITLE
🚸 Refactor `ln.track()` to improve logging and method signature

### DIFF
--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -86,7 +86,10 @@ def raise_missing_context(transform_type: str, key: str) -> bool:
     else:
         uid = transform.uid
         new_uid = f"{uid[:-4]}{increment_base62(uid[-4:])}"
-        message = f"you already have a transform with key '{key}' ('{transform.uid}')\n  - to make a revision, call `ln.track('{new_uid}')`\n  - to create a new transform, rename your file and run: `ln.track()`"
+        message = (
+            f"you already have a transform with key '{key}': Transform('{transform.uid[:8]}')\n"
+            f'  (1) to make a revision, run: ln.track("{new_uid}")\n  (2) to create a new transform, rename your {transform_type} file and re-run: ln.track()'
+        )
     if transform_type == "notebook":
         print(f"→ {message}")
         response = input("→ Ready to re-run? (y/n)")

--- a/tests/core/notebooks/not-initialized.ipynb
+++ b/tests/core/notebooks/not-initialized.ipynb
@@ -20,7 +20,7 @@
     "from io import StringIO\n",
     "from contextlib import redirect_stdout\n",
     "\n",
-    "EXPECTED_OUTPUT = \"→ to track this notebook, copy & paste\"\n",
+    "EXPECTED_OUTPUT = \"→ to track this notebook, run\"\n",
     "output = StringIO()\n",
     "\n",
     "# user input is `n`\n",
@@ -55,7 +55,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Logging

## Create transform uid

### Transform `key` does not yet exist

Before:
```python
>>> ln.track()
→ notebook imports: lamindb==0.76.13
→ to track this notebook, copy & paste `ln.track("TSGPgRifmwuX0000")` and re-run
```

After:
```python
>>> ln.track()
→ to track this notebook, run: ln.track("TSGPgRifmwuX0000")
```

### Transform `key` already exists

Before:
```python
>>> ln.track()
→ notebook imports: lamindb==0.76.13
→ you already have a transform with key 'test-cross-instance.ipynb' ('Szhz8MJz9g4J0000')
  - to make a revision, call `ln.track('Szhz8MJz9g4J0001')`
  - to create a new transform, rename your file and run: `ln.track()`
```

After:
```python
>>> ln.track()
→ you already have a transform with key 'test-cross-instance.ipynb': Transform('Szhz8MJz')
  (1) to make a revision, run: ln.track("Szhz8MJz9g4J0001")
  (2) to create a new transform, rename your notebook file and re-run: ln.track()
```


## Track transform run

Before:
```python
>>> ln.track("Szhz8MJz9g4J0000")
→ notebook imports: lamindb==0.76.13
→ loaded Transform('Szhz8MJz'), started Run('oMNgTZ6q') at 2024-11-14 20:10:11 UTC
```

After:
```python
>>> ln.track("Szhz8MJz9g4J0000")
→ loaded Transform('Szhz8MJz'), started Run('oMNgTZ6q') at 2024-11-14 20:03:16 UTC
→ notebook imports: lamindb==0.76.13
```

# Method signature

Before | After
---|---
<img width="820" alt="image" src="https://github.com/user-attachments/assets/b8534893-8d5e-447c-b207-53fd5af8c78e"> | <img width="805" alt="image" src="https://github.com/user-attachments/assets/2c847576-7a86-488b-b7ff-4db4601bb0d2">



# Materials

Needs:

- https://github.com/laminlabs/lamin-cli/pull/96

Resolves:

- https://github.com/laminlabs/lamindb/issues/2173