### PR TITLE
🎨 Self-contained definition of `CellxGene` schema / validation constraints

### DIFF
--- a/lamindb/core/datasets/_small.py
+++ b/lamindb/core/datasets/_small.py
@@ -85,8 +85,7 @@ def small_dataset3_cellxgene(
         var_ids[2]: [4, 2, 3],
         "disease_ontology_term_id": ["MONDO:0004975", "MONDO:0004980", "MONDO:0004980"],
         "organism": ["human", "human", "human"],
-        "sex_ontology_term_id": ["PATO:0000384", "PATO:0000384", "PATO:0000384"],
-        "sex": ["unkown", "unkown", "unkown"],
+        "sex": ["female", "male", "unknown"],
         "tissue": ["lungg", "lungg", "heart"],
         "donor": ["-1", "1", "2"],
     }
@@ -99,7 +98,7 @@ def small_dataset3_cellxgene(
         dataset_df[var_ids],
         obs=dataset_df[[key for key in dataset_dict if key not in var_ids]],
     )
-    if format == "df":
+    if otype == "DataFrame":
         return dataset_df
     else:
         dataset_ad = ad.AnnData(dataset_df.iloc[:, :3], obs=dataset_df.iloc[:, 3:])

--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -1742,6 +1742,8 @@ class ULabel(Record, HasParents, CanCurate, TracksRun, TracksUpdates):
     def __init__(
         self,
         name: str,
+        type: ULabel | None = None,
+        is_type: bool = False,
         description: str | None = None,
         reference: str | None = None,
         reference_type: str | None = None,
@@ -1938,9 +1940,11 @@ class Feature(Record, CanCurate, TracksRun, TracksUpdates):
         self,
         name: str,
         dtype: FeatureDtype | Registry | list[Registry],
-        unit: str | None,
-        description: str | None,
-        synonyms: str | None,
+        type: Feature | None = None,
+        is_type: bool = False,
+        unit: str | None = None,
+        description: str | None = None,
+        synonyms: str | None = None,
     ): ...
 
     @overload
@@ -2198,6 +2202,8 @@ class Schema(Record, CanCurate, TracksRun):
         features: Iterable[Record],
         dtype: str | None = None,
         name: str | None = None,
+        type: ULabel | None = None,
+        is_type: bool = False,
     ): ...
 
     @overload

--- a/tests/core/test_record.py
+++ b/tests/core/test_record.py
@@ -223,10 +223,12 @@ def test_using():
     assert artifact == artifact_ref
 
 
-def test_get_record_params():
+def test_get_record_kwargs():
     assert _get_record_kwargs(ln.Feature) == [
         ("name", "str"),
         ("dtype", "FeatureDtype | Registry | list[Registry]"),
+        ("type", "Feature | None"),
+        ("is_type", "bool"),
         ("unit", "str | None"),
         ("description", "str | None"),
         ("synonyms", "str | None"),

--- a/tests/core/test_ulabel.py
+++ b/tests/core/test_ulabel.py
@@ -9,7 +9,7 @@ def test_ulabel():
     with pytest.raises(
         FieldValidationError,
         match=re.escape(
-            "Only name, description, reference, reference_type are valid keyword arguments"
+            "Only name, type, is_type, description, reference, reference_type are valid keyword arguments"
         ),
     ):
         ln.ULabel(x=1)

--- a/tests/curators/test_cat_curators.py
+++ b/tests/curators/test_cat_curators.py
@@ -359,32 +359,6 @@ def test_anndata_curator_wrong_type(df, categoricals):
         )
 
 
-def test_categorical_key_not_present(df):
-    with pytest.raises(
-        ValidationError,
-        match="key passed to categoricals is not present in columns",
-    ):
-        ln.Curator.from_df(
-            df,
-            categoricals={"not present": None},
-            organism="human",
-        )
-
-
-def test_source_key_not_present(adata, categoricals):
-    with pytest.raises(
-        ValidationError,
-        match="key passed to sources is not present in columns",
-    ):
-        ln.Curator.from_anndata(
-            adata,
-            categoricals=categoricals,
-            var_index=bt.Gene.symbol,
-            sources={"not_present": None},
-            organism="human",
-        )
-
-
 def test_unvalidated_adata_object(adata, categoricals):
     curator = ln.Curator.from_anndata(
         adata,

--- a/tests/curators/test_cxg_curator.py
+++ b/tests/curators/test_cxg_curator.py
@@ -9,7 +9,7 @@ def test_cxg_curator():
     adata.obs.rename(columns={"donor": "donor_id"}, inplace=True)
     curator = ln.curators.CellxGeneAnnDataCurator(
         adata,
-        defaults=ln.curators.CellxGeneFields.OBS_FIELD_DEFAULTS,
+        defaults=ln.curators.CellxGeneAnnDataCurator._get_categoricals_defaults(),
         organism="human",
         schema_version="5.1.0",
     )


### PR DESCRIPTION
Is part of a sequence of PRs that refactors the curators:

- https://github.com/laminlabs/lamindb/pull/2408
- https://github.com/laminlabs/lamindb/pull/2403
- https://github.com/laminlabs/lamindb/pull/2388

---

This PR simplifies the definition of constraints to validate against the CxG schema:

Before | After
--- | ---
It was implicitly defined by the state of another database instance passed via the `using_key` parameter to `AnnDataCurator`. |  It is now self-contained in the `CellxGeneAnnDataCurator` class.

It also brings down the run time of the CxG test further down [from 50s](https://github.com/laminlabs/lamindb/pull/2408#issuecomment-2628796391) to 20s:

```
============================= slowest 50 durations =============================
37.28s call     tests/curators/test_pert_curator.py::test_pert_curator
34.08s call     tests/curators/test_cat_curators.py::test_spatialdata_curator
19.95s call     tests/curators/test_cxg_curator.py::test_cxg_curator
6.86s call     tests/curators/test_cat_curators.py::test_df_curator
6.01s call     tests/curators/test_cat_curators.py::test_soma_curator
5.71s call     tests/curators/test_cat_curators.py::test_soma_curator_genes_columns
```

Collateral:

- I'm removing the `_check_valid_keys()` utils function because throwing an error upon Curator init upon missing columns/features is problematic: we do want to be able to validate datasets with missing columns and then receive this as a SchemaError during `.validate()`. This is a common type of error.
- Fixed the signatures for `Feature`, `ULabel` & `Schema` to now include `type` and `is_type`.