### PR TITLE
🎨 Let `.from_values()` return `RecordList` and better treat categorical

### DIFF
--- a/lamindb/_can_curate.py
+++ b/lamindb/_can_curate.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
     from lamin_utils._inspect import InspectResult
     from lnschema_core.types import ListLike, StrField
 
+    from lamindb._query_set import RecordList
+
 
 # from_values doesn't apply for QuerySet or Manager
 @classmethod  # type:ignore
@@ -32,7 +34,7 @@ def from_values(
     organism: Record | str | None = None,
     source: Record | None = None,
     mute: bool = False,
-) -> list[Record]:
+) -> RecordList:
     """{}"""  # noqa: D415
     from_source = True if cls.__module__.startswith("bionty.") else False
 

--- a/lamindb/_feature.py
+++ b/lamindb/_feature.py
@@ -12,7 +12,7 @@ from pandas.api.types import CategoricalDtype, is_string_dtype
 
 from lamindb.core.exceptions import ValidationError
 
-from ._query_set import RecordsList
+from ._query_set import RecordList
 from ._utils import attach_func_to_class_method
 from .core._settings import settings
 from .core.schema import dict_schema_name_to_model_name
@@ -119,7 +119,7 @@ def categoricals_from_df(df: pd.DataFrame) -> dict:
 
 @classmethod  # type:ignore
 @doc_args(Feature.from_df.__doc__)
-def from_df(cls, df: pd.DataFrame, field: FieldAttr | None = None) -> RecordsList:
+def from_df(cls, df: pd.DataFrame, field: FieldAttr | None = None) -> RecordList:
     """{}"""  # noqa: D415
     field = Feature.name if field is None else field
     registry = field.field.model
@@ -135,7 +135,7 @@ def from_df(cls, df: pd.DataFrame, field: FieldAttr | None = None) -> RecordsLis
     with logger.mute():  # silence the warning "loaded record with exact same name "
         features = [Feature(name=name, dtype=dtype) for name, dtype in dtypes.items()]
     assert len(features) == len(df.columns)  # noqa: S101
-    return RecordsList(features)
+    return RecordList(features)
 
 
 @doc_args(Feature.save.__doc__)

--- a/lamindb/_feature.py
+++ b/lamindb/_feature.py
@@ -49,6 +49,9 @@ def convert_pandas_dtype_to_lamin_dtype(pandas_dtype: ExtensionDtype) -> str:
             dtype = "str"
         else:
             dtype = "cat"
+    # there are string-like categoricals and "pure" categoricals (pd.Categorical)
+    elif isinstance(pandas_dtype, CategoricalDtype):
+        dtype = "cat"
     else:
         # strip precision qualifiers
         dtype = "".join(dt for dt in pandas_dtype.name if not dt.isdigit())

--- a/lamindb/_from_values.py
+++ b/lamindb/_from_values.py
@@ -5,7 +5,9 @@ from typing import TYPE_CHECKING
 import pandas as pd
 from django.core.exceptions import FieldDoesNotExist
 from lamin_utils import colors, logger
-from lnschema_core.models import Feature, Field, Record, ULabel
+from lnschema_core.models import Record
+
+from lamindb._query_set import RecordList
 
 from .core._settings import settings
 
@@ -25,11 +27,11 @@ def get_or_create_records(
     organism: Record | str | None = None,
     source: Record | None = None,
     mute: bool = False,
-) -> list[Record]:
+) -> RecordList:
     """Get or create records from iterables."""
     registry = field.field.model
     if create:
-        return [registry(**{field.field.name: value}) for value in iterable]
+        return RecordList([registry(**{field.field.name: value}) for value in iterable])
     creation_search_names = settings.creation.search_names
     organism = _get_organism_record(field, organism)
     settings.creation.search_names = False
