### PR TITLE
✨ Safer gene mapping

### DIFF
--- a/docs/faq/delete.ipynb
+++ b/docs/faq/delete.ipynb
@@ -40,7 +40,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact = ln.Artifact.from_df(pd.DataFrame({\"a\": [1, 2], \"b\": [3, 4]}), description=\"mydf\")\n",
+    "artifact = ln.Artifact.from_df(\n",
+    "    pd.DataFrame({\"a\": [1, 2], \"b\": [3, 4]}), description=\"mydf\"\n",
+    ")\n",
     "artifact.save()"
    ]
   },

--- a/docs/faq/keep-artifacts-local.ipynb
+++ b/docs/faq/keep-artifacts-local.ipynb
@@ -253,7 +253,9 @@
    "source": [
     "assert artifact.path.exists()\n",
     "assert not local_path.exists()\n",
-    "assert artifact.path.as_posix().startswith(ln.setup.settings.instance.storage.root.as_posix())"
+    "assert artifact.path.as_posix().startswith(\n",
+    "    ln.setup.settings.instance.storage.root.as_posix()\n",
+    ")"
    ]
   },
   {
@@ -364,7 +366,9 @@
    },
    "outputs": [],
    "source": [
-    "my_existing_file = ln.Artifact(\"./my_storage_local/output.bam\", description=\"my existing file\").save()\n",
+    "my_existing_file = ln.Artifact(\n",
+    "    \"./my_storage_local/output.bam\", description=\"my existing file\"\n",
+    ").save()\n",
     "ln.UPath(\"my_storage_local/\").view_tree()"
    ]
   },

--- a/docs/faq/key.ipynb
+++ b/docs/faq/key.ipynb
@@ -834,7 +834,8 @@
    "outputs": [],
    "source": [
     "ds = ln.Collection(\n",
-    "    [artifact_from_raw, artifact_from_preprocessed], name=\"raw_and_processed_collection_2\"\n",
+    "    [artifact_from_raw, artifact_from_preprocessed],\n",
+    "    name=\"raw_and_processed_collection_2\",\n",
     ")\n",
     "ds.save()"
    ]

--- a/docs/faq/search.ipynb
+++ b/docs/faq/search.ipynb
@@ -20,6 +20,7 @@
    "outputs": [],
    "source": [
     "from laminci.db import setup_local_test_postgres\n",
+    "\n",
     "pgurl = setup_local_test_postgres()\n",
     "!lamin init --name benchmark_search --db {pgurl} --schema bionty --storage ./benchmark_search"
    ]
@@ -42,7 +43,14 @@
     "import lamindb as ln\n",
     "import bionty as bt\n",
     "\n",
-    "SEARCH_QUERIES_EXACT = (\"t cell\", \"stem cell\", \"b cell\", \"regulatory B cell\", \"Be2 cell\", \"adipocyte\")\n",
+    "SEARCH_QUERIES_EXACT = (\n",
+    "    \"t cell\",\n",
+    "    \"stem cell\",\n",
+    "    \"b cell\",\n",
+    "    \"regulatory B cell\",\n",
+    "    \"Be2 cell\",\n",
+    "    \"adipocyte\",\n",
+    ")\n",
     "SEARCH_QUERIES_CONTAINS = (\"t cel\", \"t-cel\", \"neural\", \"kidney\", \"kidne\")\n",
     "TOP_N = 20\n",
     "\n",
@@ -82,7 +90,7 @@
     "    print(\"Query:\", query)\n",
     "    qs = bt.CellType.search(query)\n",
     "    display(qs.df())\n",
-    "    \n",
+    "\n",
     "    assert query.lower() == qs[0].name.lower()"
    ]
   },

--- a/docs/faq/symbol-mapping.ipynb
+++ b/docs/faq/symbol-mapping.ipynb
@@ -64,9 +64,25 @@
     "# create example AnnData object with gene symbols\n",
     "rng = np.random.default_rng(42)\n",
     "X = rng.integers(0, 100, size=(5, 10))\n",
-    "var = pd.DataFrame(index=pd.Index(['BRCA1', 'TP53', 'EGFR', 'KRAS', 'PTEN', 'MYC', 'VEGFA', 'IL6', 'TNF', 'GAPDH'], name=\"symbol\"))\n",
+    "var = pd.DataFrame(\n",
+    "    index=pd.Index(\n",
+    "        [\n",
+    "            \"BRCA1\",\n",
+    "            \"TP53\",\n",
+    "            \"EGFR\",\n",
+    "            \"KRAS\",\n",
+    "            \"PTEN\",\n",
+    "            \"MYC\",\n",
+    "            \"VEGFA\",\n",
+    "            \"IL6\",\n",
+    "            \"TNF\",\n",
+    "            \"GAPDH\",\n",
+    "        ],\n",
+    "        name=\"symbol\",\n",
+    "    )\n",
+    ")\n",
     "adata = ad.AnnData(X=X, var=var)\n",
