### PR TITLE
🎨 Add defensive organism check

### DIFF
--- a/lamindb/_curate.py
+++ b/lamindb/_curate.py
@@ -209,6 +209,9 @@ class DataFrameCurator(BaseCurator):
     ) -> None:
         from lamindb.core._settings import settings
 
+        if not isinstance(organism, str):
+            raise ValueError("organism must be a string such as 'human' or 'mouse'!")
+
         self._df = df
         self._fields = categoricals or {}
         self._columns_field = columns

--- a/lamindb/_curate.py
+++ b/lamindb/_curate.py
@@ -209,7 +209,7 @@ class DataFrameCurator(BaseCurator):
     ) -> None:
         from lamindb.core._settings import settings
 
-        if not isinstance(organism, str):
+        if organism is not None and not isinstance(organism, str):
             raise ValueError("organism must be a string such as 'human' or 'mouse'!")
 
         self._df = df

--- a/tests/core/test_curator.py
+++ b/tests/core/test_curator.py
@@ -223,7 +223,7 @@ def test_unvalidated_data_object(df, categoricals):
 
 def test_invalid_organism_type(df, categoricals):
     with pytest.raises(
-        ValidationError, match="organism must be a string such as 'human' or 'mouse'!"
+        ValueError, match="organism must be a string such as 'human' or 'mouse'!"
     ):
         ln.Curator.from_df(
             df, categoricals=categoricals, organism=bt.Organism.filter(name="human")

--- a/tests/core/test_curator.py
+++ b/tests/core/test_curator.py
@@ -222,13 +222,12 @@ def test_unvalidated_data_object(df, categoricals):
 
 
 def test_invalid_organism_type(df, categoricals):
-    curator = ln.Curator.from_df(
-        df, categoricals=categoricals, organism=bt.Organism.filter(name="human")
-    )
     with pytest.raises(
         ValidationError, match="organism must be a string such as 'human' or 'mouse'!"
     ):
-        curator.save_artifact()
+        ln.Curator.from_df(
+            df, categoricals=categoricals, organism=bt.Organism.filter(name="human")
+        )
 
 
 def test_clean_up_failed_runs():

--- a/tests/core/test_curator.py
+++ b/tests/core/test_curator.py
@@ -191,32 +191,44 @@ def test_df_curator(df, categoricals):
 
 
 def test_custom_using_invalid_field_lookup(curate_lookup):
-    with pytest.raises(AttributeError) as excinfo:
+    with pytest.raises(
+        AttributeError, match='"CurateLookup" object has no attribute "invalid_field"'
+    ):
         _ = curate_lookup["invalid_field"]
-    assert '"CurateLookup" object has no attribute "invalid_field"' in str(
-        excinfo.value
-    )
 
 
 def test_additional_args_with_all_key(df, categoricals):
     curator = ln.Curator.from_df(df, categoricals=categoricals)
-    with pytest.raises(ValueError) as error:
+    with pytest.raises(
+        ValueError, match="Cannot pass additional arguments to 'all' key!"
+    ):
         curator.add_new_from("all", extra_arg="not_allowed")
-    assert "Cannot pass additional arguments to 'all' key!" in str(error.value)
 
 
 def test_save_columns_not_defined_in_fields(df, categoricals):
     curator = ln.Curator.from_df(df, categoricals=categoricals)
-    with pytest.raises(ValidationError) as error:
+    with pytest.raises(
+        ValidationError, match="Feature nonexistent is not part of the fields!"
+    ):
         curator._update_registry("nonexistent")
-    assert "Feature nonexistent is not part of the fields!" in str(error.value)
 
 
 def test_unvalidated_data_object(df, categoricals):
     curator = ln.Curator.from_df(df, categoricals=categoricals)
-    with pytest.raises(ValidationError) as error:
+    with pytest.raises(
+        ValidationError, match="Dataset does not validate. Please curate."
+    ):
         curator.save_artifact()
-    assert "Dataset does not validate. Please curate." in str(error.value)
+
+
+def test_invalid_organism_type(df, categoricals):
+    curator = ln.Curator.from_df(
+        df, categoricals=categoricals, organism=bt.Organism.filter(name="human")
+    )
+    with pytest.raises(
+        ValidationError, match="organism must be a string such as 'human' or 'mouse'!"
+    ):
+        curator.save_artifact()
 
 
 def test_clean_up_failed_runs():


### PR DESCRIPTION
Fixes https://github.com/laminlabs/lamindb/issues/2293

Now ensuring that people don't pass `Organism` to `organism` of any `Curator` but an actual str (the `Organism` name)

I am generally pretty unhappy about the fact that the `Curator` takes organism str but some other functions require an actual `Organism` and do not take str. It's inconsistent.