### PR TITLE
✨ Improve annotating with, retrieving & removing feature values

### DIFF
--- a/lamindb/_feature.py
+++ b/lamindb/_feature.py
@@ -21,6 +21,8 @@ FEATURE_TYPES = {
     "int": "int",
     "float": "float",
     "bool": "bool",
+    "date": "date",
+    "datetime": "datetime",
     "str": "cat",
     "object": "cat",
 }

--- a/lamindb/core/_feature_manager.py
+++ b/lamindb/core/_feature_manager.py
@@ -287,7 +287,10 @@ def print_features(
     from lamindb._from_values import _print_values
 
     msg = ""
-    dictionary = {}
+    dictionary: dict[str, Any] = {}
+
+    if self._state.adding:
+        return dictionary if to_dict else msg
 
     # feature sets
     if not print_params and not to_dict:
@@ -310,11 +313,11 @@ def print_features(
             msg += f"  {colors.italic('Feature sets')}\n"
             msg += feature_set_msg
 
-    feature_set = self.feature_sets.filter(registry="Feature").one_or_none()
-    if feature_set is not None:
-        internal_features = set(feature_set.members.values_list("name", flat=True))
-    else:
-        internal_features = {}  # type: ignore
+    internal_features: set[str] = {}  # type: ignore
+    if isinstance(self, Artifact):
+        feature_set = self.feature_sets.filter(registry="Feature").one_or_none()
+        if feature_set is not None:
+            internal_features = set(feature_set.members.values_list("name", flat=True))  # type: ignore
 
     # categorical feature values
     # Get the categorical data using the appropriate method

--- a/lamindb/core/_feature_manager.py
+++ b/lamindb/core/_feature_manager.py
@@ -331,10 +331,11 @@ def print_features(
                 feature_name = fv[f"{attr_name}__name"]
                 feature_dtype = fv[f"{attr_name}__dtype"]
                 values = fv["values"]
-                if not isinstance(values, list):
+                if not isinstance(values, (list, dict, set)):
                     values = {values}
-                else:
+                elif isinstance(values, list) and feature_dtype != "dict":
                     values = set(values)
+                # the remaining case is that we have a dictionary
                 if feature_dtype == "datetime":
                     values = {datetime.fromisoformat(value) for value in values}
                 if feature_dtype == "date":

--- a/lamindb/core/_feature_manager.py
+++ b/lamindb/core/_feature_manager.py
@@ -287,7 +287,7 @@ def print_features(
     from lamindb._from_values import _print_values
 
     msg = ""
-    dictionary = ""
+    dictionary = {}
 
     # feature sets
     if not print_params and not to_dict:
@@ -310,9 +310,11 @@ def print_features(
             msg += f"  {colors.italic('Feature sets')}\n"
             msg += feature_set_msg
 
-    internal_features = set(
-        self.feature_sets.get(registry="Feature").members.values_list("name", flat=True)
-    )
+    feature_set = self.feature_sets.filter(registry="Feature").one_or_none()
+    if feature_set is not None:
+        internal_features = set(feature_set.members.values_list("name", flat=True))
+    else:
+        internal_features = {}  # type: ignore
 
     # categorical feature values
     # Get the categorical data using the appropriate method
@@ -344,14 +346,14 @@ def print_features(
             # Handle dictionary conversion - no separation needed for dictionary
             if to_dict:
                 dict_value = values if len(values) > 1 else next(iter(values))
-                dictionary[feature_name] = dict_value  # type: ignore
+                dictionary[feature_name] = dict_value
             else:
                 # Format message
                 type_str = f": {feature_dtype}" if print_types else ""
                 printed_values = (
-                    _print_values(values, n=10, quotes=False)
+                    _print_values(sorted(values), n=10, quotes=False)
                     if not is_list_type or not feature_dtype.startswith("list")
-                    else values
+                    else sorted(values)
                 )
                 msg_line = f"    '{feature_name}'{type_str} = {printed_values}"
 

--- a/lamindb/core/_feature_manager.py
+++ b/lamindb/core/_feature_manager.py
@@ -411,9 +411,7 @@ def parse_feature_sets_from_anndata(
 def is_valid_datetime_str(date_string: str) -> bool | str:
     try:
         dt = datetime.fromisoformat(date_string)
-        if dt.hour == 0 and dt.minute == 0 and dt.second == 0 and dt.microsecond == 0:
-            return "date"
-        return "datetime"
+        return dt.isoformat()
     except ValueError:
         return False
 
@@ -430,10 +428,14 @@ def infer_feature_type_convert_json(
     elif isinstance(value, date):
         return FEATURE_TYPES["date"], value.isoformat()
     elif isinstance(value, datetime):
-        return FEATURE_TYPES["datetime"], value.isoformat(sep=" ")
+        return FEATURE_TYPES["datetime"], value.isoformat()
     elif isinstance(value, str):
-        if dt_type := is_valid_datetime_str(value):
-            return FEATURE_TYPES[dt_type], value  # type: ignore
+        if datetime_str := is_valid_datetime_str(value):
+            dt_type = (
+                "date" if len(value) == 10 else "datetime"
+            )  # YYYY-MM-DD is exactly 10 characters
+            sanitized_value = datetime_str[:10] if dt_type == "date" else datetime_str  # type: ignore
+            return FEATURE_TYPES[dt_type], sanitized_value  # type: ignore
         elif str_as_ulabel:
             return FEATURE_TYPES["str"] + "[ULabel]", value
         else:

--- a/lamindb/core/_feature_manager.py
+++ b/lamindb/core/_feature_manager.py
@@ -333,7 +333,11 @@ def print_features(
                 values = fv["values"]
                 if not isinstance(values, (list, dict, set)):
                     values = {values}
-                elif isinstance(values, list) and feature_dtype != "dict":
+                elif (
+                    isinstance(values, list)
+                    and feature_dtype != "dict"
+                    and not feature_dtype.startswith("list")
+                ):
                     values = set(values)
                 # the remaining case is that we have a dictionary
                 if feature_dtype == "datetime":

--- a/tests/core/test_feature_manager.py
+++ b/tests/core/test_feature_manager.py
@@ -197,12 +197,12 @@ Here is how to create ulabels for them:
     }
     # hard to test because of italic formatting
     msg = """\
-    'cell_type_by_expert' = 'T Cell'
-    'disease' = 'Alzheimer disease', 'atopic eczema'
-    'donor' = 'U0123'
-    'experiment' = 'Experiment 1', 'Experiment 2'
-    'organism' = 'mouse'
-    'project' = 'project_1'
+    'cell_type_by_expert' = T Cell
+    'disease' = Alzheimer disease, atopic eczema
+    'donor' = U0123
+    'experiment' = Experiment 1, Experiment 2
+    'organism' = mouse
+    'project' = project_1
     'date_of_experiment' = 2024-12-01
     'datetime_of_experiment' = 2024-12-01 00:00:00
     'is_validated' = True

--- a/tests/core/test_feature_manager.py
+++ b/tests/core/test_feature_manager.py
@@ -86,6 +86,9 @@ Here is how to create a feature:
     )
     artifact.features.add_values({"date_of_experiment": "2024-12-01"})
 
+    ln.Feature(name="datetime_of_experiment", dtype="datetime").save()
+    artifact.features.add_values({"datetime_of_experiment": "2024-12-01 00:00:00"})
+
     # bionty feature
     mouse = bt.Organism.from_source(name="mouse")
     with pytest.raises(ValidationError) as error:
@@ -172,6 +175,7 @@ Here is how to create ulabels for them:
         True,
         100.0,
         "2024-12-01",
+        "2024-12-01T00:00:00",
     }
 
     assert ln.Artifact.get(_feature_values__value=27.2)
@@ -189,6 +193,7 @@ Here is how to create ulabels for them:
         "is_validated": True,
         "temperature": {27.2, 100.0},
         "date_of_experiment": datetime.date(2024, 12, 1),
+        "datetime_of_experiment": datetime.datetime(2024, 12, 1, 0, 0, 0),
     }
     # hard to test because of italic formatting
     msg = """\
@@ -199,6 +204,7 @@ Here is how to create ulabels for them:
     'organism' = 'mouse'
     'project' = 'project_1'
     'date_of_experiment' = 2024-12-01
+    'datetime_of_experiment' = 2024-12-01 00:00:00
     'is_validated' = True
     'temperature' = 27.2, 100.0
 """
@@ -211,6 +217,7 @@ Here is how to create ulabels for them:
         True,
         100.0,
         "2024-12-01",
+        "2024-12-01T00:00:00",
     }
     assert artifact.features.__repr__().endswith(msg)
 

--- a/tests/core/test_feature_manager.py
+++ b/tests/core/test_feature_manager.py
@@ -1,3 +1,4 @@
+import datetime
 from pathlib import Path
 
 import bionty as bt
@@ -10,14 +11,13 @@ from lamindb.core.exceptions import DoesNotExist, ValidationError
 def adata():
     adata = ln.core.datasets.anndata_with_obs()
     # add another column
-    adata.obs["cell_type_from_expert"] = adata.obs["cell_type"]
-    adata.obs.loc["obs0", "cell_type_from_expert"] = "B cell"
+    adata.obs["cell_type_by_expert"] = adata.obs["cell_type"]
+    adata.obs.loc["obs0", "cell_type_by_expert"] = "B cell"
     return adata
 
 
-# below the test for the main way of annotating with
-# features
-def test_features_add(adata):
+# below the test for annotating with feature values
+def test_features_add_remove(adata):
     artifact = ln.Artifact.from_anndata(adata, description="test")
     artifact.save()
     with pytest.raises(ValidationError) as error:
@@ -65,6 +65,26 @@ def test_features_add(adata):
     temperature.save()
     artifact.features.add_values({"temperature": 27.2})
     assert artifact._feature_values.first().value == 27.2
+
+    # datetime feature
+    with pytest.raises(ValidationError) as error:
+        artifact.features.add_values({"date_of_experiment": "2024-12-01"})
+    assert (
+        error.exconly()
+        == """lamindb.core.exceptions.ValidationError: These keys could not be validated: ['date_of_experiment']
+Here is how to create a feature:
+
+  ln.Feature(name='date_of_experiment', dtype='date').save()"""
+    )
+
+    ln.Feature(name="date_of_experiment", dtype="date").save()
+    with pytest.raises(ValidationError) as error:
+        artifact.features.add_values({"date_of_experiment": "Typo2024-12-01"})
+    assert (
+        error.exconly()
+        == """lamindb.core.exceptions.ValidationError: Expected dtype for 'date_of_experiment' is 'date', got 'cat[ULabel]'"""
+    )
+    artifact.features.add_values({"date_of_experiment": "2024-12-01"})
 
     # bionty feature
     mouse = bt.Organism.from_source(name="mouse")
@@ -151,12 +171,25 @@ Here is how to create ulabels for them:
         27.2,
         True,
         100.0,
+        "2024-12-01",
     }
 
     assert ln.Artifact.get(_feature_values__value=27.2)
 
     print(artifact.features.get_values())
     print(artifact.features.__repr__())
+    #
+    assert artifact.features.get_values() == {
+        "disease": {"Alzheimer disease", "atopic eczema"},
+        "experiment": {"Experiment 1", "Experiment 2"},
+        "project": "project_1",
+        "cell_type_by_expert": "T Cell",
+        "donor": "U0123",
+        "organism": "mouse",
+        "is_validated": True,
+        "temperature": {27.2, 100.0},
+        "date_of_experiment": datetime.date(2024, 12, 1),
+    }
     # hard to test because of italic formatting
     msg = """\
     'cell_type_by_expert' = 'T Cell'
@@ -165,20 +198,11 @@ Here is how to create ulabels for them:
     'experiment' = 'Experiment 1', 'Experiment 2'
     'organism' = 'mouse'
     'project' = 'project_1'
+    'date_of_experiment' = 2024-12-01
     'is_validated' = True
     'temperature' = 27.2, 100.0
 """
     assert artifact.features.__repr__().endswith(msg)
-    assert artifact.features.get_values() == {
-        "disease": ["Alzheimer disease", "atopic eczema"],
-        "experiment": ["Experiment 1", "Experiment 2"],
-        "project": "project_1",
-        "cell_type_by_expert": "T Cell",
-        "donor": "U0123",
-        "organism": "mouse",
-        "is_validated": True,
-        "temperature": [27.2, 100.0],
-    }
 
     # repeat
     artifact.features.add_values(features)
@@ -186,6 +210,7 @@ Here is how to create ulabels for them:
         27.2,
         True,
         100.0,
+        "2024-12-01",
     }
     assert artifact.features.__repr__().endswith(msg)
 
@@ -219,6 +244,14 @@ Here is how to create ulabels for them:
     assert len(ln.Artifact.features.filter(experiment__contains="Experi").all()) == 2
     assert ln.Artifact.features.filter(temperature__lt=21).one_or_none() is None
     assert len(ln.Artifact.features.filter(temperature__gt=21).all()) >= 1
+
+    # test remove_values
+    artifact.features.remove_values("date_of_experiment")
+    alzheimer = bt.Disease.get(name="Alzheimer disease")
+    artifact.features.remove_values("disease", value=alzheimer)
+    values = artifact.features.get_values()
+    assert "date_of_experiment" not in values
+    assert "Alzheimer disease" not in values["disease"]
 
     # delete everything we created
     artifact.delete(permanent=True)
@@ -356,10 +389,10 @@ def test_add_labels_using_anndata(adata):
     organism = bt.Organism.from_source(name="mouse")
     cell_types = [bt.CellType(name=name) for name in adata.obs["cell_type"].unique()]
     ln.save(cell_types)
-    inspector = bt.CellType.inspect(adata.obs["cell_type_from_expert"].unique())
+    inspector = bt.CellType.inspect(adata.obs["cell_type_by_expert"].unique())
     ln.save([bt.CellType(name=name) for name in inspector.non_validated])
     cell_types_from_expert = bt.CellType.from_values(
-        adata.obs["cell_type_from_expert"].unique()
+        adata.obs["cell_type_by_expert"].unique()
     )
     actual_tissues = [bt.Tissue(name=name) for name in adata.obs["tissue"].unique()]
     organoid = ln.ULabel(name="organoid")
@@ -398,7 +431,7 @@ def test_add_labels_using_anndata(adata):
     # (we are not interested in cell_type_id, here)
     ln.save(
         ln.Feature.from_df(
-            adata.obs[["cell_type", "tissue", "cell_type_from_expert", "disease"]]
+            adata.obs[["cell_type", "tissue", "cell_type_by_expert", "disease"]]
         )
     )
     artifact = ln.Artifact.from_anndata(adata, description="Mini adata")
@@ -442,14 +475,14 @@ def test_add_labels_using_anndata(adata):
 
     # now we add cell types & tissues and run checks
     ln.Feature(name="cell_type", dtype="cat").save()
-    ln.Feature(name="cell_type_from_expert", dtype="cat").save()
+    ln.Feature(name="cell_type_by_expert", dtype="cat").save()
     ln.Feature(name="tissue", dtype="cat").save()
     artifact.labels.add(cell_types, feature=features.cell_type)
-    artifact.labels.add(cell_types_from_expert, feature=features.cell_type_from_expert)
+    artifact.labels.add(cell_types_from_expert, feature=features.cell_type_by_expert)
     artifact.labels.add(tissues, feature=features.tissue)
     feature = ln.Feature.get(name="cell_type")
     assert feature.dtype == "cat[bionty.CellType]"
-    feature = ln.Feature.get(name="cell_type_from_expert")
+    feature = ln.Feature.get(name="cell_type_by_expert")
     assert feature.dtype == "cat[bionty.CellType]"
     feature = ln.Feature.get(name="tissue")
     assert feature.dtype == "cat[bionty.Tissue|ULabel]"
@@ -461,7 +494,7 @@ def test_add_labels_using_anndata(adata):
         "cell_type",
         "disease",
         "tissue",
-        "cell_type_from_expert",
+        "cell_type_by_expert",
     }
     assert set(df["dtype"]) == {
         "cat[bionty.CellType]",
@@ -517,7 +550,7 @@ def test_add_labels_using_anndata(adata):
         "hematopoietic stem cell",
         "B cell",
     }
-    assert set(artifact.labels.get(features.cell_type_from_expert).list("name")) == {
+    assert set(artifact.labels.get(features.cell_type_by_expert).list("name")) == {
         "T cell",
         "my new cell type",
         "hepatocyte",


### PR DESCRIPTION
Note: More comprehensive examples will be added in a follow up PR that will prettify visualizations of features. This PR and the following will be announced together.

Improved annotating artifacts with feature values:

1. support date- and datetime-like feature values with new `dtype` for `Feature`: `"date"` and `"datetime"`
2. clearer feature overview that separates internal from external features
3. enable removing feature value annotations via `artifact.features.remove_values()`
4. consistent handling of annotated values via sets as they come from aggregations, before they were treated as lists
5. refactor the code to simplify and make more maintainable, performance issue still persists though

On the last 3rd point, see https://lamin.ai/laminlabs/lamindata/transform/BblTiuKxsb2g0002

Resolves:

- https://github.com/laminlabs/lamindb/issues/2039