### PR TITLE
🎨 Proper type check of FeatureSet rename

### DIFF
--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -772,7 +772,7 @@ def check_name_change(record: Record):
         return
 
     # renaming feature sets is not checked
-    if record.__class__.__name__ == "FeatureSet":
+    if isinstance(record, FeatureSet):
         return
 
     old_name = record._name


### PR DESCRIPTION
Amends https://github.com/laminlabs/lamindb/pull/2288

FeatureSet should be allowed to rename without checking, since the dataset itself will not contain the name.