### PR TITLE
🐛 Skip deleting storage when deleting outdated versions of folder-like artifacts

### DIFF
--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -1072,7 +1072,11 @@ def delete(
         # only delete in storage if DB delete is successful
         # DB delete might error because of a foreign key constraint violated etc.
         self._delete_skip_storage()
-        if self.key is None or self._key_is_virtual:
+        # by default do not delete storage if deleting only one version of multiple
+        # and the underlying store is mutable
+        if self._overwrite_versions and self.versions.count() > 1:
+            delete_in_storage = False if storage is None else storage
+        elif self.key is None or self._key_is_virtual:
             # do not ask for confirmation also if storage is None
             delete_in_storage = storage is None or storage
         else:

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -1069,12 +1069,14 @@ def delete(
             # we can still delete the record
             logger.warning("Could not get path")
             storage = False
+        # check the number of versioned artifacts before deleting the current one
+        is_versioned_mutable = self._overwrite_versions and self.versions.count() > 1
         # only delete in storage if DB delete is successful
         # DB delete might error because of a foreign key constraint violated etc.
         self._delete_skip_storage()
         # by default do not delete storage if deleting only one version of multiple
         # and the underlying store is mutable
-        if self._overwrite_versions and self.versions.count() > 1:
+        if is_versioned_mutable:
             delete_in_storage = False if storage is None else storage
         elif self.key is None or self._key_is_virtual:
             # do not ask for confirmation also if storage is None

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -466,7 +466,7 @@ def data_is_anndata(data: AnnData | UPathStr) -> bool:
             if fsspec.utils.get_protocol(data_path.as_posix()) == "file":
                 return zarr_is_adata(data_path)
             else:
-                logger.warning("We do not check if cloud zarr is AnnData or not.")
+                logger.warning("We do not check if cloud zarr is AnnData or not")
                 return False
     return False
 
@@ -1080,7 +1080,11 @@ def delete(
         # by default do not delete storage if deleting only a previous version
         # and the underlying store is mutable
         if self._overwrite_versions and not self.is_latest:
-            delete_in_storage = False if storage is None else storage
+            delete_in_storage = False
+            if storage:
+                logger.warning(
+                    "Storage argument is ignored; can't delete storage on an previous version"
+                )
         elif self.key is None or self._key_is_virtual:
             # do not ask for confirmation also if storage is None
             delete_in_storage = storage is None or storage

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -1069,14 +1069,17 @@ def delete(
             # we can still delete the record
             logger.warning("Could not get path")
             storage = False
-        # check the number of versioned artifacts before deleting the current one
-        is_versioned_mutable = self._overwrite_versions and self.versions.count() > 1
         # only delete in storage if DB delete is successful
         # DB delete might error because of a foreign key constraint violated etc.
-        self._delete_skip_storage()
-        # by default do not delete storage if deleting only one version of multiple
+        if self._overwrite_versions and self.is_latest:
+            # includes self
+            for version in self.versions.all():
+                _delete_skip_storage(version)
+        else:
+            self._delete_skip_storage()
+        # by default do not delete storage if deleting only a previous version
         # and the underlying store is mutable
-        if is_versioned_mutable:
+        if self._overwrite_versions and not self.is_latest:
             delete_in_storage = False if storage is None else storage
         elif self.key is None or self._key_is_virtual:
             # do not ask for confirmation also if storage is None

--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -2728,6 +2728,9 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
 
         A first call to `.delete()` puts an artifact into the trash (sets `_branch_code` to `-1`).
         A second call permanently deletes the artifact.
+        If it is a folder artifact with multiple versions, deleting a non-latest version
+        will not delete the underlying storage by default (if `storage=True` is not specified).
+        Deleting the latest version will delete all the versions for folder artifacts.
 
         FAQ: :doc:`docs:faq/storage`
 
@@ -2739,7 +2742,14 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
 
             For an `Artifact` object `artifact`, call:
 
-            >>> artifact.delete()
+            >>> artifact = ln.Artifact.filter(key="some.csv").one()
+            >>> artifact.delete() # delete a single file artifact
+
+            >>> artifact = ln.Artifact.filter(key="some.tiledbsoma". is_latest=False).first()
+            >>> artiact.delete() # delete an old version, the data will not be deleted
+
+            >>> artifact = ln.Artifact.filter(key="some.tiledbsoma". is_latest=True).one()
+            >>> artiact.delete() # delete all versions, the data will be deleted or prompted for deletion.
         """
         pass
 

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -355,8 +355,12 @@ def test_write_read_tiledbsoma(storage):
     # test correctness of deletion for _overwrite_versions=True
     soma_path = artifact_soma_append.path
     assert soma_path.exists()
-    # select middle version and delete
+    # select specific versions and delete
     # check that the store is stil there
+    artifact_soma_append.versions.filter(uid__endswith="0000").one().delete(
+        permanent=True
+    )
+    assert soma_path.exists()
     artifact_soma_append.versions.filter(uid__endswith="0001").one().delete(
         permanent=True
     )

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -355,19 +355,19 @@ def test_write_read_tiledbsoma(storage):
     # test correctness of deletion for _overwrite_versions=True
     soma_path = artifact_soma_append.path
     assert soma_path.exists()
-    # select specific versions and delete
+    # select specific version and delete
     # check that the store is stil there
-    artifact_soma_append.versions.filter(uid__endswith="0000").one().delete(
-        permanent=True
-    )
     assert soma_path.exists()
+    assert ln.Artifact.filter(description="test tiledbsoma").count() == 3
     artifact_soma_append.versions.filter(uid__endswith="0001").one().delete(
         permanent=True
     )
     assert soma_path.exists()
+    assert ln.Artifact.filter(description="test tiledbsoma").count() == 2
     # make sure it the store is actually deleted
-    artifact_soma_append.versions.delete(permanent=True)
+    artifact_soma_append.delete(permanent=True)
     assert not soma_path.exists()
+    assert not ln.Artifact.filter(description="test tiledbsoma").exists()
 
     if storage is not None:
         ln.settings.storage = previous_storage

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -352,7 +352,17 @@ def test_write_read_tiledbsoma(storage):
     assert set(run_ids) == {create_run.uid, append_run.uid}
     store.close()
 
-    artifact_soma_append.versions.delete(permanent=True, storage=True)
+    # test correctness of deletion for _overwrite_versions=True
+    soma_path = artifact_soma_append.path
+    assert soma_path.exists()
+    # select middle version
+    artifact_soma_append.versions.filter(uid__endswith="0001").one().delete(
+        permanent=True
+    )
+    assert soma_path.exists()
+    # make sure it the store is actually deleted
+    artifact_soma_append.versions.delete(permanent=True)
+    assert not soma_path.exists()
 
     if storage is not None:
         ln.settings.storage = previous_storage

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -355,7 +355,8 @@ def test_write_read_tiledbsoma(storage):
     # test correctness of deletion for _overwrite_versions=True
     soma_path = artifact_soma_append.path
     assert soma_path.exists()
-    # select middle version
+    # select middle version and delete
+    # check that the store is stil there
     artifact_soma_append.versions.filter(uid__endswith="0001").one().delete(
         permanent=True
     )


### PR DESCRIPTION
Now by default, if not explicitly specified with `.delete(storage=True)`, deleting a non-latest version of a mutable `Artifact` (such as `tiledbsoma`) does not delete an underlying storage.

```python
artifact = ln.Artifact.filter(key="some.tiledbsoma", is_latest=False).first()
artifact.delete() # deletes only this specific version and doesn't delete artifact.path
```

Deleting the latest version now deletes all versions so that no artifact records without underlying data survive.
```python
artifact = ln.Artifact.filter(key="some.tiledbsoma", is_latest=True).one() # virtual key
artifact.delete() # deletes all versions and the data in storage
```

Internal [Slack thread](https://laminlabs.slack.com/archives/C07DB677JF6/p1736783041648239).