### PR TITLE
✨ Hide underscore attributes in __repr__

### DIFF
--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -3186,7 +3186,7 @@ def record_repr(
         field_names.insert(0, "uid")
     fields_str = {}
     for k in field_names:
-        if hasattr(self, k):
+        if not k.startswith("_") and hasattr(self, k):
             value = getattr(self, k)
             # Force strip the time component of the version
             if k == "version" and value:


### PR DESCRIPTION
Fixes https://github.com/laminlabs/lamindb/issues/2201

- Removes underscore attributes from `__repr__`

Before:

`Artifact(uid='G9jm2669OchVQkEh0000', is_latest=True, description='bla', suffix='.parquet', type='dataset', size=1586, hash='Qu8wlxNlRjNPk9X-VJ1Slw', _hash_type='md5', _accessor='DataFrame', visibility=1, _key_is_virtual=True, storage_id=1, created_by_id=1, created_at=2025-01-07 14:52:36 UTC)`

After: 

`Artifact(uid='G9jm2669OchVQkEh0000', is_latest=True, description='bla', suffix='.parquet', type='dataset', size=1586, hash='Qu8wlxNlRjNPk9X-VJ1Slw', visibility=1, storage_id=1, created_by_id=1, created_at=2025-01-07 14:52:36 UTC)`