### PR TITLE
♻️ Re-purpose `BaseCurator` as `Curator`, introduce `CatCurator` and consolidate shared logic under `CatCurator`

### DIFF
--- a/docs/curate-df.ipynb
+++ b/docs/curate-df.ipynb
@@ -180,7 +180,7 @@
    "id": "7",
    "metadata": {},
    "source": [
-    "The {meth}`~lamindb.core.Curator.validate` method checks our data against the defined criteria. It identifies which values are already validated (exist in our registries) and which are potentially problematic (do not yet exist in our registries)."
+    "The {meth}`~lamindb.Curator.validate` method checks our data against the defined criteria. It identifies which values are already validated (exist in our registries) and which are potentially problematic (do not yet exist in our registries)."
    ]
   },
   {

--- a/docs/curate-df.ipynb
+++ b/docs/curate-df.ipynb
@@ -180,7 +180,7 @@
    "id": "7",
    "metadata": {},
    "source": [
-    "The {meth}`~lamindb.core.BaseCurator.validate` method checks our data against the defined criteria. It identifies which values are already validated (exist in our registries) and which are potentially problematic (do not yet exist in our registries)."
+    "The {meth}`~lamindb.core.Curator.validate` method checks our data against the defined criteria. It identifies which values are already validated (exist in our registries) and which are potentially problematic (do not yet exist in our registries)."
    ]
   },
   {

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -764,6 +764,7 @@ def from_mudata(
         kind="dataset",
         **kwargs,
     )
+    artifact.n_observations = mdata.n_obs
     return artifact
 
 

--- a/lamindb/core/__init__.py
+++ b/lamindb/core/__init__.py
@@ -31,7 +31,6 @@ Curators:
 .. autosummary::
    :toctree: .
 
-   Curator
    DataFrameCatCurator
    AnnDataCatCurator
    MuDataCatCurator

--- a/lamindb/core/__init__.py
+++ b/lamindb/core/__init__.py
@@ -31,7 +31,7 @@ Curators:
 .. autosummary::
    :toctree: .
 
-   BaseCurator
+   Curator
    DataFrameCatCurator
    AnnDataCatCurator
    MuDataCatCurator
@@ -76,8 +76,8 @@ from lamindb.core._feature_manager import FeatureManager, ParamManager
 from lamindb.core._label_manager import LabelManager
 from lamindb.curators import (
     AnnDataCatCurator,
-    BaseCurator,
     CurateLookup,
+    Curator,
     DataFrameCatCurator,
     MuDataCatCurator,
     TiledbsomaCatCurator,

--- a/lamindb/core/__init__.py
+++ b/lamindb/core/__init__.py
@@ -31,6 +31,7 @@ Curators:
 .. autosummary::
    :toctree: .
 
+   CatCurator
    DataFrameCatCurator
    AnnDataCatCurator
    MuDataCatCurator
@@ -75,6 +76,7 @@ from lamindb.core._feature_manager import FeatureManager, ParamManager
 from lamindb.core._label_manager import LabelManager
 from lamindb.curators import (
     AnnDataCatCurator,
+    CatCurator,
     CurateLookup,
     Curator,
     DataFrameCatCurator,

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -566,7 +566,6 @@ class DataFrameCatCurator(CatCurator):
         )
         return self._validated
 
-    @deprecated(new_name="manage manually")
     def clean_up_failed_runs(self):
         """Clean up previous failed runs that don't save any outputs."""
         from lamindb.core._context import context
@@ -830,6 +829,7 @@ class MuDataCatCurator(CatCurator):
         self._dataset = mdata
         self._organism = organism
         self._var_fields = var_index
+        self._columns_field = var_index  # this is for consistency with BaseCatCurator
         self._verify_modality(self._var_fields.keys())
         self._obs_fields = self._parse_categoricals(categoricals)
         self._modalities = set(self._var_fields.keys()) | set(self._obs_fields.keys())

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -828,7 +828,7 @@ class MuDataCatCurator(CatCurator):
             exclude = {}
         self._exclude = exclude
         self._dataset = mdata
-        self._kwargs = {"organism": organism} if organism else {}
+        self._organism = organism
         self._var_fields = var_index
         self._verify_modality(self._var_fields.keys())
         self._obs_fields = self._parse_categoricals(categoricals)

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -3601,45 +3601,6 @@ def from_spatialdata(
     *,
     sample_metadata_key: str = "sample",
 ):
-    """Curation flow for a ``Spatialdata`` object.
-
-    See also :class:`~lamindb.Curator`.
-
-    Note that if genes or other measurements are removed from the SpatialData object,
-    the object should be recreated.
-
-    In the following docstring, an accessor refers to either a ``.table`` key or the ``sample_metadata_key``.
-
-    Args:
-        sdata: The SpatialData object to curate.
-        var_index: A dictionary mapping table keys to the ``.var`` indices.
-        categoricals: A nested dictionary mapping an accessor to dictionaries that map columns to a registry field.
-
-        organism: The organism name.
-        sources: A dictionary mapping an accessor to dictionaries that map columns to Source records.
-        exclude: A dictionary mapping an accessor to dictionaries of column names to values to exclude from validation.
-            When specific :class:`~bionty.Source` instances are pinned and may lack default values (e.g., "unknown" or "na"),
-            using the exclude parameter ensures they are not validated.
-        verbosity: The verbosity level of the logger.
-        sample_metadata_key: The key in ``.attrs`` that stores the sample level metadata.
-
-    Examples:
-        >>> import lamindb as ln
-        >>> import bionty as bt
-        >>> curator = ln.Curator.from_spatialdata(
-        ...     sdata,
-        ...     var_index={
-        ...         "table_1": bt.Gene.ensembl_gene_id,
-        ...     },
-        ...     categoricals={
-        ...         "table1":
-        ...             {"cell_type_ontology_id": bt.CellType.ontology_id, "donor_id": ULabel.name},
-        ...         "sample":
-        ...             {"experimental_factor": bt.ExperimentalFactor.name},
-        ...     },
-        ...     organism="human",
-        ... )
-    """
     try:
         import spatialdata
     except ImportError as e:

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -1589,7 +1589,7 @@ class SpatialDataCatCurator:
         self._exclude = exclude
         self._sdata: SpatialData = sdata
         self._sample_metadata_key = sample_metadata_key
-        self._kwargs = {"organism": organism} if organism else {}
+        self._organism = organism
         self._var_fields = var_index
         self._verify_accessor_exists(self._var_fields.keys())
         self._categoricals = categoricals
@@ -1884,7 +1884,7 @@ class SpatialDataCatCurator:
             # Link schemas
             feature_kwargs = check_registry_organism(
                 (list(self._var_fields.values())[0].field.model),
-                self._kwargs.get("organism"),
+                self._organism,
             )
 
             def _add_set_from_spatialdata(
@@ -1958,9 +1958,7 @@ class SpatialDataCatCurator:
                 for key, field in fields.items():
                     feature = features.get(key)
                     registry = field.field.model
-                    filter_kwargs = check_registry_organism(
-                        registry, self._kwargs.get("organism")
-                    )
+                    filter_kwargs = check_registry_organism(registry, self._organism)
                     filter_kwargs_current = get_current_filter_kwargs(
                         registry, filter_kwargs
                     )

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -773,7 +773,7 @@ class AnnDataCatCurator(DataFrameCatCurator):
                 )
 
 
-class MuDataCatCurator:
+class MuDataCatCurator(CatCurator):
     """Curation flow for a ``MuData`` object.
 
     See also :class:`~lamindb.Curator`.
@@ -827,7 +827,7 @@ class MuDataCatCurator:
         if exclude is None:
             exclude = {}
         self._exclude = exclude
-        self._mdata = mdata
+        self._dataset = mdata
         self._kwargs = {"organism": organism} if organism else {}
         self._var_fields = var_index
         self._verify_modality(self._var_fields.keys())
@@ -872,7 +872,7 @@ class MuDataCatCurator:
         return self._obs_fields
 
     @property
-    def non_validated(self) -> dict[str, dict[str, list[str]]]:
+    def non_validated(self) -> dict[str, dict[str, list[str]]]:  # type: ignore
         """Return the non-validated features and labels."""
         if self._non_validated is None:
             raise ValidationError("Please run validate() first!")
@@ -881,15 +881,15 @@ class MuDataCatCurator:
     def _verify_modality(self, modalities: Iterable[str]):
         """Verify the modality exists."""
         for modality in modalities:
-            if modality not in self._mdata.mod.keys():
+            if modality not in self._dataset.mod.keys():
                 raise ValidationError(f"modality '{modality}' does not exist!")
 
     def _parse_categoricals(self, categoricals: dict[str, FieldAttr]) -> dict:
         """Parse the categorical fields."""
-        prefixes = {f"{k}:" for k in self._mdata.mod.keys()}
+        prefixes = {f"{k}:" for k in self._dataset.mod.keys()}
         obs_fields: dict[str, dict[str, FieldAttr]] = {}
         for k, v in categoricals.items():
-            if k not in self._mdata.obs.columns:
+            if k not in self._dataset.obs.columns:
                 raise ValidationError(f"column '{k}' does not exist in mdata.obs!")
             if any(k.startswith(prefix) for prefix in prefixes):
                 modality, col = k.split(":")[0], k.split(":")[1]
@@ -1030,7 +1030,7 @@ def _maybe_curation_keys_not_present(nonval_keys: list[str], name: str):
         )
 
 
-class TiledbsomaCatCurator(Curator):
+class TiledbsomaCatCurator(CatCurator):
     """Curation flow for `tiledbsoma.Experiment`.
 
     See also :class:`~lamindb.Curator`.

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -225,14 +225,14 @@ class CatCurator(Curator):
     def __init__(
         self, *, dataset, categoricals, sources, organism, exclude, columns_field=None
     ):
+        super().__init__(dataset=dataset)
+        self._categoricals = categoricals or {}
         self._non_validated = None
         self._organism = organism
-        self._columns_field = columns_field
-        self._categoricals = categoricals or {}
         self._sources = sources or {}
         self._exclude = exclude or {}
+        self._columns_field = columns_field
         self._validate_category_error_messages: str = ""
-        super().__init__(dataset=dataset)
 
     @property
     def non_validated(self) -> dict[str, list[str]]:

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -959,7 +959,7 @@ class MuDataCatCurator(CatCurator):
         if self._obs_df_curator is not None:
             self._obs_df_curator._update_registry_all(validated_only=True)
         for _, adata_curator in self._mod_adata_curators.items():
-            adata_curator._update_registry_all(validated_only=True)
+            adata_curator._obs_df_curator._update_registry_all(validated_only=True)
 
     def add_new_from(
         self,

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -216,159 +216,6 @@ class Curator:
             key=key, description=description, revises=revises, run=run
         )
 
-        # backward compat constructors ------------------
-
-        @deprecated(new_name="use Curator(data, schema)")  # type: ignore
-        @classmethod  # type: ignore
-        def from_df(
-            cls,
-            df: pd.DataFrame,
-            categoricals: dict[str, FieldAttr] | None = None,
-            columns: FieldAttr = Feature.name,
-            verbosity: str = "hint",
-            organism: str | None = None,
-        ) -> DataFrameCatCurator:
-            return DataFrameCatCurator(
-                df=df,
-                categoricals=categoricals,
-                columns=columns,
-                verbosity=verbosity,
-                organism=organism,
-            )
-
-        @deprecated(new_name="use Curator(data, schema)")  # type: ignore
-        @classmethod  # type: ignore
-        def from_anndata(
-            cls,
-            data: ad.AnnData | UPathStr,
-            var_index: FieldAttr,
-            categoricals: dict[str, FieldAttr] | None = None,
-            obs_columns: FieldAttr = Feature.name,
-            verbosity: str = "hint",
-            organism: str | None = None,
-            sources: dict[str, Record] | None = None,
-        ) -> AnnDataCatCurator:
-            return AnnDataCatCurator(
-                data=data,
-                var_index=var_index,
-                categoricals=categoricals,
-                obs_columns=obs_columns,
-                verbosity=verbosity,
-                organism=organism,
-                sources=sources,
-            )
-
-        @deprecated(new_name="use Curator(data, schema)")  # type: ignore
-        @classmethod  # type: ignore
-        def from_mudata(
-            cls,
-            mdata: MuData,
-            var_index: dict[str, dict[str, FieldAttr]],
-            categoricals: dict[str, FieldAttr] | None = None,
-            verbosity: str = "hint",
-            organism: str | None = None,
-        ) -> MuDataCatCurator:
-            return MuDataCatCurator(
-                mdata=mdata,
-                var_index=var_index,
-                categoricals=categoricals,
-                verbosity=verbosity,
-                organism=organism,
-            )
-
-        @deprecated(new_name="use Curator(data, schema)")  # type: ignore
-        @classmethod  # type: ignore
-        def from_tiledbsoma(
-            cls,
-            experiment_uri: UPathStr,
-            var_index: dict[str, tuple[str, FieldAttr]],
-            categoricals: dict[str, FieldAttr] | None = None,
-            obs_columns: FieldAttr = Feature.name,
-            organism: str | None = None,
-            sources: dict[str, Record] | None = None,
-            exclude: dict[str, str | list[str]] | None = None,
-        ) -> TiledbsomaCatCurator:
-            return TiledbsomaCatCurator(
-                experiment_uri=experiment_uri,
-                var_index=var_index,
-                categoricals=categoricals,
-                obs_columns=obs_columns,
-                organism=organism,
-                sources=sources,
-                exclude=exclude,
-            )
-
-        @deprecated(new_name="use Curator(data, schema)")  # type: ignore
-        @classmethod  # type: ignore
-        def from_spatialdata(
-            cls,
-            sdata,
-            var_index: dict[str, FieldAttr],
-            categoricals: dict[str, dict[str, FieldAttr]] | None = None,
-            organism: str | None = None,
-            sources: dict[str, dict[str, Record]] | None = None,
-            exclude: dict[str, dict] | None = None,
-            verbosity: str = "hint",
-            *,
-            sample_metadata_key: str = "sample",
-        ):
-            """Curation flow for a ``Spatialdata`` object.
-
-            See also :class:`~lamindb.Curator`.
-
-            Note that if genes or other measurements are removed from the SpatialData object,
-            the object should be recreated.
-
-            In the following docstring, an accessor refers to either a ``.table`` key or the ``sample_metadata_key``.
-
-            Args:
-                sdata: The SpatialData object to curate.
-                var_index: A dictionary mapping table keys to the ``.var`` indices.
-                categoricals: A nested dictionary mapping an accessor to dictionaries that map columns to a registry field.
-
-                organism: The organism name.
-                sources: A dictionary mapping an accessor to dictionaries that map columns to Source records.
-                exclude: A dictionary mapping an accessor to dictionaries of column names to values to exclude from validation.
-                    When specific :class:`~bionty.Source` instances are pinned and may lack default values (e.g., "unknown" or "na"),
-                    using the exclude parameter ensures they are not validated.
-                verbosity: The verbosity level of the logger.
-                sample_metadata_key: The key in ``.attrs`` that stores the sample level metadata.
-
-            Examples:
-                >>> import lamindb as ln
-                >>> import bionty as bt
-                >>> curator = ln.Curator.from_spatialdata(
-                ...     sdata,
-                ...     var_index={
-                ...         "table_1": bt.Gene.ensembl_gene_id,
-                ...     },
-                ...     categoricals={
-                ...         "table1":
-                ...             {"cell_type_ontology_id": bt.CellType.ontology_id, "donor_id": ULabel.name},
-                ...         "sample":
-                ...             {"experimental_factor": bt.ExperimentalFactor.name},
-                ...     },
-                ...     organism="human",
-                ... )
-            """
-            try:
-                import spatialdata
-            except ImportError as e:
-                raise ImportError(
-                    "Please install spatialdata: pip install spatialdata"
-                ) from e
-
-            return SpatialDataCatCurator(
-                sdata=sdata,
-                var_index=var_index,
-                categoricals=categoricals,
-                verbosity=verbosity,
-                organism=organism,
-                sources=sources,
-                exclude=exclude,
-                sample_metadata_key=sample_metadata_key,
-            )
-
 
 class DataFrameCurator(Curator):
     """Curator for a DataFrame object.
@@ -3656,3 +3503,162 @@ def _ref_is_name(field: FieldAttr) -> bool | None:
 
     name_field = get_name_field(field.field.model)
     return field.field.name == name_field
+
+
+# backward compat constructors ------------------
+
+
+@classmethod  # type: ignore
+def from_df(
+    cls,
+    df: pd.DataFrame,
+    categoricals: dict[str, FieldAttr] | None = None,
+    columns: FieldAttr = Feature.name,
+    verbosity: str = "hint",
+    organism: str | None = None,
+) -> DataFrameCatCurator:
+    return DataFrameCatCurator(
+        df=df,
+        categoricals=categoricals,
+        columns=columns,
+        verbosity=verbosity,
+        organism=organism,
+    )
+
+
+@classmethod  # type: ignore
+def from_anndata(
+    cls,
+    data: ad.AnnData | UPathStr,
+    var_index: FieldAttr,
+    categoricals: dict[str, FieldAttr] | None = None,
+    obs_columns: FieldAttr = Feature.name,
+    verbosity: str = "hint",
+    organism: str | None = None,
+    sources: dict[str, Record] | None = None,
+) -> AnnDataCatCurator:
+    return AnnDataCatCurator(
+        data=data,
+        var_index=var_index,
+        categoricals=categoricals,
+        obs_columns=obs_columns,
+        verbosity=verbosity,
+        organism=organism,
+        sources=sources,
+    )
+
+
+@classmethod  # type: ignore
+def from_mudata(
+    cls,
+    mdata: MuData,
+    var_index: dict[str, dict[str, FieldAttr]],
+    categoricals: dict[str, FieldAttr] | None = None,
+    verbosity: str = "hint",
+    organism: str | None = None,
+) -> MuDataCatCurator:
+    return MuDataCatCurator(
+        mdata=mdata,
+        var_index=var_index,
+        categoricals=categoricals,
+        verbosity=verbosity,
+        organism=organism,
+    )
+
+
+@classmethod  # type: ignore
+def from_tiledbsoma(
+    cls,
+    experiment_uri: UPathStr,
+    var_index: dict[str, tuple[str, FieldAttr]],
+    categoricals: dict[str, FieldAttr] | None = None,
+    obs_columns: FieldAttr = Feature.name,
+    organism: str | None = None,
+    sources: dict[str, Record] | None = None,
+    exclude: dict[str, str | list[str]] | None = None,
+) -> TiledbsomaCatCurator:
+    return TiledbsomaCatCurator(
+        experiment_uri=experiment_uri,
+        var_index=var_index,
+        categoricals=categoricals,
+        obs_columns=obs_columns,
+        organism=organism,
+        sources=sources,
+        exclude=exclude,
+    )
+
+
+@classmethod  # type: ignore
+def from_spatialdata(
+    cls,
+    sdata,
+    var_index: dict[str, FieldAttr],
+    categoricals: dict[str, dict[str, FieldAttr]] | None = None,
+    organism: str | None = None,
+    sources: dict[str, dict[str, Record]] | None = None,
+    exclude: dict[str, dict] | None = None,
+    verbosity: str = "hint",
+    *,
+    sample_metadata_key: str = "sample",
+):
+    """Curation flow for a ``Spatialdata`` object.
+
+    See also :class:`~lamindb.Curator`.
+
+    Note that if genes or other measurements are removed from the SpatialData object,
+    the object should be recreated.
+
+    In the following docstring, an accessor refers to either a ``.table`` key or the ``sample_metadata_key``.
+
+    Args:
+        sdata: The SpatialData object to curate.
+        var_index: A dictionary mapping table keys to the ``.var`` indices.
+        categoricals: A nested dictionary mapping an accessor to dictionaries that map columns to a registry field.
+
+        organism: The organism name.
+        sources: A dictionary mapping an accessor to dictionaries that map columns to Source records.
+        exclude: A dictionary mapping an accessor to dictionaries of column names to values to exclude from validation.
+            When specific :class:`~bionty.Source` instances are pinned and may lack default values (e.g., "unknown" or "na"),
+            using the exclude parameter ensures they are not validated.
+        verbosity: The verbosity level of the logger.
+        sample_metadata_key: The key in ``.attrs`` that stores the sample level metadata.
+
+    Examples:
+        >>> import lamindb as ln
+        >>> import bionty as bt
+        >>> curator = ln.Curator.from_spatialdata(
+        ...     sdata,
+        ...     var_index={
+        ...         "table_1": bt.Gene.ensembl_gene_id,
+        ...     },
+        ...     categoricals={
+        ...         "table1":
+        ...             {"cell_type_ontology_id": bt.CellType.ontology_id, "donor_id": ULabel.name},
+        ...         "sample":
+        ...             {"experimental_factor": bt.ExperimentalFactor.name},
+        ...     },
+        ...     organism="human",
+        ... )
+    """
+    try:
+        import spatialdata
+    except ImportError as e:
+        raise ImportError("Please install spatialdata: pip install spatialdata") from e
+
+    return SpatialDataCatCurator(
+        sdata=sdata,
+        var_index=var_index,
+        categoricals=categoricals,
+        verbosity=verbosity,
+        organism=organism,
+        sources=sources,
+        exclude=exclude,
+        sample_metadata_key=sample_metadata_key,
+    )
+
+
+Curator.from_df = from_df  # type: ignore
+Curator.from_anndata = from_anndata  # type: ignore
+Curator.from_mudata = from_mudata  # type: ignore
+Curator.from_spatialdata = from_spatialdata  # type: ignore
+Curator.from_tiledbsoma = from_tiledbsoma  # type: ignore

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -165,7 +165,6 @@ class Curator:
     """
 
     def __init__(self, dataset: Any):
-        self._validate_category_error_messages: str = ""
         self._dataset: Any = dataset  # pass the dataset as a UPathStr or data object
         self._artifact: Artifact = None  # pass the dataset as a non-curated artifact
         self._validated: bool = False
@@ -232,6 +231,7 @@ class CatCurator(Curator):
         self._categoricals = categoricals or {}
         self._sources = sources or {}
         self._exclude = exclude or {}
+        self._validate_category_error_messages: str = ""
         super().__init__(dataset=dataset)
 
     @property
@@ -2924,7 +2924,7 @@ def validate_categories(
     source: Record | None = None,
     exclude: str | list | None = None,
     hint_print: str | None = None,
-    curator: Curator | None = None,
+    curator: CatCurator | None = None,
 ) -> tuple[bool, list]:
     """Validate ontology terms in a pandas series using LaminDB registries.
 
@@ -3044,7 +3044,7 @@ def validate_categories_in_df(
     fields: dict[str, FieldAttr],
     sources: dict[str, Record] = None,
     exclude: dict | None = None,
-    curator: Curator | None = None,
+    curator: CatCurator | None = None,
     **kwargs,
 ) -> tuple[bool, dict]:
     """Validate categories in DataFrame columns using LaminDB registries."""

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import copy
 import random
 import re
-import warnings
 from importlib import resources
 from itertools import chain
 from typing import TYPE_CHECKING, Any, Literal
@@ -64,6 +63,19 @@ if TYPE_CHECKING:
     from spatialdata import SpatialData
 
     from lamindb._query_set import RecordList
+
+
+SAVE_ARTIFACT_DOCSTRING = """Save an annotated artifact.
+
+Args:
+    key: A path-like key to reference artifact in default storage, e.g., `"myfolder/myfile.fcs"`. Artifacts with the same key form a revision family.
+    description: A description.
+    revises: Previous version of the artifact. Is an alternative way to passing `key` to trigger a revision.
+    run: The run that creates the artifact.
+
+Returns:
+    A saved artifact record.
+"""
 
 
 def strip_ansi_codes(text):
@@ -169,6 +181,7 @@ class BaseCurator:
         """
         pass  # pdagma: no cover
 
+    @doc_args(SAVE_ARTIFACT_DOCSTRING)
     def save_artifact(
         self,
         *,
@@ -177,17 +190,7 @@ class BaseCurator:
         revises: Artifact | None = None,
         run: Run | None = None,
     ) -> Artifact:
-        """Save the dataset as artifact.
-
-        Args:
-            description: A description of the DataFrame object.
-            key: A path-like key to reference artifact in default storage, e.g., `"myfolder/myfile.fcs"`. Artifacts with the same key form a revision family.
-            revises: Previous version of the artifact. Triggers a revision.
-            run: The run that creates the artifact.
-
-        Returns:
-            A saved artifact record.
-        """
+        """{}"""  # noqa: D415
         pass  # pdagma: no cover
 
 
@@ -247,6 +250,7 @@ class DataFrameCurator(BaseCurator):
             # return the error message so that we can test for it
             return str_message
 
+    @doc_args(SAVE_ARTIFACT_DOCSTRING)
     def save_artifact(
         self,
         *,
@@ -951,18 +955,14 @@ class MuDataCatCurator:
             public=public,
         )
 
+    @deprecated(new_name="is run by default")
     def add_new_from_columns(
         self,
         modality: str,
         column_names: list[str] | None = None,
         **kwargs,
     ):
-        """Update columns records."""
-        warnings.warn(
-            "`.add_new_from_columns()` is deprecated and will be removed in a future version. It's run by default during initialization.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        pass
 
     def add_new_from_var_index(self, modality: str, **kwargs):
         """Update variable records.
@@ -2538,12 +2538,6 @@ class CellxGeneAnnDataCatCurator(AnnDataCatCurator):
         return adata_cxg
 
 
-class PertValidatorUnavailable(SystemExit):
-    """Curator for perturbation data when dependencies are unavailable."""
-
-    pass
-
-
 class ValueUnit:
     """Base class for handling value-unit combinations."""
 
@@ -2933,7 +2927,7 @@ class PertAnnDataCatCurator(CellxGeneAnnDataCatCurator):
 class Curator(BaseCurator):
     """Dataset curator.
 
-    A `Curator` object makes it easy to save validated & annotated artifacts.
+    A `Curator` object makes it easy to validate, standardize & annotate datasets.
 
     Example:
 

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -411,7 +411,6 @@ class DataFrameCatCurator(CatCurator):
             raise ValueError("organism must be a string such as 'human' or 'mouse'!")
 
         settings.verbosity = verbosity
-        self._artifact = None
         self._non_validated = None
         super().__init__(
             dataset=df,

--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -2290,6 +2290,7 @@ class Schema(Record, CanCurate, TracksRun):
 
 
 class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
+    # Note that this docstring has to be consistent with Curator.save_artifact()
     """Datasets & models stored as files, folders, or arrays.
 
     Artifacts manage data in local or remote storage.

--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -2302,7 +2302,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
         kind: `Literal["dataset", "model"] | None = None` Distinguish models from datasets from other files & folders.
         key: `str | None = None` A path-like key to reference artifact in default storage, e.g., `"myfolder/myfile.fcs"`. Artifacts with the same key form a revision family.
         description: `str | None = None` A description.
-        revises: `Artifact | None = None` Previous version of the artifact. Triggers a revision.
+        revises: `Artifact | None = None` Previous version of the artifact. Is an alternative way to passing `key` to trigger a revision.
         run: `Run | None = None` The run that creates the artifact.
 
     .. dropdown:: Typical storage formats & their API accessors


### PR DESCRIPTION
Is part of a sequence of PRs that refactors the curators:

- https://github.com/laminlabs/lamindb/pull/2415
- https://github.com/laminlabs/lamindb/pull/2413
- https://github.com/laminlabs/lamindb/pull/2412
- https://github.com/laminlabs/lamindb/pull/2408
- https://github.com/laminlabs/lamindb/pull/2403
- https://github.com/laminlabs/lamindb/pull/2388

## Consolidate under `Curator`

Rename `BaseCurator` to `Curator` and eliminate the previous `Curator` https://github.com/laminlabs/lamindb/pull/2416/commits/1080aedb9d12c419bba8322f21ec117470847c95

The private attributes of `Curator` enable the most basic curation functionality.
```python
class Curator:
    def __init__(self, dataset: Any):
        self._dataset: Any = dataset  # pass the dataset as a UPathStr or data object
        self._artifact: Artifact = None  # pass the dataset as a (non-curated) artifact
        self._cat_curator: CatCurator = None
        self._validated: bool = False
```

## Consolidate under `CatCurator` https://github.com/laminlabs/lamindb/pull/2416/commits/99e145b06aa470341198b9a09585709bb8033613

Rename `.fields` and `._fields` to `.categoricals` and `._categoricals`, respectively

The private attributes of `CatCurator` extend `Curator` to enable the curating categoricals.
```python
class CatCurator(Curator):
    def __init__(
        self, *, dataset, categoricals, sources, organism, exclude, columns_field=None
    ):
        super().__init__(dataset=dataset)
        self._categoricals = categoricals or {}
        self._non_validated = None
        self._organism = organism
        self._sources = sources or {}
        self._exclude = exclude or {}
        self._columns_field = columns_field
        self._validate_category_error_messages: str = ""
```

`DataFrameCatCurator`, `AnnDataCatCurator`, and `MuDataCatCurator` now all leverage these fields. They also all leverage `CatCurator.save_artifact()`.

`TiledbsomaCatCurator` and `SpatialDataCatCurator` both have more custom logic that should be consolidated in another PR.