### PR TITLE
💚 Fix tiledbsoma installation in CI

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -90,6 +90,8 @@ def install_ci(session, group):
         run(session, "uv pip install --system huggingface_hub")
     elif group == "unit-storage":
         extras += "aws,zarr,bionty"
+        # for tiledbsoma, otherwise resolution fails for some reason
+        run(session, "uv pip install --system scanpy>=1.10.0")
         run(session, "uv pip install --system tiledbsoma>=1.15.0rc3")
     elif group == "tutorial":
         extras += "aws,jupyter,bionty"

--- a/noxfile.py
+++ b/noxfile.py
@@ -92,7 +92,7 @@ def install_ci(session, group):
         extras += "aws,zarr,bionty"
         # for tiledbsoma, otherwise resolution fails for some reason
         run(session, "uv pip install --system scanpy>=1.10.0")
-        run(session, "uv pip install --system tiledbsoma>=1.15.0rc3")
+        run(session, "uv pip install --system tiledbsoma>=1.15.0rc3,!=1.15.0rc4")
     elif group == "tutorial":
         extras += "aws,jupyter,bionty"
         run(session, "uv pip install --system huggingface_hub")


### PR DESCRIPTION
Problems with `uv` resolver again.

Also `tiledbsoma==1.15.0rc4` seems to be problematic (appending to an existing `tiledbsoma` store fails), i won't try to figure out the problem for now because it is an rc release.