### PR TITLE
✨ Require keyword parameters for `Artifact.from_x` methods

### DIFF
--- a/docs/faq/track-run-inputs.ipynb
+++ b/docs/faq/track-run-inputs.ipynb
@@ -53,7 +53,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.context.track(transform=ln.Transform(name=\"Dummpy pipeline\"))\n",
+    "ln.context.track(transform=ln.Transform(key=\"Dummpy pipeline\"))\n",
     "ln.Artifact(ln.core.datasets.file_jpg_paradisi05(), description=\"My image\").save()\n",
     "ln.Artifact(ln.core.datasets.file_mini_csv(), description=\"My csv\").save()"
    ]

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -83,6 +83,7 @@ def process_pathlike(
     using_key: str | None,
     skip_existence_check: bool = False,
 ) -> tuple[Storage, bool]:
+    """Determines the appropriate storage for a given path and whether to use an existing storage key."""
     if not skip_existence_check:
         try:  # check if file exists
             if not filepath.exists():
@@ -192,8 +193,7 @@ def process_data(
         use_existing_storage_key = False
     else:
         raise NotImplementedError(
-            f"Do not know how to create a artifact object from {data}, pass a path"
-            " instead!"
+            f"Do not know how to create a artifact object from {data}, pass a path instead!"
         )
     return memory_rep, path, suffix, storage, use_existing_storage_key
 
@@ -205,6 +205,7 @@ def get_stat_or_artifact(
     is_replace: bool = False,
     instance: str | None = None,
 ) -> tuple[int, str | None, str | None, int | None, Artifact | None] | Artifact:
+    """Retrieves file statistics or an existing artifact based on the path, hash, and key."""
     n_files = None
     if settings.creation.artifact_skip_size_hash:
         return None, None, None, n_files, None
@@ -676,6 +677,7 @@ def __init__(artifact: Artifact, *args, **kwargs):
 def from_df(
     cls,
     df: pd.DataFrame,
+    *,
     key: str | None = None,
     description: str | None = None,
     run: Run | None = None,
@@ -701,6 +703,7 @@ def from_df(
 def from_anndata(
     cls,
     adata: AnnData | UPathStr,
+    *,
     key: str | None = None,
     description: str | None = None,
     run: Run | None = None,
@@ -728,6 +731,7 @@ def from_anndata(
 def from_mudata(
     cls,
     mdata: MuData,
+    *,
     key: str | None = None,
     description: str | None = None,
     run: Run | None = None,
@@ -753,8 +757,8 @@ def from_mudata(
 def from_dir(
     cls,
     path: UPathStr,
-    key: str | None = None,
     *,
+    key: str | None = None,
     run: Run | None = None,
 ) -> list[Artifact]:
     """{}"""  # noqa: D415

--- a/lamindb/_save.py
+++ b/lamindb/_save.py
@@ -57,7 +57,7 @@ def save(records: Iterable[Record], ignore_conflicts: bool | None = False) -> No
 
         For a single record, use ``record.save()``:
 
-        >>> transform = ln.Transform(name="My pipeline")
+        >>> transform = ln.Transform(key="My pipeline")
         >>> transform.save()
 
         Update a single existing record:

--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -2652,6 +2652,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
     def from_df(
         cls,
         df: pd.DataFrame,
+        *,
         key: str | None = None,
         description: str | None = None,
         run: Run | None = None,
@@ -2692,6 +2693,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
     def from_anndata(
         cls,
         adata: AnnData | UPathStr,
+        *,
         key: str | None = None,
         description: str | None = None,
         run: Run | None = None,
@@ -2728,6 +2730,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
     def from_mudata(
         cls,
         mdata: MuData,
+        *,
         key: str | None = None,
         description: str | None = None,
         run: Run | None = None,
@@ -2763,8 +2766,8 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
     def from_dir(
         cls,
         path: UPathStr,
-        key: str | None = None,
         *,
+        key: str | None = None,
         run: Run | None = None,
     ) -> list[Artifact]:
         """Create a list of artifact objects from a directory.

--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -1187,7 +1187,7 @@ class Transform(Record, IsVersioned):
 
         Create a transform for a pipeline:
 
-        >>> transform = ln.Transform(name="Cell Ranger", version="7.2.0", type="pipeline").save()
+        >>> transform = ln.Transform(key="Cell Ranger", version="7.2.0", type="pipeline").save()
 
         Create a transform from a notebook:
 
@@ -1460,8 +1460,8 @@ class Run(Record):
 
         Create a run record:
 
-        >>> ln.Transform(name="Cell Ranger", version="7.2.0", type="pipeline").save()
-        >>> transform = ln.Transform.get(name="Cell Ranger", version="7.2.0")
+        >>> ln.Transform(key="Cell Ranger", version="7.2.0", type="pipeline").save()
+        >>> transform = ln.Transform.get(key="Cell Ranger", version="7.2.0")
         >>> run = ln.Run(transform)
 
         Create a global run context for a custom transform:

--- a/tests/core/test_collection.py
+++ b/tests/core/test_collection.py
@@ -75,11 +75,11 @@ def test_from_single_artifact(adata):
     assert str(error.exconly()).startswith(
         "ValueError: Only one non-keyword arg allowed: artifacts"
     )
-    transform = ln.Transform(name="My test transform")
+    transform = ln.Transform(key="My test transform")
     transform.save()
     run = ln.Run(transform)
     run.save()
-    collection = ln.Collection(artifact, name="My new collection", run=run)
+    collection = ln.Collection(artifact, key="My new collection", run=run)
     collection.save()
     assert collection.run.input_artifacts.get() == artifact
     collection.delete(permanent=True)
@@ -122,7 +122,7 @@ def test_from_inconsistent_artifacts(df, adata):
     # test idempotency of .save()
     collection.save()
     # create a run context
-    ln.context.track(transform=ln.Transform(name="My test transform"))
+    ln.context.track(transform=ln.Transform(key="My test transform"))
     # can iterate over them
     collection.cache()
     assert set(ln.context.run.input_collections.all()) == {collection}
@@ -149,7 +149,7 @@ def test_from_consistent_artifacts(adata, adata2):
         adata2, var_index=bt.Gene.symbol, organism="human"
     )
     artifact2 = curator.save_artifact(description="My test2").save()
-    transform = ln.Transform(name="My test transform").save()
+    transform = ln.Transform(key="My test transform").save()
     run = ln.Run(transform).save()
     collection = ln.Collection([artifact1, artifact2], name="My test", run=run)
     assert collection._state.adding

--- a/tests/core/test_collection.py
+++ b/tests/core/test_collection.py
@@ -65,7 +65,7 @@ def test_from_single_artifact(adata):
         artifact.delete(permanent=True)  # make sure we get a fresh one
         artifact = ln.Artifact.from_anndata(adata, description="My adata")
     with pytest.raises(ValueError) as error:
-        ln.Collection(artifact, name="Test")
+        ln.Collection(artifact, key="Test")
     assert str(error.exconly()).startswith(
         "ValueError: Not all artifacts are yet saved, please save them"
     )
@@ -383,7 +383,7 @@ def test_collection_mapped(adata, adata2):
 def test_revise_collection(df, adata):
     # create a versioned collection
     artifact = ln.Artifact.from_df(df, description="test").save()
-    collection = ln.Collection(artifact, name="test", version="1")
+    collection = ln.Collection(artifact, key="test", version="1")
     assert collection.version == "1"
     assert collection.uid.endswith("0000")
     collection.save()
@@ -432,7 +432,7 @@ def test_revise_collection(df, adata):
 def test_collection_append(df, adata):
     artifact = ln.Artifact.from_df(df, description="test").save()
     artifact_1 = ln.Artifact.from_anndata(adata, description="test").save()
-    col = ln.Collection(artifact, name="Test", description="Test append").save()
+    col = ln.Collection(artifact, key="Test", description="Test append").save()
 
     col_append = col.append(artifact_1).save()
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -15,9 +15,9 @@ NOTEBOOKS_DIR = Path(__file__).parent.resolve() / "notebooks"
 
 
 def test_track_with_multi_parents():
-    parent1 = ln.Transform(name="parent 1").save()
-    parent2 = ln.Transform(name="parent 2").save()
-    child = ln.Transform(name="Child").save()
+    parent1 = ln.Transform(key="parent 1").save()
+    parent2 = ln.Transform(key="parent 2").save()
+    child = ln.Transform(key="Child").save()
     child.predecessors.set([parent1, parent2])
 
     # first invocation
@@ -81,7 +81,7 @@ def test_finish_before_track():
 
 
 def test_invalid_transform_type():
-    transform = ln.Transform(name="test transform")
+    transform = ln.Transform(key="test transform")
     ln.context.track(transform=transform)
     ln.context._path = None
     ln.context.run.transform.type = "script"
@@ -259,7 +259,7 @@ def test_run_external_script():
 
 @pytest.mark.parametrize("type", ["notebook", "script"])
 def test_track_notebook_or_script_manually(type):
-    transform = ln.Transform(name="My notebook", type=type)
+    transform = ln.Transform(key="My notebook", type=type)
     with pytest.raises(ValueError) as error:
         ln.context.track(transform=transform)
     assert (

--- a/tests/core/test_db.py
+++ b/tests/core/test_db.py
@@ -2,7 +2,7 @@ import lamindb as ln
 
 
 def test_create_to_load():
-    transform = ln.Transform(version="0", name="test", type="pipeline")
+    transform = ln.Transform(version="0", key="test", type="pipeline")
     transform.save()
     run = ln.Run(transform=transform)
     run.save()

--- a/tests/core/test_parents.py
+++ b/tests/core/test_parents.py
@@ -78,7 +78,7 @@ def test_add_ontology_from_values():
 def test_view_lineage_circular():
     import pandas as pd
 
-    transform = ln.Transform(name="test").save()
+    transform = ln.Transform(key="test").save()
     run = ln.Run(transform=transform).save()
     artifact = ln.Artifact.from_df(
         pd.DataFrame({"a": [1, 2, 3]}), description="test artifact", run=run

--- a/tests/core/test_parents.py
+++ b/tests/core/test_parents.py
@@ -31,7 +31,7 @@ def test_query_parents_children():
 
 
 def test_add_emoji():
-    transform = ln.Transform(name="test-12345", type="upload")
+    transform = ln.Transform(key="test-12345", type="upload")
     assert _add_emoji(transform, label="transform") == "🖥️ transform"
     transform.save()
     run = ln.Run(transform=transform)

--- a/tests/core/test_record.py
+++ b/tests/core/test_record.py
@@ -31,7 +31,7 @@ def test_signatures():
 def test_validate_literal_fields():
     # validate literal
     with pytest.raises(FieldValidationError):
-        ln.Transform(name="new-name-not-existing-123", type="invalid")
+        ln.Transform(key="new-name-not-existing-123", type="invalid")
 
 
 def test_init_with_args():

--- a/tests/core/test_record.py
+++ b/tests/core/test_record.py
@@ -184,7 +184,7 @@ def test_pass_version():
 
 
 def test_get_name_field():
-    transform = ln.Transform(name="test")
+    transform = ln.Transform(key="test")
     transform.save()
     assert _record.get_name_field(ln.Run(transform)) == "started_at"
     with pytest.raises(ValueError):

--- a/tests/core/test_run.py
+++ b/tests/core/test_run.py
@@ -3,7 +3,7 @@ import pytest
 
 
 def test_run():
-    transform = ln.Transform(name="My transform")
+    transform = ln.Transform(key="My transform")
     with pytest.raises(ValueError) as error:
         ln.Run(transform)
     assert (

--- a/tests/core/test_schema.py
+++ b/tests/core/test_schema.py
@@ -147,7 +147,7 @@ def test_validate_features():
         validate_features(["feature"])
     with pytest.raises(TypeError):
         validate_features({"feature"})
-    transform = ln.Transform(name="test")
+    transform = ln.Transform(key="test")
     transform.save()
     # This is just a type check
     with pytest.raises(TypeError) as error:

--- a/tests/core/test_transform.py
+++ b/tests/core/test_transform.py
@@ -7,7 +7,7 @@ import pytest
 def test_revise_transforms():
     # attempt to create a transform with an invalid version
     with pytest.raises(ValueError) as error:
-        transform = ln.Transform(name="My transform", version=0)
+        transform = ln.Transform(key="My transform", version=0)
     assert (
         error.exconly()
         == "ValueError: `version` parameter must be `None` or `str`, e.g., '0.1', '1',"
@@ -15,7 +15,7 @@ def test_revise_transforms():
     )
 
     # create a versioned transform
-    transform = ln.Transform(name="My transform", version="1")
+    transform = ln.Transform(key="My transform", version="1")
     assert transform.version == "1"
     assert len(transform.uid) == ln.Transform._len_full_uid == 16
     assert len(transform.stem_uid) == ln.Transform._len_stem_uid == 12
@@ -106,7 +106,7 @@ def test_revise_transforms():
     transform.delete()
 
     # unversioned transform
-    transform = ln.Transform(name="My transform")
+    transform = ln.Transform(key="My transform")
     assert transform.version is None
 
     # what happens if we don't save the old transform?
@@ -125,7 +125,7 @@ def test_revise_transforms():
 
 def test_delete():
     # prepare the creation of a transform with its artifacts
-    transform = ln.Transform(name="My transform").save()
+    transform = ln.Transform(key="My transform").save()
     run = ln.Run(transform)
     report_path = Path("report.html")
     with open(report_path, "w") as f:

--- a/tests/curators/test_curator.py
+++ b/tests/curators/test_curator.py
@@ -98,7 +98,7 @@ def mock_registry():
 
 @pytest.fixture
 def mock_transform():
-    mock_transform = ln.Transform(name="mock", version="0.0.0", type="notebook")
+    mock_transform = ln.Transform(key="mock", version="0.0.0", type="notebook")
     mock_transform.save()
     return mock_transform
 

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -242,7 +242,7 @@ def test_write_read_tiledbsoma(storage):
     else:
         adata.write_h5ad(test_file)
 
-    create_transform = ln.Transform(name="test create tiledbsoma store").save()
+    create_transform = ln.Transform(key="test create tiledbsoma store").save()
     create_run = ln.Run(create_transform).save()
 
     # fails with a view
@@ -309,7 +309,7 @@ def test_write_read_tiledbsoma(storage):
     adata_to_append_2.var["var_id"] = adata_to_append_2.var.index
     adata_to_append_2.write_h5ad("adata_to_append_2.h5ad")
 
-    append_transform = ln.Transform(name="test append tiledbsoma store").save()
+    append_transform = ln.Transform(key="test append tiledbsoma store").save()
     append_run = ln.Run(append_transform).save()
 
     # here run should be passed


### PR DESCRIPTION
Fixes https://github.com/laminlabs/lamindb/issues/2394

- Adds `*` to function signatures of `from_x` methods
- Fixes many deprecated `name` parameter args for `Transform` and `Collection`