### PR TITLE
✨ Use etag as hash for http Artifacts

### DIFF
--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -978,6 +978,8 @@ def test_http_paths():
         "https://raw.githubusercontent.com/laminlabs/lamindb/refs/heads/main/README.md"
     )
     artifact_readme = ln.Artifact(http_path, description="register http readme").save()
+    # might change
+    assert artifact_readme.hash is not None
     cache_path = artifact_readme.cache()
     assert cache_path.exists()
     assert cache_path.stat().st_size == http_path.stat().st_size
@@ -987,6 +989,7 @@ def test_http_paths():
         "https://raw.githubusercontent.com/laminlabs/lamindb/refs/heads/main/LICENSE",
         description="register http license",
     ).save()
+    assert artifact_license.hash == "IQxRSNjvb7w2OLFeWqYlsg"
 
     artifact_readme.delete(permanent=True, storage=False)
     artifact_license.delete(permanent=True, storage=False)


### PR DESCRIPTION
MD5-hash etag from headers and use it as a hash for http and https `Artifact`s.
https://github.com/laminlabs/lamindb-setup/commit/944168a3e4adc049317fb5075a06586c3eb0c081 (pushed directly to main by mistake)
https://github.com/laminlabs/lamindb-setup/pull/926