### PR TITLE
🐛 Fix init (when the instance exists) and connect with migration for cloud sqlite instances

### DIFF
--- a/docs/storage/add-replace-cache.ipynb
+++ b/docs/storage/add-replace-cache.ipynb
@@ -11,14 +11,49 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dca2c05d",
+   "id": "bd29dc17",
    "metadata": {},
    "outputs": [],
    "source": [
     "import pytest\n",
-    "import lamindb as ln\n",
-    "\n",
-    "ln.setup.login(\"testuser1\")\n",
+    "import lamindb as ln"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac7266de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln.setup.login(\"testuser1\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c126065",
+   "metadata": {
+    "tags": [
+     "hide-output",
+     "hide-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    ln.setup.delete(\"testuser1/test-add-replace-cache\", force=True)\n",
+    "except BaseException:  # noqa: S110\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dca2c05d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "ln.setup.init(storage=\"s3://lamindb-ci/test-add-replace-cache\")"
    ]
   },
@@ -702,7 +737,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.16"
   },
   "nbproject": {
    "id": "uBQMCcdYwEjA",

--- a/docs/storage/upload.ipynb
+++ b/docs/storage/upload.ipynb
@@ -11,14 +11,49 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8eb097f4-4114-4a35-8764-ebcfe1e85bdc",
+   "id": "ce3356b1",
    "metadata": {},
    "outputs": [],
    "source": [
     "import lamindb as ln\n",
-    "import pytest\n",
-    "\n",
-    "ln.setup.login(\"testuser1\")\n",
+    "import pytest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b6a334e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln.setup.login(\"testuser1\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "382f6745",
+   "metadata": {
+    "tags": [
+     "hide-output",
+     "hide-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    ln.setup.delete(\"testuser1/test-upload\")\n",
+    "except BaseException:  # noqa: S110\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8eb097f4-4114-4a35-8764-ebcfe1e85bdc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "ln.setup.init(storage=\"s3://lamindb-ci/test-upload\")"
    ]
   },
@@ -327,7 +362,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.17"
+   "version": "3.10.16"
   },
   "nbproject": {
    "id": "psZgub4FOmzS",


### PR DESCRIPTION
Also adds a proper cleanup to some storage CI group notebooks.

Related https://github.com/laminlabs/lamindb-setup/pull/951 with explanation of the problem.

Fix https://github.com/laminlabs/lamindb/issues/2356