### PR TITLE
🐛 Fix signal outside main thread

### DIFF
--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -42,7 +42,7 @@ def save_run_logs(run: Run, save_run: bool = False) -> None:
         )
         artifact.save(upload=True, print_progress=False)
         run.report = artifact
-        if save_run:  # defaults to fast because is slow
+        if save_run:  # defaults to false because is slow
             run.save()
 
 

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -245,6 +245,7 @@ class Context:
         params: dict | None = None,
         new_run: bool | None = None,
         path: str | None = None,
+        log_to_file: bool | None = None,
     ) -> None:
         """Initiate a run with tracked data lineage.
 
@@ -259,10 +260,13 @@ class Context:
         Args:
             transform: A transform `uid` or record. If `None`, creates a `uid`.
             params: A dictionary of parameters to track for the run.
-            new_run: If `False`, loads latest run of transform
-                (default notebook), if `True`, creates new run (default pipeline).
+            new_run: If `False`, loads the latest run of transform
+                (default notebook), if `True`, creates new run (default non-notebook).
             path: Filepath of notebook or script. Only needed if it can't be
                 automatically detected.
+            log_to_file: If `True`, logs stdout and stderr to a file and
+                saves the file within the current run (default non-notebook),
+                if `False`, does not log the output (default notebook).
 
         Examples:
 
@@ -353,7 +357,9 @@ class Context:
             )
         self._run = run
         track_environment(run)
-        if self.transform.type != "notebook":
+        if log_to_file is None:
+            log_to_file = self.transform.type != "notebook"
+        if log_to_file:
             self._stream_tracker.start(run)
         logger.important(self._logging_message_track)
         if self._logging_message_imports:


### PR DESCRIPTION
Fixes `ValueError: signal only works in main thread of the main interpreter` from redun.