### PR TITLE
🩹 Make search rules the same across all systems

### DIFF
--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -345,7 +345,9 @@ def _search(
         ranks.append(sub_rank)
         # startswith and avoid matching string with " " on the right
         # mostly for truncated
-        startswith_expr = regex_lookup(field_expr, rf"(?:^|.*\|){string}[^ ]*(\|.*|$)")
+        startswith_expr = regex_lookup(
+            field_expr, rf"(?:^|.*\|){string}[^ ]*(?:\|.*|$)"
+        )
         startswith_rank = Cast(startswith_expr, output_field=IntegerField()) * 8
         ranks.append(startswith_rank)
         # match as sub-phrase from the left, mostly for truncated

--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -345,7 +345,7 @@ def _search(
         ranks.append(sub_rank)
         # startswith and avoid matching string with " " on the right
         # mostly for truncated
-        startswith_expr = regex_lookup(field_expr, rf"(?:^|\|){string}[^ ]*(\||$)")
+        startswith_expr = regex_lookup(field_expr, rf"(?:^|.*\|){string}[^ ]*(\|.*|$)")
         startswith_rank = Cast(startswith_expr, output_field=IntegerField()) * 8
         ranks.append(startswith_rank)
         # match as sub-phrase from the left, mostly for truncated


### PR DESCRIPTION
Use the same rule for startswith rank across all packages (`hub`, `lamindb`, `bionty`). Needed due to differences in `pd.Series.str.match`, `sqlalchemy` `regexp_match` and `django` `Regex`.

https://github.com/laminlabs/lamin-utils/pull/95
https://github.com/laminlabs/bionty/pull/170
https://github.com/laminlabs/laminhub/pull/1604