### PR TITLE
🐛 Fix the error on existing cache on copy to cache in Artifact.save

### DIFF
--- a/lamindb/_save.py
+++ b/lamindb/_save.py
@@ -184,10 +184,17 @@ def copy_or_move_to_cache(
         return None
     # non-local storage_path further
     if local_path != cache_path:
-        cache_path.parent.mkdir(parents=True, exist_ok=True)
-        if cache_dir in local_path.parents:
+        if cache_path.exists():
+            logger.warning(
+                f"The cache path {cache_path.as_posix()} already exists, replacing it."
+            )
             if cache_path.is_dir():
                 shutil.rmtree(cache_path)
+            else:
+                cache_path.unlink()
+        else:
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+        if cache_dir in local_path.parents:
             local_path.replace(cache_path)
         else:
             if is_dir:


### PR DESCRIPTION
Fixes a problem when `Artifact.save()` is called on a cloud instance but cache with the same path already exists, happens when an `Artifact` is deleted and then created again.