-    "adata.var\n"
+    "adata.var"
    ]
   },
   {
@@ -85,10 +101,12 @@
     "    field=bt.Gene.symbol,\n",
     "    return_field=bt.Gene.ensembl_gene_id,\n",
     "    return_mapper=True,\n",
-    "    organism=\"human\"\n",
+    "    organism=\"human\",\n",
     ")\n",
-    "adata.var[\"ensembl_id\"] = adata.var.index.map(gene_mapper)\n",
-    "adata.var\n"
+    "adata.var[\"ensembl_id\"] = adata.var.index.map(\n",
+    "    lambda gene_id: gene_mapper.get(gene_id, gene_id)\n",
+    ")\n",
+    "adata.var"
    ]
   },
   {
@@ -102,9 +120,20 @@
    "outputs": [],
    "source": [
     "standardized_genes = bt.Gene.from_values(\n",
-    "    ['ENSG00000141510', 'ENSG00000133703', 'ENSG00000111640', 'ENSG00000171862', 'ENSG00000204490', 'ENSG00000112715', 'ENSG00000146648', 'ENSG00000136997', 'ENSG00000012048', 'ENSG00000136244'],\n",
+    "    [\n",
+    "        \"ENSG00000141510\",\n",
+    "        \"ENSG00000133703\",\n",
+    "        \"ENSG00000111640\",\n",
+    "        \"ENSG00000171862\",\n",
+    "        \"ENSG00000204490\",\n",
+    "        \"ENSG00000112715\",\n",
+    "        \"ENSG00000146648\",\n",
+    "        \"ENSG00000136997\",\n",
+    "        \"ENSG00000012048\",\n",
+    "        \"ENSG00000136244\",\n",
+    "    ],\n",
     "    field=bt.Gene.ensembl_gene_id,\n",
-    "    organism=\"human\"\n",
+    "    organism=\"human\",\n",
     ")\n",
     "ln.save(standardized_genes)"
    ]

--- a/docs/faq/track-run-inputs.ipynb
+++ b/docs/faq/track-run-inputs.ipynb
@@ -72,7 +72,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.track(\"Rx2s9aPTMQLY0000\")\n"
+    "ln.track(\"Rx2s9aPTMQLY0000\")"
    ]
   },
   {

--- a/docs/faq/validate-fields.ipynb
+++ b/docs/faq/validate-fields.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "[Django field validation](https://docs.djangoproject.com/en/5.1/ref/validators/) are enabled for models that inherit the `ValidateFields` class.\n",
     "\n",
-    "For instance: [`findrefs.Reference`](https://docs.lamin.ai/findrefs.reference)"
+    "For instance: [`ourprojects.Reference`](https://docs.lamin.ai/ourprojects.reference)"
    ]
   },
   {
@@ -17,8 +17,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# !pip install lamindb, findrefs\n",
-    "!lamin init --storage ./test-django-validation --schema findrefs"
+    "# !pip install lamindb[ourprojects]\n",
+    "!lamin init --storage ./test-django-validation --schema ourprojects"
    ]
   },
   {
@@ -27,7 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import findrefs as fr\n",
+    "import ourprojects as pj\n",
     "from lnschema_core.validation import FieldValidationError"
    ]
   },
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    fr.Reference(name=\"my ref\", doi=\"abc.ef\", url=\"myurl.com\")\n",
+    "    pj.Reference(name=\"my ref\", doi=\"abc.ef\", url=\"myurl.com\")\n",
     "except FieldValidationError as e:\n",
     "    print(e)"
    ]

--- a/docs/faq/validate-fields.ipynb
+++ b/docs/faq/validate-fields.ipynb
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    fr.Reference(name=\"my ref\", doi=\"abc.ef\", url='myurl.com')\n",
+    "    fr.Reference(name=\"my ref\", doi=\"abc.ef\", url=\"myurl.com\")\n",
     "except FieldValidationError as e:\n",
     "    print(e)"
    ]

--- a/docs/faq/visibility.ipynb
+++ b/docs/faq/visibility.ipynb
@@ -38,7 +38,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact = ln.Artifact.from_df(pd.DataFrame({\"a\": [1, 2], \"b\": [3, 4]}), description=\"mydf\")\n",
+    "artifact = ln.Artifact.from_df(\n",
+    "    pd.DataFrame({\"a\": [1, 2], \"b\": [3, 4]}), description=\"mydf\"\n",
+    ")\n",
     "artifact.save()"
    ]
   },

--- a/docs/storage/prepare-transfer-local-to-cloud.ipynb
+++ b/docs/storage/prepare-transfer-local-to-cloud.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.setup.init(storage=\"./test-transfer-to-cloud\", schema=\"bionty,wetlab,findrefs\")\n",
+    "ln.setup.init(storage=\"./test-transfer-to-cloud\", schema=\"bionty,wetlab,ourprojects\")\n",
     "ln.setup.settings.auto_connect = False"
    ]
   },

--- a/noxfile.py
+++ b/noxfile.py
@@ -109,6 +109,7 @@ def install_ci(session, group):
     elif group == "faq":
         extras += "aws,bionty,jupyter"
         run(session, "uv pip install --system --no-deps ./sub/findrefs")
+        run(session, "uv pip install --system --no-deps ./sub/ourprojects")
     elif group == "storage":
         extras += "aws,zarr,bionty,jupyter"
         run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -108,13 +108,15 @@ def install_ci(session, group):
         run(session, "uv pip install --system ipywidgets")
     elif group == "faq":
         extras += "aws,bionty,jupyter"
-        run(session, "uv pip install --system --no-deps ./sub/findrefs")
-        run(session, "uv pip install --system --no-deps ./sub/ourprojects")
+        run(
+            session,
+            "uv pip install --system --no-deps ./sub/findrefs ./sub/ourprojects",
+        )
     elif group == "storage":
         extras += "aws,zarr,bionty,jupyter"
         run(
             session,
-            "uv pip install --system --no-deps ./sub/wetlab ./sub/findrefs",
+            "uv pip install --system --no-deps ./sub/wetlab ./sub/findrefs ./sub/ourprojects",
         )
         run(session, "uv pip install --system vitessce")
     elif group == "docs":


### PR DESCRIPTION
Earlier all genes that could not be mapped were simply set to `nan`. Now, the implementation will retain all unmapped symbols and users can decide what to do with them.

Internal context: https://laminlabs.slack.com/archives/C04MU979KD3/p1734345498957699

This PR also formats some notebooks and replaces `findrefs` with `ourprojects`