### PR TITLE
🐛 Better error behavior for repeated calls of `standardize`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,23 +29,28 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+
       - uses: actions/setup-python@v5
         if: ${{ matrix.group == 'storage' }}
         with:
           python-version: "3.9"
+
       - uses: actions/setup-python@v5
         if: ${{ matrix.group == 'unit-storage' }}
         with:
           python-version: "3.11" # there are problems with installation time with python 3.12
+
       - uses: actions/setup-python@v5
         if: ${{ matrix.group != 'storage' && matrix.group != 'unit-storage'}}
         with:
           python-version: "3.12"
+
       - name: cache pre-commit
         uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+
       - name: cache postgres
         if: ${{ matrix.group == 'faq' || matrix.group == 'unit-core' || matrix.group == 'unit-storage' }}
         id: cache-postgres
@@ -63,9 +68,11 @@ jobs:
       - name: install postgres
         if: ${{ matrix.group == 'faq' }}
         run: sudo apt-get install libpq-dev
+
       - name: install graphviz
         if: ${{ matrix.group == 'tutorial' || matrix.group == 'guide' || matrix.group == 'biology' }}
         run: sudo apt-get -y install graphviz
+
       - run: nox -s lint
         if: ${{ matrix.group == 'tutorial' }} # choose a fast-running a group
       - run: nox -s "install_ci(group='${{ matrix.group }}')"
@@ -75,12 +82,14 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
       - run: nox -s "build(group='${{ matrix.group }}')"
+
       - name: upload coverage
         uses: actions/upload-artifact@v4
         with:
           name: coverage--${{ matrix.group }}
           path: .coverage
           include-hidden-files: true
+
       - name: upload docs
         if: ${{ matrix.group == 'tutorial' || matrix.group == 'guide' || matrix.group == 'biology' || matrix.group == 'faq' || matrix.group == 'storage' }}
         uses: actions/upload-artifact@v4
@@ -96,6 +105,7 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+
       - name: checkout lndocs
         uses: actions/checkout@v4
         with:
@@ -103,11 +113,13 @@ jobs:
           ssh-key: ${{ secrets.READ_LNDOCS }}
           path: lndocs
           ref: main
+
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10" # use 3.10 because 3.11+ give issues (ablog lacks 3.12 support)
@@ -124,6 +136,7 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+
       - uses: peter-evans/repository-dispatch@v2
         if: ${{ github.event_name == 'push' }}
         with:
@@ -143,6 +156,7 @@ jobs:
           python -m pip install -U uv
           uv pip install --system coverage[toml]
           uv pip install --system --no-deps .
+
       - uses: actions/download-artifact@v4
       - name: run coverage
         run: |

--- a/lamindb/_can_curate.py
+++ b/lamindb/_can_curate.py
@@ -10,7 +10,7 @@ from lamin_utils import colors, logger
 from lamindb_setup.core._docs import doc_args
 from lnschema_core import CanCurate, Record
 
-from ._from_values import _has_organism_field, _print_values, get_or_create_records
+from ._from_values import _format_values, _has_organism_field, get_or_create_records
 from ._record import _queryset, get_name_field
 from ._utils import attach_func_to_class_method
 from .core.exceptions import ValidationError
