### PR TITLE
✨ Also search git blob hash in remote branches

### DIFF
--- a/lamindb/core/_sync_git.py
+++ b/lamindb/core/_sync_git.py
@@ -74,11 +74,9 @@ def get_git_commit_hash(blob_hash: str, repo_dir: Path | None = None) -> str | N
     # Hence, we split by new line ("\n") and use the first one
     commit_hash = result.stdout.decode().split("\n")[0]
 
-    # Return None if no commit was found or if the log command failed
     if not commit_hash or result.returncode == 1:
         return None
 
-    # Get the default branch
     default_branch = (
         subprocess.run(
             ["git", "rev-parse", "--abbrev-ref", "origin/HEAD"],
@@ -91,7 +89,7 @@ def get_git_commit_hash(blob_hash: str, repo_dir: Path | None = None) -> str | N
     )
 
     # Find all branches containing the commit
-    branches = subprocess.run(
+    commit_containing_branches = subprocess.run(
         ["git", "branch", "--all", "--contains", commit_hash],
         capture_output=True,
         cwd=repo_dir,
@@ -99,11 +97,13 @@ def get_git_commit_hash(blob_hash: str, repo_dir: Path | None = None) -> str | N
     ).stdout.split("\n")
 
     # Clean up branch names and filter out the default branch
-    branches = [
-        branch.strip().replace("remotes/", "") for branch in branches if branch.strip()
+    commit_containing_branches = [
+        branch.strip().replace("remotes/", "")
+        for branch in commit_containing_branches
+        if branch.strip()
     ]
     non_default_branches = [
-        branch for branch in branches if default_branch not in branch
+        branch for branch in commit_containing_branches if default_branch not in branch
     ]
 
     if non_default_branches:

--- a/lamindb/core/_sync_git.py
+++ b/lamindb/core/_sync_git.py
@@ -53,11 +53,11 @@ def check_local_git_repo() -> bool:
 
 
 def get_git_commit_hash(blob_hash: str, repo_dir: Path | None = None) -> str | None:
-    # Fetch all remote branch names so that we can also search them
+    # Fetch all remote branches so that we can also search them
     fetch_command = ["git", "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*"]
     subprocess.run(fetch_command, cwd=repo_dir, check=True)
 
-    # Find the commit containing the blob hash
+    # Find the commit containing the blob hash in all branches
     command = [
         "git",
         "log",

--- a/lamindb/core/_sync_git.py
+++ b/lamindb/core/_sync_git.py
@@ -53,22 +53,69 @@ def check_local_git_repo() -> bool:
 
 
 def get_git_commit_hash(blob_hash: str, repo_dir: Path | None = None) -> str | None:
-    command = ["git", "log", f"--find-object={blob_hash}", "--pretty=format:%H"]
+    # Fetch all remote branch names so that we can also search them
+    fetch_command = ["git", "fetch", "origin", "+refs/heads/*:refs/remotes/origin/*"]
+    subprocess.run(fetch_command, cwd=repo_dir, check=True)
+
+    # Find the commit containing the blob hash
+    command = [
+        "git",
+        "log",
+        "--all",
+        f"--find-object={blob_hash}",
+        "--pretty=format:%H",
+    ]
     result = subprocess.run(
         command,
         capture_output=True,
         cwd=repo_dir,
     )
-    # we just care to find one commit
-    # hence, we split by new line ("\n") and use the first one
+    # We just care to find one commit
+    # Hence, we split by new line ("\n") and use the first one
     commit_hash = result.stdout.decode().split("\n")[0]
-    if commit_hash == "" or result.returncode == 1:
+
+    # Return None if no commit was found or if the log command failed
+    if not commit_hash or result.returncode == 1:
         return None
-    else:
-        assert (  # noqa: S101
-            len(commit_hash) == 40
-        ), f"commit hash |{commit_hash}| is not 40 characters long"
-        return commit_hash
+
+    # Get the default branch
+    default_branch = (
+        subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "origin/HEAD"],
+            capture_output=True,
+            cwd=repo_dir,
+            text=True,
+        )
+        .stdout.strip()
+        .split("/")[-1]
+    )
+
+    # Find all branches containing the commit
+    branches = subprocess.run(
+        ["git", "branch", "--all", "--contains", commit_hash],
+        capture_output=True,
+        cwd=repo_dir,
+        text=True,
+    ).stdout.split("\n")
+
+    # Clean up branch names and filter out the default branch
+    branches = [
+        branch.strip().replace("remotes/", "") for branch in branches if branch.strip()
+    ]
+    non_default_branches = [
+        branch for branch in branches if default_branch not in branch
+    ]
+
+    if non_default_branches:
+        logger.warning(
+            f"code blob hash {blob_hash} was found in non-default branch(es): {', '.join(non_default_branches)}"
+        )
+
+    assert (  # noqa: S101
+        len(commit_hash) == 40
+    ), f"commit hash |{commit_hash}| is not 40 characters long"
+
+    return commit_hash
 
 
 def get_filepath_within_git_repo(


### PR DESCRIPTION
Fixes #2331 

**Before:**

Errors when the code blob was not on the default branch.

**After:**
```
code blob hash 313ce3a4116476f1e83a14c17d8d2dcb6138e141 was found in non-default branch(es): origin/feature/ruff
```
