### PR TITLE
🐛 Fix the error on special chars in search strings

### DIFF
--- a/docs/faq/search.ipynb
+++ b/docs/faq/search.ipynb
@@ -50,6 +50,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a95bcef6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln.ULabel(name=\"cat[*_*]\").save()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "799b528e",
    "metadata": {},
@@ -95,6 +105,34 @@
     "    top_record = qs[0]\n",
     "    query = query.lower()\n",
     "    assert query in top_record.name.lower() or query in top_record.synonyms.lower()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00427176",
+   "metadata": {},
+   "source": [
+    "Check escaping of special characters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cea360c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert len(ln.ULabel.search(\"cat[\")) == 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04f1e84a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert len(ln.ULabel.search(\"*_*\")) == 1"
    ]
   },
   {


### PR DESCRIPTION
`ln.Feature.search("cat[")` errors without this fix because unclosed `"["` is considered an incorrect regex.