### PR TITLE
🚸 In `ln.finish()` enhance experience of waiting for editor flush (attempt 2)

### DIFF
--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 def get_save_notebook_message() -> str:
     # do not add bold() or any other complicated characters as then we can't match this
     # easily anymore in an html to strip it out
-    return f"please save the notebook in your editor (shortcut {get_shortcut()})"
+    return f"please hit {get_shortcut()} to save the notebook in your editor"
 
 
 def get_save_notebook_message_retry() -> str:
@@ -130,7 +130,7 @@ def prepare_notebook(
         # this is normally the last cell
         if cell["cell_type"] == "code" and ".finish(" in cell["source"]:
             for output in cell["outputs"]:
-                if "please save the notebook in your editor" in output.get("text", ""):
+                if "to save the notebook in your editor" in output.get("text", ""):
                     cell["outputs"] = []
                     break
     return None
@@ -191,13 +191,13 @@ def clean_r_notebook_html(file_path: Path) -> tuple[str | None, Path]:
         cleaned_content = re.sub(pattern_title, "", cleaned_content)
         cleaned_content = re.sub(pattern_h1, "", cleaned_content)
     # remove error message from content
-    if "! please save the notebook in your editor" in cleaned_content:
+    if "to save the notebook in your editor" in cleaned_content:
         orig_error_message = f"! {get_save_notebook_message_retry()}"
         # coming up with the regex for this is a bit tricky due to all the
         # escape characters we'd need to insert into the message; hence,
         # we do this with a replace() instead
         cleaned_content = cleaned_content.replace(orig_error_message, "")
-        if "! please save the notebook in your editor" in cleaned_content:
+        if "to save the notebook in your editor" in cleaned_content:
             orig_error_message = orig_error_message.replace(
                 " finish()", "\nfinish()"
             )  # RStudio might insert a newline
@@ -207,15 +207,17 @@ def clean_r_notebook_html(file_path: Path) -> tuple[str | None, Path]:
     return title_text, cleaned_path
 
 
-def check_filepath_recently_saved(filepath: Path, is_retry: bool) -> bool:
-    recently_saved_time = 2.5 if not is_retry else 10
-    for retry in range(10):
+def check_filepath_recently_saved(filepath: Path, is_finish_retry: bool) -> bool:
+    recently_saved_time = 3 if not is_finish_retry else 20
+    for retry in range(30):
         if get_seconds_since_modified(filepath) > recently_saved_time:
             if retry == 0:
                 prefix = f"{LEVEL_TO_COLORS[20]}{LEVEL_TO_ICONS[20]}{RESET_COLOR}"
                 print(f"{prefix} {get_save_notebook_message()}", end=" ")
             elif retry == 9:
                 print(".", end="\n")
+            elif retry == 4:
+                print(". still waiting ", end="")
             else:
                 print(".", end="")
             sleep(1)
@@ -315,7 +317,7 @@ def save_context_core(
                 f"no html report found; to attach one, create an .html export for your {filepath.suffix} file and then run: lamin save {filepath}"
             )
     if report_path is not None and is_r_notebook and not from_cli:  # R notebooks
-        recently_saved_time = 2.5 if not is_retry else 10
+        recently_saved_time = 3 if not is_retry else 20
         if get_seconds_since_modified(report_path) > recently_saved_time:
             # the automated retry solution of Jupyter notebooks does not work in RStudio because the execution of the notebook cell
             # seems to block the event loop of the frontend
@@ -324,7 +326,7 @@ def save_context_core(
                 return "retry"
             else:
                 logger.warning(
-                    "the notebook on disk wasn't saved within the last 10 sec"
+                    "the notebook on disk hasn't been saved within the last 20 sec"
                 )
             save_source_code_and_report = False
     ln.settings.creation.artifact_silence_missing_run_warning = True

--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -263,7 +263,7 @@ def save_context_core(
             transform.save()
         if not ln_setup._TESTING:
             save_source_code_and_report = check_filepath_recently_saved(
-                filepath, is_retry=is_retry
+                filepath, is_retry
             )
             if not save_source_code_and_report and not is_retry:
                 logger.warning(get_save_notebook_message_retry())

--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -176,7 +176,6 @@ def notebook_to_script(
         script_path.write_text(py_content)
 
 
-# removes NotebookNotSaved error message from notebook html
 def clean_r_notebook_html(file_path: Path) -> tuple[str | None, Path]:
     import re
 

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -307,6 +307,10 @@ class Context:
                 ) = self._track_source_code(path=path)
             if description is None:
                 description = self._description
+            # temporarily until the hub displays the key by default
+            # populate the description with the filename again
+            if description is None:
+                description = self._path.name
             self._create_or_load_transform(
                 description=description,
                 transform_ref=transform_ref,

--- a/tests/core/notebooks/basic-r-notebook.Rmd.html
+++ b/tests/core/notebooks/basic-r-notebook.Rmd.html
@@ -35,7 +35,7 @@ db &lt;- connect()</code></pre>
   <!-- rnb-source-end -->
   <!-- rnb-output-end -->
   <!-- rnb-output-begin eyJkYXRhIjoiRXJyb3IgaW4gcHlfY2FsbF9pbXBsKGNhbGxhYmxlLCBjYWxsX2FyZ3MkdW5uYW1lZCwgY2FsbF9hcmdzJG5hbWVkKSA6IFxuICBsYW1pbmRiLmNvcmUuZXhjZXB0aW9ucy5Ob3RlYm9va05vdFNhdmVkOiBQbGVhc2Ugc2F2ZSB0aGUgbm90ZWJvb2sgaW4gUlN0dWRpbyAoc2hvcnRjdXQgYENNRCArIHNgKSB3aXRoaW4gMiBzZWMgYmVmb3JlIGNhbGxpbmcgYGRiJGZpbmlzaCgpYFxuUnVuIFx1MDAxYl04Oztyc3R1ZGlvOnJ1bjpyZXRpY3VsYXRlOjpweV9sYXN0X2Vycm9yKClcdTAwMDdgcmV0aWN1bGF0ZTo6cHlfbGFzdF9lcnJvcigpYFx1MDAxYl04OztcdTAwMDcgZm9yIGRldGFpbHMuXG4ifQ== -->
-  <pre><code>MoreOUTPUT ! please save the notebook in your editor (shortcut SHORTCUT) and re-run finish()</code></pre>
+  <pre><code>MoreOUTPUT ! hit SHORTCUT to save the notebook in your editor and re-run finish()</code></pre>
   <!-- rnb-output-end -->
   <!-- rnb-chunk-end -->
   <!-- rnb-text-begin -->

--- a/tests/core/notebooks/basic-r-notebook.Rmd.html
+++ b/tests/core/notebooks/basic-r-notebook.Rmd.html
@@ -35,7 +35,7 @@ db &lt;- connect()</code></pre>
   <!-- rnb-source-end -->
   <!-- rnb-output-end -->
   <!-- rnb-output-begin eyJkYXRhIjoiRXJyb3IgaW4gcHlfY2FsbF9pbXBsKGNhbGxhYmxlLCBjYWxsX2FyZ3MkdW5uYW1lZCwgY2FsbF9hcmdzJG5hbWVkKSA6IFxuICBsYW1pbmRiLmNvcmUuZXhjZXB0aW9ucy5Ob3RlYm9va05vdFNhdmVkOiBQbGVhc2Ugc2F2ZSB0aGUgbm90ZWJvb2sgaW4gUlN0dWRpbyAoc2hvcnRjdXQgYENNRCArIHNgKSB3aXRoaW4gMiBzZWMgYmVmb3JlIGNhbGxpbmcgYGRiJGZpbmlzaCgpYFxuUnVuIFx1MDAxYl04Oztyc3R1ZGlvOnJ1bjpyZXRpY3VsYXRlOjpweV9sYXN0X2Vycm9yKClcdTAwMDdgcmV0aWN1bGF0ZTo6cHlfbGFzdF9lcnJvcigpYFx1MDAxYl04OztcdTAwMDcgZm9yIGRldGFpbHMuXG4ifQ== -->
-  <pre><code>MoreOUTPUT ! hit SHORTCUT to save the notebook in your editor and re-run finish()</code></pre>
+  <pre><code>MoreOUTPUT ! please hit SHORTCUT to save the notebook in your editor and re-run finish()</code></pre>
   <!-- rnb-output-end -->
   <!-- rnb-chunk-end -->
   <!-- rnb-text-begin -->

--- a/tests/core/notebooks/no-title.ipynb
+++ b/tests/core/notebooks/no-title.ipynb
@@ -35,7 +35,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert ln.context.transform.description is None\n",
+    "assert ln.context.transform.description == \"no-title.ipynb\"\n",
     "assert ln.context.transform.key == \"no-title.ipynb\""
    ]
   }


### PR DESCRIPTION
Attempts to improve on:

- https://github.com/laminlabs/lamindb/pull/2378

Compared to:

- https://github.com/laminlabs/lamindb/pull/2375

the new experience here adds a "still waiting" after 4 seconds of waiting and extends the maximal waiting period to 30 seconds to account for notebooks that might be very large and take very long to save.

```bash
• please hit CMD + s to save the notebook in your editor .... still waiting .................. ✓
```