### PR TITLE
🐛 Further fixes and tests for Artifact.replace

### DIFF
--- a/docs/storage/add-replace-cache.ipynb
+++ b/docs/storage/add-replace-cache.ipynb
@@ -615,10 +615,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with pytest.raises(\n",
-    "    ValueError, match=\"Can only replace with a local path not in any Storage.\"\n",
-    "):\n",
-    "    artifact.replace(path_in_storage)"
+    "with pytest.raises(ValueError) as err:\n",
+    "    artifact.replace(path_in_storage)\n",
+    "assert err.exconly().endswith(\"Can only replace with a local path not in any Storage.\")"
    ]
   },
   {
@@ -753,10 +752,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with pytest.raises(\n",
-    "    ValueError, match=\"It is not allowed to replace a folder with a file.\"\n",
-    "):\n",
-    "    artifact.replace(\"./test-files/iris.csv\")"
+    "with pytest.raises(ValueError):\n",
+    "    artifact.replace(\"./test-files/iris.csv\")\n",
+    "assert err.exconly().endswith(\"It is not allowed to replace a folder with a file.\")"
    ]
   },
   {
@@ -779,7 +777,7 @@
    "source": [
     "adata.obs[\"new_col\"] = \"new\"\n",
     "\n",
-    "adata.write_zarr(\"./test-files/pbmc68k_new.zrad\")"
+    "adata.write_zarr(\"./test-files/pbmc68k_new.anndata.zarr\")"
    ]
   },
   {
@@ -789,7 +787,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact.replace(\"./test-files/pbmc68k_new.zrad\")\n",
+    "artifact.replace(\"./test-files/pbmc68k_new.anndata.zarr\")\n",
     "artifact.save()"
    ]
   },
@@ -800,10 +798,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert artifact.key == \"pbmc68k.zrad\"\n",
+    "assert artifact.key == \"pbmc68k.anndata.zarr\"\n",
     "assert artifact.hash != save_hash\n",
     "assert artifact.n_files != save_n_files\n",
     "assert artifact.path.is_dir()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06eadae1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with artifact.open() as store:\n",
