### PR TITLE
🎨 Raise ValueError when trying to search a None value

### DIFF
--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -285,6 +285,9 @@ def _search(
     using_key: str | None = None,
     truncate_string: bool = False,
 ) -> QuerySet:
+    if string is None:
+        raise ValueError("Cannot search for None value! Please pass a valid string.")
+
     input_queryset = _queryset(cls, using_key=using_key)
     registry = input_queryset.model
     name_field = getattr(registry, "_name_field", "name")

--- a/tests/core/test_search.py
+++ b/tests/core/test_search.py
@@ -56,3 +56,10 @@ def test_search_limit(prepare_cell_type_registry):
 def test_search_case_sensitive(prepare_cell_type_registry):
     result = bt.CellType.search("b cell", case_sensitive=False).df()
     assert result.name.iloc[0] == "B cell"
+
+
+def test_search_None():
+    with pytest.raises(
+        ValueError, match="Cannot search for None value! Please pass a valid string."
+    ):
+        bt.CellType.search(None)


### PR DESCRIPTION
Fixes https://github.com/laminlabs/lamindb/issues/2292

Like @Koncopd pointed out, search assumes a string. However, in practice I sometimes ran into cases where earlier pieces of (lamindb) code returned None which led to this error. I'm not a fan of too defensive programming in general but I think that this one is fine.