### PR TITLE
✨ Check for corrupted cache in Artifact.open

### DIFF
--- a/tests/core/test_cache.py
+++ b/tests/core/test_cache.py
@@ -236,5 +236,14 @@ def test_corrupted_cache_cloud(switch_storage):
         load_h5ad(artifact.cache())
     # should load successfully
     artifact.load()
+    # check open also
+    assert artifact._cache_path.exists()
+    with open(artifact._cache_path, "r+b") as f:
+        f.write(b"corruption")
+    # should open successfully
+    with artifact.open():
+        pass
+    # corrupted cache has been deleted
+    assert not artifact._cache_path.exists()
 
     artifact.delete(permanent=True)

--- a/tests/core/test_cache.py
+++ b/tests/core/test_cache.py
@@ -209,6 +209,8 @@ def test_corrupted_cache_local():
     # just raises an exception, nothing to re-sync on local
     with pytest.raises(OSError):
         artifact.load()
+    with pytest.raises(OSError):
+        artifact.open()
 
     artifact.delete(permanent=True)
 


### PR DESCRIPTION
`Artifact.open` uses cached files if they exist. This PR adds a check of `.open`, if it is unsuccessful, it tries to bypass the cache, open directly and delete the corrupted cache if the remote store has been opened successfully.
Related https://github.com/laminlabs/lamindb/pull/2386
Closes https://github.com/laminlabs/lamindb/issues/2392