+    "    assert \"new_col\" in store.obs"
    ]
   },
   {

--- a/docs/storage/add-replace-cache.ipynb
+++ b/docs/storage/add-replace-cache.ipynb
@@ -617,7 +617,10 @@
    "source": [
     "with pytest.raises(ValueError) as err:\n",
     "    artifact.replace(path_in_storage)\n",
-    "assert err.exconly().endswith(\"Can only replace with a local path not in any Storage.\")"
+    "err_text = err.exconly()\n",
+    "assert err_text.endswith(\n",
+    "    \"Can only replace with a local path not in any Storage.\"\n",
+    "), err_text"
    ]
   },
   {
@@ -754,7 +757,8 @@
    "source": [
     "with pytest.raises(ValueError):\n",
     "    artifact.replace(\"./test-files/iris.csv\")\n",
-    "assert err.exconly().endswith(\"It is not allowed to replace a folder with a file.\")"
+    "err_text = err.exconly()\n",
+    "assert err_text.endswith(\"It is not allowed to replace a folder with a file.\"), err_text"
    ]
   },
   {

--- a/docs/storage/add-replace-cache.ipynb
+++ b/docs/storage/add-replace-cache.ipynb
@@ -617,10 +617,9 @@
    "source": [
     "with pytest.raises(ValueError) as err:\n",
     "    artifact.replace(path_in_storage)\n",
-    "err_text = err.exconly()\n",
-    "assert err_text.startswith(\n",
+    "assert err.exconly().startswith(\n",
     "    \"ValueError: Can only replace with a local path not in any Storage.\"\n",
-    "), err_text"
+    ")"
    ]
   },
   {
@@ -755,10 +754,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with pytest.raises(ValueError):\n",
+    "with pytest.raises(ValueError) as err:\n",
     "    artifact.replace(\"./test-files/iris.csv\")\n",
-    "err_text = err.exconly()\n",
-    "assert err_text.endswith(\"It is not allowed to replace a folder with a file.\"), err_text"
+    "assert err.exconly().endswith(\"It is not allowed to replace a folder with a file.\")"
    ]
   },
   {

--- a/docs/storage/add-replace-cache.ipynb
+++ b/docs/storage/add-replace-cache.ipynb
@@ -618,8 +618,8 @@
     "with pytest.raises(ValueError) as err:\n",
     "    artifact.replace(path_in_storage)\n",
     "err_text = err.exconly()\n",
-    "assert err_text.endswith(\n",
-    "    \"Can only replace with a local path not in any Storage.\"\n",
+    "assert err_text.startswith(\n",
+    "    \"ValueError: Can only replace with a local path not in any Storage.\"\n",
     "), err_text"
    ]
   },

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -867,7 +867,11 @@ def replace(
 
     check_path_in_storage = privates["check_path_in_storage"]
     if check_path_in_storage:
-        raise ValueError("Can only replace with a local path not in any Storage.")
+        err_msg = (
+            "Can only replace with a local path not in any Storage. "
+            f"This data is in {Storage.objects.get(id=kwargs['storage_id'])}."
+        )
+        raise ValueError(err_msg)
 
     _overwrite_versions = kwargs["_overwrite_versions"]
     if self._overwrite_versions != _overwrite_versions:

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -64,7 +64,7 @@ try:
 except ImportError:
 
     def zarr_is_adata(storepath):  # type: ignore
-        raise ImportError("Please install zarr: pip install zarr")
+        raise ImportError("Please install zarr: pip install zarr<=2.18.4")
 
 
 if TYPE_CHECKING:

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -938,7 +938,15 @@ def open(
     if self._overwrite_versions and not self.is_latest:
         raise ValueError(inconsistent_state_msg)
     # ignore empty suffix for now
-    suffixes = ("", ".h5", ".hdf5", ".h5ad", ".zarr", ".tiledbsoma") + PYARROW_SUFFIXES
+    suffixes = (
+        "",
+        ".h5",
+        ".hdf5",
+        ".h5ad",
+        ".zarr",
+        ".anndata.zarr",
+        ".tiledbsoma",
+    ) + PYARROW_SUFFIXES
     if self.suffix not in suffixes:
         raise ValueError(
             "Artifact should have a zarr, h5, tiledbsoma object"

--- a/lamindb/core/loaders.py
+++ b/lamindb/core/loaders.py
@@ -40,7 +40,7 @@ try:
 except ImportError:
 
     def load_anndata_zarr(storepath):  # type: ignore
-        raise ImportError("Please install zarr: pip install zarr")
+        raise ImportError("Please install zarr: pip install zarr<=2.18.4")
 
 
 is_run_from_ipython = getattr(builtins, "__IPYTHON__", False)

--- a/lamindb/core/storage/_backed_access.py
+++ b/lamindb/core/storage/_backed_access.py
@@ -88,7 +88,7 @@ def backed_access(
         return _open_tiledbsoma(objectpath, mode=mode)  # type: ignore
     elif suffix in {".h5", ".hdf5", ".h5ad"}:
         conn, storage = registry.open("h5py", objectpath, mode=mode)
-    elif suffix == ".zarr":
+    elif suffix in {".zarr", ".anndata.zarr"}:
         conn, storage = registry.open("zarr", objectpath, mode=mode)
     elif _is_pyarrow_dataset(objectpath):
         return _open_pyarrow_dataset(objectpath)

--- a/lamindb/core/storage/_backed_access.py
+++ b/lamindb/core/storage/_backed_access.py
@@ -88,7 +88,7 @@ def backed_access(
         return _open_tiledbsoma(objectpath, mode=mode)  # type: ignore
     elif suffix in {".h5", ".hdf5", ".h5ad"}:
         conn, storage = registry.open("h5py", objectpath, mode=mode)
-    elif suffix in {".zarr", ".anndata.zarr"}:
+    elif suffix == ".zarr":
         conn, storage = registry.open("zarr", objectpath, mode=mode)
     elif _is_pyarrow_dataset(objectpath):
         return _open_pyarrow_dataset(objectpath)

--- a/lamindb/core/storage/paths.py
+++ b/lamindb/core/storage/paths.py
@@ -139,7 +139,23 @@ def store_file_or_folder(
     local_path = UPath(local_path)
     if not isinstance(storage_path, LocalPathClasses):
         # this uploads files and directories
-        create_folder = False if local_path.is_dir() else None
+        if local_path.is_dir():
+            create_folder = False
+            try:
+                # if storage_path already exists we need to delete it
+                # if local_path is a directory
+                # to replace storage_path correctly
+                is_dir_storage_path = (
+                    storage_path.stat().as_info()["type"] == "directory"
+                )
+                if is_dir_storage_path:
+                    storage_path.rmdir()
+                else:
+                    storage_path.unlink()
+            except (FileNotFoundError, PermissionError):
+                pass
+        else:
+            create_folder = None
         storage_path.upload_from(
             local_path, create_folder=create_folder, print_progress=print_progress
         )

--- a/lamindb/core/storage/paths.py
+++ b/lamindb/core/storage/paths.py
@@ -145,10 +145,7 @@ def store_file_or_folder(
                 # if storage_path already exists we need to delete it
                 # if local_path is a directory
                 # to replace storage_path correctly
-                is_dir_storage_path = (
-                    storage_path.stat().as_info()["type"] == "directory"
-                )
-                if is_dir_storage_path:
+                if storage_path.stat().as_info()["type"] == "directory":
                     storage_path.rmdir()
                 else:
                     storage_path.unlink()


### PR DESCRIPTION
Delete an existing folder in a remote destination on upload of a new folder.

Also see comments in https://github.com/laminlabs/lamindb/pull/2374