### PR TITLE
🚸 In `ln.track()`, do not update transform `description` if it is `None` and improve logging in RStudio sessions

### DIFF
--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -208,7 +208,7 @@ def save_context_core(
             report_path = filepath.with_suffix(".html")
         else:
             logger.warning(
-                f"no {filepath.with_suffix('.nb.html')} found, save your manually rendered .html report via the CLI: lamin save {filepath}"
+                f"no html report found; to attach one, render an .html report for your {filepath.suffix} file and then run: lamin save {filepath}"
             )
     if report_path is not None and not from_cli:
         if get_seconds_since_modified(report_path) > 2 and not ln_setup._TESTING:

--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -292,10 +292,13 @@ def save_context_core(
                 )
                 report_file.save(upload=True, print_progress=False)
                 run.report = report_file
+            if is_r_notebook:
+                # this is the "cleaned" report
+                report_path.unlink()
             logger.debug(
                 f"saved transform.latest_run.report: {transform.latest_run.report}"
             )
-        run.is_consecutive = is_consecutive
+        run._is_consecutive = is_consecutive
 
         # save both run & transform records if we arrive here
         run.save()

--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -208,7 +208,7 @@ def save_context_core(
             report_path = filepath.with_suffix(".html")
         else:
             logger.warning(
-                f"no html report found; to attach one, render an .html report for your {filepath.suffix} file and then run: lamin save {filepath}"
+                f"no html report found; to attach one, create an .html export for your {filepath.suffix} file and then run: lamin save {filepath}"
             )
     if report_path is not None and not from_cli:
         if get_seconds_since_modified(report_path) > 2 and not ln_setup._TESTING:

--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -159,8 +159,6 @@ def save_context_core(
         format_field_value,  # needs to come after lamindb was imported because of CLI use
     )
 
-    from .core._context import context
-
     ln.settings.verbosity = "success"
 
     # for scripts, things are easy
@@ -335,7 +333,4 @@ def save_context_core(
             logger.important(
                 f"if you want to update your {thing} without re-running it, use `lamin save {filepath}`"
             )
-    # because run & transform changed, update the global context
-    context._run = run
-    context._transform = transform
     return None

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -508,7 +508,7 @@ class Context:
                             for transform in transforms
                         ]
                     )
-                    message = f"ignoring transform{plural_s} with same filedescription:\n{transforms_str}"
+                    message = f"ignoring transform{plural_s} with same filename:\n{transforms_str}"
                 if message != "":
                     logger.important(message)
             self.uid, transform = uid, target_transform
@@ -581,7 +581,7 @@ class Context:
             # check whether the transform.key is consistent
             if transform.key != key:
                 raise UpdateContext(get_key_clashing_message(transform, key))
-            elif transform.description != description:
+            elif transform.description != description and description is not None:
                 transform.description = description
                 transform.save()
                 self._logging_message_track += (

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -632,12 +632,12 @@ class Context:
                         )
                 if bump_revision:
                     change_type = (
-                        "re-running saved notebook"
+                        "re-running notebook with already-saved source code"
                         if transform.type == "notebook"
                         else "source code changed"
                     )
                     raise UpdateContext(
-                        f'✗ {change_type}, update `uid` in `track()` to "{uid[:-4]}{increment_base62(uid[-4:])}"'
+                        f'✗ {change_type}, please update the `uid` argument in `track()` to "{uid[:-4]}{increment_base62(uid[-4:])}"'
                     )
             else:
                 self._logging_message_track += f"loaded Transform('{transform.uid}')"

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -395,6 +395,9 @@ class Context:
             path = Path(module.__file__)
         else:
             path = Path(path)
+        # for Rmd and qmd, we could also extract the title
+        # we don't do this for now as we're setting the title upon `ln.finish()` or `lamin save`
+        # by extracting it from the html while cleaning it: see clean_r_notebook_html()
         transform_type = "notebook" if path.suffix in {".Rmd", ".qmd"} else "script"
         reference = None
         reference_type = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 dependencies = [
     # Lamin PINNED packages
     "lamin_utils==0.13.10",
-    "lamin_cli==1.0.2",
+    "lamin_cli==1.0.3",
     "lamindb_setup[aws]==1.0.3",
     # others
     "pyarrow",


### PR DESCRIPTION
Also, pro-actively make new transform versions in RStudio if running an `Rmd` or `qmd` file in exact analogy to how a Jupyter Notebook is treated.