### PR TITLE
♻️ Refactor `organism` handling in curators

### DIFF
--- a/docs/ehrcurator.py
+++ b/docs/ehrcurator.py
@@ -55,7 +55,7 @@ class EHRCurator(DataFrameCatCurator):
             organism="human",
         )
 
-    def validate(self, organism: str | None = None) -> bool:
+    def validate(self) -> bool:
         """Validates the internal EHR standard."""
         missing_columns = {"disease", "phenotype", "developmental_stage", "age"} - set(
             self.data.columns
@@ -66,4 +66,4 @@ class EHRCurator(DataFrameCatCurator):
             )
             return False
 
-        return DataFrameCatCurator.validate(self, organism)
+        return DataFrameCatCurator.validate(self)

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -863,6 +863,7 @@ class MuDataCatCurator:
         self._modalities = set(self._var_fields.keys()) | set(self._obs_fields.keys())
         self._verbosity = verbosity
         self._obs_df_curator = None
+        self._organism = organism
         if "obs" in self._modalities:
             self._obs_df_curator = DataFrameCatCurator(
                 df=mdata.obs,
@@ -1088,6 +1089,7 @@ class MuDataCatCurator:
                 revises=revises,
                 run=run,
                 schema=None,
+                organism=self._organism,
             )
         finally:
             settings.verbosity = verbosity

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -976,13 +976,9 @@ class MuDataCatCurator:
     def _update_registry_all(self):
         """Update all registries."""
         if self._obs_df_curator is not None:
-            self._obs_df_curator._update_registry_all(
-                validated_only=True, organism=self._organism
-            )
+            self._obs_df_curator._update_registry_all(validated_only=True)
         for _, adata_curator in self._mod_adata_curators.items():
-            adata_curator._update_registry_all(
-                validated_only=True, organism=self._organism
-            )
+            adata_curator._update_registry_all(validated_only=True)
 
     def add_new_from(
         self,


### PR DESCRIPTION
Is part of a sequence of PRs that refactors the curators:

- https://github.com/laminlabs/lamindb/pull/2415
- https://github.com/laminlabs/lamindb/pull/2413
- https://github.com/laminlabs/lamindb/pull/2412
- https://github.com/laminlabs/lamindb/pull/2408
- https://github.com/laminlabs/lamindb/pull/2403
- https://github.com/laminlabs/lamindb/pull/2388

---

Replace `self._kwargs` with explicit organism passing; remove ability to pass an organism ad-hoc in `.validate()` etc.
  - goal is to define an organism as part of a feature dtype in cases in which it is needed -- e.g., `Gene.ensembl_gene_id` does not need it, whereas `Gene.symbol` needs it
  - there should and can't be no need to pass an `organism` at any later stages of the workflow; it both opens up the door for integrity errors and makes the code complicated