### PR TITLE
🎨 Remove quotes and rename sessions in describe

### DIFF
--- a/lamindb/core/_feature_manager.py
+++ b/lamindb/core/_feature_manager.py
@@ -409,7 +409,7 @@ def describe_features(
     if to_dict:
         return dictionary
 
-    # Internal features section
+    # Dataset featuers section
     # internal features that contain labels (only `Feature` features contain labels)
     internal_feature_labels_slot: dict[str, list] = {}
     for feature_name, feature_row in internal_feature_labels.items():
@@ -465,7 +465,7 @@ def describe_features(
     if int_features_tree_children:
         dataset_tree = tree.add(
             Text.assemble(
-                ("Internal features", "bold bright_magenta"),
+                ("Dataset featuers", "bold bright_magenta"),
                 ("/", "dim"),
                 (".feature_sets", "dim bold"),
             )
@@ -473,7 +473,7 @@ def describe_features(
         for child in int_features_tree_children:
             dataset_tree.add(child)
 
-    # External features
+    # Linked featuers
     ext_features_tree_children = []
     if external_data:
         ext_features_tree_children.append(
@@ -485,7 +485,7 @@ def describe_features(
         )
     # ext_features_tree = None
     ext_features_header = Text(
-        "Params" if print_params else "External features", style="bold dark_orange"
+        "Params" if print_params else "Linked featuers", style="bold dark_orange"
     )
     if ext_features_tree_children:
         ext_features_tree = tree.add(ext_features_header)

--- a/lamindb/core/_label_manager.py
+++ b/lamindb/core/_label_manager.py
@@ -113,7 +113,9 @@ def describe_labels(
             print_values = _print_values(labels.values(), n=10)
         else:  # labels are a QuerySet
             field = get_name_field(labels)
-            print_values = _print_values(labels.values_list(field, flat=True), n=10)
+            print_values = _print_values(
+                labels.values_list(field, flat=True), n=10, sep=""
+            )
         if print_values:
             related_model = get_related_model(self, related_name)
             type_str = related_model.__get_name_with_schema__()

--- a/lamindb/core/_label_manager.py
+++ b/lamindb/core/_label_manager.py
@@ -110,11 +110,11 @@ def describe_labels(
         if not labels or related_name == "feature_sets":
             continue
         if isinstance(labels, dict):  # postgres, labels are a dict[id, name]
-            print_values = _print_values(labels.values(), n=10)
+            print_values = _print_values(labels.values(), n=10, quotes=False)
         else:  # labels are a QuerySet
             field = get_name_field(labels)
             print_values = _print_values(
-                labels.values_list(field, flat=True), n=10, sep=""
+                labels.values_list(field, flat=True), n=10, quotes=False
             )
         if print_values:
             related_model = get_related_model(self, related_name)

--- a/tests/core/test_describe_df.py
+++ b/tests/core/test_describe_df.py
@@ -237,8 +237,8 @@ def test_curate_df():
     assert labels_node.children[0].label.columns[1]._cells[0].plain == "bionty.CellType"
     assert labels_node.children[0].label.columns[1]._cells[1].plain == "ULabel"
     assert labels_node.children[0].label.columns[2]._cells == [
-        "'B cell', 'T cell'",
-        "'DMSO', 'IFNG', 'Candidate marker study 1'",
+        "B cell, T cell",
+        "DMSO, IFNG, Candidate marker study 1",
     ]
 
     artifact.delete(permanent=True)

--- a/tests/core/test_describe_df.py
+++ b/tests/core/test_describe_df.py
@@ -160,7 +160,7 @@ def test_curate_df():
 
     # dataset section
     int_features_node = description_tree.children[1]
-    assert int_features_node.label.plain == "Internal features/.feature_sets"
+    assert int_features_node.label.plain == "Dataset featuers/.feature_sets"
     assert len(int_features_node.children) == 2
     assert len(int_features_node.children[0].label.rows) == 3
     assert len(int_features_node.children[0].label.columns) == 3
@@ -202,7 +202,7 @@ def test_curate_df():
 
     # external features section
     ext_features_node = description_tree.children[2]
-    assert ext_features_node.label.plain == "External features"
+    assert ext_features_node.label.plain == "Linked featuers"
     assert len(ext_features_node.children) == 1
     assert len(ext_features_node.children[0].label.columns) == 3
     assert len(ext_features_node.children[0].label.rows) == 4

--- a/tests/core/test_feature_label_manager.py
+++ b/tests/core/test_feature_label_manager.py
@@ -219,7 +219,7 @@ Here is how to create ulabels for them:
     tree = describe_features(artifact)
     print_rich_tree(tree)
     assert tree.label.plain == "Artifact .h5ad/AnnData"
-    assert tree.children[0].label.plain == "External features"
+    assert tree.children[0].label.plain == "Linked featuers"
     assert len(tree.children[0].children[0].label.columns) == 3
     assert len(tree.children[0].children[0].label.rows) == 10
     assert tree.children[0].children[0].label.columns[0]._cells == [


### PR DESCRIPTION
`Internal features` → `Dataset features`
`External features` → `Linked features`

Before | After
--- | ---
<img width="784" alt="Screenshot 2024-12-05 at 16 47 05" src="https://github.com/user-attachments/assets/6c81f50a-1162-466e-81fb-e00834ba1eb8"> | <img width="780" alt="Screenshot 2024-12-05 at 16 52 42" src="https://github.com/user-attachments/assets/353c7cd8-f936-41bf-9380-54e353ac2991">

