### PR TITLE
⬇️ Upper bound scipy because 1.15.0 is incompatible with anndata backed sparse

### DIFF
--- a/docs/arrays.ipynb
+++ b/docs/arrays.ipynb
@@ -254,7 +254,7 @@
    },
    "outputs": [],
    "source": [
-    "# adata_subset.to_memory()"
+    "adata_subset.to_memory()"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "pyarrow",
     "typing_extensions!=4.6.0",
     "python-dateutil",
+    "scipy<1.15.0", # backed sparse is incompatible with 1.15.0 for anndata 1.11.1
     "pandas>=2.0.0", # for .infer_objects(copy=False) in lamin-utils
     "anndata>=0.8.0,<=0.11.1",  # will upgrade to new anndata releases
     "fsspec",


### PR DESCRIPTION
subj
maybe fixed here https://github.com/scverse/anndata/pull/1806