### PR TITLE
🔥 Eliminate all logic related to `using_key` in curators

### DIFF
--- a/tests/curators/test_cat_curators.py
+++ b/tests/curators/test_cat_curators.py
@@ -86,7 +86,7 @@ def categoricals():
 
 @pytest.fixture
 def curate_lookup(categoricals):
-    return CurateLookup(categoricals=categoricals, using_key="undefined")
+    return CurateLookup(categoricals=categoricals)
 
 
 @pytest.fixture


### PR DESCRIPTION
Is part of a sequence of PRs that refactors the curators:

- https://github.com/laminlabs/lamindb/pull/2413
- https://github.com/laminlabs/lamindb/pull/2412
- https://github.com/laminlabs/lamindb/pull/2408
- https://github.com/laminlabs/lamindb/pull/2403
- https://github.com/laminlabs/lamindb/pull/2388

--- 

Removing all logic related to `using_key` in curators is desirable because:

1. it gives rise to a leaner definition of a "valid category" that no longer involves the state of another database, but is restricted to the state of the current database & well-defined public ontology versions
2. it eliminates much code that makes refactoring easier

This is possible because PR 2412 eliminated the need for passing `using_key` for validating against the CellxGene schema, whose non-ontology based control values were its only motivation in the first place.

`using_key` was never a user-facing argument and hence its removal doesn't break backward compat.