### PR TITLE
🚸 No longer throw a `NotebookNotSaved` error in `ln.finish()` but wait for the user or gracefully exit

### DIFF
--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -126,11 +126,11 @@ def prepare_notebook(
                     if strip_title:
                         lines.pop(i)
                         cell["source"] = "\n".join(lines)
-        # strip resaved finish error if present
+        # strip logging message about saving notebook in editor
         # this is normally the last cell
         if cell["cell_type"] == "code" and ".finish(" in cell["source"]:
             for output in cell["outputs"]:
-                if output.get("ename", None) == "NotebookNotSaved":
+                if "please save the notebook in your editor" in output.get("text", ""):
                     cell["outputs"] = []
                     break
     return None

--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -7,7 +7,7 @@ from time import sleep
 from typing import TYPE_CHECKING
 
 import lamindb_setup as ln_setup
-from lamin_utils import colors, logger
+from lamin_utils import logger
 from lamin_utils._logger import LEVEL_TO_COLORS, LEVEL_TO_ICONS, RESET_COLOR
 from lamindb_setup.core.hashing import hash_file
 
@@ -20,7 +20,9 @@ if TYPE_CHECKING:
 
 
 def get_save_notebook_message() -> str:
-    return f"please save the notebook in your editor (shortcut {colors.bold(get_shortcut())})"
+    # do not add bold() or any other complicated characters as then we can't match this
+    # easily anymore in an html to strip it out
+    return f"please save the notebook in your editor (shortcut {get_shortcut()})"
 
 
 def get_save_notebook_message_r() -> str:

--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -24,7 +24,7 @@ def get_save_notebook_message() -> str:
 
 
 def get_save_notebook_message_r() -> str:
-    return f"{get_save_notebook_message()} and re-run db$finish()"
+    return f"{get_save_notebook_message()} and re-run finish()"
 
 
 # this code was originally in nbproject by the same authors
@@ -189,15 +189,15 @@ def clean_r_notebook_html(file_path: Path) -> tuple[str | None, Path]:
         cleaned_content = re.sub(pattern_title, "", cleaned_content)
         cleaned_content = re.sub(pattern_h1, "", cleaned_content)
     # remove error message from content
-    if "NotebookNotSaved" in cleaned_content:
-        orig_error_message = f"NotebookNotSaved: {get_save_notebook_message_r()}"
+    if "! please save the notebook in your editor" in cleaned_content:
+        orig_error_message = f"! {get_save_notebook_message_r()}"
         # coming up with the regex for this is a bit tricky due to all the
         # escape characters we'd need to insert into the message; hence,
         # we do this with a replace() instead
         cleaned_content = cleaned_content.replace(orig_error_message, "")
-        if "NotebookNotSaved" in cleaned_content:
+        if "! please save the notebook in your editor" in cleaned_content:
             orig_error_message = orig_error_message.replace(
-                " `finish()`", "\n`finish()`"
+                " finish()", "\nfinish()"
             )  # RStudio might insert a newline
             cleaned_content = cleaned_content.replace(orig_error_message, "")
     cleaned_path = file_path.parent / (f"{file_path.stem}.cleaned{file_path.suffix}")

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -200,6 +200,7 @@ class Context:
         self._logging_message_track: str = ""
         self._logging_message_imports: str = ""
         self._stream_tracker: LogStreamTracker = LogStreamTracker()
+        self._is_finish_retry: bool = False
 
     @property
     def transform(self) -> Transform | None:
@@ -683,13 +684,17 @@ class Context:
             self.run.save()
             # nothing else to do
             return None
-        save_context_core(
+        return_code = save_context_core(
             run=self.run,
             transform=self.run.transform,
             filepath=self._path,
             finished_at=True,
             ignore_non_consecutive=ignore_non_consecutive,
+            is_retry=self._is_finish_retry,
         )
+        if return_code == "retry":
+            self._is_finish_retry = True
+            return None
         if self.transform.type != "notebook":
             self._stream_tracker.finish()
         # reset the context attributes so that somebody who runs `track()` after finish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 dependencies = [
     # Lamin PINNED packages
     "lamin_utils==0.13.10",
-    "lamin_cli==1.0.4",
+    "lamin_cli==1.0.5",
     "lamindb_setup[aws]==1.0.3",
     # others
     "pyarrow",

--- a/tests/core/notebooks/basic-r-notebook.Rmd.html
+++ b/tests/core/notebooks/basic-r-notebook.Rmd.html
@@ -35,7 +35,7 @@ db &lt;- connect()</code></pre>
   <!-- rnb-source-end -->
   <!-- rnb-output-end -->
   <!-- rnb-output-begin eyJkYXRhIjoiRXJyb3IgaW4gcHlfY2FsbF9pbXBsKGNhbGxhYmxlLCBjYWxsX2FyZ3MkdW5uYW1lZCwgY2FsbF9hcmdzJG5hbWVkKSA6IFxuICBsYW1pbmRiLmNvcmUuZXhjZXB0aW9ucy5Ob3RlYm9va05vdFNhdmVkOiBQbGVhc2Ugc2F2ZSB0aGUgbm90ZWJvb2sgaW4gUlN0dWRpbyAoc2hvcnRjdXQgYENNRCArIHNgKSB3aXRoaW4gMiBzZWMgYmVmb3JlIGNhbGxpbmcgYGRiJGZpbmlzaCgpYFxuUnVuIFx1MDAxYl04Oztyc3R1ZGlvOnJ1bjpyZXRpY3VsYXRlOjpweV9sYXN0X2Vycm9yKClcdTAwMDdgcmV0aWN1bGF0ZTo6cHlfbGFzdF9lcnJvcigpYFx1MDAxYl04OztcdTAwMDcgZm9yIGRldGFpbHMuXG4ifQ== -->
-  <pre><code>MoreOUTPUT ! please save the notebook in your editor (shortcut CMD + s) and re-run finish()</code></pre>
+  <pre><code>MoreOUTPUT ! please save the notebook in your editor (shortcut SHORTCUT) and re-run finish()</code></pre>
   <!-- rnb-output-end -->
   <!-- rnb-chunk-end -->
   <!-- rnb-text-begin -->

--- a/tests/core/notebooks/basic-r-notebook.Rmd.html
+++ b/tests/core/notebooks/basic-r-notebook.Rmd.html
@@ -35,7 +35,7 @@ db &lt;- connect()</code></pre>
   <!-- rnb-source-end -->
   <!-- rnb-output-end -->
   <!-- rnb-output-begin eyJkYXRhIjoiRXJyb3IgaW4gcHlfY2FsbF9pbXBsKGNhbGxhYmxlLCBjYWxsX2FyZ3MkdW5uYW1lZCwgY2FsbF9hcmdzJG5hbWVkKSA6IFxuICBsYW1pbmRiLmNvcmUuZXhjZXB0aW9ucy5Ob3RlYm9va05vdFNhdmVkOiBQbGVhc2Ugc2F2ZSB0aGUgbm90ZWJvb2sgaW4gUlN0dWRpbyAoc2hvcnRjdXQgYENNRCArIHNgKSB3aXRoaW4gMiBzZWMgYmVmb3JlIGNhbGxpbmcgYGRiJGZpbmlzaCgpYFxuUnVuIFx1MDAxYl04Oztyc3R1ZGlvOnJ1bjpyZXRpY3VsYXRlOjpweV9sYXN0X2Vycm9yKClcdTAwMDdgcmV0aWN1bGF0ZTo6cHlfbGFzdF9lcnJvcigpYFx1MDAxYl04OztcdTAwMDcgZm9yIGRldGFpbHMuXG4ifQ== -->
-  <pre><code>MoreOUTPUT NotebookNotSaved: Please save the notebook in your editor (shortcut `SHORTCUT`) within 2 sec before calling `finish()`</code></pre>
+  <pre><code>MoreOUTPUT ! please save the notebook in your editor (shortcut CMD + s) and re-run finish()</code></pre>
   <!-- rnb-output-end -->
   <!-- rnb-chunk-end -->
   <!-- rnb-text-begin -->

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -279,6 +279,7 @@ def test_clean_r_notebook_html():
     assert comparison_path == cleaned_path
     assert title_text == "My exemplary R analysis"
     assert compare == cleaned_path.read_text()  # check that things have been stripped
+    comparison_path.write_text(compare)
     orig_notebook_path.write_text(content.replace(get_shortcut(), "SHORTCUT"))
 
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -278,7 +278,7 @@ def test_clean_r_notebook_html():
     title_text, cleaned_path = clean_r_notebook_html(orig_notebook_path)
     assert comparison_path == cleaned_path
     assert title_text == "My exemplary R analysis"
-    assert compare == comparison_path.read_text()
+    assert compare == cleaned_path.read_text()  # check that things have been stripped
     orig_notebook_path.write_text(content.replace(get_shortcut(), "SHORTCUT"))
 
 


### PR DESCRIPTION
Before this PR, `finish()` used to raise a `NotebookNotSaved` exception asking the user to save the notebook within 2 seconds before running `finish()`.

Now, it behaves more gracefully across Jupyter & RStudio.

# Jupyter Notebook

Tested the following behavior in VSCode and Jupyter Lab. It works if event loop of editor frontend and kernel execution of the notebook cell are decoupled. This should be true for most editors. If it's not true the user won't be able to save while the cell runs and will see the second behavior below.

## (1) User saves the notebook within a few seconds of calling `ln.finish()`

```bash
• please save the notebook in your editor (shortcut CMD + s) .... ✓
→ finished Run('vxl76EUB') after 9s at 2025-01-23 13:58:26 UTC
→ go to: https://lamin.ai/laminlabs/lamin-dev/transform/UcRrvg5YuNgC0009
→ to update your notebook from the CLI, run: lamin save /Users/falexwolf/dbs/lamindata/my-analysis-2024-12.ipynb
```

## (2) User does not save the notebook

```bash
• please save the notebook in your editor (shortcut CMD + s) .........
→ finished Run('oCclsnkd') after 18s at 2025-01-23 14:00:52 UTC
! did *not* save source code and report -- to do so, run: lamin save /Users/falexwolf/dbs/lamindata/my-analysis-2024-12.ipynb
```

# RStudio

Unlike VSCode and Jupyter Lab, RStudio seems to couple the kernel & frontend event loop: it's **not** responsive to a "save" event via `CMD/CTRL + S` to the editor until the notebook cell finishes execution.

Hence, we prompt the user for a manual retry.

```bash
> db$finish()
! please save the notebook in your editor (shortcut CMD + s) and re-run db$finish()
> db$finish()
→ finished Run('aL4Nxl7d') after 12s at 2025-01-23 14:37:14 UTC
→ go to: https://lamin.ai/laminlabs/lamin-dev/transform/9w3DLWRMsoDx0003
→ to update your notebook from the CLI, run: lamin save alex-rnb.Rmd
```