### PR TITLE
📝 Prettify gene symbols guide & logging

### DIFF
--- a/docs/faq/symbol-mapping.ipynb
+++ b/docs/faq/symbol-mapping.ipynb
@@ -4,14 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Why should I validate against gene symbols?"
+    "# Why should I not index datasets with gene symbols?"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Gene symbols are widely used in count data for readability, particularly for visualization. However, storing and validating gene symbols presents challenges:\n",
+    "Gene symbols are widely used for readability, particularly for visualization. However, indexing datasets with gene symbols presents challenges:\n",
     "\n",
     "- A single gene may have multiple symbols or aliases.\n",
     "- Gene symbols change over time (e.g., *BRCA2* was once *FACD*) without version tracking.\n",
@@ -55,6 +55,8 @@
    },
    "outputs": [],
    "source": [
+    "import lamindb as ln\n",
+    "import bionty as bt\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "import anndata as ad\n",
@@ -77,15 +79,14 @@
    },
    "outputs": [],
    "source": [
-    "import lamindb as ln\n",
-    "import bionty as bt\n",
-    "\n",
     "# map Gene symbols to ENSEMBL IDs\n",
-    "gene_mapper = bt.Gene.standardize(adata.var.index,\n",
-    "                                  field=bt.Gene.symbol,\n",
-    "                                  return_field=bt.Gene.ensembl_gene_id,\n",
-    "                                  return_mapper=True,\n",
-    "                                  organism=\"human\")\n",
+    "gene_mapper = bt.Gene.standardize(\n",
+    "    adata.var.index,\n",
+    "    field=bt.Gene.symbol,\n",
+    "    return_field=bt.Gene.ensembl_gene_id,\n",
+    "    return_mapper=True,\n",
+    "    organism=\"human\"\n",
+    ")\n",
     "adata.var[\"ensembl_id\"] = adata.var.index.map(gene_mapper)\n",
     "adata.var\n"
    ]
@@ -100,9 +101,11 @@
    },
    "outputs": [],
    "source": [
-    "standardized_genes = bt.Gene.from_values(['ENSG00000141510', 'ENSG00000133703', 'ENSG00000111640', 'ENSG00000171862', 'ENSG00000204490', 'ENSG00000112715', 'ENSG00000146648', 'ENSG00000136997', 'ENSG00000012048', 'ENSG00000136244'],\n",
-    "                                         field=bt.Gene.ensembl_gene_id,\n",
-    "                                         organism=\"human\")\n",
+    "standardized_genes = bt.Gene.from_values(\n",
+    "    ['ENSG00000141510', 'ENSG00000133703', 'ENSG00000111640', 'ENSG00000171862', 'ENSG00000204490', 'ENSG00000112715', 'ENSG00000146648', 'ENSG00000136997', 'ENSG00000012048', 'ENSG00000136244'],\n",
+    "    field=bt.Gene.ensembl_gene_id,\n",
+    "    organism=\"human\"\n",
+    ")\n",
     "ln.save(standardized_genes)"
    ]
   },

--- a/lamindb/_curate.py
+++ b/lamindb/_curate.py
@@ -456,7 +456,7 @@ class AnnDataCurator(DataFrameCurator):
 
         if "symbol" in str(var_index):
             logger.warning(
-                "Curating gene symbols is discouraged. See FAQ for more details."
+                "indexing datasets with gene symbols can be problematic: https://docs.lamin.ai/faq/symbol-mapping"
             )
 
         self._data = data


### PR DESCRIPTION
Before:
```
! Curating gene symbols is discouraged. See FAQ for more details.
```

After:
```
! indexing datasets with gene symbols can be problematic: https://docs.lamin.ai/faq/symbol-mapping
```

I have a case where I consciously want to use gene symbols for the sake of illustrating something; not for the sake of curating a large body of data.

Hearing some feedback from some users this seems to be very common. So, I'd not make the warning as harsh.

I was missing the URL so that I could read up on this.

Made the warning lowercase consistent with all other logging messages (including warnings).

Replace hanging indentation with vertically aligned indendation.

See: 

- https://github.com/laminlabs/lamindb/issues/2211