### PR TITLE
Remove self.kwargs leftover argument

### DIFF
--- a/lamindb/_curate.py
+++ b/lamindb/_curate.py
@@ -280,7 +280,7 @@ class DataFrameCurator(BaseCurator):
             **kwargs: Additional keyword arguments to pass to the registry model.
         """
         self._kwargs.update({"organism": organism} if organism else {})
-        self._save_columns(validated_only=False, **self._kwargs, **kwargs)
+        self._save_columns(validated_only=False, **kwargs)
 
     def _update_registry(self, categorical: str, validated_only: bool = True, **kwargs):
         if categorical == "all":


### PR DESCRIPTION
Looks like `self.kwargs` was not removed properly in the `add_new_from_columns` function, calls to which were failing because of an unexpected argument.

See [this blame](https://github.com/laminlabs/lamindb/commit/5e200087811134d0d99a6892c5e4d7eed8b3b4f5#diff-9302b7cc488bfda3ef24a100d6a5f6e5d49cbdc1fe0714708952b9c51f0109d2L230) for the cause