@@ -112,7 +114,7 @@ def get_or_create_records(
         #             for record in records:
         #                 record._feature = feature_name
         #         logger.debug(f"added default feature '{feature_name}'")
-        return records
+        return RecordList(records)
     finally:
         settings.creation.search_names = creation_search_names
 

--- a/lamindb/core/__init__.py
+++ b/lamindb/core/__init__.py
@@ -9,7 +9,7 @@ Registries:
    Registry
    QuerySet
    QueryManager
-   RecordsList
+   RecordList
    FeatureManager
    ParamManager
    LabelManager
@@ -88,7 +88,7 @@ from lamindb._curate import (
     MuDataCurator,
 )
 from lamindb._query_manager import QueryManager
-from lamindb._query_set import QuerySet, RecordsList
+from lamindb._query_set import QuerySet, RecordList
 from lamindb.core._feature_manager import FeatureManager, ParamManager
 from lamindb.core._label_manager import LabelManager
 

--- a/lamindb/core/_feature_manager.py
+++ b/lamindb/core/_feature_manager.py
@@ -471,9 +471,9 @@ def infer_feature_type_convert_json(
             sanitized_value = datetime_str[:10] if dt_type == "date" else datetime_str  # type: ignore
             return dt_type, sanitized_value  # type: ignore
         else:
-            return "cat[ULabel] / str / cat[bionty.CellType] / etc.", value
+            return "cat ? str", value
     elif isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
-        if isinstance(value, (pd.Series, np.ndarray)):
+        if isinstance(value, (pd.Series, np.ndarray, pd.Categorical)):
             return convert_pandas_dtype_to_lamin_dtype(value.dtype), list(value)
         if isinstance(value, dict):
             return "dict", value
@@ -488,7 +488,7 @@ def infer_feature_type_convert_json(
                     return "list[float]", value
                 elif first_element_type is str:
                     return (
-                        "list[cat[ULabel] / str / cat[bionty.CellType] / etc.]",
+                        "list[cat ? str]",
                         value,
                     )
                 elif first_element_type == Record:

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -25,7 +25,7 @@ def test_track_with_multi_parents():
 Here is how to create a param:
 
   ln.Param(name='param1', dtype='int').save()
-  ln.Param(name='param2', dtype='cat[ULabel] / str / cat[bionty.CellType] / etc.').save()
+  ln.Param(name='param2', dtype='cat ? str').save()
   ln.Param(name='param3', dtype='float').save()"""
     )
     ln.Param(name="param1", dtype="int").save()

--- a/tests/core/test_curate_annotate_df.py
+++ b/tests/core/test_curate_annotate_df.py
@@ -20,14 +20,11 @@ def test_curate_annotate_df():
     ln.Feature(name="study_note", dtype="str").save()
 
     ## Register permissible values for categoricals
-
-    ln.save(ln.ULabel.from_values(["DMSO", "IFNG"], create=True))
-    ln.save(
-        ln.ULabel.from_values(
-            ["Candidate marker study 1", "Candidate marker study 2"], create=True
-        )
-    )
-    ln.save(bt.CellType.from_values(["B cell", "T cell"], create=True))
+    ln.ULabel.from_values(["DMSO", "IFNG"], create=True).save()
+    ln.ULabel.from_values(
+        ["Candidate marker study 1", "Candidate marker study 2"], create=True
+    ).save()
+    bt.CellType.from_values(["B cell", "T cell"], create=True).save()
 
     ## Ingest a dataset
 

--- a/tests/core/test_feature_manager.py
+++ b/tests/core/test_feature_manager.py
@@ -83,7 +83,7 @@ Here is how to create a feature:
         artifact.features.add_values({"date_of_experiment": "Typo2024-12-01"})
     assert (
         error.exconly()
-        == """lamindb.core.exceptions.ValidationError: Expected dtype for 'date_of_experiment' is 'date', got 'cat[ULabel] / str / cat[bionty.CellType] / etc.'"""
+        == """lamindb.core.exceptions.ValidationError: Expected dtype for 'date_of_experiment' is 'date', got 'cat ? str'"""
     )
     artifact.features.add_values({"date_of_experiment": "2024-12-01"})
 
@@ -141,10 +141,10 @@ Here is how to create a feature:
 lamindb.core.exceptions.ValidationError: These keys could not be validated: ['project', 'is_validated', 'cell_type_by_expert', 'donor']
 Here is how to create a feature:
 
-  ln.Feature(name='project', dtype='cat[ULabel] / str / cat[bionty.CellType] / etc.').save()
+  ln.Feature(name='project', dtype='cat ? str').save()
   ln.Feature(name='is_validated', dtype='bool').save()
-  ln.Feature(name='cell_type_by_expert', dtype='cat[ULabel] / str / cat[bionty.CellType] / etc.').save()
-  ln.Feature(name='donor', dtype='cat[ULabel] / str / cat[bionty.CellType] / etc.').save()"""
+  ln.Feature(name='cell_type_by_expert', dtype='cat ? str').save()
+  ln.Feature(name='donor', dtype='cat ? str').save()"""
     )
 
     ln.Feature(name="project", dtype="cat[ULabel]").save()


### PR DESCRIPTION
## RecordList

Before: `.from_values()` returns a `list[Record]`

```python
ln.save(ln.ULabel.from_values(["DMSO", "IFNG"], create=True))
```

After: Because it now returns a `RecordList`, these all work:

```python
ln.ULabel.from_values(["DMSO", "IFNG"], create=True).save()
ln.ULabel.from_values(["DMSO", "IFNG"], create=True).df()
ln.ULabel.from_values(["DMSO", "IFNG"], create=True).one()
```

## pd.Categorical

Dedicated for support for `pd.Categorical` and better logging message for user to decided on `str` vs. `cat` dtype.

## Material

Needs:

- https://github.com/laminlabs/lnschema-core/pull/461