### PR TITLE
⬆️ Add a lower bound for pandas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "pyarrow",
     "typing_extensions!=4.6.0",
     "python-dateutil",
+    "pandas>=2.0.0", # for .infer_objects(copy=False) in lamin-utils
     "anndata>=0.8.0,<=0.11.1",  # will upgrade to new anndata releases
     "fsspec",
     "graphviz",


### PR DESCRIPTION
Fix https://github.com/laminlabs/lamindb/issues/2227
this is needed because `.infer_objects` doesnt have the `copy` argument before `pandas==2.0.0`, and it is used [here](https://github.com/laminlabs/lamin-utils/blob/2b9d4fcc865c8241752f10860411d516079f16a0/lamin_utils/_map_synonyms.py#L159).