### PR TITLE
✨ Allow to register artifacts with http urls

### DIFF
--- a/lamindb/core/storage/paths.py
+++ b/lamindb/core/storage/paths.py
@@ -52,10 +52,19 @@ def check_path_is_child_of_root(path: UPathStr, root: UPathStr) -> bool:
     # and for fsspec.utils.get_protocol
     path_str = str(path)
     root_str = str(root)
+    root_protocol = fsspec.utils.get_protocol(root_str)
     # check that the protocols are the same first
-    if fsspec.utils.get_protocol(path_str) != fsspec.utils.get_protocol(root_str):
+    if fsspec.utils.get_protocol(path_str) != root_protocol:
         return False
-    return UPath(root_str).resolve() in UPath(path_str).resolve().parents
+    if root_protocol in {"http", "https"}:
+        # in this case it is a base url, not a file
+        # so formally does not exist
+        resolve_kwargs = {"follow_redirects": False}
+    else:
+        resolve_kwargs = {}
+    return (
+        UPath(root_str).resolve(**resolve_kwargs) in UPath(path_str).resolve().parents
+    )
 
 
 # returns filepath and root of the storage

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -693,6 +693,11 @@ def test_check_path_is_child_of_root():
     assert check_path_is_child_of_root(upath, root=root)
     upath2 = UPath("s3://lamindb-ci/test-data-1/test/test.csv")
     assert not check_path_is_child_of_root(upath2, root=root)
+    # http
+    assert check_path_is_child_of_root(
+        "https://raw.githubusercontent.com/laminlabs/lamindb/refs/heads/main/README.md",
+        root="https://raw.githubusercontent.com",
+    )
 
 
 def test_serialize_paths():

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -971,3 +971,22 @@ def test_gcp_paths():
     cache_path.unlink()
     artifact_folder.delete(permanent=True, storage=False)
     artifact_file.delete(permanent=True, storage=False)
+
+
+def test_http_paths():
+    http_path = UPath(
+        "https://raw.githubusercontent.com/laminlabs/lamindb/refs/heads/main/README.md"
+    )
+    artifact_readme = ln.Artifact(http_path, description="register http readme").save()
+    cache_path = artifact_readme.cache()
+    assert cache_path.exists()
+    assert cache_path.stat().st_size == http_path.stat().st_size
+    cache_path.unlink()
+    # just check saving for the second time (when Strage record is in the db)
+    artifact_license = ln.Artifact(
+        "https://raw.githubusercontent.com/laminlabs/lamindb/refs/heads/main/LICENSE",
+        description="register http license",
+    ).save()
+
+    artifact_readme.delete(permanent=True, storage=False)
+    artifact_license.delete(permanent=True, storage=False)


### PR DESCRIPTION
Related https://github.com/laminlabs/lamindb-setup/pull/913

This PR enables to register http and https links as artifacts.

```python
secondary_analysis = ln.Artifact(
    "https://assets.hubmapconsortium.org/1d91e74d48a309724ede35bdb33b5eb2/secondary_analysis.h5ad",
    description = "Normalized gene expression with additional metadata, in HDF5 format, readable with the 'anndata' Python package (Format: EDAM_1.24.format_3590)"
).save()
secondary_analysis.load()
secondary_analysis.open()
```
See also https://lamin.ai/laminlabs/lamindata/transform/Wa7Fep0r3Hwp0000