### PR TITLE
🎨 Deprecate `n_objects`, introduce better `deprecated` decorator

### DIFF
--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -530,9 +530,12 @@ def __init__(artifact: Artifact, *args, **kwargs):
     )
     revises: Artifact | None = kwargs.pop("revises") if "revises" in kwargs else None
     version: str | None = kwargs.pop("version") if "version" in kwargs else None
-    _branch_code: int | None = (
-        kwargs.pop("_branch_code") if "_branch_code" in kwargs else 1
-    )
+    if "visibility" in kwargs:
+        _branch_code = kwargs.pop("visibility")
+    elif "_branch_code" in kwargs:
+        _branch_code = kwargs.pop("_branch_code")
+    else:
+        _branch_code = 1
     format = kwargs.pop("format") if "format" in kwargs else None
     _is_internal_call = kwargs.pop("_is_internal_call", False)
     skip_check_exists = (

--- a/lamindb/_query_set.py
+++ b/lamindb/_query_set.py
@@ -82,6 +82,7 @@ def one_helper(self):
 def get_backward_compat_filter_kwargs(expressions):
     name_mappings = {
         "name": "key",  # backward compat <1.0
+        "n_objects": "n_files",
         "visibility": "_branch_code",  # for convenience (and backward compat <1.0)
         "transform": "run__transform",  # for convenience (and backward compat <1.0)
     }

--- a/lamindb/_transform.py
+++ b/lamindb/_transform.py
@@ -138,7 +138,7 @@ def view_lineage(self, with_successors: bool = False, distance: int = 5):
         field="key",
         with_children=with_successors,
         distance=distance,
-        attr_description="predecessors",
+        attr_name="predecessors",
     )
 
 

--- a/lamindb/base/__init__.py
+++ b/lamindb/base/__init__.py
@@ -9,6 +9,16 @@ Modules:
 
    types
 
+Utils:
+
+.. autosummary::
+   :toctree: .
+
+   doc_args
+   deprecated
+
 """
+
+from lamindb_setup.core import deprecated, doc_args
 
 from . import types

--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -24,10 +24,9 @@ from django.db.models.fields.related import (
 )
 from lamin_utils import colors
 from lamindb_setup import _check_instance_setup
-from lamindb_setup.core import deprecated
-from lamindb_setup.core._docs import doc_args
 from lamindb_setup.core.hashing import HASH_LENGTH, hash_dict
 
+from lamindb.base import deprecated, doc_args
 from lamindb.base.fields import (
     BigIntegerField,
     BooleanField,
@@ -2285,6 +2284,9 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
     """Number of files for folder-like artifacts, `None` for file-like artifacts.
 
     Note that some arrays are also stored as folders, e.g., `.zarr` or `.tiledbsoma`.
+
+    .. versionchanged:: 1.0
+        Renamed from `n_objects` to `n_files`.
     """
     n_observations: int | None = BigIntegerField(null=True, db_index=True, default=None)
     """Number of observations.
@@ -2385,7 +2387,6 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
     @property
     @deprecated("n_files")
     def n_objects(self) -> int:
-        """Deprecated version of `n_files`."""
         return self.n_files
 
     @property

--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -24,6 +24,7 @@ from django.db.models.fields.related import (
 )
 from lamin_utils import colors
 from lamindb_setup import _check_instance_setup
+from lamindb_setup.core import deprecated
 from lamindb_setup.core._docs import doc_args
 from lamindb_setup.core.hashing import HASH_LENGTH, hash_dict
 
@@ -2380,6 +2381,12 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
     def transform(self) -> Transform | None:
         """Transform whose run created the artifact."""
         return self.run.transform if self.run is not None else None
+
+    @property
+    @deprecated("n_files")
+    def n_objects(self) -> int:
+        """Deprecated version of `n_files`."""
+        return self.n_files
 
     @property
     def path(self) -> Path:


### PR DESCRIPTION
Bring back `n_objects` but deprecate it with `@deprecated` which now hides the deprecated function from the docs.

See here:
<img width="179" alt="image" src="https://github.com/user-attachments/assets/65ea7257-c9f0-4187-9934-e98cf644a179" />

Internal [Slack thread](https://laminlabs.slack.com/archives/C03Q5TXF797/p1736628804406989?thread_ts=1730810395.555979&cid=C03Q5TXF797).