### PR TITLE
🎨 Let `Curator.validate()` throw an error

### DIFF
--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -45,6 +45,7 @@ Modules and settings.
    integrations
    context
    settings
+   errors
    setup
    UPath
    base
@@ -60,7 +61,7 @@ from lamindb_setup._check_setup import _check_instance_setup
 from lamindb_setup._connect_instance import connect
 from lamindb_setup.core.upath import UPath
 
-from . import base, setup
+from . import base, errors, setup
 
 
 def __getattr__(name):

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -24,7 +24,7 @@ from lamindb_setup.core.upath import (
 )
 
 from lamindb._record import _get_record_kwargs
-from lamindb.core.exceptions import FieldValidationError
+from lamindb.errors import FieldValidationError
 from lamindb.models import Artifact, FeatureManager, ParamManager, Run, Storage
 
 from ._parents import view_lineage
@@ -37,7 +37,6 @@ from .core._data import (
     save_staged__schemas_m2m,
 )
 from .core._settings import settings
-from .core.exceptions import IntegrityError, InvalidArgument
 from .core.loaders import load_to_memory
 from .core.storage import (
     LocalPathClasses,
@@ -61,6 +60,7 @@ from .core.versioning import (
     create_uid,
     message_update_key_in_version_family,
 )
+from .errors import IntegrityError, InvalidArgument
 
 try:
     from .core.storage._zarr import zarr_is_adata

--- a/lamindb/_can_curate.py
+++ b/lamindb/_can_curate.py
@@ -14,7 +14,7 @@ from lamindb.models import CanCurate, Record
 from ._from_values import _format_values, _has_organism_field, get_or_create_records
 from ._record import _queryset, get_name_field
 from ._utils import attach_func_to_class_method
-from .core.exceptions import ValidationError
+from .errors import ValidationError
 
 if TYPE_CHECKING:
     from django.db.models import QuerySet

--- a/lamindb/_collection.py
+++ b/lamindb/_collection.py
@@ -16,7 +16,7 @@ from lamindb_setup.core._docs import doc_args
 from lamindb_setup.core.hashing import hash_set
 
 from lamindb._record import _get_record_kwargs
-from lamindb.core.exceptions import FieldValidationError
+from lamindb.errors import FieldValidationError
 from lamindb.models import (
     Collection,
     CollectionArtifact,

--- a/lamindb/_feature.py
+++ b/lamindb/_feature.py
@@ -10,7 +10,7 @@ from pandas.api.types import CategoricalDtype, is_string_dtype
 
 from lamindb._record import _get_record_kwargs
 from lamindb.base.types import FeatureDtype
-from lamindb.core.exceptions import FieldValidationError, ValidationError
+from lamindb.errors import FieldValidationError, ValidationError
 from lamindb.models import Artifact, Feature, Record
 
 from ._query_set import RecordList

--- a/lamindb/_query_set.py
+++ b/lamindb/_query_set.py
@@ -26,7 +26,7 @@ from lamindb.models import (
     Transform,
 )
 
-from .core.exceptions import DoesNotExist
+from .errors import DoesNotExist
 
 T = TypeVar("T")
 

--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -42,7 +42,7 @@ from lamindb_setup.core._hub_core import connect_instance_hub
 from lamindb_setup.core._settings_store import instance_settings_file
 from lamindb_setup.core.upath import extract_suffix_from_path
 
-from lamindb.core.exceptions import FieldValidationError
+from lamindb.errors import FieldValidationError
 from lamindb.models import (
     Artifact,
     BasicRecord,
@@ -61,7 +61,7 @@ from lamindb.models import (
 
 from ._utils import attach_func_to_class_method
 from .core._settings import settings
-from .core.exceptions import (
+from .errors import (
     InvalidArgument,
     RecordNameChangeIntegrityError,
     ValidationError,

--- a/lamindb/_schema.py
+++ b/lamindb/_schema.py
@@ -15,11 +15,11 @@ from lamindb.models import Feature, Record, Schema
 from ._feature import convert_pandas_dtype_to_lamin_dtype
 from ._record import init_self_from_db, update_attributes
 from ._utils import attach_func_to_class_method
-from .core.exceptions import ValidationError
 from .core.relations import (
     dict_related_model_to_related_name,
     get_related_name,
 )
+from .errors import ValidationError
 
 if TYPE_CHECKING:
     from collections.abc import Iterable

--- a/lamindb/_transform.py
+++ b/lamindb/_transform.py
@@ -11,8 +11,8 @@ from lamindb.models import Run, Transform
 from ._parents import _view_parents
 from ._run import delete_run_artifacts
 from .core._settings import settings
-from .core.exceptions import InconsistentKey
 from .core.versioning import message_update_key_in_version_family, process_revises
+from .errors import InconsistentKey
 
 if TYPE_CHECKING:
     from lamindb.base.types import TransformType

--- a/lamindb/_ulabel.py
+++ b/lamindb/_ulabel.py
@@ -4,7 +4,7 @@ import lamindb_setup as ln_setup
 from lamin_utils import logger
 
 from lamindb._record import _get_record_kwargs
-from lamindb.core.exceptions import FieldValidationError, ValidationError
+from lamindb.errors import FieldValidationError, ValidationError
 from lamindb.models import ULabel
 
 from ._utils import attach_func_to_class_method

--- a/lamindb/base/validation.py
+++ b/lamindb/base/validation.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING, Literal, Union, get_args, get_origin, get_type
 
 from lamin_utils import colors
 
-from lamindb.core.exceptions import FieldValidationError
+from lamindb.errors import FieldValidationError
 
 if TYPE_CHECKING:
     from .models import Record

--- a/lamindb/core/__init__.py
+++ b/lamindb/core/__init__.py
@@ -97,7 +97,6 @@ from lamindb.models import (
     ValidateFields,
 )
 
-from .. import errors as exceptions  # backward compat
 from . import _data, datasets, fields, loaders, subsettings, types
 from ._context import Context
 from ._mapped_collection import MappedCollection

--- a/lamindb/core/__init__.py
+++ b/lamindb/core/__init__.py
@@ -61,7 +61,6 @@ Modules:
    loaders
    datasets
    storage
-   exceptions
    subsettings
    logger
 
@@ -98,7 +97,8 @@ from lamindb.models import (
     ValidateFields,
 )
 
-from . import _data, datasets, exceptions, fields, loaders, subsettings, types
+from .. import errors as exceptions  # backward compat
+from . import _data, datasets, fields, loaders, subsettings, types
 from ._context import Context
 from ._mapped_collection import MappedCollection
 from ._settings import Settings

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -19,14 +19,14 @@ from lamindb.base import ids
 from lamindb.base.ids import base62_12
 from lamindb.models import Run, Transform, format_field_value
 
-from ._settings import settings
-from ._sync_git import get_transform_reference_from_git_repo
-from ._track_environment import track_environment
-from .exceptions import (
+from ..errors import (
     InconsistentKey,
     TrackNotCalled,
     UpdateContext,
 )
+from ._settings import settings
+from ._sync_git import get_transform_reference_from_git_repo
+from ._track_environment import track_environment
 from .versioning import bump_version as bump_version_function
 from .versioning import increment_base62, message_update_key_in_version_family
 

--- a/lamindb/core/_data.py
+++ b/lamindb/core/_data.py
@@ -21,6 +21,7 @@ from lamindb.models import (
     record_repr,
 )
 
+from ..errors import ValidationError
 from ._context import context
 from ._django import get_artifact_with_related, get_related_model
 from ._feature_manager import (
@@ -28,7 +29,6 @@ from ._feature_manager import (
     get_host_id_field,
     get_label_links,
 )
-from .exceptions import ValidationError
 from .relations import (
     dict_module_name_to_model_name,
     dict_related_model_to_related_name,

--- a/lamindb/core/_feature_manager.py
+++ b/lamindb/core/_feature_manager.py
@@ -33,8 +33,8 @@ from lamindb._record import (
 )
 from lamindb._save import save
 from lamindb._schema import DICT_KEYS_TYPE, Schema
-from lamindb.core.exceptions import DoesNotExist, ValidationError
 from lamindb.core.storage import LocalPathClasses
+from lamindb.errors import DoesNotExist, ValidationError
 from lamindb.models import (
     Artifact,
     Collection,

--- a/lamindb/core/exceptions.py
+++ b/lamindb/core/exceptions.py
@@ -1,0 +1,1 @@
+from ..errors import *  # noqa: F403 backward compat

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -52,7 +52,7 @@ from lamindb.models import (
 )
 
 from .._from_values import _format_values
-from ..core.exceptions import ValidationError
+from ..errors import ValidationError
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, MutableMapping

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -344,25 +344,21 @@ class DataFrameCurator(Curator):
             categoricals=categoricals,
         )
 
-    def validate(self) -> bool | str:
+    def validate(self) -> None:
         self._cat_curator.validate()
         try:
             self._pda_schema.validate(self._dataset)
             if self._cat_curator._is_validated:
                 self._is_validated = True
-                return True
             else:
                 self._is_validated = False
-                return self._cat_curator._validate_category_error_messages
+                raise ValidationError(
+                    self._cat_curator._validate_category_error_messages
+                )
         except pda.errors.SchemaError as err:
-            # .exconly() doesn't seem to exist on SchemaError
-            str_message = str(err)
-            logger.warning(str_message)
-            # need to set the cat curator to False
             self._is_validated = False
-            self._cat_curator._is_validated = False
-            # return the error message so that we can test for it
-            return str_message
+            # .exconly() doesn't exist on SchemaError
+            raise ValidationError(str(err)) from err
 
 
 class DataFrameCatCurator(CatCurator):

--- a/lamindb/errors.py
+++ b/lamindb/errors.py
@@ -3,9 +3,9 @@
 .. autosummary::
    :toctree: .
 
+   ValidationError
    InvalidArgument
    DoesNotExist
-   ValidationError
    NotebookNotSaved
    MissingContextUID
    UpdateContext
@@ -17,6 +17,12 @@
 # inheriting from SystemExit has the sole purpose of suppressing
 # the traceback - this isn't optimal but the current best solution
 # https://laminlabs.slack.com/archives/C04A0RMA0SC/p1726856875597489
+
+
+class ValidationError(SystemExit):
+    """Validation error."""
+
+    pass
 
 
 class InvalidArgument(SystemExit):
@@ -37,14 +43,8 @@ class NotebookNotSaved(SystemExit):
     pass
 
 
-class ValidationError(SystemExit):
-    """Validation error: not mapped in registry."""
-
-    pass
-
-
-# inspired by Django's DoesNotExist
-# equivalent to SQLAlchemy's NoResultFound
+# equivalent to Django's DoesNotExist
+# and SQLAlchemy's NoResultFound
 class DoesNotExist(SystemExit):
     """No record found."""
 
@@ -59,6 +59,12 @@ class InconsistentKey(Exception):
 
 class RecordNameChangeIntegrityError(SystemExit):
     """Custom exception for name change errors."""
+
+    pass
+
+
+class FieldValidationError(SystemExit):
+    """Field validation error."""
 
     pass
 
@@ -86,11 +92,5 @@ class MissingContextUID(SystemExit):
 
 class UpdateContext(SystemExit):
     """Transform settings require update."""
-
-    pass
-
-
-class FieldValidationError(SystemExit):
-    """Field validation error."""
 
     pass

--- a/tests/core/notebooks/with-title-initialized-consecutive-finish.ipynb
+++ b/tests/core/notebooks/with-title-initialized-consecutive-finish.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "import lamindb as ln\n",
     "import pytest\n",
-    "from lamindb.core.exceptions import ValidationError"
+    "from lamindb.errors import ValidationError"
    ]
   },
   {

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -24,17 +24,17 @@ from lamindb._artifact import (
     process_data,
 )
 from lamindb.core._settings import settings
-from lamindb.core.exceptions import (
-    FieldValidationError,
-    IntegrityError,
-    InvalidArgument,
-)
 from lamindb.core.loaders import load_fcs, load_to_memory, load_tsv
 from lamindb.core.storage._zarr import write_adata_zarr, zarr_is_adata
 from lamindb.core.storage.paths import (
     AUTO_KEY_PREFIX,
     auto_storage_key_from_artifact_uid,
     delete_storage,
+)
+from lamindb.errors import (
+    FieldValidationError,
+    IntegrityError,
+    InvalidArgument,
 )
 from lamindb_setup.core.upath import (
     CloudPath,
@@ -420,7 +420,7 @@ def test_create_from_local_filepath(
             artifact = ln.Artifact(test_filepath, key=key, description=description)
         assert (
             error.exconly()
-            == f"lamindb.core.exceptions.InvalidArgument: The path '{test_filepath}' is already in registered"
+            == f"lamindb.errors.InvalidArgument: The path '{test_filepath}' is already in registered"
             " storage"
             f" '{root_dir.resolve().as_posix()}' with key '{inferred_key}'\nYou"
             f" passed conflicting key '{key}': please move the file before"
@@ -503,7 +503,7 @@ def test_from_dir_many_artifacts(get_test_filepaths, key):
         with pytest.raises(InvalidArgument) as error:
             ln.Artifact.from_dir(test_dirpath, key=key)
         assert error.exconly().startswith(
-            "lamindb.core.exceptions.InvalidArgument: The path"  # The path {data} is already in registered storage
+            "lamindb.errors.InvalidArgument: The path"  # The path {data} is already in registered storage
         )
         return None
     else:
@@ -559,7 +559,7 @@ def test_delete_artifact(df):
     with pytest.raises(IntegrityError) as e:
         artifact.delete()
     assert e.exconly().startswith(
-        "lamindb.core.exceptions.IntegrityError: Cannot simply delete artifacts"
+        "lamindb.errors.IntegrityError: Cannot simply delete artifacts"
     )
     artifact.delete(storage=False, permanent=True)
     assert (
@@ -854,7 +854,7 @@ def test_df_suffix(df):
         artifact = ln.Artifact.from_df(df, key="test_.def")
     assert (
         error.exconly().partition(",")[0]
-        == "lamindb.core.exceptions.InvalidArgument: The suffix '.def' of the provided key is incorrect"
+        == "lamindb.errors.InvalidArgument: The suffix '.def' of the provided key is incorrect"
     )
 
 
@@ -877,7 +877,7 @@ def test_adata_suffix(adata):
         artifact = ln.Artifact.from_anndata(adata, key="test_")
     assert (
         error.exconly().partition(",")[0]
-        == "lamindb.core.exceptions.InvalidArgument: The suffix '' of the provided key is incorrect"
+        == "lamindb.errors.InvalidArgument: The suffix '' of the provided key is incorrect"
     )
 
 

--- a/tests/core/test_artifact_folders.py
+++ b/tests/core/test_artifact_folders.py
@@ -1,6 +1,6 @@
 import lamindb as ln
 import pytest
-from lamindb.core.exceptions import InvalidArgument
+from lamindb.errors import InvalidArgument
 
 
 @pytest.mark.parametrize("key", [None, "my_new_folder"])
@@ -15,7 +15,7 @@ def test_folder_like_artifact(get_test_filepaths, key):
         with pytest.raises(InvalidArgument) as error:
             ln.Artifact(test_dirpath, key=key)
         assert error.exconly().startswith(
-            "lamindb.core.exceptions.InvalidArgument: The path"  # The path {data} is already in registered storage
+            "lamindb.errors.InvalidArgument: The path"  # The path {data} is already in registered storage
         )
         return None
     if key is None and not is_in_registered_storage:

--- a/tests/core/test_can_curate.py
+++ b/tests/core/test_can_curate.py
@@ -1,7 +1,7 @@
 import bionty as bt
 import lamindb as ln
 import pytest
-from lamindb.core.exceptions import ValidationError
+from lamindb.errors import ValidationError
 
 
 # some validate tests are in test_queryset

--- a/tests/core/test_collection.py
+++ b/tests/core/test_collection.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from lamindb import _collection
-from lamindb.core.exceptions import FieldValidationError
+from lamindb.errors import FieldValidationError
 from scipy.sparse import csc_matrix, csr_matrix
 
 

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -8,7 +8,7 @@ import lamindb_setup as ln_setup
 import pytest
 from lamindb._finish import clean_r_notebook_html, get_shortcut
 from lamindb.core._context import LogStreamTracker, context
-from lamindb.core.exceptions import TrackNotCalled, ValidationError
+from lamindb.errors import TrackNotCalled, ValidationError
 
 SCRIPTS_DIR = Path(__file__).parent.resolve() / "scripts"
 NOTEBOOKS_DIR = Path(__file__).parent.resolve() / "notebooks"
@@ -26,7 +26,7 @@ def test_track_with_multi_parents():
         ln.context.track(transform=child, params=params)
     assert (
         error.exconly()
-        == """lamindb.core.exceptions.ValidationError: These keys could not be validated: ['param1', 'param2', 'param3']
+        == """lamindb.errors.ValidationError: These keys could not be validated: ['param1', 'param2', 'param3']
 Here is how to create a param:
 
   ln.Param(name='param1', dtype='int').save()
@@ -46,7 +46,7 @@ Here is how to create a param:
         ln.context.track(transform=child, params=params)
     assert (
         error.exconly()
-        == """lamindb.core.exceptions.ValidationError: Expected dtype for 'param4' is 'int', got 'list[int]'"""
+        == """lamindb.errors.ValidationError: Expected dtype for 'param4' is 'int', got 'list[int]'"""
     )
     # fix param4 dtype
     param4.dtype = "list[int]"

--- a/tests/core/test_data.py
+++ b/tests/core/test_data.py
@@ -4,7 +4,7 @@ import pytest
 
 def test_rename():
     import pandas as pd
-    from lamindb.core.exceptions import RecordNameChangeIntegrityError
+    from lamindb.errors import RecordNameChangeIntegrityError
 
     df = pd.DataFrame(
         {

--- a/tests/core/test_dtype.py
+++ b/tests/core/test_dtype.py
@@ -2,7 +2,7 @@ import bionty
 import pytest
 from lamindb import ULabel
 from lamindb._feature import parse_dtype
-from lamindb.core.exceptions import ValidationError
+from lamindb.errors import ValidationError
 
 
 def test_simple_ulabel_with_subtype_and_field():

--- a/tests/core/test_feature.py
+++ b/tests/core/test_feature.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 from lamindb import _feature
 from lamindb._feature import convert_pandas_dtype_to_lamin_dtype
-from lamindb.core.exceptions import ValidationError
+from lamindb.errors import ValidationError
 from pandas.api.types import is_string_dtype
 
 
@@ -64,7 +64,7 @@ def test_feature_init():
         ln.Feature(name="feat", dtype="cat")
     assert (
         error.exconly()
-        == "lamindb.core.exceptions.ValidationError: Feature feat already exists with dtype str, you passed cat"
+        == "lamindb.errors.ValidationError: Feature feat already exists with dtype str, you passed cat"
     )
     feat1.delete()
     # check that this works
@@ -103,14 +103,14 @@ def test_feature_from_df(df):
         artifact.labels.add(labels, feature=feature)
     assert (
         err.exconly()
-        == "lamindb.core.exceptions.ValidationError: Cannot manually annotate internal feature with label. Please use ln.Curator"
+        == "lamindb.errors.ValidationError: Cannot manually annotate internal feature with label. Please use ln.Curator"
     )
     extfeature = ln.Feature(name="extfeat", dtype="str").save()
     with pytest.raises(ValidationError) as err:
         artifact.labels.add(labels, feature=extfeature)
     assert (
         err.exconly()
-        == f"lamindb.core.exceptions.ValidationError: Feature {extfeature.name} needs dtype='cat' for label annotation, currently has dtype='str'"
+        == f"lamindb.errors.ValidationError: Feature {extfeature.name} needs dtype='cat' for label annotation, currently has dtype='str'"
     )
 
     # clean up

--- a/tests/core/test_feature_label_manager.py
+++ b/tests/core/test_feature_label_manager.py
@@ -8,7 +8,7 @@ from lamindb.core._data import add_labels
 from lamindb.core._feature_manager import describe_features
 from lamindb.core._label_manager import print_rich_tree
 from lamindb.core.datasets import small_dataset1
-from lamindb.core.exceptions import DoesNotExist, ValidationError
+from lamindb.errors import DoesNotExist, ValidationError
 
 
 @pytest.fixture(scope="module")
@@ -27,7 +27,7 @@ def test_features_add():
         artifact.features.add_values({"cell_medium": df.cell_medium.unique()})
     assert (
         err.exconly()
-        == """lamindb.core.exceptions.ValidationError: These keys could not be validated: ['cell_medium']
+        == """lamindb.errors.ValidationError: These keys could not be validated: ['cell_medium']
 Here is how to create a feature:
 
   ln.Feature(name='cell_medium', dtype='cat ? str').save()"""
@@ -48,18 +48,18 @@ def test_features_add_remove(adata):
         artifact.params.add_values({"learning_rate": 0.01})
     assert (
         error.exconly()
-        == "lamindb.core.exceptions.ValidationError: Can only set params for model-like artifacts."
+        == "lamindb.errors.ValidationError: Can only set params for model-like artifacts."
     )
     with pytest.raises(ValidationError) as error:
         artifact.features.add_values({"experiment": "Experiment 1"})
     assert error.exconly().startswith(
-        "lamindb.core.exceptions.ValidationError: These keys could not be validated:"
+        "lamindb.errors.ValidationError: These keys could not be validated:"
     )
     ln.Feature(name="experiment", dtype="cat").save()
     with pytest.raises(ValidationError) as error:
         artifact.features.add_values({"experiment": "Experiment 1"})
     assert error.exconly().startswith(
-        "lamindb.core.exceptions.ValidationError: These values could not be validated: ['Experiment 1']"
+        "lamindb.errors.ValidationError: These values could not be validated: ['Experiment 1']"
     )
     experiment_label = ln.ULabel(name="Experiment 1").save()
     # add the label without the feature first
@@ -93,7 +93,7 @@ def test_features_add_remove(adata):
         artifact.features.add_values({"date_of_experiment": "2024-12-01"})
     assert (
         error.exconly()
-        == """lamindb.core.exceptions.ValidationError: These keys could not be validated: ['date_of_experiment']
+        == """lamindb.errors.ValidationError: These keys could not be validated: ['date_of_experiment']
 Here is how to create a feature:
 
   ln.Feature(name='date_of_experiment', dtype='date').save()"""
@@ -104,7 +104,7 @@ Here is how to create a feature:
         artifact.features.add_values({"date_of_experiment": "Typo2024-12-01"})
     assert (
         error.exconly()
-        == """lamindb.core.exceptions.ValidationError: Expected dtype for 'date_of_experiment' is 'date', got 'cat ? str'"""
+        == """lamindb.errors.ValidationError: Expected dtype for 'date_of_experiment' is 'date', got 'cat ? str'"""
     )
     artifact.features.add_values({"date_of_experiment": "2024-12-01"})
 
@@ -117,7 +117,7 @@ Here is how to create a feature:
         artifact.features.add_values({"organism": mouse})
     assert (
         error.exconly()
-        == """lamindb.core.exceptions.ValidationError: These keys could not be validated: ['organism']
+        == """lamindb.errors.ValidationError: These keys could not be validated: ['organism']
 Here is how to create a feature:
 
   ln.Feature(name='organism', dtype='cat[bionty.Organism]').save()"""
@@ -127,9 +127,7 @@ Here is how to create a feature:
         artifact.features.add_values({"organism": mouse})
     assert (
         # ensure the label is saved
-        error.exconly().startswith(
-            "lamindb.core.exceptions.ValidationError: Please save"
-        )
+        error.exconly().startswith("lamindb.errors.ValidationError: Please save")
     )
     mouse.save()
     artifact.features.add_values({"organism": mouse})
@@ -159,7 +157,7 @@ Here is how to create a feature:
     assert (
         error.exconly()
         == """\
-lamindb.core.exceptions.ValidationError: These keys could not be validated: ['project', 'is_validated', 'cell_type_by_expert', 'donor']
+lamindb.errors.ValidationError: These keys could not be validated: ['project', 'is_validated', 'cell_type_by_expert', 'donor']
 Here is how to create a feature:
 
   ln.Feature(name='project', dtype='cat ? str').save()
@@ -179,7 +177,7 @@ Here is how to create a feature:
     assert (
         error.exconly()
         == """\
-lamindb.core.exceptions.ValidationError: These values could not be validated: ['Experiment 2', 'project_1', 'T Cell', 'U0123']
+lamindb.errors.ValidationError: These values could not be validated: ['Experiment 2', 'project_1', 'T Cell', 'U0123']
 Here is how to create ulabels for them:
 
   ulabels = ln.ULabel.from_values(['Experiment 2', 'project_1', 'T Cell', 'U0123'], create=True)
@@ -274,7 +272,7 @@ Here is how to create ulabels for them:
             temperature_with_typo=100.0, project="project_1"
         ).one()
     assert error.exconly().startswith(
-        "lamindb.core.exceptions.ValidationError: Some keys in the filter expression are not registered as features:"
+        "lamindb.errors.ValidationError: Some keys in the filter expression are not registered as features:"
     )
 
     ln.Artifact.features.get(temperature=100.0)
@@ -290,7 +288,7 @@ Here is how to create ulabels for them:
     with pytest.raises(DoesNotExist) as error:
         ln.Artifact.features.get(project="project__1")
     assert error.exconly().startswith(
-        "lamindb.core.exceptions.DoesNotExist: Did not find a ULabel matching"
+        "lamindb.errors.DoesNotExist: Did not find a ULabel matching"
     )
 
     # test comparator
@@ -327,7 +325,7 @@ def test_params_add():
         artifact.features.add_values({"temperature": 27})
     assert (
         error.exconly()
-        == "lamindb.core.exceptions.ValidationError: Can only set features for dataset-like artifacts."
+        == "lamindb.errors.ValidationError: Can only set features for dataset-like artifacts."
     )
     ln.Param(name="learning_rate", dtype="float").save()
     ln.Param(name="quantification", dtype="dict").save()
@@ -389,7 +387,7 @@ def test_labels_add(adata):
         artifact.labels.add(label, feature=experiment)
     assert (
         error.exconly()
-        == "lamindb.core.exceptions.ValidationError: Feature not validated. If it looks"
+        == "lamindb.errors.ValidationError: Feature not validated. If it looks"
         " correct: ln.Feature(name='experiment', type='cat[ULabel]').save()"
     )
     experiment.save()
@@ -547,7 +545,7 @@ def test_add_labels_using_anndata(adata):
         add_labels(artifact, tissues, feature=features.tissue, from_curator=True)
     assert (
         err.exconly()
-        == "lamindb.core.exceptions.ValidationError: Label type ULabel is not valid for Feature(name='tissue', dtype='cat[bionty.Tissue]'), consider updating to dtype='cat[bionty.Tissue|ULabel]'"
+        == "lamindb.errors.ValidationError: Label type ULabel is not valid for Feature(name='tissue', dtype='cat[bionty.Tissue]'), consider updating to dtype='cat[bionty.Tissue|ULabel]'"
     )
     tissue = ln.Feature.get(name="tissue")
     tissue.dtype = "cat[bionty.Tissue|ULabel]"

--- a/tests/core/test_feature_label_manager.py
+++ b/tests/core/test_feature_label_manager.py
@@ -514,7 +514,7 @@ def test_add_labels_using_anndata(adata):
 
     # now, we add organism and run checks
     features = ln.Feature.lookup()
-    with pytest.raises(ln.core.exceptions.ValidationError):
+    with pytest.raises(ln.errors.ValidationError):
         artifact.labels.add(organism, feature=features.organism)
     organism.save()
     artifact.labels.add(organism, feature=features.organism)

--- a/tests/core/test_record.py
+++ b/tests/core/test_record.py
@@ -12,7 +12,7 @@ from lamindb._record import (
     _search,
     suggest_records_with_similar_names,
 )
-from lamindb.core.exceptions import FieldValidationError
+from lamindb.errors import FieldValidationError
 
 
 def test_signatures():

--- a/tests/core/test_schema.py
+++ b/tests/core/test_schema.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 from lamindb import _schema
 from lamindb._schema import get_related_name, validate_features
-from lamindb.core.exceptions import ValidationError
+from lamindb.errors import ValidationError
 
 
 @pytest.fixture(scope="module")
@@ -46,7 +46,7 @@ def test_schema_from_values():
     with pytest.raises(ValidationError) as error:
         schema = ln.Schema.from_values(gene_symbols, bt.Gene.symbol, type=int)
     assert error.exconly().startswith(
-        "lamindb.core.exceptions.ValidationError: These values could not be validated:"
+        "lamindb.errors.ValidationError: These values could not be validated:"
     )
     ln.save(bt.Gene.from_values(gene_symbols, "symbol"))
     schema = ln.Schema.from_values(gene_symbols, bt.Gene.symbol)

--- a/tests/core/test_ulabel.py
+++ b/tests/core/test_ulabel.py
@@ -2,7 +2,7 @@ import re
 
 import lamindb as ln
 import pytest
-from lamindb.core.exceptions import FieldValidationError
+from lamindb.errors import FieldValidationError
 
 
 def test_ulabel():

--- a/tests/curators/test_cat_curators.py
+++ b/tests/curators/test_cat_curators.py
@@ -641,7 +641,7 @@ def test_spatialdata_curator():
         "developmental_stage": "very early",  # does not exist - to test add_new_from
     }
 
-    from lamindb.core.exceptions import ValidationError
+    from lamindb.errors import ValidationError
 
     with pytest.raises(
         ValidationError, match="key passed to categoricals is not present"

--- a/tests/curators/test_dataframe_curators_accounting_example.py
+++ b/tests/curators/test_dataframe_curators_accounting_example.py
@@ -162,4 +162,6 @@ def test_invalid_label(transactions_schema):
 
     with pytest.raises(ln.errors.ValidationError) as err:
         curator.validate()
-    assert "1 term is not validated: 'GBP'" in err.exconly()
+    exconly = """lamindb.errors.ValidationError: 1 term is not validated: 'GBP'
+    → fix typos, remove non-existent values, or save terms via .add_new_from("currency_name")"""
+    assert err.exconly() == exconly


### PR DESCRIPTION
Is part of a sequence of PRs that refactors the curators:

- https://github.com/laminlabs/lamindb/pull/2416
- https://github.com/laminlabs/lamindb/pull/2415
- https://github.com/laminlabs/lamindb/pull/2413
- https://github.com/laminlabs/lamindb/pull/2412
- https://github.com/laminlabs/lamindb/pull/2408
- https://github.com/laminlabs/lamindb/pull/2403
- https://github.com/laminlabs/lamindb/pull/2388

---

The new-style curators are now consistent with pydantic and pandera in that they raise informative errors upon `.validate()` rather than returning `False`.

Say, there is a typo in the "T cell" label:

```python
with pytest.raises(ln.errors.ValidationError) as err:
    curator.validate()
message = """1 term is not validated: 'T_cell'
    → fix typos, remove non-existent values, or save terms via .add_new_from("cell_type_by_expert")"""
assert err.exconly() == f"lamindb.errors.ValidationError: {message}"
```

Or a column is missing from a `DataFrame` (via `pandera` under-the-hood):

```python
with pytest.raises(ln.errors.ValidationError) as err:
    curator.validate()
message = "column 'cell_type_by_model' not in dataframe. Columns in dataframe: ['date', 'cell_type_by_expert']"
assert err.exconly() == f"lamindb.errors.ValidationError: {message}"
```

The old-style family of `CatCurator` classes keeps returning a boolean upon `.validate()` for backward compatibility.

Also: `lamindb.core.exceptions` got moved to `lamindb.errors`.

See internal [Slack thread](https://laminlabs.slack.com/archives/C04FPE8V01W/p1738378068116369).