### PR TITLE
✅ Test folder replacement correctly

### DIFF
--- a/docs/storage/add-replace-cache.ipynb
+++ b/docs/storage/add-replace-cache.ipynb
@@ -779,7 +779,7 @@
    "source": [
     "adata.obs[\"add_new_col\"] = \"new\"\n",
     "\n",
-    "adata.write_zarr(\"./test-files/pbmc68k_new.anndata.zarr\")"
+    "adata.write_zarr(\"./test-files/pbmc68k_new.zarr\")"
    ]
   },
   {
@@ -789,7 +789,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact.replace(\"./test-files/pbmc68k_new.anndata.zarr\")\n",
+    "artifact.replace(\"./test-files/pbmc68k_new.zarr\")\n",
     "artifact.save()"
    ]
   },
@@ -800,10 +800,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert artifact.key == \"pbmc68k.anndata.zarr\"\n",
+    "assert artifact.key == \"pbmc68k.zarr\"\n",
     "assert artifact.hash != save_hash\n",
     "assert artifact.n_files != save_n_files\n",
     "assert artifact.path.is_dir()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ca7eb57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shutil.rmtree(artifact.cache())"
    ]
   },
   {
@@ -825,7 +835,7 @@
    "outputs": [],
    "source": [
     "shutil.rmtree(\"./test-files/pbmc68k.zarr\")\n",
-    "shutil.rmtree(\"./test-files/pbmc68k_new.anndata.zarr\")"
+    "shutil.rmtree(\"./test-files/pbmc68k_new.zarr\")"
    ]
   },
   {

--- a/docs/storage/add-replace-cache.ipynb
+++ b/docs/storage/add-replace-cache.ipynb
@@ -777,7 +777,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "adata.obs[\"new_col\"] = \"new\"\n",
+    "adata.obs[\"add_new_col\"] = \"new\"\n",
     "\n",
     "adata.write_zarr(\"./test-files/pbmc68k_new.anndata.zarr\")"
    ]
@@ -814,7 +814,7 @@
    "outputs": [],
    "source": [
     "with artifact.open() as store:\n",
-    "    assert \"new_col\" in store.obs"
+    "    assert \"add_new_col\" in store.obs"
    ]
   },
   {
@@ -824,7 +824,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "shutil.rmtree(\"./test-files\")"
+    "shutil.rmtree(\"./test-files/pbmc68k.zarr\")\n",
+    "shutil.rmtree(\"./test-files/pbmc68k_new.anndata.zarr\")"
    ]
   },
   {


### PR DESCRIPTION
It wasn't testing the replacement of the folder in the same remote path because the replacement has a different suffix.