### PR TITLE
✨ Check for corrupted cache in Artifact.load

### DIFF
--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -1037,6 +1037,9 @@ def load(self, is_run_input: bool | None = None, **kwargs) -> Any:
             # cache_path is local so doesn't trigger any sync in load_to_memory
             access_memory = load_to_memory(cache_path, **kwargs)
         except Exception as e:
+            # just raise the exception if the original path is local
+            if isinstance(filepath, LocalPathClasses):
+                raise e
             logger.warning(
                 f"The cache might be corrupted: {e}. Retrying to synchronize."
             )

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -1044,7 +1044,7 @@ def load(self, is_run_input: bool | None = None, **kwargs) -> Any:
                 f"The cache might be corrupted: {e}. Retrying to synchronize."
             )
             # delete the existing cache
-            if cache_path.isdir():
+            if cache_path.is_dir():
                 shutil.rmtree(cache_path)
             else:
                 cache_path.unlink(missing_ok=True)

--- a/tests/core/test_cache.py
+++ b/tests/core/test_cache.py
@@ -214,6 +214,9 @@ def test_corrupted_cache_local():
 
 
 def test_corrupted_cache_cloud(switch_storage):
+    # check that we have cloud storage
+    assert ln.setup.settings.storage.root_as_str == switch_storage
+
     filepath = ln.core.datasets.anndata_file_pbmc68k_test()
     artifact = ln.Artifact.from_anndata(filepath, key="test_corrupt_cache_cloud.h5ad")
     artifact.save()
@@ -222,7 +225,7 @@ def test_corrupted_cache_cloud(switch_storage):
         f.write(b"corruption")
     # check that it is indeed corrupted
     with pytest.raises(OSError):
-        load_h5ad(artifact._cache_path)
+        load_h5ad(artifact.cache())
     # should load successfully
     artifact.load()
 

--- a/tests/core/test_cache.py
+++ b/tests/core/test_cache.py
@@ -197,3 +197,21 @@ def test_cloud_cache_versions(switch_storage):
     assert cache_path_v1.name == f"{artifact.uid}.h5ad"
 
     artifact_v2.versions.delete(permanent=True)
+
+
+def test_corrupted_cache_cloud(switch_storage):
+    filepath = ln.core.datasets.anndata_file_pbmc68k_test()
+
+    artifact = ln.Artifact.from_anndata(filepath, key="test_corrupted_cache.h5ad")
+    artifact.save()
+
+    # corrupt cache
+    with open(artifact._cache_path, "r+b") as f:
+        f.write(b"corruption")
+
+    with pytest.raises(OSError):
+        load_h5ad(artifact._cache_path)
+    # should load successfully
+    artifact.load()
+
+    artifact.delete(permanent=True)


### PR DESCRIPTION
If the first attempt to load from the cache in `Artifact.load` fails, it attempts to re-download the cache and load into memory again.