@@ -168,7 +168,7 @@ def _inspect(
             bionty_mapper = bionty_result.synonyms_mapper
             hint = False
             if len(bionty_validated) > 0 and not mute:
-                print_values = _print_values(bionty_validated)
+                print_values = _format_values(bionty_validated)
                 s = "" if len(bionty_validated) == 1 else "s"
                 labels = colors.yellow(f"{len(bionty_validated)} {model_name} term{s}")
                 logger.print(
@@ -178,7 +178,7 @@ def _inspect(
                 hint = True
 
             if len(bionty_mapper) > 0 and not mute:
-                print_values = _print_values(list(bionty_mapper.keys()))
+                print_values = _format_values(list(bionty_mapper.keys()))
                 s = "" if len(bionty_mapper) == 1 else "s"
                 labels = colors.yellow(f"{len(bionty_mapper)} {model_name} term{s}")
                 logger.print(
@@ -199,7 +199,7 @@ def _inspect(
             logger.warning("no Bionty source found, skipping Bionty validation")
 
     if len(nonval) > 0 and not mute:
-        print_values = _print_values(list(nonval))
+        print_values = _format_values(list(nonval))
         s = "" if len(nonval) == 1 else "s"
         labels = colors.red(f"{len(nonval)} term{s}")
         logger.print(f"   couldn't validate {labels}: {colors.red(print_values)}")

--- a/lamindb/_curate.py
+++ b/lamindb/_curate.py
@@ -221,9 +221,14 @@ class DataFrameCurator(BaseCurator):
         super().__init_subclass__(**kwargs)
         import sys
 
+        # Debug version - show us what's in sys.modules
+        sphinx_modules = [m for m in sys.modules if "sphinx" in m.lower()]
+        if sphinx_modules:
+            raise RuntimeError(f"Unexpected sphinx modules found: {sphinx_modules}")
+
         # Deprecated methods
         if "sphinx" not in sys.modules:
-            cls.add_new_from_columns = cls._add_new_from_columns
+            cls.add_new_from_columns = classmethod(cls._add_new_from_columns)
 
     @property
     def non_validated(self) -> dict[str, list[str]]:

--- a/lamindb/_curate.py
+++ b/lamindb/_curate.py
@@ -21,7 +21,7 @@ from lnschema_core import (
     ULabel,
 )
 
-from ._from_values import _print_values
+from ._from_values import _format_values
 from .core.exceptions import ValidationError
 
 if TYPE_CHECKING:
@@ -261,7 +261,7 @@ class DataFrameCurator(BaseCurator):
             are = "are" if n > 1 else "is"
             if len(nonval_keys) > 0:
                 raise ValidationError(
-                    f"the following {n} key{s} passed to {name} {are} not allowed: {colors.yellow(_print_values(nonval_keys))}"
+                    f"the following {n} key{s} passed to {name} {are} not allowed: {colors.yellow(_format_values(nonval_keys))}"
                 )
 
     def _save_columns(self, validated_only: bool = True) -> None:
@@ -329,7 +329,7 @@ class DataFrameCurator(BaseCurator):
         # logging
         n = len(syn_mapper)
         if n > 0:
-            syn_mapper_print = _print_values(
+            syn_mapper_print = _format_values(
                 [f'"{k}" → "{v}"' for k, v in syn_mapper.items()], sep=""
             )
             s = "s" if n > 1 else ""
@@ -366,7 +366,7 @@ class DataFrameCurator(BaseCurator):
         else:
             if key not in avail_keys:
                 raise KeyError(
-                    f"{key!r} is not a valid key, available keys are: {_print_values(avail_keys)}!"
+                    f"{key!r} is not a valid key, available keys are: {_format_values(avail_keys)}!"
                 )
             else:
                 if key in self._fields:  # needed to exclude var_index
@@ -1073,7 +1073,7 @@ def _maybe_curation_keys_not_present(nonval_keys: list[str], name: str):
         s = "s" if n > 1 else ""
         are = "are" if n > 1 else "is"
         raise ValidationError(
-            f"the following {n} key{s} passed to {name} {are} not allowed: {colors.yellow(_print_values(nonval_keys))}"
+            f"the following {n} key{s} passed to {name} {are} not allowed: {colors.yellow(_format_values(nonval_keys))}"
         )
 
 
@@ -1333,7 +1333,7 @@ class SOMACurator(BaseCurator):
             )
             if key not in avail_keys:
                 raise KeyError(
-                    f'"{key!r}" is not a valid key, available keys are: {_print_values(avail_keys + ["all"])}!'
+                    f"'{key!r}' is not a valid key, available keys are: {_format_values(avail_keys + ['all'])}!"
                 )
             keys = [key]
         for k in keys:
@@ -1409,7 +1409,7 @@ class SOMACurator(BaseCurator):
         else:
             if key not in avail_keys:
                 raise KeyError(
-                    f'"{key!r}" is not a valid key, available keys are: {_print_values(avail_keys + ["all"])}!'
+                    f"'{key!r}' is not a valid key, available keys are: {_format_values(avail_keys + ['all'])}!"
                 )
             keys = [key]
 
@@ -1461,7 +1461,7 @@ class SOMACurator(BaseCurator):
             ]
             self._non_validated_values[k] = non_val_k
 
-            syn_mapper_print = _print_values(
+            syn_mapper_print = _format_values(
                 [f'"{m_k}" → "{m_v}"' for m_k, m_v in syn_mapper.items()], sep=""
             )
             s = "s" if n_syn_mapper > 1 else ""
@@ -1777,7 +1777,7 @@ def validate_categories(
         standardize: Whether to standardize the values.
         hint_print: The hint to print that suggests fixing non-validated values.
     """
-    from lamindb._from_values import _print_values
+    from lamindb._from_values import _format_values
     from lamindb.core._settings import settings
 
     model_field = f"{field.field.model.__name__}.{field.field.name}"
@@ -1850,11 +1850,11 @@ def validate_categories(
     else:
         are = "is" if n_non_validated == 1 else "are"
         s = "" if n_non_validated == 1 else "s"
-        print_values = _print_values(non_validated)
+        print_values = _format_values(non_validated)
         warning_message = f"{colors.red(f'{n_non_validated} term{s}')} {are} not validated: {colors.red(print_values)}\n"
         if syn_mapper:
             s = "" if len(syn_mapper) == 1 else "s"
-            syn_mapper_print = _print_values(
+            syn_mapper_print = _format_values(
                 [f'"{k}" → "{v}"' for k, v in syn_mapper.items()], sep=""
             )
             hint_msg = f'.standardize("{key}")'
@@ -2235,7 +2235,7 @@ def log_saved_labels(
     validated_only: bool = True,
 ) -> None:
     """Log the saved labels."""
-    from ._from_values import _print_values
+    from ._from_values import _format_values
 
     model_field = colors.italic(model_field)
     for k, labels in labels_saved.items():
@@ -2249,7 +2249,7 @@ def log_saved_labels(
             # labels from a public ontology or a different instance to the present instance
             s = "s" if len(labels) > 1 else ""
             logger.success(
-                f'added {len(labels)} record{s} {k}with {model_field} for "{key}": {_print_values(labels)}'
+                f'added {len(labels)} record{s} {k}with {model_field} for "{key}": {_format_values(labels)}'
             )
 
 

--- a/lamindb/_curate.py
+++ b/lamindb/_curate.py
@@ -111,6 +111,14 @@ class CurateLookup:
 class BaseCurator:
     """Curate a dataset."""
 
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        import sys
+
+        # Deprecated methods
+        if "sphinx" not in sys.modules:
+            cls.add_new_from_columns = cls._add_new_from_columns
+
     def validate(self) -> bool:
         """Validate dataset.
 
@@ -216,19 +224,6 @@ class DataFrameCurator(BaseCurator):
         if check_valid_keys:
             self._check_valid_keys()
         self._save_columns()
-
-    def __init_subclass__(cls, **kwargs):
-        super().__init_subclass__(**kwargs)
-        import sys
-
-        # Debug version - show us what's in sys.modules
-        sphinx_modules = [m for m in sys.modules if "sphinx" in m.lower()]
-        if sphinx_modules:
-            raise RuntimeError(f"Unexpected sphinx modules found: {sphinx_modules}")
-
-        # Deprecated methods
-        if "sphinx" not in sys.modules:
-            cls.add_new_from_columns = classmethod(cls._add_new_from_columns)
 
     @property
     def non_validated(self) -> dict[str, list[str]]:
@@ -1085,7 +1080,7 @@ def _maybe_curation_keys_not_present(nonval_keys: list[str], name: str):
         s = "s" if n > 1 else ""
         are = "are" if n > 1 else "is"
         raise ValidationError(
-            f"the following {n} key{s} passed to {name} {are} not allowed: {colors.yellow(_format_values(nonval_keys))}"
+            f"key{s} passed to {name} {are} not present: {colors.yellow(_format_values(nonval_keys))}"
         )
 
 

--- a/lamindb/_curate.py
+++ b/lamindb/_curate.py
@@ -347,7 +347,15 @@ class DataFrameCurator(BaseCurator):
             )
         return std_values
 
-    def standardize(self, key: str):
+    def standardize(self, key: str) -> None:
+        """Replace synonyms with standardized values.
+
+        Modifies the input dataset inplace.
+
+        Args:
+            key: The key referencing the column in the DataFrame to standardize.
+        """
+        # list is needed to avoid RuntimeError: dictionary changed size during iteration
         avail_keys = list(self.non_validated.keys())
         if len(avail_keys) == 0:
             logger.warning("values are already standardized")

--- a/lamindb/_curate.py
+++ b/lamindb/_curate.py
@@ -117,7 +117,8 @@ class BaseCurator:
 
         # Deprecated methods
         if "sphinx" not in sys.modules:
-            cls.add_new_from_columns = cls._add_new_from_columns
+            if hasattr(cls, "_add_new_from_columns"):
+                cls.add_new_from_columns = cls._add_new_from_columns
 
     def validate(self) -> bool:
         """Validate dataset.

--- a/lamindb/_curate.py
+++ b/lamindb/_curate.py
@@ -366,7 +366,7 @@ class DataFrameCurator(BaseCurator):
         else:
             if key not in avail_keys:
                 raise KeyError(
-                    f'"{key}" is not a valid key, available keys are: {_print_values(avail_keys)}!'
+                    f"{key!r} is not a valid key, available keys are: {_print_values(avail_keys)}!"
                 )
             else:
                 if key in self._fields:  # needed to exclude var_index
@@ -1333,7 +1333,7 @@ class SOMACurator(BaseCurator):
             )
             if key not in avail_keys:
                 raise KeyError(
-                    f'"{key}" is not a valid key, available keys are: {_print_values(avail_keys + ["all"])}!'
+                    f'"{key!r}" is not a valid key, available keys are: {_print_values(avail_keys + ["all"])}!'
                 )
             keys = [key]
         for k in keys:
@@ -1409,7 +1409,7 @@ class SOMACurator(BaseCurator):
         else:
             if key not in avail_keys:
                 raise KeyError(
-                    f'"{key}" is not a valid key, available keys are: {_print_values(avail_keys + ["all"])}!'
+                    f'"{key!r}" is not a valid key, available keys are: {_print_values(avail_keys + ["all"])}!'
                 )
             keys = [key]
 

--- a/lamindb/_from_values.py
+++ b/lamindb/_from_values.py
@@ -95,7 +95,7 @@ def get_or_create_records(
                 if len(msg) > 0 and not mute:
                     logger.success(msg)
                 s = "" if len(unmapped_values) == 1 else "s"
-                print_values = colors.yellow(_print_values(unmapped_values))
+                print_values = colors.yellow(_format_values(unmapped_values))
                 name = registry.__name__
                 n_nonval = colors.yellow(f"{len(unmapped_values)} non-validated")
                 if not mute:
@@ -167,7 +167,7 @@ def get_existing_records(
     if not mute:
         if len(validated) > 0:
             s = "" if len(validated) == 1 else "s"
-            print_values = colors.green(_print_values(validated))
+            print_values = colors.green(_format_values(validated))
             msg = (
                 "loaded"
                 f" {colors.green(f'{len(validated)} {model.__name__} record{s}')}"
@@ -176,7 +176,7 @@ def get_existing_records(
         if len(syn_mapper) > 0:
             s = "" if len(syn_mapper) == 1 else "s"
             names = list(syn_mapper.keys())
-            print_values = colors.green(_print_values(names))
+            print_values = colors.green(_format_values(names))
             syn_msg = (
                 "loaded"
                 f" {colors.green(f'{len(syn_mapper)} {model.__name__} record{s}')}"
@@ -243,7 +243,7 @@ def create_records_from_source(
     if len(syn_mapper) > 0:
         s = "" if len(syn_mapper) == 1 else "s"
         names = list(syn_mapper.keys())
-        print_values = colors.purple(_print_values(names))
+        print_values = colors.purple(_format_values(names))
         msg_syn = (
             "created"
             f" {colors.purple(f'{len(syn_mapper)} {model.__name__} record{s} from Bionty')}"
@@ -277,7 +277,7 @@ def create_records_from_source(
         validated = result.validated
         if len(validated) > 0:
             s = "" if len(validated) == 1 else "s"
-            print_values = colors.purple(_print_values(validated))
+            print_values = colors.purple(_format_values(validated))
             # this is the success msg for existing records in the DB
             if len(msg) > 0 and not mute:
                 logger.success(msg)
@@ -307,7 +307,7 @@ def index_iterable(iterable: Iterable) -> pd.Index:
     return idx[(idx != "") & (~idx.isnull())]
 
 
-def _print_values(
+def _format_values(
     names: Iterable, n: int = 20, quotes: bool = True, sep: str = "'"
 ) -> str:
     if isinstance(names, dict):
@@ -317,6 +317,7 @@ def _print_values(
             if key != "None" and value != "None"
         }
     else:
+        # Use a dictionary instead of a list to have unique values and preserve order
         items = {str(name): None for name in names if name != "None"}
 
     unique_items = list(items.keys())
@@ -344,7 +345,7 @@ def _bulk_create_dicts_from_df(
         dup = df.index[df.index.duplicated()].unique().tolist()
         if len(dup) > 0:
             s = "" if len(dup) == 1 else "s"
-            print_values = _print_values(dup)
+            print_values = _format_values(dup)
             multi_msg = (
                 f"ambiguous validation in Bionty for {len(dup)} record{s}:"
                 f" {print_values}"

--- a/lamindb/_from_values.py
+++ b/lamindb/_from_values.py
@@ -317,7 +317,6 @@ def _print_values(
             if key != "None" and value != "None"
         }
     else:
-        # Use a dictionary instead of a list to have unique values and preserve order
         items = {str(name): None for name in names if name != "None"}
 
     unique_items = list(items.keys())

--- a/lamindb/core/_feature_manager.py
+++ b/lamindb/core/_feature_manager.py
@@ -42,7 +42,7 @@ from lamindb._feature import (
     suggest_categorical_for_str_iterable,
 )
 from lamindb._feature_set import DICT_KEYS_TYPE, FeatureSet
-from lamindb._from_values import _print_values
+from lamindb._from_values import _format_values
 from lamindb._record import (
     REGISTRY_UNIQUE_FIELD,
     get_name_field,
@@ -390,7 +390,7 @@ def describe_features(
 
             # Format message
             printed_values = (
-                _print_values(sorted(values), n=10, quotes=False)
+                _format_values(sorted(values), n=10, quotes=False)
                 if not is_list_type or not feature_dtype.startswith("list")
                 else sorted(values)
             )

--- a/lamindb/core/_label_manager.py
+++ b/lamindb/core/_label_manager.py
@@ -11,7 +11,7 @@ from rich.table import Column, Table
 from rich.text import Text
 from rich.tree import Tree
 
-from lamindb._from_values import _print_values
+from lamindb._from_values import _format_values
 from lamindb._record import (
     REGISTRY_UNIQUE_FIELD,
     get_name_field,
@@ -110,10 +110,10 @@ def describe_labels(
         if not labels or related_name == "feature_sets":
             continue
         if isinstance(labels, dict):  # postgres, labels are a dict[id, name]
-            print_values = _print_values(labels.values(), n=10, quotes=False)
+            print_values = _format_values(labels.values(), n=10, quotes=False)
         else:  # labels are a QuerySet
             field = get_name_field(labels)
-            print_values = _print_values(
+            print_values = _format_values(
                 labels.values_list(field, flat=True), n=10, quotes=False
             )
         if print_values:

--- a/tests/core/test_curator.py
+++ b/tests/core/test_curator.py
@@ -458,14 +458,14 @@ def test_soma_curator(adata, categoricals):
             categoricals={"invalid_key": bt.CellType.name},
         )
 
-    with pytest.raises(ValidationError, match="key passed to var_index is not allowed"):
+    with pytest.raises(ValidationError, match="key passed to var_index is not present"):
         ln.Curator.from_tiledbsoma(
             "curate.tiledbsoma",
             {"RNA": ("invalid_key", bt.Gene.symbol)},
             categoricals={"cell_type": bt.CellType.name},
         )
 
-    with pytest.raises(ValidationError, match="key passed to sources is not allowed"):
+    with pytest.raises(ValidationError, match="key passed to sources is not present"):
         ln.Curator.from_tiledbsoma(
             "curate.tiledbsoma",
             {"RNA": ("var_id", bt.Gene.symbol)},

--- a/tests/core/test_curator.py
+++ b/tests/core/test_curator.py
@@ -449,7 +449,9 @@ def test_mudata_curator(mdata):
 def test_soma_curator(adata, categoricals):
     tiledbsoma.io.from_anndata("curate.tiledbsoma", adata, measurement_name="RNA")
 
-    with pytest.raises(ValidationError, match="key not present"):
+    with pytest.raises(
+        ValidationError, match="key passed to categoricals is not present"
+    ):
         ln.Curator.from_tiledbsoma(
             "curate.tiledbsoma",
             {"RNA": ("var_id", bt.Gene.symbol)},

--- a/tests/core/test_curator.py
+++ b/tests/core/test_curator.py
@@ -1,4 +1,5 @@
 import shutil
+from pathlib import Path
 from unittest.mock import Mock
 
 import anndata as ad
@@ -569,6 +570,9 @@ def test_soma_curator(adata, categoricals):
 
 
 def test_soma_curator_genes_columns(adata):
+    if Path("curate.tiledbsoma").exists():
+        shutil.rmtree("curate.tiledbsoma")
+
     adata.obs = pd.DataFrame(adata.X[:, :3], columns=adata.var_names[:3])
     tiledbsoma.io.from_anndata("curate.tiledbsoma", adata, measurement_name="RNA")
 

--- a/tests/core/test_curator.py
+++ b/tests/core/test_curator.py
@@ -344,7 +344,7 @@ def test_anndata_curator_wrong_type(df, categoricals):
 def test_categorical_key_not_present(df):
     with pytest.raises(
         ValidationError,
-        match="key not present in columns",
+        match="key passed to categoricals is not present in columns",
     ):
         ln.Curator.from_df(
             df,
@@ -356,7 +356,7 @@ def test_categorical_key_not_present(df):
 def test_source_key_not_present(adata, categoricals):
     with pytest.raises(
         ValidationError,
-        match="the following 1 key passed to sources is not allowed:",
+        match="key passed to sources is not present in columns",
     ):
         ln.Curator.from_anndata(
             adata,

--- a/tests/core/test_curator.py
+++ b/tests/core/test_curator.py
@@ -449,7 +449,7 @@ def test_mudata_curator(mdata):
 
 @pytest.fixture()
 def clean_soma_files():
-    if Path("curate.tiledbsoma").exits():
+    if Path("curate.tiledbsoma").exists():
         shutil.rmtree("curate.tiledbsoma")
 
     yield  # Let the test run

--- a/tests/core/test_curator.py
+++ b/tests/core/test_curator.py
@@ -344,7 +344,7 @@ def test_anndata_curator_wrong_type(df, categoricals):
 def test_categorical_key_not_present(df):
     with pytest.raises(
         ValidationError,
-        match="the following 1 key passed to categoricals is not allowed:",
+        match="key not present in columns",
     ):
         ln.Curator.from_df(
             df,
@@ -449,9 +449,7 @@ def test_mudata_curator(mdata):
 def test_soma_curator(adata, categoricals):
     tiledbsoma.io.from_anndata("curate.tiledbsoma", adata, measurement_name="RNA")
 
-    with pytest.raises(
-        ValidationError, match="key passed to categoricals is not allowed"
-    ):
+    with pytest.raises(ValidationError, match="key not present in columns"):
         ln.Curator.from_tiledbsoma(
             "curate.tiledbsoma",
             {"RNA": ("var_id", bt.Gene.symbol)},

--- a/tests/core/test_curator.py
+++ b/tests/core/test_curator.py
@@ -449,7 +449,7 @@ def test_mudata_curator(mdata):
 def test_soma_curator(adata, categoricals):
     tiledbsoma.io.from_anndata("curate.tiledbsoma", adata, measurement_name="RNA")
 
-    with pytest.raises(ValidationError, match="key not present in columns"):
+    with pytest.raises(ValidationError, match="key not present"):
         ln.Curator.from_tiledbsoma(
             "curate.tiledbsoma",
             {"RNA": ("var_id", bt.Gene.symbol)},

--- a/tests/core/test_curator.py
+++ b/tests/core/test_curator.py
@@ -447,7 +447,18 @@ def test_mudata_curator(mdata):
     bt.Gene.filter().delete()
 
 
-def test_soma_curator(adata, categoricals):
+@pytest.fixture()
+def clean_soma_files():
+    if Path("curate.tiledbsoma").exits():
+        shutil.rmtree("curate.tiledbsoma")
+
+    yield  # Let the test run
+
+    if Path("curate.tiledbsoma").exists():
+        shutil.rmtree("curate.tiledbsoma")
+
+
+def test_soma_curator(adata, categoricals, clean_soma_files):
     tiledbsoma.io.from_anndata("curate.tiledbsoma", adata, measurement_name="RNA")
 
     with pytest.raises(
@@ -559,7 +570,6 @@ def test_soma_curator(adata, categoricals):
     }
 
     # clean up
-    shutil.rmtree("curate.tiledbsoma")
     artifact.delete(permanent=True)
     ln.ULabel.filter().delete()
     bt.ExperimentalFactor.filter().delete()
@@ -569,10 +579,7 @@ def test_soma_curator(adata, categoricals):
     bt.Gene.filter().delete()
 
 
-def test_soma_curator_genes_columns(adata):
-    if Path("curate.tiledbsoma").exists():
-        shutil.rmtree("curate.tiledbsoma")
-
+def test_soma_curator_genes_columns(adata, clean_soma_files):
     adata.obs = pd.DataFrame(adata.X[:, :3], columns=adata.var_names[:3])
     tiledbsoma.io.from_anndata("curate.tiledbsoma", adata, measurement_name="RNA")
 


### PR DESCRIPTION
Fixes #2262 

# Fixes KeyError formatting

## Before

`KeyError: '\"cell_line\" is not a valid key, available keys are: \\'well\\', \\'sirna\\'!'"`

## After

`KeyError: "'cell_line' is not a valid key, available keys are: 'well', 'sirna'!"`

# Fixes repeated calls of `standardize()`

```python
curator.standardize("disease")
curator.standardize("disease")
```

## Before

led to a traceback with 'KeyError: 'disease' is not a valid key.

## After

`• No unstandardized values found for 'disease'`

# Now hides the `add_new_from_columns` method from sphinx

Before this PR, the deprecated `add_new_from_columns` method was still listed in our documentation. It is now hidden.