### PR TITLE
✨ Capture logs of scripts during `ln.track()`

### DIFF
--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -266,7 +266,7 @@ def save_context_core(
 
     # track logs
     if run is not None and not from_cli and not is_ipynb and not is_r_notebook:
-        save_run_logs()
+        save_run_logs(run)
 
     # track report and set is_consecutive
     if run is not None:

--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -9,13 +9,10 @@ from lamin_utils import logger
 from lamindb_setup.core.hashing import hash_file
 
 from lamindb.core.exceptions import NotebookNotSaved
+from lamindb.models import Artifact, Run, Transform
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    from lamindb import Run, Transform
-
-    from ._query_set import QuerySet
 
 
 def get_save_notebook_message() -> str:
@@ -30,6 +27,23 @@ def get_shortcut() -> str:
 
 def get_seconds_since_modified(filepath) -> float:
     return datetime.now().timestamp() - filepath.stat().st_mtime
+
+
+def save_run_logs(run: Run, save_run: bool = False) -> None:
+    logs_path = ln_setup.settings.cache_dir / f"run_logs_{run.uid}.txt"
+    if logs_path.exists():
+        if run.report is not None:
+            logger.important("overwriting run.report")
+        artifact = Artifact(
+            logs_path,
+            description=f"log streams of run {run.uid}",
+            visibility=0,
+            run=False,
+        )
+        artifact.save(upload=True, print_progress=False)
+        run.report = artifact
+        if save_run:  # defaults to fast because is slow
+            run.save()
 
 
 # this is from the get_title function in nbproject
@@ -252,18 +266,7 @@ def save_context_core(
 
     # track logs
     if run is not None and not from_cli and not is_ipynb and not is_r_notebook:
-        logs_path = ln_setup.settings.cache_dir / f"run_logs_{run.uid}.txt"
-        if logs_path.exists():
-            if run.report is not None:
-                logger.important("run.report is already saved, ignoring")
-            artifact = ln.Artifact(
-                logs_path,
-                description=f"log streams of run {run.uid}",
-                visibility=0,
-                run=False,
-            )
-            artifact.save(upload=True, print_progress=False)
-            run.report = artifact
+        save_run_logs()
 
     # track report and set is_consecutive
     if run is not None:

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -145,10 +145,10 @@ class LogStreamTracker:
             if signo is not None:
                 signal_msg = f"\nProcess terminated by signal {signo} ({signal.Signals(signo).name})\n"
                 if frame:
-                    signal_msg += "Frame info:\n"
-                    signal_msg += "".join(traceback.format_stack(frame))
+                    signal_msg += (
+                        f"Frame info:\n{''.join(traceback.format_stack(frame))}"
+                    )
                 self.log_file.write(signal_msg)
-                self.log_file.flush()
             sys.stdout = self.original_stdout
             sys.stderr = self.original_stderr
             self.log_file.flush()

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -470,7 +470,7 @@ class Context:
                 and self.version != transform.version  # type: ignore
             ):
                 raise SystemExit(
-                    f"Please pass consistent version: ln.context.version = '{transform.version}'"  # type: ignore
+                    f"✗ please pass consistent version: ln.context.version = '{transform.version}'"  # type: ignore
                 )
             # test whether version was already used for another member of the family
             suid, vuid = (self.uid[:-4], self.uid[-4:])
@@ -480,7 +480,7 @@ class Context:
             if transform is not None and vuid != transform.uid[-4:]:
                 better_version = bump_version_function(self.version)
                 raise SystemExit(
-                    f"Version '{self.version}' is already taken by Transform('{transform.uid}'); please set another version, e.g., ln.context.version = '{better_version}'"
+                    f"✗ version '{self.version}' is already taken by Transform('{transform.uid}'); please set another version, e.g., ln.context.version = '{better_version}'"
                 )
         # make a new transform record
         if transform is None:
@@ -549,13 +549,12 @@ class Context:
                         )
                 if bump_revision:
                     change_type = (
-                        "Re-running saved notebook"
+                        "re-running saved notebook"
                         if is_run_from_ipython
-                        else "Source code changed"
+                        else "source code changed"
                     )
                     raise UpdateContext(
-                        f"{change_type}, bump revision by setting:\n\n"
-                        f'ln.track("{uid[:-4]}{increment_base62(uid[-4:])}")'
+                        f'✗ {change_type}, run: ln.track("{uid[:-4]}{increment_base62(uid[-4:])}")'
                     )
             else:
                 self._logging_message_track += f"loaded Transform('{transform.uid}')"

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -158,6 +158,8 @@ class LogStreamTracker:
     def handle_exception(self, exc_type, exc_value, exc_traceback):
         if not self.is_cleaning_up:
             error_msg = f"{''.join(traceback.format_exception(exc_type, exc_value, exc_traceback))}"
