### PR TITLE
✨ Support Python 3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
           python-version: |
             ${{ matrix.group == 'storage' && '3.10' ||
                 matrix.group == 'unit-storage' && '3.11' ||
-                '3.12' }}
+                '3.13' }}
 
       - name: cache pre-commit
         uses: actions/cache@v4
@@ -141,7 +141,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - run: pip install "laminci@git+https://x-access-token:${{ secrets.LAMIN_BUILD_DOCS }}@github.com/laminlabs/laminci"
       - run: nox -s "install_ci(group='docs')"
       - uses: actions/download-artifact@v4
@@ -170,7 +170,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - run: |
           python -m pip install -U uv
           uv pip install --system coverage[toml]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.12"
       - run: pip install "laminci@git+https://x-access-token:${{ secrets.LAMIN_BUILD_DOCS }}@github.com/laminlabs/laminci"
       - run: nox -s "install_ci(group='docs')"
       - uses: actions/download-artifact@v4

--- a/docs/faq/idempotency.ipynb
+++ b/docs/faq/idempotency.ipynb
@@ -515,7 +515,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.Artifact.filter(hash=\"KCEXRahJ-Ui9Y6nksQ8z1A\").df()"
+    "ln.Artifact.filter(hash=\"rCPvmZB19xs4zHZ7p_-Wrg\").df()"
    ]
   },
   {
@@ -529,7 +529,7 @@
    },
    "outputs": [],
    "source": [
-    "assert len(ln.Artifact.filter(hash=\"KCEXRahJ-Ui9Y6nksQ8z1A\").all()) == 2"
+    "assert len(ln.Artifact.filter(hash=\"rCPvmZB19xs4zHZ7p_-Wrg\").all()) == 2"
    ]
   },
   {

--- a/docs/faq/idempotency.ipynb
+++ b/docs/faq/idempotency.ipynb
@@ -314,7 +314,7 @@
    },
    "outputs": [],
    "source": [
-    "assert artifact.hash == \"KCEXRahJ-Ui9Y6nksQ8z1A\"\n",
+    "assert artifact.hash == \"rCPvmZB19xs4zHZ7p_-Wrg\"\n",
     "assert artifact.run == ln.context.run\n",
     "assert len(artifact._previous_runs.all()) == 0"
    ]

--- a/lamindb/core/datasets/_core.py
+++ b/lamindb/core/datasets/_core.py
@@ -18,7 +18,8 @@ if TYPE_CHECKING:
 def file_fcs() -> Path:
     """Example FCS artifact."""
     filepath, _ = urlretrieve(
-        "https://lamindb-test.s3.amazonaws.com/example.fcs", "example.fcs"
+        "https://lamindb-dev-datasets.s3.amazonaws.com/.lamindb/DBNEczSgBui0bbzBXMGH.fcs",
+        "example.fcs",
     )
     return Path(filepath)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -124,7 +124,7 @@ def install_ci(session, group):
         )
         run(
             session,
-            "uv pip install --system -U git+https://github.com/scverse/spatialdata.git@refs/pull/806/head",
+            "uv pip install --system -U spatialdata",
         )  # Required to access metadata attrs
         run(session, "uv pip install --system tiledbsoma==1.15.0rc3")
     elif group == "docs":
@@ -140,6 +140,14 @@ def install_ci(session, group):
     elif group == "cli":
         extras += "jupyter,bionty"
     run(session, f"uv pip install --system -e .[dev,{extras}]")
+
+    # TEMPORARILY GET READFCS
+    if group == "unit-core":
+        run(
+            session,
+            "uv pip install --system -U git+https://github.com/laminlabs/readfcs",
+        )
+
     # on the release branch, do not use submodules but run with pypi install
     # only exception is the docs group which should always use the submodule
     # to push docs fixes fast

--- a/noxfile.py
+++ b/noxfile.py
@@ -141,13 +141,6 @@ def install_ci(session, group):
         extras += "jupyter,bionty"
     run(session, f"uv pip install --system -e .[dev,{extras}]")
 
-    # TEMPORARILY GET READFCS
-    if group == "unit-core":
-        run(
-            session,
-            "uv pip install --system -U git+https://github.com/laminlabs/readfcs",
-        )
-
     # on the release branch, do not use submodules but run with pypi install
     # only exception is the docs group which should always use the submodule
     # to push docs fixes fast

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "lamindb"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 authors = [{name = "Lamin Labs", email = "open-source@lamin.ai"}]
 readme = "README.md"
 dynamic = ["version", "description"]
@@ -12,6 +12,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     # Lamin PINNED packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ zarr = [
     "zarr>=2.16.0,<3.0.0a0", # not yet compatible with 3.0.*
 ]
 fcs = [
-    "readfcs>=2.0.0",
+    "readfcs>=2.0.1",
 ]
 erdiagram = [
     "django-schema-graph",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ zarr = [
     "zarr>=2.16.0,<3.0.0a0", # not yet compatible with 3.0.*
 ]
 fcs = [
-    "readfcs>=1.1.9",
+    "readfcs>=2.0.0",
 ]
 erdiagram = [
     "django-schema-graph",

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -754,7 +754,7 @@ def test_load_to_memory(tsv_file, zip_file, fcs_file, yaml_file):
     df = load_tsv(tsv_file)
     assert isinstance(df, pd.DataFrame)
     # fcs
-    adata = load_fcs(fcs_file, ignore_offset_error=True)
+    adata = load_fcs(fcs_file)
     assert isinstance(adata, ad.AnnData)
     # none
     load_to_memory(zip_file)

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -754,7 +754,7 @@ def test_load_to_memory(tsv_file, zip_file, fcs_file, yaml_file):
     df = load_tsv(tsv_file)
     assert isinstance(df, pd.DataFrame)
     # fcs
-    adata = load_fcs(str(fcs_file))
+    adata = load_fcs(fcs_file, ignore_offset_error=True)
     assert isinstance(adata, ad.AnnData)
     # none
     load_to_memory(zip_file)

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -754,7 +754,7 @@ def test_load_to_memory(tsv_file, zip_file, fcs_file, yaml_file):
     df = load_tsv(tsv_file)
     assert isinstance(df, pd.DataFrame)
     # fcs
-    adata = load_fcs(fcs_file)
+    adata = load_fcs(str(fcs_file))
     assert isinstance(adata, ad.AnnData)
     # none
     load_to_memory(zip_file)


### PR DESCRIPTION
Fixes https://github.com/laminlabs/lamindb/issues/2346#issuecomment-2603361418

- Adds official support for Python 3.13
- Replace 3.12 with 3.13 in the test matrix
- Require `readfcs>=2.0.1`

We stick to Python 3.12 for the docs for now because they fail https://github.com/laminlabs/lamindb/pull/2366#issuecomment-2607526154