### PR TITLE
✨ Enable to include features in `Artifact.df()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ lamin-tutorial/
 mytest/
 rds/
 mydb/
+docs/test-registries/
 docs/test-annotate-flexible/
 docs/lamindb.*
 lamin_sphinx

--- a/docs/arrays.ipynb
+++ b/docs/arrays.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Query arrays"
+    "# Slice arrays"
    ]
   },
   {

--- a/docs/faq/search.ipynb
+++ b/docs/faq/search.ipynb
@@ -11,30 +11,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "955b6253",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from laminci.db import setup_local_test_postgres"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7f312433",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pgurl = setup_local_test_postgres()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "286aeebc",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-cell"
+    ]
+   },
    "outputs": [],
    "source": [
+    "from laminci.db import setup_local_test_postgres\n",
+    "pgurl = setup_local_test_postgres()\n",
     "!lamin init --name benchmark_search --db {pgurl} --schema bionty --storage ./benchmark_search"
    ]
   },
@@ -43,7 +29,7 @@
    "id": "40234d47",
    "metadata": {},
    "source": [
-    "Here we show how to perform text search on `Record` and evaluate some search queries."
+    "Here we show how to perform text search on `Record` and evaluate some search queries for the {class}`bionty.CellType` ontology."
    ]
   },
   {
@@ -54,36 +40,32 @@
    "outputs": [],
    "source": [
     "import lamindb as ln\n",
-    "import bionty as bt"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "83a46a9a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "import bionty as bt\n",
+    "\n",
+    "SEARCH_QUERIES_EXACT = (\"t cell\", \"stem cell\", \"b cell\", \"regulatory B cell\", \"Be2 cell\", \"adipocyte\")\n",
+    "SEARCH_QUERIES_CONTAINS = (\"t cel\", \"t-cel\", \"neural\", \"kidney\", \"kidne\")\n",
+    "TOP_N = 20\n",
+    "\n",
     "bt.CellType.import_source()"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7991a73f",
+   "cell_type": "markdown",
+   "id": "799b528e",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "SEARCH_QUERIES_EXACT = (\"t cell\", \"stem cell\", \"b cell\", \"regulatory B cell\", \"Be2 cell\", \"adipocyte\")\n",
-    "SEARCH_QUERIES_CONTAINS = (\"t cel\", \"t-cel\", \"neural\", \"kidney\", \"kidne\")\n",
-    "TOP_N = 20"
+    "## Search the registry"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "682fcd2f",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "for query in SEARCH_QUERIES_EXACT:\n",
@@ -98,7 +80,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ee059b0d",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "for query in SEARCH_QUERIES_CONTAINS:\n",
@@ -116,29 +102,24 @@
    "id": "f4e41c9b",
    "metadata": {},
    "source": [
-    "Also check `bionty` public ontologies search:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "eb5aa05a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ct_public = bt.CellType.public()"
+    "## Search the public ontology"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "d42c3594",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
+    "ct_public = bt.CellType.public()\n",
+    "\n",
     "df = ct_public.search(\"b cell\", limit=20)\n",
     "assert df.iloc[0][\"name\"] == \"B cell\"\n",
-    "\n",
     "df"
    ]
   },

--- a/docs/registries.ipynb
+++ b/docs/registries.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "0a706415",
+   "metadata": {},
+   "source": [
+    "[![Jupyter Notebook](https://img.shields.io/badge/Source%20on%20GitHub-orange)](https://github.com/laminlabs/lamindb/blob/main/docs/registries.ipynb)"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "id": "21d1f73c",
@@ -14,7 +22,7 @@
    "id": "2079f103",
    "metadata": {},
    "source": [
-    "This guide walks through all the ways of finding metadata records in LaminDB registries."
+    "This guide walks through different ways of querying & searching LaminDB registries."
    ]
   },
   {
@@ -28,8 +36,8 @@
    },
    "outputs": [],
    "source": [
-    "# !pip install lamindb\n",
-    "!lamin init --storage ./test-registries"
+    "# !pip install 'lamindb[bionty]'\n",
+    "!lamin init --storage ./test-registries --schema bionty"
    ]
   },
   {
@@ -37,7 +45,7 @@
    "id": "86abfd19",
    "metadata": {},
    "source": [
-    "We'll need some toy data."
+    "The hidden cell below creates exemplary datasets and saves them in a LaminDB instance."
    ]
   },
   {
@@ -46,17 +54,61 @@
    "id": "3ba53765",
    "metadata": {
     "tags": [
-     "hide-output"
+     "hide-cell"
     ]
    },
    "outputs": [],
    "source": [
     "import lamindb as ln\n",
+    "import bionty as bt\n",
+    "from lamindb.core import datasets\n",
     "\n",
-    "# create toy data\n",
-    "ln.Artifact(ln.core.datasets.file_jpg_paradisi05(), description=\"My image\").save()\n",
-    "ln.Artifact.from_df(ln.core.datasets.df_iris(), description=\"The iris collection\").save()\n",
-    "ln.Artifact(ln.core.datasets.file_fastq(), description=\"My fastq\").save()\n",
+    "ln.track(\"pd7UR7Z8hoTq0000\")\n",
+    "\n",
+    "# Create non-curated datasets\n",
+    "ln.Artifact(datasets.file_jpg_paradisi05(), key=\"images/my_image.jpg\").save()\n",
+    "ln.Artifact(datasets.file_fastq(), key=\"raw/my_fastq.fastq\").save()\n",
+    "ln.Artifact.from_df(datasets.df_iris(), key=\"iris/iris_collection.parquet\").save()\n",
+    "\n",
+    "# Create a more complex case\n",
+    "# observation-level metadata\n",
+    "ln.Feature(name=\"cell_medium\", dtype=\"cat[ULabel]\").save()\n",
+    "ln.Feature(name=\"sample_note\", dtype=\"str\").save()\n",
+    "ln.Feature(name=\"cell_type_by_expert\", dtype=\"cat[bionty.CellType]\").save()\n",
+    "ln.Feature(name=\"cell_type_by_model\", dtype=\"cat[bionty.CellType]\").save()\n",
+    "# dataset-level metadata\n",
+    "ln.Feature(name=\"temperature\", dtype=\"float\").save()\n",
+    "ln.Feature(name=\"study\", dtype=\"cat[ULabel]\").save()\n",
+    "ln.Feature(name=\"date_of_study\", dtype=\"date\").save()\n",
+    "ln.Feature(name=\"study_note\", dtype=\"str\").save()\n",
+    "\n",
+    "## Permissible values for categoricals\n",
+    "ln.ULabel.from_values([\"DMSO\", \"IFNG\"], create=True).save()\n",
+    "ln.ULabel.from_values(\n",
+    "    [\"Candidate marker study 1\", \"Candidate marker study 2\"], create=True\n",
+    ").save()\n",
+    "bt.CellType.from_values([\"B cell\", \"T cell\"], create=True).save()\n",
+    "\n",
+    "# Ingest dataset1\n",
+    "adata = datasets.small_dataset1(format=\"anndata\")\n",
+    "curator = ln.Curator.from_anndata(\n",
+    "    adata,\n",
+    "    var_index=bt.Gene.symbol,\n",
+    "    categoricals={\n",
+    "        \"cell_medium\": ln.ULabel.name,\n",
+    "        \"cell_type_by_expert\": bt.CellType.name,\n",
+    "        \"cell_type_by_model\": bt.CellType.name,\n",
+    "    },\n",
+    "    organism=\"human\",\n",
+    ")\n",
+    "artifact = curator.save_artifact(key=\"example_datasets/dataset1.h5ad\")\n",
+    "artifact.features.add_values(adata.uns)\n",
+    "\n",
+    "# Ingest dataset2\n",
+    "adata2 = datasets.small_dataset2(format=\"anndata\")\n",
+    "curator = ln.Curator.from_anndata(adata2, var_index=bt.Gene.symbol, categoricals={\"cell_medium\": ln.ULabel.name, \"cell_type_by_model\": bt.CellType.name}, organism=\"human\")\n",
+    "artifact2 = curator.save_artifact(key=\"example_datasets/dataset2.h5ad\")\n",
+    "artifact2.features.add_values(adata2.uns)\n",
     "\n",
     "# see the content of the artifact registry\n",
     "ln.Artifact.df()"
@@ -619,7 +671,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "py310",
    "language": "python",
    "name": "python3"
   },
@@ -633,12 +685,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "ae1fefc8646a06dd2e75004cd934adda7c5727b046986a772e3b44b0ffba9754"
-   }
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/docs/registries.ipynb
+++ b/docs/registries.ipynb
@@ -151,7 +151,7 @@
    },
    "outputs": [],
    "source": [
-    "ln.Artifact.df(include=[\"created_by__name\", \"ulabels__name\", \"cell_types__name\", \"feature_sets__registry\"])"
+    "ln.Artifact.df(include=[\"created_by__name\", \"ulabels__name\", \"cell_types__name\", \"feature_sets__registry\", \"suffix\"])"
    ]
   },
   {
@@ -174,7 +174,7 @@
    "outputs": [],
    "source": [
     "df = ln.Artifact.df(features=True)\n",
-    "ln.view(df)  # for clarity, leverage ln.view() to display a dataframe with dtype annotations"
+    "ln.view(df)  # for clarity, leverage ln.view() to display dtype annotations"
    ]
   },
   {

--- a/docs/registries.ipynb
+++ b/docs/registries.ipynb
@@ -178,6 +178,24 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "82f563e0",
+   "metadata": {},
+   "source": [
+    "Compare this with the underlying normalized view of the data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a9c04f85",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln.view()"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "id": "bbda4807",

--- a/docs/registries.ipynb
+++ b/docs/registries.ipynb
@@ -292,7 +292,7 @@
    },
    "outputs": [],
    "source": [
-    "print(study.uid)\n",
+    "print(study1.uid)\n",
     "\n",
     "# by uid\n",
     "ln.ULabel.get(study1.uid)\n",

--- a/docs/registries.ipynb
+++ b/docs/registries.ipynb
@@ -113,7 +113,7 @@
    "id": "c6410d93",
    "metadata": {},
    "source": [
-    "The easiest way to get an overview over all datasets is by typing {meth}`~lamindb.Artifact.df`, which returns the 100 latest artifacts in the {class}`~lamindb.Artifact` registry."
+    "The easiest way to get an overview over all artifacts is by typing {meth}`~lamindb.Artifact.df`, which returns the 100 latest artifacts in the {class}`~lamindb.Artifact` registry."
    ]
   },
   {
@@ -137,7 +137,7 @@
    "id": "682d8295",
    "metadata": {},
    "source": [
-    "To join fields from other registries into this overview, pass them via the `include` argument."
+    "You can include fields from other registries."
    ]
   },
   {
@@ -159,7 +159,7 @@
    "id": "aa3954d7",
    "metadata": {},
    "source": [
-    "If you'd like to see which artifacts measure which features, use the `features` argument."
+    "You can include information about which artifact measures which `feature`."
    ]
   },
   {
@@ -174,7 +174,7 @@
    "outputs": [],
    "source": [
     "df = ln.Artifact.df(features=True)\n",
-    "ln.view(df)  # for clarity, we visualize this with type annotations"
+    "ln.view(df)  # for clarity, leverage ln.view() to display a dataframe with dtype annotations"
    ]
   },
   {
@@ -182,14 +182,18 @@
    "id": "82f563e0",
    "metadata": {},
    "source": [
-    "Compare this with the underlying normalized view of the data."
+    "The flattened table that includes information from all relevant registries is easier to understand than the normalized data. For comparison, here is how to see the later."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "a9c04f85",
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "ln.view()"
@@ -201,7 +205,7 @@
    "id": "bbda4807",
    "metadata": {},
    "source": [
-    "## Look up metadata"
+    "## Auto-complete records"
    ]
   },
   {
@@ -224,6 +228,8 @@
    },
    "outputs": [],
    "source": [
+    "import bionty as bt\n",
+    "\n",
     "# query the database for all ulabels or all cell types\n",
     "ulabels = ln.ULabel.lookup()\n",
     "cell_types = bt.CellType.lookup()"
@@ -270,7 +276,7 @@
    "id": "d54676dd",
    "metadata": {},
    "source": [
-    "## Query exactly one record"
+    "## Get one record"
    ]
   },
   {
@@ -307,7 +313,7 @@
    "id": "45ac3b5c",
    "metadata": {},
    "source": [
-    "## Query sets of records"
+    "## Query multiple records"
    ]
   },
   {
@@ -344,7 +350,7 @@
     "- {meth}`~lamindb.core.QuerySet.df`: A pandas `DataFrame` with each record in a row.\n",
     "- {meth}`~lamindb.core.QuerySet.all`: A {class}`~lamindb.core.QuerySet`.\n",
     "- {meth}`~lamindb.core.QuerySet.one`: Exactly one record. Will raise an error if there is none. Is equivalent to the `.get()` method shown above.\n",
-    "- {meth}`~lamindb.core.QuerySet.one_or_one`: Either one record or `None` if there is no query result."
+    "- {meth}`~lamindb.core.QuerySet.one_or_none`: Either one record or `None` if there is no query result."
    ]
   },
   {
@@ -387,7 +393,7 @@
    "id": "a925a678",
    "metadata": {},
    "source": [
-    "Search the toy data:"
+    "You can search every registry via {meth}`~lamindb.core.Record.search`. For example, the `Artifact` registry."
    ]
   },
   {
@@ -405,42 +411,11 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "id": "b8ba2bfe",
+   "id": "ed43c3fa",
    "metadata": {},
    "source": [
-    "Let us create 500 notebook objects with fake titles, save, and search them:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4b0b0c0c",
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "transforms = [ln.Transform(name=title, type=\"notebook\") for title in ln.core.datasets.fake_bio_notebook_titles(n=500)]\n",
-    "ln.save(transforms)\n",
-    "\n",
-    "# search\n",
-    "ln.Transform.search(\"intestine\").df().head(5)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4ba825ab",
-   "metadata": {},
-   "source": [
-    "```{note}\n",
-    "\n",
-    "Currently, the LaminHub UI search is more powerful than the search of the `lamindb` open-source package.\n",
-    "\n",
-    "```"
+    "Here is more background on search and examples for searching the entire cell type ontology: {doc}`/faq/search` "
    ]
   },
   {
@@ -449,7 +424,7 @@
    "id": "f85478c0",
    "metadata": {},
    "source": [
-    "## Leverage relations"
+    "## Query related registries"
    ]
   },
   {
@@ -483,10 +458,49 @@
    "id": "8aa6378a",
    "metadata": {},
    "source": [
-    "The filter selects all artifacts based on the users who ran the generating notebook.\n",
+    "The filter selects all artifacts based on the users who ran the generating notebook. Under the hood, in the SQL database, it's joining the artifact table with the user table.\n",
     "\n",
-    "Under the hood, in the SQL database, it's joining the artifact table with the run and the user table.\n",
-    "\n"
+    "Another typical example is querying all datasets that measure a particular feature. For instance, which datasets measure `\"CD8A\"`. Here is how to do it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32cda0d5",
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "cd8a = bt.Gene.get(symbol=\"CD8A\")\n",
+    "# query for all feature sets that contain CD8A\n",
+    "feature_sets_with_cd8a = ln.FeatureSet.filter(genes=cd8a).all()\n",
+    "# get all artifacts \n",
+    "ln.Artifact.filter(feature_sets__in=feature_sets_with_cd8a).df()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1fe9bef9",
+   "metadata": {},
+   "source": [
+    "Instead of splitting this across three queries, the double-underscore syntax allows you to define a path for one query."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c338cf8e",
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "ln.Artifact.filter(feature_sets__genes__symbol=\"CD8A\").df()"
    ]
   },
   {
@@ -494,7 +508,7 @@
    "id": "dc54f4f6",
    "metadata": {},
    "source": [
-    "## Comparators"
+    "## Filter operators"
    ]
   },
   {
@@ -719,21 +733,6 @@
    "outputs": [],
    "source": [
     "ln.Artifact.filter(~ln.Q(suffix=\".jpg\")).df()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "72b03f8b",
-   "metadata": {
-    "tags": [
-     "hide-cell"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "!rm -r ./test-registries\n",
-    "!lamin delete --force test-registries"
    ]
   }
  ],

--- a/docs/registries.ipynb
+++ b/docs/registries.ipynb
@@ -26,26 +26,11 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "03242699",
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "# !pip install 'lamindb[bionty]'\n",
-    "!lamin init --storage ./test-registries --schema bionty"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "86abfd19",
    "metadata": {},
    "source": [
-    "The hidden cell below creates exemplary datasets and saves them in a LaminDB instance."
+    "Let's start by creating a few exemplary datasets and saving them into a LaminDB instance (hidden cell)."
    ]
   },
   {
@@ -59,6 +44,10 @@
    },
    "outputs": [],
    "source": [
+    "# !pip install 'lamindb[bionty]'\n",
+    "!lamin init --storage ./test-registries --schema bionty\n",
+    "\n",
+    "# python\n",
     "import lamindb as ln\n",
     "import bionty as bt\n",
     "from lamindb.core import datasets\n",
@@ -108,10 +97,84 @@
     "adata2 = datasets.small_dataset2(format=\"anndata\")\n",
     "curator = ln.Curator.from_anndata(adata2, var_index=bt.Gene.symbol, categoricals={\"cell_medium\": ln.ULabel.name, \"cell_type_by_model\": bt.CellType.name}, organism=\"human\")\n",
     "artifact2 = curator.save_artifact(key=\"example_datasets/dataset2.h5ad\")\n",
-    "artifact2.features.add_values(adata2.uns)\n",
+    "artifact2.features.add_values(adata2.uns)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36b8d44a",
+   "metadata": {},
+   "source": [
+    "## Get an overview"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6410d93",
+   "metadata": {},
+   "source": [
+    "The easiest way to get an overview over all datasets is by typing {meth}`~lamindb.Artifact.df`, which returns the 100 latest artifacts in the {class}`~lamindb.Artifact` registry."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4413cc02",
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import lamindb as ln\n",
     "\n",
-    "# see the content of the artifact registry\n",
     "ln.Artifact.df()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "682d8295",
+   "metadata": {},
+   "source": [
+    "To join values from other registries into this overview, pass them via the `include` parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "462284cc",
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "ln.Artifact.df(include=[\"created_by__name\", \"ulabels__name\", \"cell_types__name\", \"feature_sets__registry\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa3954d7",
+   "metadata": {},
+   "source": [
+    "If you'd like to see which artifacts measure which features, use parameter `features`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "061047fb",
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "df = ln.Artifact.df(features=True)\n",
+    "ln.view(df)  # for clarity, we visualize this with type annotations"
    ]
   },
   {

--- a/docs/registries.ipynb
+++ b/docs/registries.ipynb
@@ -137,7 +137,7 @@
    "id": "682d8295",
    "metadata": {},
    "source": [
-    "To join values from other registries into this overview, pass them via the `include` parameter."
+    "To join fields from other registries into this overview, pass them via the `include` argument."
    ]
   },
   {
@@ -159,7 +159,7 @@
    "id": "aa3954d7",
    "metadata": {},
    "source": [
-    "If you'd like to see which artifacts measure which features, use parameter `features`."
+    "If you'd like to see which artifacts measure which features, use the `features` argument."
    ]
   },
   {
@@ -210,9 +210,7 @@
    "id": "5cb551b4",
    "metadata": {},
    "source": [
-    "For registries with less than 100k records, auto-completing a `Lookup` object is the most convenient way of finding a record.\n",
-    "\n",
-    "For example, take the `User` registry:"
+    "For registries with less than 100k records, auto-completing a `Lookup` object is the most convenient way of finding a record."
    ]
   },
   {

--- a/docs/registries.ipynb
+++ b/docs/registries.ipynb
@@ -208,11 +208,21 @@
    },
    "outputs": [],
    "source": [
-    "# query the database for all users, optionally pass the field that creates the key\n",
-    "users = ln.User.lookup(field=\"handle\")\n",
+    "# query the database for all ulabels or all cell types\n",
+    "ulabels = ln.ULabel.lookup()\n",
+    "cell_types = bt.CellType.lookup()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24926aa1",
+   "metadata": {},
+   "source": [
+    ":::{dropdown} Show me a screenshot\n",
     "\n",
-    "# the lookup object is a NamedTuple\n",
-    "users"
+    "<img src=\"https://lamin-site-assets.s3.amazonaws.com/.lamindb/lgRNHNtMxjU0y8nIagt7.png\" width=\"400px\">\n",
+    "\n",
+    ":::"
    ]
   },
   {
@@ -221,7 +231,7 @@
    "id": "82a31938",
    "metadata": {},
    "source": [
-    "With auto-complete, we find a specific user record:"
+    "With auto-complete, we find a ulabel:"
    ]
   },
   {
@@ -235,31 +245,8 @@
    },
    "outputs": [],
    "source": [
-    "user = users.testuser1\n",
-    "user"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bf7e1415",
-   "metadata": {},
-   "source": [
-    "You can also get a dictionary:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "04130d47",
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "users_dict = ln.User.lookup().dict()\n",
-    "users_dict"
+    "study1 = ulabels.candidate_marker_study_1\n",
+    "study1"
    ]
   },
   {
@@ -289,11 +276,13 @@
    },
    "outputs": [],
    "source": [
-    "# by the universal base62 uid\n",
-    "ln.User.get(\"DzTjkKse\")\n",
+    "print(study.uid)\n",
     "\n",
-    "# by any expression involving fields\n",
-    "ln.User.get(handle=\"testuser1\")"
+    "# by uid\n",
+    "ln.ULabel.get(study1.uid)\n",
+    "\n",
+    "# by field\n",
+    "ln.ULabel.get(name=\"Canidate marker study 1\")"
    ]
   },
   {
@@ -311,7 +300,7 @@
    "id": "02b75183",
    "metadata": {},
    "source": [
-    "Filter for all artifacts created by a user:"
+    "Filter for all artifacts annotated by a ulabel:"
    ]
   },
   {
@@ -325,7 +314,7 @@
    },
    "outputs": [],
    "source": [
-    "ln.Artifact.filter(created_by=user).df()"
+    "ln.Artifact.filter(ulabels=user).df()"
    ]
   },
   {
@@ -336,10 +325,10 @@
    "source": [
     "To access the results encoded in a filter statement, execute its return value with one of:\n",
     "\n",
-    "- `.df()`: A pandas `DataFrame` with each record in a row.\n",
-    "- `.all()`: A {class}`~lamindb.core.QuerySet`.\n",
-    "- `.one()`: Exactly one record. Will raise an error if there is none. Is equivalent to the `.get()` method shown above.\n",
-    "- `.one_or_none()`: Either one record or `None` if there is no query result."
+    "- {meth}`~lamindb.core.QuerySet.df`: A pandas `DataFrame` with each record in a row.\n",
+    "- {meth}`~lamindb.core.QuerySet.all`: A {class}`~lamindb.core.QuerySet`.\n",
+    "- {meth}`~lamindb.core.QuerySet.one`: Exactly one record. Will raise an error if there is none. Is equivalent to the `.get()` method shown above.\n",
+    "- {meth}`~lamindb.core.QuerySet.one_or_one`: Either one record or `None` if there is no query result."
    ]
   },
   {
@@ -351,11 +340,19 @@
     "\n",
     "{meth}`~lamindb.core.Record.filter` returns a {class}`~lamindb.core.QuerySet`.\n",
     "\n",
-    "The ORMs in LaminDB are Django Models and any [Django query](https://docs.djangoproject.com/en/stable/topics/db/queries/) works. LaminDB extends Django's API for data scientists.\n",
+    "The registries in LaminDB are Django Models and any [Django query](https://docs.djangoproject.com/en/stable/topics/db/queries/) works.\n",
+    "\n",
+    "LaminDB re-interprets Django's API for data scientists.\n",
+    "\n",
+    "```\n",
+    "\n",
+    "```{dropdown} What does this have to do with SQL?\n",
     "\n",
     "Under the hood, any `.filter()` call translates into a SQL select statement.\n",
     "\n",
-    "`.one()` and `.one_or_none()` are two parts of LaminDB's API that are borrowed from SQLAlchemy.\n",
+    "LaminDB's registries are object relational mappers (ORMs) that rely on Django for all the heavy lifting.\n",
+    "\n",
+    "Of note, `.one()` and `.one_or_none()` are the two parts of LaminDB's API that are borrowed from SQLAlchemy. In its first year, LaminDB built on SQLAlchemy.\n",
     "\n",
     "```"
    ]

--- a/docs/registries.ipynb
+++ b/docs/registries.ipynb
@@ -298,7 +298,7 @@
     "ln.ULabel.get(study1.uid)\n",
     "\n",
     "# by field\n",
-    "ln.ULabel.get(name=\"Canidate marker study 1\")"
+    "ln.ULabel.get(name=\"Candidate marker study 1\")"
    ]
   },
   {
@@ -330,7 +330,7 @@
    },
    "outputs": [],
    "source": [
-    "ln.Artifact.filter(ulabels=user).df()"
+    "ln.Artifact.filter(ulabels=study1).df()"
    ]
   },
   {
@@ -528,7 +528,7 @@
    },
    "outputs": [],
    "source": [
-    "ln.Artifact.filter(suffix=\".jpg\", created_by=user).df()"
+    "ln.Artifact.filter(suffix=\".h5ad\", ulabels=study1).df()"
    ]
   },
   {
@@ -546,7 +546,7 @@
    "id": "fdd61cf1-d3c7-4bfb-a0b2-14e81201db03",
    "metadata": {},
    "source": [
-    "Or subset to artifacts smaller than 10kB. Here, we can't use keyword arguments, but need an explicit where statement."
+    "Or subset to artifacts greater than 10kB. Here, we can't use keyword arguments, but need an explicit where statement."
    ]
   },
   {
@@ -560,7 +560,7 @@
    },
    "outputs": [],
    "source": [
-    "ln.Artifact.filter(created_by=user, size__lt=1e4).df()"
+    "ln.Artifact.filter(ulabels=study1, size__gt=1e4).df()"
    ]
   },
   {
@@ -606,7 +606,7 @@
    },
    "outputs": [],
    "source": [
-    "ln.Artifact.filter().order_by(\"-updated_at\").df()"
+    "ln.Artifact.filter().order_by(\"-created_at\").df()"
    ]
   },
   {
@@ -722,20 +722,12 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "ffb9c7a9",
-   "metadata": {},
-   "source": [
-    "Clean up the test instance."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "72b03f8b",
    "metadata": {
     "tags": [
-     "hide-output"
+     "hide-cell"
     ]
    },
    "outputs": [],

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -615,11 +615,14 @@ def __init__(artifact: Artifact, *args, **kwargs):
 
         init_self_from_db(artifact, kwargs_or_artifact)
         # adding "key" here is dangerous because key might be auto-populated
-        update_attributes(artifact, {"description": description})
-        if artifact.key != key and key is not None:
+        attr_to_update = {"description": description}
+        if kwargs_or_artifact._key_is_virtual and kwargs_or_artifact.key is None:
+            attr_to_update["key"] = key
+        elif artifact.key != key and key is not None:
             logger.warning(
                 f"key {artifact.key} on existing artifact differs from passed key {key}"
             )
+        update_attributes(artifact, attr_to_update)
         return None
     else:
         kwargs = kwargs_or_artifact

--- a/lamindb/_feature.py
+++ b/lamindb/_feature.py
@@ -57,6 +57,8 @@ def convert_pandas_dtype_to_lamin_dtype(pandas_dtype: ExtensionDtype) -> str:
     else:
         # strip precision qualifiers
         dtype = "".join(dt for dt in pandas_dtype.name if not dt.isdigit())
+    if dtype.startswith("datetime"):
+        dtype = dtype.split("[")[0]
     assert dtype in FEATURE_DTYPES  # noqa: S101
     return dtype
 

--- a/lamindb/_query_set.py
+++ b/lamindb/_query_set.py
@@ -32,7 +32,7 @@ T = TypeVar("T")
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from lnschema_core.types import StrField, listLike
+    from lnschema_core.types import ListLike, StrField
 
 
 class MultipleResultsFound(Exception):
@@ -354,7 +354,7 @@ def reshape_annotate_result(
                 for col in feature_values.columns:
                     if col in result.columns:
                         continue
-                    result.insert(3, col, feature_values[col])
+                    result.insert(0, col, feature_values[col])
 
         # Handle links features if they exist
         links_features = [
@@ -425,7 +425,7 @@ def process_links_features(
         for feature_name in feature_names:
             mask = df[feature_col] == feature_name
             feature_values = df[mask].groupby("id")[value_col].agg(set)
-            result.insert(3, feature_name, result["id"].map(feature_values))
+            result.insert(0, feature_name, result["id"].map(feature_values))
 
     return result
 
@@ -583,7 +583,7 @@ def lookup(self, field: StrField | None = None, **kwargs) -> NamedTuple:
 
 
 @doc_args(CanCurate.validate.__doc__)
-def validate(self, values: listLike, field: str | StrField | None = None, **kwargs):
+def validate(self, values: ListLike, field: str | StrField | None = None, **kwargs):
     """{}"""  # noqa: D415
     from ._can_curate import _validate
 
@@ -591,7 +591,7 @@ def validate(self, values: listLike, field: str | StrField | None = None, **kwar
 
 
 @doc_args(CanCurate.inspect.__doc__)
-def inspect(self, values: listLike, field: str | StrField | None = None, **kwargs):
+def inspect(self, values: ListLike, field: str | StrField | None = None, **kwargs):
     """{}"""  # noqa: D415
     from ._can_curate import _inspect
 

--- a/lamindb/_query_set.py
+++ b/lamindb/_query_set.py
@@ -463,7 +463,6 @@ class QuerySet(models.QuerySet):
         self,
         include: str | list[str] | None = None,
         features: bool | list[str] = False,
-        join: str = "inner",
     ) -> pd.DataFrame:
         """{}"""  # noqa: D415
         field_names = get_basic_field_names(self)

--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -265,14 +265,13 @@ def df(
     cls,
     include: str | list[str] | None = None,
     features: bool | list[str] = False,
-    join: str = "inner",
     limit: int = 100,
 ) -> pd.DataFrame:
     """{}"""  # noqa: D415
     query_set = cls.filter()
     if hasattr(cls, "updated_at"):
         query_set = query_set.order_by("-updated_at")
-    return query_set[:limit].df(include=include, features=features, join=join)
+    return query_set[:limit].df(include=include, features=features)
 
 
 def _search(

--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -264,6 +264,7 @@ def get(
 def df(
     cls,
     include: str | list[str] | None = None,
+    features: bool | list[str] = False,
     join: str = "inner",
     limit: int = 100,
 ) -> pd.DataFrame:
@@ -271,7 +272,7 @@ def df(
     query_set = cls.filter()
     if hasattr(cls, "updated_at"):
         query_set = query_set.order_by("-updated_at")
-    return query_set[:limit].df(include=include, join=join)
+    return query_set[:limit].df(include=include, features=features, join=join)
 
 
 def _search(

--- a/lamindb/_save.py
+++ b/lamindb/_save.py
@@ -112,6 +112,7 @@ def bulk_create(records: Iterable[Record], ignore_conflicts: bool | None = False
         records_by_orm[record.__class__].append(record)
     for registry, records in records_by_orm.items():
         registry.objects.bulk_create(records, ignore_conflicts=ignore_conflicts)
+        # records[:] = created  # In-place list update; does not seem to be necessary
 
 
 def bulk_update(records: Iterable[Record], ignore_conflicts: bool | None = False):

--- a/lamindb/_view.py
+++ b/lamindb/_view.py
@@ -3,22 +3,107 @@ from __future__ import annotations
 import builtins
 import importlib
 import inspect
+from typing import TYPE_CHECKING
 
+from IPython.display import HTML, display
 from lamin_utils import colors, logger
 from lamindb_setup import settings
 from lamindb_setup._init_instance import get_schema_module_name
-from lnschema_core import Record
+from lnschema_core import Feature, Record
+
+from lamindb.core import FeatureValue, ParamValue
+
+from ._feature import convert_pandas_dtype_to_lamin_dtype
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 is_run_from_ipython = getattr(builtins, "__IPYTHON__", False)
 
 
+def display_df_with_descriptions(
+    df: pd.DataFrame, descriptions: dict[str, str] | None = None
+):
+    if descriptions is None:
+        display(df)
+        return None
+
+    # Start building HTML table
+    html = '<table class="dataframe">'
+
+    # Create header with title and description rows
+    html += "<thead>"
+
+    # Column names row
+    html += "<tr>"
+    html += '<th class="header-title index-header"></th>'  # Index header
+    for col in df.columns:
+        html += f'<th class="header-title">{col}</th>'
+    html += "</tr>"
+
+    # Descriptions row
+    html += "<tr>"
+    html += f'<th class="header-desc index-header">{df.index.name or ""}</th>'  # Index column
+    for col in df.columns:
+        desc = descriptions.get(col, "")
+        html += f'<th class="header-desc">{desc}</th>'
+    html += "</tr>"
+
+    html += "</thead>"
+
+    # Add body rows
+    html += "<tbody>"
+    for idx, row in df.iterrows():
+        html += "<tr>"
+        html += f'<th class="row-index">{idx}</th>'  # Index value
+        for col in df.columns:
+            html += f"<td>{row[col]}</td>"
+        html += "</tr>"
+    html += "</tbody>"
+    html += "</table>"
+
+    # Add CSS styles
+    styled_html = f"""
+    <style>
+        .dataframe {{
+            border-collapse: collapse;
+            margin: 10px 0;
+        }}
+        .dataframe th, .dataframe td {{
+            border: 1px solid #ddd;
+            padding: 8px;
+            text-align: left;
+        }}
+        .header-title {{
+            font-weight: bold;
+        }}
+        .header-desc {{
+            color: #666;
+            font-weight: normal;
+        }}
+        .row-index {{
+            font-weight: bold;
+        }}
+        .index-header {{
+            font-weight: bold;
+        }}
+    </style>
+    {html}
+    """
+    return display(HTML(styled_html))
+
+
 def view(
-    n: int = 7, schema: str | None = None, registries: list[str] | None = None
+    df: pd.DataFrame | None = None,
+    limit: int = 7,
+    schema: str | None = None,
+    registries: list[str] | None = None,
 ) -> None:
-    """View latest metadata state.
+    """View metadata.
 
     Args:
-        n: Display the last `n` rows of a registry.
+        df: A DataFrame to display.
+        limit: Display the latest `n` records
         schema: Schema module to view. Default's to
             `None` and displays all schema modules.
         registries: List of Record names. Defaults to
@@ -27,6 +112,16 @@ def view(
     Examples:
         >>> ln.view()
     """
+    if df is not None:
+        descriptions = {
+            col_name: convert_pandas_dtype_to_lamin_dtype(dtype)
+            for col_name, dtype in df.dtypes.to_dict().items()
+        }
+        feature_dtypes = dict(Feature.objects.values_list("name", "dtype"))
+        descriptions.update(feature_dtypes)
+        display_df_with_descriptions(df, descriptions)
+        return None
+
     if is_run_from_ipython:
         from IPython.display import display as show
     else:
@@ -39,6 +134,9 @@ def view(
 
     for schema_name in schema_names:
         schema_module = importlib.import_module(get_schema_module_name(schema_name))
+        # the below is necessary because a schema module might not have been
+        # explicitly accessed
+        importlib.reload(schema_module)
 
         all_registries = {
             registry
@@ -47,6 +145,8 @@ def view(
             and issubclass(registry, Record)
             and registry is not Record
         }
+        if schema_name == "core":
+            all_registries.update({FeatureValue, ParamValue})
         if registries is not None:
             filtered_registries = {
                 registry
@@ -62,11 +162,7 @@ def view(
             logger.print(section)
             logger.print("*" * len(section_no_color))
         for registry in sorted(filtered_registries, key=lambda x: x.__name__):
-            if hasattr(registry, "updated_at"):
-                df = registry.filter().order_by("-updated_at")[:n].df()
-            else:
-                # need to adjust in the future
-                df = registry.df().iloc[-n:]
+            df = registry.df(limit=limit)
             if df.shape[0] > 0:
                 logger.print(colors.blue(colors.bold(registry.__name__)))
                 show(df)

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -433,7 +433,7 @@ class Context:
                 nb = nbproject.dev.read_notebook(path_str)
                 self._logging_message_imports += (
                     "notebook imports:"
-                    f" {pretty_pypackages(infer_pypackages(nb, pin_versions=True))}\n"
+                    f" {pretty_pypackages(infer_pypackages(nb, pin_versions=True))}"
                 )
             except Exception:
                 logger.debug("inferring imported packages failed")

--- a/lamindb/core/datasets/__init__.py
+++ b/lamindb/core/datasets/__init__.py
@@ -6,6 +6,7 @@ Small in-memory datasets.
    :toctree: .
 
    small_dataset1
+   small_dataset2
    anndata_with_obs
 
 Files.
@@ -84,7 +85,4 @@ from ._core import (
     schmidt22_perturbseq,
 )
 from ._fake import fake_bio_notebook_titles
-from ._small import (
-    anndata_with_obs,
-    small_dataset1,
-)
+from ._small import anndata_with_obs, small_dataset1, small_dataset2

--- a/lamindb/core/datasets/_small.py
+++ b/lamindb/core/datasets/_small.py
@@ -9,14 +9,16 @@ import pandas as pd
 
 def small_dataset1(
     format: Literal["df", "anndata"],
+    with_typo: bool = False,
 ) -> tuple[pd.DataFrame, dict[str, Any]] | ad.AnnData:
     # define the data in the dataset
     # it's a mix of numerical measurements and observation-level metadata
+    ifng = "IFNJ" if with_typo else "IFNG"
     dataset_dict = {
         "CD8A": [1, 2, 3],
         "CD4": [3, 4, 5],
         "CD14": [5, 6, 7],
-        "cell_medium": ["DMSO", "IFNG", "DMSO"],
+        "cell_medium": ["DMSO", ifng, "DMSO"],
         "sample_note": ["was ok", "looks naah", "pretty! 🤩"],
         "cell_type_by_expert": ["B cell", "T cell", "T cell"],
         "cell_type_by_model": ["B cell", "T cell", "T cell"],
@@ -30,12 +32,44 @@ def small_dataset1(
     }
     # the dataset as DataFrame
     dataset_df = pd.DataFrame(dataset_dict, index=["sample1", "sample2", "sample3"])
-    dataset_ad = ad.AnnData(
-        dataset_df.iloc[:, :3], obs=dataset_df.iloc[:, 3:], uns=metadata
+    if format == "df":
+        return dataset_df, metadata
+    else:
+        dataset_ad = ad.AnnData(
+            dataset_df.iloc[:, :3], obs=dataset_df.iloc[:, 3:], uns=metadata
+        )
+        return dataset_ad
+
+
+def small_dataset2(
+    format: Literal["df", "anndata"],
+) -> tuple[pd.DataFrame, dict[str, Any]] | ad.AnnData:
+    dataset_dict = {
+        "CD8A": [2, 3, 3],
+        "CD4": [3, 4, 5],
+        "CD38": [4, 2, 3],
+        "cell_medium": ["DMSO", "IFNG", "IFNG"],
+        "cell_type_by_model": ["B cell", "T cell", "T cell"],
+    }
+    metadata = {
+        "temperature": 22.6,
+        "study": "Candidate marker study 2",
+        "date_of_study": "2025-02-13",
+    }
+    dataset_df = pd.DataFrame(
+        dataset_dict,
+        index=["sample4", "sample5", "sample6"],
+    )
+    ad.AnnData(
+        dataset_df[["CD8A", "CD4", "CD38"]],
+        obs=dataset_df[["cell_medium", "cell_type_by_model"]],
     )
     if format == "df":
         return dataset_df, metadata
     else:
+        dataset_ad = ad.AnnData(
+            dataset_df.iloc[:, :3], obs=dataset_df.iloc[:, 3:], uns=metadata
+        )
         return dataset_ad
 
 

--- a/tests/core/test_queryset.py
+++ b/tests/core/test_queryset.py
@@ -8,30 +8,23 @@ from lnschema_core.users import current_user_id
 
 
 def test_df():
-    # for self-referential models
-    project_label = ln.ULabel(name="Project")
-    project_label.save()
+    project_label = ln.ULabel(name="project").save()
     project_names = [f"Project {i}" for i in range(3)]
-    labels = [ln.ULabel(name=name) for name in project_names]
-    ln.save(labels)
-    for label in labels:
-        label.parents.add(project_label)
-    df = ln.ULabel.filter().df(include="parents__name")
+    labels = ln.ULabel.from_values(project_names, create=True).save()
+    project_label.children.add(*labels)
+    df = ln.ULabel.df(include="parents__name")
     assert df.columns[0] == "parents__name"
-    # order is not conserved
-    assert df["parents__name"].iloc[0] == [project_label.name]
-    # pass a list
-    df = ln.ULabel.filter().df(include=["parents__name", "parents__created_by_id"])
+    assert df["parents__name"].iloc[0] == {project_label.name}
+    df = ln.ULabel.df(include=["parents__name", "parents__created_by_id"])
     assert df.columns[1] == "parents__created_by_id"
-    assert df["parents__name"].iloc[0] == [project_label.name]
+    assert df["parents__name"].iloc[0] == {project_label.name}
     assert set(df["parents__created_by_id"].iloc[0]) == {current_user_id()}
 
     # for other models
     feature_names = [f"Feature {i}" for i in range(3)]
     features = [ln.Feature(name=name, dtype=int) for name in feature_names]
     ln.save(features)
-    feature_set = ln.FeatureSet(features, name="my feature_set")
-    feature_set.save()
+    feature_set = ln.FeatureSet(features, name="my feature_set").save()
     feature_set.features.set(features)
 
     df = ln.FeatureSet.filter(name="my feature_set").df(include="features__name")
@@ -48,18 +41,8 @@ def test_df():
 
     # inner join parents on features
     df = ln.FeatureSet.filter().df(
-        include=["features__name", "features__created_by_id"], join="inner"
+        include=["features__name", "features__created_by_id"]
     )
-    print(df)
-    assert set(df["features__name"].iloc[0]) == set(feature_names)
-    assert set(df["features__created_by_id"].iloc[0]) == {current_user_id()}
-
-    # outer join parents on features (this test should be expanded to make it
-    # actually relevant)
-    df = ln.FeatureSet.filter().df(
-        include=["features__name", "features__created_by_id"], join="outer"
-    )
-    print(df)
     assert set(df["features__name"].iloc[0]) == set(feature_names)
     assert set(df["features__created_by_id"].iloc[0]) == {current_user_id()}
 
@@ -68,14 +51,16 @@ def test_df():
     assert df["created_by__name"].iloc[0] == "Test User1"
 
     # do not return fields with no data in the registry
-    df = (
-        ln.Artifact.using("laminlabs/cellxgene")
-        .filter(suffix=".h5ad")
-        .df(include=["tissues__name", "pathways__name"])
-    )
-    assert "tissues__name" in df.columns
-    assert "pathways__name" not in df.columns
-    assert df.shape[0] > 0
+    # does not make sense in Alex's opinion
+    # too much magic; got removed in https://github.com/laminlabs/lamindb/pull/2238
+    # df = (
+    #     ln.Artifact.using("laminlabs/cellxgene")
+    #     .filter(suffix=".h5ad")
+    #     .df(include=["tissues__name", "pathways__name"])
+    # )
+    # assert "tissues__name" in df.columns
+    # assert "pathways__name" not in df.columns
+    # assert df.shape[0] > 0
 
     # clean up
     project_label.delete()

--- a/tests/core/test_queryset.py
+++ b/tests/core/test_queryset.py
@@ -13,10 +13,10 @@ def test_df():
     labels = ln.ULabel.from_values(project_names, create=True).save()
     project_label.children.add(*labels)
     df = ln.ULabel.df(include="parents__name")
-    assert df.columns[0] == "parents__name"
+    assert df.columns[3] == "parents__name"
     assert df["parents__name"].iloc[0] == {project_label.name}
     df = ln.ULabel.df(include=["parents__name", "parents__created_by_id"])
-    assert df.columns[1] == "parents__created_by_id"
+    assert df.columns[4] == "parents__created_by_id"
     assert df["parents__name"].iloc[0] == {project_label.name}
     assert set(df["parents__created_by_id"].iloc[0]) == {current_user_id()}
 
@@ -28,14 +28,14 @@ def test_df():
     feature_set.features.set(features)
 
     df = ln.FeatureSet.filter(name="my feature_set").df(include="features__name")
-    assert df.columns[0] == "features__name"
+    assert df.columns[3] == "features__name"
     # order is not conserved
     assert set(df["features__name"].iloc[0]) == set(feature_names)
     # pass a list
     df = ln.FeatureSet.filter(name="my feature_set").df(
         include=["features__name", "features__created_by_id"]
     )
-    assert df.columns[1] == "features__created_by_id"
+    assert df.columns[4] == "features__created_by_id"
     assert set(df["features__name"].iloc[0]) == set(feature_names)
     assert set(df["features__created_by_id"].iloc[0]) == {current_user_id()}
 


### PR DESCRIPTION
## Summary

You can now easily join features onto the `Artifact` registry.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/6ccddefd-019d-424c-81b0-255426a94b5d">

We find the features from the schema definition, independent of whether they are used as observation-level or dataset-level metadata.

```python
ln.Feature(name="cell_medium", dtype="cat[ULabel]").save()
ln.Feature(name="cell_type_by_expert", dtype="cat[bionty.CellType]").save()
ln.Feature(name="cell_type_by_model", dtype="cat[bionty.CellType]").save()
ln.Feature(name="temperature", dtype="float").save()
ln.Feature(name="study", dtype="cat[ULabel]").save()
ln.Feature(name="date_of_study", dtype="date").save()
ln.Feature(name="study_note", dtype="str").save()
```

Here is another screenshot, scrolling the table further to the right.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/6c86df28-9aa0-4fa4-b3d7-35a890f0176b">


More changes.

- `QuerySet.df(include=[...])` now relies on `.annotate()` instead of `pandas` for simple join on Django fields
- `ln.view(df)` displays a DataFrame with types in the columns

## Docs changes

Overhauled the `registries` guide.

Before | After
--- | ---
<img width="201" alt="image" src="https://github.com/user-attachments/assets/0998f533-b1f5-494b-bbdc-4554ffd734ab"> | Better section names<br><img width="183" alt="image" src="https://github.com/user-attachments/assets/5f3c605f-9fdb-4ea3-ada2-134855858ad8">
First impression was on generating "toy data"<img width="807" alt="image" src="https://github.com/user-attachments/assets/47be01a4-f1e6-431c-a3eb-10fbd37cb1a2"> | The first impression is now on a "Get an overview" section  <img width="400" alt="image" src="https://github.com/user-attachments/assets/299375bc-0591-40e5-a7e6-f93146b32a21"> 
/ | The guide now leverages `small_dataset1` and `small_dataset2` as many tests & the quickstart  <img width="400" alt="image" src="https://github.com/user-attachments/assets/404d5ffb-e047-4eb7-92ac-fde75863674f"><img width="400" alt="image" src="https://github.com/user-attachments/assets/0d59570e-97c3-43e4-b9ca-ff52f6f4cbab">
/ | It's documented how to include fields from other registries and these start at position 3 in the columns <img width="806" alt="image" src="https://github.com/user-attachments/assets/e05d5fd9-349c-4528-89d6-54423cbf7813">
/ | You can now easily join features onto the Artifact registry <img width="815" alt="image" src="https://github.com/user-attachments/assets/6ccddefd-019d-424c-81b0-255426a94b5d"> <img width="811" alt="image" src="https://github.com/user-attachments/assets/6c86df28-9aa0-4fa4-b3d7-35a890f0176b">
<img width="811" alt="image" src="https://github.com/user-attachments/assets/ece1d5e2-f4a9-47c6-8ad6-baab03c60417"> | <img width="805" alt="image" src="https://github.com/user-attachments/assets/7ad33ab7-339d-4876-8ad3-8d29b1572df8">
<img width="814" alt="image" src="https://github.com/user-attachments/assets/63e34e52-3b62-4f51-bbd3-a6b209d84f2b"> | <img width="812" alt="image" src="https://github.com/user-attachments/assets/115d4aa0-7094-456f-992a-012db89f6e3f">
<img width="814" alt="image" src="https://github.com/user-attachments/assets/f831d70e-a33c-4cf2-a10c-52d8e3d05a99"> | <img width="816" alt="image" src="https://github.com/user-attachments/assets/3e483dce-f514-467b-9590-e062eb3a53db">

## Materials

Needs:

- https://github.com/laminlabs/lndocs/pull/111
- https://github.com/laminlabs/lnschema-core/pull/462