+            if self.log_file.closed:
+                self.log_file = open(self.log_file_path, "a")
             self.log_file.write(error_msg)
             self.log_file.flush()
             self.cleanup()
@@ -347,7 +349,8 @@ class Context:
             )
         self._run = run
         track_environment(run)
-        self._stream_tracker.start(run)
+        if self.transform.type != "notebook":
+            self._stream_tracker.start(run)
         logger.important(self._logging_message_track)
         if self._logging_message_imports:
             logger.important(self._logging_message_imports)
@@ -656,7 +659,8 @@ class Context:
             finished_at=True,
             ignore_non_consecutive=ignore_non_consecutive,
         )
-        self._stream_tracker.finish()
+        if self.transform.type != "notebook":
+            self._stream_tracker.finish()
 
 
 context = Context()

--- a/lamindb/core/exceptions.py
+++ b/lamindb/core/exceptions.py
@@ -7,7 +7,6 @@
    DoesNotExist
    ValidationError
    NotebookNotSaved
-   NoTitleError
    MissingContextUID
    UpdateContext
    IntegrityError
@@ -75,12 +74,6 @@ class IntegrityError(Exception):
     For instance, it's not allowed to delete artifacts outside managed storage
     locations.
     """
-
-    pass
-
-
-class NoTitleError(SystemExit):
-    """Notebook has no title."""
 
     pass
 

--- a/tests/core/notebooks/no-title.ipynb
+++ b/tests/core/notebooks/no-title.ipynb
@@ -16,7 +16,6 @@
    "outputs": [],
    "source": [
     "import lamindb as ln\n",
-    "from lamindb.core._context import NoTitleError\n",
     "import pytest"
    ]
   },

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -150,7 +150,7 @@ def test_run_scripts():
     )
     assert result.returncode == 1
     assert (
-        "Version '1' is already taken by Transform('Ro1gl7n8YrdH0000'); please set another version, e.g., ln.context.version = '1.1'"
+        "✗ version '1' is already taken by Transform('Ro1gl7n8YrdH0000'); please set another version, e.g., ln.context.version = '1.1'"
         in result.stderr.decode()
     )
 
@@ -176,7 +176,7 @@ def test_run_scripts():
     )
     assert result.returncode == 1
     assert (
-        "Please pass consistent version: ln.context.version = '2'"
+        "✗ please pass consistent version: ln.context.version = '2'"
         in result.stderr.decode()
     )
 


### PR DESCRIPTION
Standard stream logs are now captured in `run.report` for scripts & functions (i.e. transforms that aren't notebooks).

See the illustration via he hub screenshots below.

Behavior when an error occurs | Behavior when killed through signal
--- | ---
<img width="500" alt="image" src="https://github.com/user-attachments/assets/e9174e1b-5836-488c-b8ab-ead8af5ecfb5" /> | <img width="500" alt="image" src="https://github.com/user-attachments/assets/21d2ec9c-60ae-4bbd-b19a-e59239520d32" />

Note: In LaminDB 1.0, these logs will also be available for notebooks through a `_logfile` M2M with artifact. The `.report` field isn't the canonical location for these.