### PR TITLE
✨ Schema-based curators: `AnnDataCurator`

### DIFF
--- a/docs/registries.ipynb
+++ b/docs/registries.ipynb
@@ -44,7 +44,7 @@
    },
    "outputs": [],
    "source": [
-    "# !pip install 'lamindb[bionty]'\n",
+    "# pip install 'lamindb[bionty]'\n",
     "!lamin init --storage ./test-registries --modules bionty\n",
     "\n",
     "# python\n",
@@ -82,7 +82,7 @@
     "adata = datasets.small_dataset1(otype=\"AnnData\")\n",
     "curator = ln.Curator.from_anndata(\n",
     "    adata,\n",
-    "    var_index=bt.Gene.symbol,\n",
+    "    var_index=bt.Gene.ensembl_gene_id,\n",
     "    categoricals={\n",
     "        \"cell_medium\": ln.ULabel.name,\n",
     "        \"cell_type_by_expert\": bt.CellType.name,\n",

--- a/docs/registries.ipynb
+++ b/docs/registries.ipynb
@@ -94,7 +94,7 @@
     "artifact.features.add_values(adata.uns)\n",
     "\n",
     "# Ingest dataset2\n",
-    "adata2 = datasets.small_dataset2(format=\"anndata\")\n",
+    "adata2 = datasets.small_dataset2(otype=\"AnnData\")\n",
     "curator = ln.Curator.from_anndata(\n",
     "    adata2,\n",
     "    var_index=bt.Gene.symbol,\n",

--- a/docs/registries.ipynb
+++ b/docs/registries.ipynb
@@ -79,7 +79,7 @@
     "bt.CellType.from_values([\"B cell\", \"T cell\"], create=True).save()\n",
     "\n",
     "# Ingest dataset1\n",
-    "adata = datasets.small_dataset1(format=\"anndata\")\n",
+    "adata = datasets.small_dataset1(otype=\"AnnData\")\n",
     "curator = ln.Curator.from_anndata(\n",
     "    adata,\n",
     "    var_index=bt.Gene.symbol,\n",

--- a/docs/registries.ipynb
+++ b/docs/registries.ipynb
@@ -97,7 +97,7 @@
     "adata2 = datasets.small_dataset2(otype=\"AnnData\")\n",
     "curator = ln.Curator.from_anndata(\n",
     "    adata2,\n",
-    "    var_index=bt.Gene.symbol,\n",
+    "    var_index=bt.Gene.ensembl_gene_id,\n",
     "    categoricals={\n",
     "        \"cell_medium\": ln.ULabel.name,\n",
     "        \"cell_type_by_model\": bt.CellType.name,\n",

--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -91,7 +91,7 @@ if _check_instance_setup(from_module="lamindb"):
     from ._view import view
     from .core._context import context
     from .core._settings import settings
-    from .curators import Curator
+    from .curators import CatCurator as Curator
     from .models import (
         Artifact,
         Collection,

--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -44,6 +44,7 @@ Modules and settings.
 
    integrations
    context
+   curators
    settings
    errors
    setup

--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -33,7 +33,6 @@ Key functionality.
    :toctree: .
 
    connect
-   Curator
    view
    save
 

--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -20,7 +20,7 @@ Registries.
    User
    Storage
    Feature
-   FeatureSet
+   Schema
    Param
    Collection
    Project
@@ -50,6 +50,13 @@ Modules and settings.
    UPath
    base
    core
+
+Backward compatibility.
+
+.. autosummary::
+   :toctree: .
+
+   FeatureSet
 
 """
 

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -34,7 +34,7 @@ from .core._data import (
     describe,
     get_run,
     save_schema_links,
-    save_staged__schemas_m2m,
+    save_staged_schemas_m2m,
 )
 from .core._settings import settings
 from .core.loaders import load_to_memory
@@ -1247,7 +1247,7 @@ def save(self, upload: bool | None = None, **kwargs) -> Artifact:
 
 
 def _save_skip_storage(file, **kwargs) -> None:
-    save_staged__schemas_m2m(file)
+    save_staged_schemas_m2m(file)
     super(Artifact, file).save(**kwargs)
     save_schema_links(file)
 

--- a/lamindb/_collection.py
+++ b/lamindb/_collection.py
@@ -31,7 +31,7 @@ from .core._data import (
     describe,
     get_run,
     save_schema_links,
-    save_staged__schemas_m2m,
+    save_staged_schemas_m2m,
 )
 from .core._mapped_collection import MappedCollection
 from .core._settings import settings
@@ -52,7 +52,7 @@ class CollectionFeatureManager:
     def __init__(self, collection: Collection):
         self._collection = collection
 
-    def _get_staged__schemas_m2m_union(self) -> dict[str, Schema]:
+    def _get_staged_schemas_m2m_union(self) -> dict[str, Schema]:
         links_schema_artifact = Artifact._schemas_m2m.through.objects.filter(
             artifact_id__in=self._collection.artifacts.values_list("id", flat=True)
         )
@@ -338,7 +338,7 @@ def save(self, using: str | None = None) -> Collection:
     if self.meta_artifact is not None:
         self.meta_artifact.save()
     # we don't need to save feature sets again
-    save_staged__schemas_m2m(self)
+    save_staged_schemas_m2m(self)
     super(Collection, self).save()
     # we don't allow updating the collection of artifacts
     # if users want to update the set of artifacts, they

--- a/lamindb/_feature.py
+++ b/lamindb/_feature.py
@@ -28,6 +28,62 @@ if TYPE_CHECKING:
 FEATURE_DTYPES = set(get_args(FeatureDtype))
 
 
+def parse_dtype_single_cat(
+    dtype_str: str, related_registries: dict[str, Record] | None = None
+) -> dict:
+    if related_registries is None:
+        related_registries = dict_module_name_to_model_name(Artifact)
+    split_result = dtype_str.split("[")
+    # has sub type
+    sub_type_str = ""
+    if len(split_result) == 2:
+        registry_str = split_result[0]
+        assert "]" in split_result[1]  # noqa: S101
+        sub_type_field_split = split_result[1].split("].")
+        if len(sub_type_field_split) == 1:
+            sub_type_str = sub_type_field_split[0].strip("]")
+            field_str = ""
+        else:
+            sub_type_str = sub_type_field_split[0]
+            field_str = sub_type_field_split[1]
+    elif len(split_result) == 1:
+        registry_field_split = split_result[0].split(".")
+        if (
+            len(registry_field_split) == 2 and registry_field_split[1][0].isupper()
+        ) or len(registry_field_split) == 3:
+            # bionty.CellType or bionty.CellType.name
+            registry_str = f"{registry_field_split[0]}.{registry_field_split[1]}"
+            field_str = (
+                "" if len(registry_field_split) == 2 else registry_field_split[2]
+            )
+        else:
+            # ULabel or ULabel.name
+            registry_str = registry_field_split[0]
+            field_str = (
+                "" if len(registry_field_split) == 1 else registry_field_split[1]
+            )
+    if registry_str not in related_registries:
+        raise ValidationError(
+            f"'{registry_str}' is an invalid dtype, has to be registry, e.g. ULabel or bionty.CellType"
+        )
+    if sub_type_str != "":
+        pass
+        # validate that the subtype is a record in the registry with is_type = True
+    registry = related_registries[registry_str]
+    if field_str != "":
+        pass
+        # validate that field_str is an actual field of the module
+    else:
+        field_str = registry._name_field if hasattr(registry, "_name_field") else "name"
+    return {
+        "registry": registry,  # should be typed as CanCurate
+        "registry_str": registry_str,
+        "subtype_str": sub_type_str,
+        "field_str": field_str,
+        "field": getattr(registry, field_str),
+    }
+
+
 def parse_dtype(dtype_str: str) -> list[dict[str, str]]:
     result = []
     # simple dtypes are in FEATURE_DTYPES, composed dtypes are in the form `cat...`
@@ -42,68 +98,10 @@ def parse_dtype(dtype_str: str) -> list[dict[str, str]]:
         if registries_str != "":
             registry_str_list = registries_str.split("|")
             for cat_single_dtype_str in registry_str_list:
-                split_result = cat_single_dtype_str.split("[")
-                # has sub type
-                sub_type_str = ""
-                if len(split_result) == 2:
-                    registry_str = split_result[0]
-                    assert "]" in split_result[1]  # noqa: S101
-                    sub_type_field_split = split_result[1].split("].")
-                    if len(sub_type_field_split) == 1:
-                        sub_type_str = sub_type_field_split[0].strip("]")
-                        field_str = ""
-                    else:
-                        sub_type_str = sub_type_field_split[0]
-                        field_str = sub_type_field_split[1]
-                elif len(split_result) == 1:
-                    registry_field_split = split_result[0].split(".")
-                    if (
-                        len(registry_field_split) == 2
-                        and registry_field_split[1][0].isupper()
-                    ) or len(registry_field_split) == 3:
-                        # bionty.CellType or bionty.CellType.name
-                        registry_str = (
-                            f"{registry_field_split[0]}.{registry_field_split[1]}"
-                        )
-                        field_str = (
-                            ""
-                            if len(registry_field_split) == 2
-                            else registry_field_split[2]
-                        )
-                    else:
-                        # ULabel or ULabel.name
-                        registry_str = registry_field_split[0]
-                        field_str = (
-                            ""
-                            if len(registry_field_split) == 1
-                            else registry_field_split[1]
-                        )
-                if registry_str not in related_registries:
-                    raise ValidationError(
-                        f"'{registry_str}' is an invalid dtype, has to be registry, e.g. ULabel or bionty.CellType"
-                    )
-                if sub_type_str != "":
-                    pass
-                    # validate that the subtype is a record in the registry with is_type = True
-                registry = related_registries[registry_str]
-                if field_str != "":
-                    pass
-                    # validate that field_str is an actual field of the module
-                else:
-                    field_str = (
-                        registry._name_field
-                        if hasattr(registry, "_name_field")
-                        else "name"
-                    )
-                result.append(
-                    {
-                        "registry": registry,
-                        "registry_str": registry_str,
-                        "subtype_str": sub_type_str,
-                        "field_str": field_str,
-                        "field": getattr(registry, field_str),
-                    }
+                single_result = parse_dtype_single_cat(
+                    cat_single_dtype_str, related_registries
                 )
+                result.append(single_result)
     return result
 
 

--- a/lamindb/_record.py
+++ b/lamindb/_record.py
@@ -87,7 +87,12 @@ def init_self_from_db(self: Record, existing_record: Record):
 
 def update_attributes(record: Record, attributes: dict[str, str]):
     for key, value in attributes.items():
-        if getattr(record, key) != value and value is not None and key != "dtype":
+        if (
+            getattr(record, key) != value
+            and value is not None
+            and key != "dtype"
+            and key != "_aux"
+        ):
             logger.warning(f"updated {key} from {getattr(record, key)} to {value}")
             setattr(record, key, value)
 

--- a/lamindb/_schema.py
+++ b/lamindb/_schema.py
@@ -339,4 +339,3 @@ for name in METHOD_NAMES:
 
 Schema.members = members  # type: ignore
 Schema._get_related_name = _get_related_name
-Schema.feature_sets = Schema._artifacts_m2m  # backward compat

--- a/lamindb/_schema.py
+++ b/lamindb/_schema.py
@@ -142,8 +142,13 @@ def __init__(self, *args, **kwargs):
 @doc_args(Schema.save.__doc__)
 def save(self, *args, **kwargs) -> Schema:
     """{}"""  # noqa: D415
+    if self.slot is not None:
+        assert self.composite is not None, "pass `composite` schema"  # noqa: S101
+    if self.composite is not None:
+        assert self.slot is not None, "pass `slot`, e.g., to 'var', 'obs', etc."  # noqa: S101
     super(Schema, self).save(*args, **kwargs)
     if hasattr(self, "_features"):
+        assert self.n > 0  # noqa: S101
         related_name, records = self._features
         # only the following method preserves the order
         # .set() does not preserve the order but orders by

--- a/lamindb/_schema.py
+++ b/lamindb/_schema.py
@@ -81,6 +81,7 @@ def __init__(self, *args, **kwargs):
     composite: Schema | None = kwargs.pop("composite", None)
     slot: str | None = kwargs.pop("slot", None)
     validated_by: Schema | None = kwargs.pop("validated_by", None)
+    coerce_dtype: bool | None = kwargs.pop("coerce_dtype", None)
 
     # Check for unexpected keyword arguments
     if kwargs:
@@ -88,7 +89,7 @@ def __init__(self, *args, **kwargs):
             f"Unexpected keyword arguments: {', '.join(kwargs.keys())}\n"
             "Valid arguments are: features, description, dtype, itype, type, "
             "is_type, otype, minimal_set, ordered_set, maximal_set, composite, "
-            "slot, validated_by"
+            "slot, validated_by, coerce_dtype"
         )
 
     # now code
@@ -116,6 +117,8 @@ def __init__(self, *args, **kwargs):
         "slot": slot,
         "validated_by": validated_by,
     }
+    if coerce_dtype:
+        validated_kwargs["_aux"] = {"af": {"0": coerce_dtype}}
     # compute hash
     schema = Schema.filter(hash=hash).one_or_none()
     if schema is not None:

--- a/lamindb/core/__init__.py
+++ b/lamindb/core/__init__.py
@@ -10,7 +10,6 @@ Registries:
    Registry
    QuerySet
    QueryManager
-   Schema
    RecordList
    FeatureManager
    ParamManager
@@ -91,7 +90,6 @@ from lamindb.models import (
     ParamValue,
     Record,
     Registry,
-    Schema,
     TracksRun,
     TracksUpdates,
     ValidateFields,

--- a/lamindb/core/_data.py
+++ b/lamindb/core/_data.py
@@ -56,26 +56,26 @@ def get_run(run: Run | None) -> Run | None:
     return run
 
 
-def save_staged__schemas_m2m(self: Artifact | Collection) -> None:
-    if hasattr(self, "_staged__schemas_m2m"):
+def save_staged_schemas_m2m(self: Artifact | Collection) -> None:
+    if hasattr(self, "_staged_schemas_m2m"):
         from lamindb.core._feature_manager import get_schema_by_slot_
 
-        existing_staged__schemas_m2m = get_schema_by_slot_(self)
-        saved_staged__schemas_m2m = {}
-        for key, schema in self._staged__schemas_m2m.items():
+        existing_staged_schemas_m2m = get_schema_by_slot_(self)
+        saved_staged_schemas_m2m = {}
+        for key, schema in self._staged_schemas_m2m.items():
             if isinstance(schema, Schema) and schema._state.adding:
                 schema.save()
-                saved_staged__schemas_m2m[key] = schema
-            if key in existing_staged__schemas_m2m:
+                saved_staged_schemas_m2m[key] = schema
+            if key in existing_staged_schemas_m2m:
                 # remove existing feature set on the same slot
-                self._schemas_m2m.remove(existing_staged__schemas_m2m[key])
-        if len(saved_staged__schemas_m2m) > 0:
-            s = "s" if len(saved_staged__schemas_m2m) > 1 else ""
+                self._schemas_m2m.remove(existing_staged_schemas_m2m[key])
+        if len(saved_staged_schemas_m2m) > 0:
+            s = "s" if len(saved_staged_schemas_m2m) > 1 else ""
             display_schema_keys = ",".join(
-                f"'{key}'" for key in saved_staged__schemas_m2m.keys()
+                f"'{key}'" for key in saved_staged_schemas_m2m.keys()
             )
             logger.save(
-                f"saved {len(saved_staged__schemas_m2m)} feature set{s} for slot{s}:"
+                f"saved {len(saved_staged_schemas_m2m)} feature set{s} for slot{s}:"
                 f" {display_schema_keys}"
             )
 
@@ -84,10 +84,10 @@ def save_schema_links(self: Artifact | Collection) -> None:
     from lamindb._save import bulk_create
 
     Data = self.__class__
-    if hasattr(self, "_staged__schemas_m2m"):
+    if hasattr(self, "_staged_schemas_m2m"):
         links = []
         host_id_field = get_host_id_field(self)
-        for slot, schema in self._staged__schemas_m2m.items():
+        for slot, schema in self._staged_schemas_m2m.items():
             kwargs = {
                 host_id_field: self.id,
                 "schema_id": schema.id,

--- a/lamindb/core/_feature_manager.py
+++ b/lamindb/core/_feature_manager.py
@@ -96,8 +96,8 @@ def get_schema_by_slot_(host: Artifact | Collection) -> dict:
         return {}
     # if the host is not yet saved
     if host._state.adding:
-        if hasattr(host, "_staged__schemas_m2m"):
-            return host._staged__schemas_m2m
+        if hasattr(host, "_staged_schemas_m2m"):
+            return host._staged_schemas_m2m
         else:
             return {}
     host_db = host._state.db
@@ -500,7 +500,7 @@ def describe_features(
     return tree
 
 
-def parse_staged__schemas_m2m_from_anndata(
+def parse_staged_schemas_m2m_from_anndata(
     adata: AnnData,
     var_field: FieldAttr | None = None,
     obs_field: FieldAttr = Feature.name,
@@ -1101,7 +1101,7 @@ def _add_set_from_df(
         mute=mute,
         organism=organism,
     )
-    self._host._staged__schemas_m2m = {"columns": schema}
+    self._host._staged_schemas_m2m = {"columns": schema}
     self._host.save()
 
 
@@ -1120,7 +1120,7 @@ def _add_set_from_anndata(
 
     # parse and register features
     adata = self._host.load()
-    _schemas_m2m = parse_staged__schemas_m2m_from_anndata(
+    _schemas_m2m = parse_staged_schemas_m2m_from_anndata(
         adata,
         var_field=var_field,
         obs_field=obs_field,
@@ -1129,7 +1129,7 @@ def _add_set_from_anndata(
     )
 
     # link feature sets
-    self._host._staged__schemas_m2m = _schemas_m2m
+    self._host._staged_schemas_m2m = _schemas_m2m
     self._host.save()
 
 
@@ -1155,7 +1155,7 @@ def _add_set_from_mudata(
     if len(obs_features) > 0:
         _schemas_m2m["obs"] = Schema(features=obs_features)
     for modality, field in var_fields.items():
-        modality_fs = parse_staged__schemas_m2m_from_anndata(
+        modality_fs = parse_staged_schemas_m2m_from_anndata(
             mdata[modality],
             var_field=field,
             obs_field=obs_fields.get(modality, Feature.name),
@@ -1165,7 +1165,7 @@ def _add_set_from_mudata(
         for k, v in modality_fs.items():
             _schemas_m2m[f"['{modality}'].{k}"] = v
 
-    def unify_staged__schemas_m2m_by_hash(_schemas_m2m):
+    def unify_staged_schemas_m2m_by_hash(_schemas_m2m):
         unique_values = {}
 
         for key, value in _schemas_m2m.items():
@@ -1178,7 +1178,7 @@ def _add_set_from_mudata(
         return _schemas_m2m
 
     # link feature sets
-    self._host._staged__schemas_m2m = unify_staged__schemas_m2m_by_hash(_schemas_m2m)
+    self._host._staged_schemas_m2m = unify_staged_schemas_m2m_by_hash(_schemas_m2m)
     self._host.save()
 
 

--- a/lamindb/core/datasets/_small.py
+++ b/lamindb/core/datasets/_small.py
@@ -8,16 +8,21 @@ import pandas as pd
 
 
 def small_dataset1(
-    format: Literal["df", "anndata"],
+    otype: Literal["DataFrame", "AnnData"],
+    gene_symbols_in_index: bool = False,
     with_typo: bool = False,
 ) -> tuple[pd.DataFrame, dict[str, Any]] | ad.AnnData:
     # define the data in the dataset
     # it's a mix of numerical measurements and observation-level metadata
     ifng = "IFNJ" if with_typo else "IFNG"
+    if gene_symbols_in_index:
+        var_ids = ["CD8A", "CD4", "CD14"]
+    else:
+        var_ids = ["ENSG00000153563", "ENSG00000010610", "ENSG00000170458"]
     dataset_dict = {
-        "CD8A": [1, 2, 3],
-        "CD4": [3, 4, 5],
-        "CD14": [5, 6, 7],
+        var_ids[0]: [1, 2, 3],
+        var_ids[1]: [3, 4, 5],
+        var_ids[2]: [5, 6, 7],
         "cell_medium": ["DMSO", ifng, "DMSO"],
         "sample_note": ["was ok", "looks naah", "pretty! 🤩"],
         "cell_type_by_expert": ["B cell", "T cell", "T cell"],
@@ -42,12 +47,17 @@ def small_dataset1(
 
 
 def small_dataset2(
-    format: Literal["df", "anndata"],
+    otype: Literal["DataFrame", "AnnData"],
+    gene_symbols_in_index: bool = False,
 ) -> tuple[pd.DataFrame, dict[str, Any]] | ad.AnnData:
+    if gene_symbols_in_index:
+        var_ids = ["CD8A", "CD4", "CD38"]
+    else:
+        var_ids = ["ENSG00000153563", "ENSG00000010610", "ENSG00000004468"]
     dataset_dict = {
-        "CD8A": [2, 3, 3],
-        "CD4": [3, 4, 5],
-        "CD38": [4, 2, 3],
+        var_ids[0]: [2, 3, 3],
+        var_ids[1]: [3, 4, 5],
+        var_ids[2]: [4, 2, 3],
         "cell_medium": ["DMSO", "IFNG", "IFNG"],
         "cell_type_by_model": ["B cell", "T cell", "T cell"],
     }

--- a/lamindb/core/datasets/_small.py
+++ b/lamindb/core/datasets/_small.py
@@ -37,7 +37,7 @@ def small_dataset1(
     }
     # the dataset as DataFrame
     dataset_df = pd.DataFrame(dataset_dict, index=["sample1", "sample2", "sample3"])
-    if format == "df":
+    if otype == "DataFrame":
         return dataset_df, metadata
     else:
         dataset_ad = ad.AnnData(
@@ -74,7 +74,7 @@ def small_dataset2(
         dataset_df[["CD8A", "CD4", "CD38"]],
         obs=dataset_df[["cell_medium", "cell_type_by_model"]],
     )
-    if format == "df":
+    if otype == "DataFrame":
         return dataset_df, metadata
     else:
         dataset_ad = ad.AnnData(

--- a/lamindb/core/datasets/_small.py
+++ b/lamindb/core/datasets/_small.py
@@ -71,7 +71,7 @@ def small_dataset2(
         index=["sample4", "sample5", "sample6"],
     )
     ad.AnnData(
-        dataset_df[["CD8A", "CD4", "CD38"]],
+        dataset_df[var_ids],
         obs=dataset_df[["cell_medium", "cell_type_by_model"]],
     )
     if otype == "DataFrame":

--- a/lamindb/core/datasets/_small.py
+++ b/lamindb/core/datasets/_small.py
@@ -11,7 +11,7 @@ def small_dataset1(
     otype: Literal["DataFrame", "AnnData"],
     gene_symbols_in_index: bool = False,
     with_typo: bool = False,
-) -> tuple[pd.DataFrame, dict[str, Any]] | ad.AnnData:
+) -> pd.DataFrame | ad.AnnData:
     # define the data in the dataset
     # it's a mix of numerical measurements and observation-level metadata
     ifng = "IFNJ" if with_typo else "IFNG"
@@ -38,7 +38,9 @@ def small_dataset1(
     # the dataset as DataFrame
     dataset_df = pd.DataFrame(dataset_dict, index=["sample1", "sample2", "sample3"])
     if otype == "DataFrame":
-        return dataset_df, metadata
+        for key, value in metadata.items():
+            dataset_df.attrs[key] = value
+        return dataset_df
     else:
         dataset_ad = ad.AnnData(
             dataset_df.iloc[:, :3], obs=dataset_df.iloc[:, 3:], uns=metadata
@@ -49,7 +51,7 @@ def small_dataset1(
 def small_dataset2(
     otype: Literal["DataFrame", "AnnData"],
     gene_symbols_in_index: bool = False,
-) -> tuple[pd.DataFrame, dict[str, Any]] | ad.AnnData:
+) -> pd.DataFrame | ad.AnnData:
     if gene_symbols_in_index:
         var_ids = ["CD8A", "CD4", "CD38"]
     else:
@@ -75,7 +77,9 @@ def small_dataset2(
         obs=dataset_df[["cell_medium", "cell_type_by_model"]],
     )
     if otype == "DataFrame":
-        return dataset_df, metadata
+        for key, value in metadata.items():
+            dataset_df.attrs[key] = value
+        return dataset_df
     else:
         dataset_ad = ad.AnnData(
             dataset_df.iloc[:, :3], obs=dataset_df.iloc[:, 3:], uns=metadata

--- a/lamindb/core/relations.py
+++ b/lamindb/core/relations.py
@@ -8,7 +8,7 @@ from lamindb_setup._connect_instance import (
 )
 from lamindb_setup.core._settings_store import instance_settings_file
 
-from lamindb.models import LinkORM, Record, Schema
+from lamindb.models import LinkORM, Record, Registry, Schema
 
 
 def get_schema_modules(instance: str | None) -> set[str]:
@@ -38,8 +38,8 @@ def get_schema_modules(instance: str | None) -> set[str]:
 # this function here should likely be renamed
 # it maps the __get_name_with_module__() onto the actual model
 def dict_module_name_to_model_name(
-    registry: type[Record], instance: str | None = None
-) -> dict[str, Record]:
+    registry: Registry, instance: str | None = None
+) -> dict[str, Registry]:
     schema_modules = get_schema_modules(instance)
     d: dict = {
         i.related_model.__get_name_with_module__(): i.related_model

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -281,7 +281,7 @@ class DataFrameCurator(Curator):
                 # .exconly() doesn't exist on SchemaError
                 raise ValidationError(str(err)) from err
         else:
-            result = parse_dtype_single_cat(self._schema.itype)
+            result = parse_dtype_single_cat(self._schema.itype, is_itype=True)
             registry: CanCurate = result["registry"]
             inspector = registry.inspect(
                 self._dataset.columns,
@@ -313,7 +313,7 @@ class DataFrameCurator(Curator):
     ):
         if not self._is_validated:
             self.validate()  # raises ValidationError if doesn't validate
-        result = parse_dtype_single_cat(self._schema.itype)
+        result = parse_dtype_single_cat(self._schema.itype, is_itype=True)
         return save_artifact(  # type: ignore
             self._dataset,
             description=description,

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -4,6 +4,7 @@
    :toctree: .
 
    DataFrameCurator
+   AnnDataCurator
 
 """
 

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -222,6 +222,7 @@ class Curator:
 
 
 class DataFrameCurator(Curator):
+    # the example in the docstring is tested in test_curators_quickstart_example
     """Curator for a DataFrame object.
 
     See also :class:`~lamindb.Curator` and :class:`~lamindb.Schema`.
@@ -232,18 +233,17 @@ class DataFrameCurator(Curator):
 
     Example::
 
-        # Labels
+        # define labels
         ln.ULabel.from_values(["DMSO", "IFNG"], create=True).save()
         bt.CellType.from_values(["B cell", "T cell"], create=True).save()
 
-        # Features
-        # observation-level
+        # define features
         cell_medium = ln.Feature(name="cell_medium", dtype="cat[ULabel]").save()
         sample_note = ln.Feature(name="sample_note", dtype="str").save()
         cell_type_by_expert = ln.Feature(name="cell_type_by_expert", dtype="cat[bionty.CellType]").save()
         cell_type_by_model = ln.Feature(name="cell_type_by_model", dtype="cat[bionty.CellType]").save()
 
-        # Schema
+        # define schema
         schema = ln.Schema(
             name="small_dataset1_obs_level_metadata",
             otype="DataFrame",
@@ -354,6 +354,7 @@ class DataFrameCurator(Curator):
 
 
 class AnnDataCurator(Curator):
+    # the example in the docstring is tested in test_curators_quickstart_example
     """Curator for a DataFrame object.
 
     See also :class:`~lamindb.Curator` and :class:`~lamindb.Schema`.
@@ -366,7 +367,7 @@ class AnnDataCurator(Curator):
 
         import lamindb as ln
 
-        # Labels
+        # define labels
         ln.ULabel.from_values(["DMSO", "IFNG"], create=True).save()
         bt.CellType.from_values(["B cell", "T cell"], create=True).save()
 

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -287,12 +287,13 @@ class DataFrameCurator(Curator):
         else:
             result = parse_dtype_single_cat(self._schema.itype)
             registry: CanCurate = result["registry"]
-            registry.import_source()  # type: ignore
-            indicator = registry.validate(self._dataset.columns, result["field"])
-            if (~indicator).any():
+            inspector = registry.inspect(
+                self._dataset.columns, result["field"], mute=True
+            )
+            if len(inspector.non_validated):
                 self._is_validated = False
                 raise ValidationError(
-                    f"Invalid column identifiers found: {self._dataset.columns[~indicator]}"
+                    f"Invalid column identifiers found: {inspector.non_validated}"
                 )
 
 

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -233,6 +233,9 @@ class DataFrameCurator(Curator):
 
     Example::
 
+        import lamindb as ln
+        import bionty as bt
+
         # define valid labels
         cell_medium = ln.ULabel(name="CellMedium", is_type=True).save()
         ln.ULabel(name="DMSO", type=cell_medium).save()
@@ -363,6 +366,7 @@ class AnnDataCurator(Curator):
     Example::
 
         import lamindb as ln
+        import bionty as bt
 
         # define valid labels
         cell_medium = ln.ULabel(name="CellMedium", is_type=True).save()

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -146,7 +146,7 @@ class CurateLookup:
 VALIDATE_DOCSTRING = """Validate dataset.
 
 Raises:
-    lamindb.errors.ValidationError
+    lamindb.errors.ValidationError: If validation fails.
 """
 
 SAVE_ARTIFACT_DOCSTRING = """Save an annotated artifact.
@@ -268,7 +268,9 @@ class DataFrameCurator(Curator):
         else:
             assert schema.itype is not None  # noqa: S101
 
+    @doc_args(VALIDATE_DOCSTRING)
     def validate(self) -> None:
+        """{}"""  # noqa: D415
         if self._schema.n > 0:
             self._cat_curator.validate()
             try:
@@ -404,12 +406,16 @@ class AnnDataCurator(Curator):
             dataset.var.T, schema._get_component("var")
         )
 
+    @doc_args(VALIDATE_DOCSTRING)
     def validate(self) -> None:
+        """{}"""  # noqa: D415
         self._obs_curator.validate()
         self._var_curator.validate()
         self._is_validated = True
 
+    @doc_args(SAVE_ARTIFACT_DOCSTRING)
     def save_artifact(self, *, key=None, description=None, revises=None, run=None):
+        """{}"""  # noqa: D415
         if not self._is_validated:
             self.validate()  # raises ValidationError if doesn't validate
         result = parse_dtype_single_cat(self._var_curator._schema.itype, is_itype=True)
@@ -497,6 +503,16 @@ class CatCurator(Curator):
             )
         return std_values
 
+    def validate(self) -> bool:
+        """Validate dataset.
+
+        This method also registers the validated records in the current instance.
+
+        Returns:
+            The boolean `True` if the dataset is validated. Otherwise, a string with the error message.
+        """
+        pass
+
     def standardize(self, key: str) -> None:
         """Replace synonyms with standardized values.
 
@@ -510,6 +526,7 @@ class CatCurator(Curator):
         """
         pass  # pdagma: no cover
 
+    @doc_args(SAVE_ARTIFACT_DOCSTRING)
     def save_artifact(
         self,
         *,
@@ -518,6 +535,7 @@ class CatCurator(Curator):
         revises: Artifact | None = None,
         run: Run | None = None,
     ) -> Artifact:
+        """{}"""  # noqa: D415
         from lamindb.core._settings import settings
 
         if not self._is_validated:

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -336,11 +336,49 @@ class AnnDataCurator(Curator):
         dataset: The AnnData-like object to validate & annotate.
         schema: A `Schema` object that defines the validation constraints.
 
-    Examples:
-        >>> curator = curators.DataFrameCurator(
-        ...     df,
-        ...     schema,
-        ... )
+    Example::
+
+        import lamindb as ln
+
+        # define features
+        cell_medium = ln.Feature(name="cell_medium", dtype="cat[ULabel]").save()
+        sample_note = ln.Feature(name="sample_note", dtype="str").save()
+        cell_type_by_expert = ln.Feature(name="cell_type_by_expert", dtype="cat[bionty.CellType]").save()
+        cell_type_by_model = ln.Feature(name="cell_type_by_model", dtype="cat[bionty.CellType]").save()
+
+        # define obs schema
+        obs_schema = ln.Schema(
+            name="small_dataset1_obs_level_metadata",
+            otype="DataFrame",
+            features=[
+                cell_medium,
+                sample_note,
+                cell_type_by_expert,
+                cell_type_by_model,
+            ],
+            coerce_dtype=True,
+        ).save()
+
+        # define var schema
+        var_schema = ln.Schema(
+            name="small_dataset1_var_schema",
+            otype="DataFrame",
+            itype="bionty.Gene.ensembl_gene_id",
+            dtype="num",
+        ).save()
+
+        # define composite schema
+        anndata_schema = ln.Schema(
+            name="small_dataset1_anndata_schema",
+            otype="AnnData",
+            components={"obs": obs_schema, "var": var_schema},
+        ).save()
+
+        # curate an AnnData
+        adata = datasets.small_dataset1(otype="AnnData")
+        curator = ln.curators.AnnDataCurator(adata, anndata_schema)
+        artifact = curator.save_artifact(key="example_datasets/dataset1.h5ad")
+        assert artifact.schema == anndata_schema
     """
 
     def __init__(
@@ -3621,8 +3659,8 @@ def from_spatialdata(
     )
 
 
-Curator.from_df = from_df  # type: ignore
-Curator.from_anndata = from_anndata  # type: ignore
-Curator.from_mudata = from_mudata  # type: ignore
-Curator.from_spatialdata = from_spatialdata  # type: ignore
-Curator.from_tiledbsoma = from_tiledbsoma  # type: ignore
+CatCurator.from_df = from_df  # type: ignore
+CatCurator.from_anndata = from_anndata  # type: ignore
+CatCurator.from_mudata = from_mudata  # type: ignore
+CatCurator.from_spatialdata = from_spatialdata  # type: ignore
+CatCurator.from_tiledbsoma = from_tiledbsoma  # type: ignore

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -233,25 +233,22 @@ class DataFrameCurator(Curator):
 
     Example::
 
-        # define labels
-        ln.ULabel.from_values(["DMSO", "IFNG"], create=True).save()
-        bt.CellType.from_values(["B cell", "T cell"], create=True).save()
-
-        # define features
-        cell_medium = ln.Feature(name="cell_medium", dtype="cat[ULabel]").save()
-        sample_note = ln.Feature(name="sample_note", dtype="str").save()
-        cell_type_by_expert = ln.Feature(name="cell_type_by_expert", dtype="cat[bionty.CellType]").save()
-        cell_type_by_model = ln.Feature(name="cell_type_by_model", dtype="cat[bionty.CellType]").save()
+        # define valid labels
+        cell_medium = ln.ULabel(name="CellMedium", is_type=True).save()
+        ln.ULabel(name="DMSO", type=cell_medium).save()
+        ln.ULabel(name="IFNG", type=cell_medium).save()
+        bt.CellType.from_source(name="B cell").save()
+        bt.CellType.from_source(name="T cell").save()
 
         # define schema
         schema = ln.Schema(
             name="small_dataset1_obs_level_metadata",
             otype="DataFrame",
             features=[
-                cell_medium,
-                sample_note,
-                cell_type_by_expert,
-                cell_type_by_model,
+                ln.Feature(name="cell_medium", dtype="cat[ULabel[CellMedium]]").save(),
+                ln.Feature(name="sample_note", dtype="str").save(),
+                ln.Feature(name="cell_type_by_expert", dtype="cat[bionty.CellType]").save(),
+                ln.Feature(name="cell_type_by_model", dtype="cat[bionty.CellType]").save(),
             ],
             coerce_dtype=True,
         ).save()
@@ -367,25 +364,22 @@ class AnnDataCurator(Curator):
 
         import lamindb as ln
 
-        # define labels
-        ln.ULabel.from_values(["DMSO", "IFNG"], create=True).save()
-        bt.CellType.from_values(["B cell", "T cell"], create=True).save()
-
-        # define features
-        cell_medium = ln.Feature(name="cell_medium", dtype="cat[ULabel]").save()
-        sample_note = ln.Feature(name="sample_note", dtype="str").save()
-        cell_type_by_expert = ln.Feature(name="cell_type_by_expert", dtype="cat[bionty.CellType]").save()
-        cell_type_by_model = ln.Feature(name="cell_type_by_model", dtype="cat[bionty.CellType]").save()
+        # define valid labels
+        cell_medium = ln.ULabel(name="CellMedium", is_type=True).save()
+        ln.ULabel(name="DMSO", type=cell_medium).save()
+        ln.ULabel(name="IFNG", type=cell_medium).save()
+        bt.CellType.from_source(name="B cell").save()
+        bt.CellType.from_source(name="T cell").save()
 
         # define obs schema
         obs_schema = ln.Schema(
             name="small_dataset1_obs_level_metadata",
             otype="DataFrame",
             features=[
-                cell_medium,
-                sample_note,
-                cell_type_by_expert,
-                cell_type_by_model,
+                ln.Feature(name="cell_medium", dtype="cat[ULabel[CellMedium]]").save(),
+                ln.Feature(name="sample_note", dtype="str").save(),
+                ln.Feature(name="cell_type_by_expert", dtype="cat[bionty.CellType]").save(),
+                ln.Feature(name="cell_type_by_model", dtype="cat[bionty.CellType]").save(),
             ],
             coerce_dtype=True,
         ).save()

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -365,7 +365,7 @@ class AnnDataCurator(Curator):
     def save_artifact(self, *, key=None, description=None, revises=None, run=None):
         if not self._is_validated:
             self.validate()  # raises ValidationError if doesn't validate
-        result = parse_dtype_single_cat(self._var_curator._schema.itype)
+        result = parse_dtype_single_cat(self._var_curator._schema.itype, is_itype=True)
         return save_artifact(  # type: ignore
             self._dataset,
             description=description,

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -163,13 +163,13 @@ Returns:
 
 
 class Curator:
-    """Categorical dataset curator.
+    """Dataset curator.
 
     A `Curator` object makes it easy to validate, standardize & annotate datasets.
 
     See:
-    - :class:`~lamindb.curators.DataFrameCurator`
-    - :class:`~lamindb.curators.AnnDataCurator`
+        - :class:`~lamindb.curators.DataFrameCurator`
+        - :class:`~lamindb.curators.AnnDataCurator`
     """
 
     def __init__(self, dataset: Any, schema: Schema | None = None):

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -344,7 +344,6 @@ class AnnDataCurator(Curator):
             revises=revises,
             run=run,
             schema=self,
-            organism="human",  # TODO: why necessary for humans?
         )
 
 
@@ -3185,14 +3184,17 @@ def save_artifact(
         )
     artifact.save()
 
-    feature_kwargs = check_registry_organism(
-        (
-            list(columns_field.values())[0].field.model
-            if isinstance(columns_field, dict)
-            else columns_field.field.model
-        ),
-        organism,
-    )
+    if organism is not None:
+        feature_kwargs = check_registry_organism(
+            (
+                list(columns_field.values())[0].field.model
+                if isinstance(columns_field, dict)
+                else columns_field.field.model
+            ),
+            organism,
+        )
+    else:
+        feature_kwargs = {}
 
     if artifact.otype == "DataFrame":
         # old style

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -184,19 +184,6 @@ class Curator:
         """
         pass  # pdagma: no cover
 
-    def standardize(self, key: str) -> None:
-        """Replace synonyms with standardized values.
-
-        Inplace modification of the dataset.
-
-        Args:
-            key: The name of the column to standardize.
-
-        Returns:
-            None
-        """
-        pass  # pdagma: no cover
-
     def save_artifact(
         self,
         *,
@@ -493,6 +480,19 @@ class CatCurator(Curator):
                 f'standardized {n} synonym{s} in "{key}": {colors.green(syn_mapper_print)}'
             )
         return std_values
+
+    def standardize(self, key: str) -> None:
+        """Replace synonyms with standardized values.
+
+        Inplace modification of the dataset.
+
+        Args:
+            key: The name of the column to standardize.
+
+        Returns:
+            None
+        """
+        pass  # pdagma: no cover
 
     def save_artifact(
         self,

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -230,11 +230,37 @@ class DataFrameCurator(Curator):
         dataset: The DataFrame-like object to validate & annotate.
         schema: A `Schema` object that defines the validation constraints.
 
-    Examples:
-        >>> curator = curators.DataFrameCurator(
-        ...     df,
-        ...     schema,
-        ... )
+    Example::
+
+        # Labels
+        ln.ULabel.from_values(["DMSO", "IFNG"], create=True).save()
+        bt.CellType.from_values(["B cell", "T cell"], create=True).save()
+
+        # Features
+        # observation-level
+        cell_medium = ln.Feature(name="cell_medium", dtype="cat[ULabel]").save()
+        sample_note = ln.Feature(name="sample_note", dtype="str").save()
+        cell_type_by_expert = ln.Feature(name="cell_type_by_expert", dtype="cat[bionty.CellType]").save()
+        cell_type_by_model = ln.Feature(name="cell_type_by_model", dtype="cat[bionty.CellType]").save()
+
+        # Schema
+        schema = ln.Schema(
+            name="small_dataset1_obs_level_metadata",
+            otype="DataFrame",
+            features=[
+                cell_medium,
+                sample_note,
+                cell_type_by_expert,
+                cell_type_by_model,
+            ],
+            coerce_dtype=True,
+        ).save()
+
+        # curate a DataFrame
+        df = datasets.small_dataset1(otype="DataFrame")
+        curator = ln.curators.DataFrameCurator(df, small_dataset1_schema)
+        artifact = curator.save_artifact(key="example_datasets/dataset1.parquet")
+        assert artifact.schema == anndata_schema
     """
 
     def __init__(
@@ -339,6 +365,10 @@ class AnnDataCurator(Curator):
     Example::
 
         import lamindb as ln
+
+        # Labels
+        ln.ULabel.from_values(["DMSO", "IFNG"], create=True).save()
+        bt.CellType.from_values(["B cell", "T cell"], create=True).save()
 
         # define features
         cell_medium = ln.Feature(name="cell_medium", dtype="cat[ULabel]").save()

--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -2594,7 +2594,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
     _schemas_m2m: Schema = models.ManyToManyField(
         Schema, related_name="_artifacts_m2m", through="ArtifactSchema"
     )
-    """[For backward compatibility] The feature sets measured in the artifact."""
+    """The inferred schemas / feature sets measured by the artifact."""
     _feature_values: FeatureValue = models.ManyToManyField(
         FeatureValue, through="ArtifactFeatureValue", related_name="artifacts"
     )

--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -2108,6 +2108,7 @@ class Schema(Record, CanCurate, TracksRun):
         abstract = False
 
     _name_field: str = "name"
+    _aux_fields: dict[str, tuple[str, type]] = {"0": ("coerce_dtype", bool)}
 
     id: int = models.AutoField(primary_key=True)
     """Internal id, valid only in one DB instance."""
@@ -2204,6 +2205,7 @@ class Schema(Record, CanCurate, TracksRun):
         name: str | None = None,
         type: ULabel | None = None,
         is_type: bool = False,
+        coerce_dtype: bool = False,
     ): ...
 
     @overload
@@ -2278,6 +2280,22 @@ class Schema(Record, CanCurate, TracksRun):
     def members(self) -> QuerySet:
         """A queryset for the individual records of the set."""
         pass
+
+    @property
+    def coerce_dtype(self) -> bool:
+        """Whether dtypes should be coerced during validation."""
+        if self._aux is not None and "af" in self._aux and "0" in self._aux["af"]:
+            return self._aux["af"]["0"]
+        else:
+            return False
+
+    @coerce_dtype.setter
+    def coerce_dtype(self, value: bool) -> None:
+        if self._aux is None:
+            self._aux = {}
+        if "af" not in self._aux["af"]:
+            self._aux["af"] = {}
+        self._aux["af"]["0"] = value
 
     @property
     @deprecated("itype")

--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -2129,7 +2129,7 @@ class Schema(Record, CanCurate, TracksRun):
     Depending on the registry, `.members` stores, e.g., `Feature` or `bionty.Gene` records.
 
     .. versionchanged:: 1.0.0
-        Was called `itype` before.
+        Was called `registry` before.
     """
     type: Feature | None = ForeignKey(
         "self", PROTECT, null=True, related_name="records"
@@ -2163,6 +2163,11 @@ class Schema(Record, CanCurate, TracksRun):
 
     If `True`, the the minimal set is a maximal set and no additional features are allowed.
     """
+    components: Schema
+    """Components of this schema.
+
+    A schema can be composed of sub-schemas.
+    """
     composite: Schema | None = ForeignKey(
         "self", PROTECT, related_name="components", default=None, null=True
     )
@@ -2177,14 +2182,15 @@ class Schema(Record, CanCurate, TracksRun):
     validated_by: Schema | None = ForeignKey(
         "self", PROTECT, related_name="validated_schemas", default=None, null=True
     )
-    """The schema that validated this schema during curation.
+    # for lamindb v2
+    # """The schema that validated this schema during curation.
 
-    When performing validation, the schema that enforced validation is often less concrete than what is validated.
+    # When performing validation, the schema that enforced validation is often less concrete than what is validated.
 
-    For instance, the set of measured features might be a superset of the minimally required set of features.
+    # For instance, the set of measured features might be a superset of the minimally required set of features.
 
-    Often, the curating schema does not specficy any concrete features at all
-    """
+    # Often, the curating schema does not specficy any concrete features at all
+    # """
     features: Feature
     """The features contained in the schema."""
     params: Param
@@ -2197,6 +2203,7 @@ class Schema(Record, CanCurate, TracksRun):
     def __init__(
         self,
         features: Iterable[Record] | None = None,
+        components: Iterable[Schema] | None = None,
         name: str | None = None,
         description: str | None = None,
         dtype: str | None = None,
@@ -2581,7 +2588,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
     schema: Schema | None = ForeignKey(
         Schema, PROTECT, null=True, default=None, related_name="artifacts"
     )
-    """The schema of the artifact (to be populated in lamindb 1.1)."""
+    """The validating schema of the artifact (to be populated in lamindb 1.1)."""
     _schemas_m2m: Schema = models.ManyToManyField(
         Schema, related_name="_artifacts_m2m", through="ArtifactSchema"
     )

--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -2323,6 +2323,10 @@ class Schema(Record, CanCurate, TracksRun):
             print(message)
             return None
 
+    def _get_component(self, slot: str) -> Schema:
+        components = Schema.filter(composite=self).all()
+        return components.get(slot=slot)
+
 
 class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
     # Note that this docstring has to be consistent with Curator.save_artifact()

--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -2168,6 +2168,8 @@ class Schema(Record, CanCurate, TracksRun):
 
     A schema can be composed of sub-schemas.
     """
+    # in lamindb v2, the below will be a M2M to enable re-using a component
+    # across composites
     composite: Schema | None = ForeignKey(
         "self", PROTECT, related_name="components", default=None, null=True
     )
@@ -2203,7 +2205,7 @@ class Schema(Record, CanCurate, TracksRun):
     def __init__(
         self,
         features: Iterable[Record] | None = None,
-        components: Iterable[Schema] | None = None,
+        components: dict[str, Schema] | None = None,
         name: str | None = None,
         description: str | None = None,
         dtype: str | None = None,

--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -2039,7 +2039,7 @@ class FeatureValue(Record, TracksRun):
 
 
 class Schema(Record, CanCurate, TracksRun):
-    """Feature sets (dataset schemas).
+    """Schemas / feature sets.
 
     Stores references to dataset schemas: these are the sets of columns in a dataset
     that correspond to :class:`~lamindb.Feature`, :class:`~bionty.Gene`, :class:`~bionty.Protein` or other

--- a/tests/core/test_collection.py
+++ b/tests/core/test_collection.py
@@ -165,7 +165,7 @@ def test_from_consistent_artifacts(adata, adata2):
     assert "artifact_uid" in adata_joined.obs.columns
     assert artifact1.uid in adata_joined.obs.artifact_uid.cat.categories
 
-    _schemas_m2m = collection.features._get_staged__schemas_m2m_union()
+    _schemas_m2m = collection.features._get_staged_schemas_m2m_union()
     assert set(_schemas_m2m["var"].members.values_list("symbol", flat=True)) == {
         "MYC",
         "TCF7",

--- a/tests/core/test_describe_and_df_calls.py
+++ b/tests/core/test_describe_and_df_calls.py
@@ -66,6 +66,7 @@ def test_curate_df():
 
     ## Ingest dataset1
     adata = datasets.small_dataset1(otype="AnnData")
+    print(adata.var)
     curator = ln.Curator.from_anndata(
         adata,
         var_index=bt.Gene.ensembl_gene_id,
@@ -80,7 +81,8 @@ def test_curate_df():
     artifact.features.add_values(adata.uns)
 
     # Ingest dataset2
-    adata2 = datasets.small_dataset2(format="anndata")
+    adata2 = datasets.small_dataset2(otype="AnnData")
+    print(adata2.var)
     curator = ln.Curator.from_anndata(
         adata2,
         var_index=bt.Gene.ensembl_gene_id,

--- a/tests/core/test_describe_and_df_calls.py
+++ b/tests/core/test_describe_and_df_calls.py
@@ -65,7 +65,7 @@ def test_curate_df():
     bt.CellType.from_values(["B cell", "T cell"], create=True).save()
 
     ## Ingest dataset1
-    adata = datasets.small_dataset1(format="anndata")
+    adata = datasets.small_dataset1(otype="AnnData")
     curator = ln.Curator.from_anndata(
         adata,
         var_index=bt.Gene.symbol,

--- a/tests/core/test_describe_and_df_calls.py
+++ b/tests/core/test_describe_and_df_calls.py
@@ -68,7 +68,7 @@ def test_curate_df():
     adata = datasets.small_dataset1(otype="AnnData")
     curator = ln.Curator.from_anndata(
         adata,
-        var_index=bt.Gene.symbol,
+        var_index=bt.Gene.ensembl_gene_id,
         categoricals={
             "cell_medium": ln.ULabel.name,
             "cell_type_by_expert": bt.CellType.name,
@@ -83,7 +83,7 @@ def test_curate_df():
     adata2 = datasets.small_dataset2(format="anndata")
     curator = ln.Curator.from_anndata(
         adata2,
-        var_index=bt.Gene.symbol,
+        var_index=bt.Gene.ensembl_gene_id,
         categoricals={
             "cell_medium": ln.ULabel.name,
             "cell_type_by_model": bt.CellType.name,

--- a/tests/core/test_feature_label_manager.py
+++ b/tests/core/test_feature_label_manager.py
@@ -21,7 +21,7 @@ def adata():
 
 
 def test_features_add():
-    df, metadata = small_dataset1(format="df")
+    df, metadata = small_dataset1(otype="DataFrame")
     artifact = ln.Artifact.from_df(df, description="test dataset").save()
     with pytest.raises(ValidationError) as err:
         artifact.features.add_values({"cell_medium": df.cell_medium.unique()})

--- a/tests/core/test_feature_label_manager.py
+++ b/tests/core/test_feature_label_manager.py
@@ -21,7 +21,7 @@ def adata():
 
 
 def test_features_add():
-    df, metadata = small_dataset1(otype="DataFrame")
+    df = small_dataset1(otype="DataFrame")
     artifact = ln.Artifact.from_df(df, description="test dataset").save()
     with pytest.raises(ValidationError) as err:
         artifact.features.add_values({"cell_medium": df.cell_medium.unique()})

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -52,6 +52,25 @@ def curator_params():
     }
 
 
+def test_dataframe_curator(small_dataset1_features, curator_params):
+    """Test DataFrame curator implementation."""
+    df, metadata = datasets.small_dataset1(format="df")
+    curator = ln.Curator.from_df(df, **curator_params)
+    artifact = curator.save_artifact(key="example_datasets/dataset1.parquet")
+    artifact.features.add_values(metadata)
+
+    assert set(artifact.features.get_values()["cell_type_by_expert"]) == {
+        "T cell",
+        "B cell",
+    }
+    assert set(artifact.features.get_values()["cell_type_by_model"]) == {
+        "T cell",
+        "B cell",
+    }
+
+    artifact.delete(permanent=True)
+
+
 def test_anndata_curator(small_dataset1_features, curator_params):
     """Test AnnData curator implementation."""
     adata = datasets.small_dataset1(format="anndata")
@@ -98,22 +117,3 @@ def test_soma_curator(small_dataset1_features, curator_params):
     assert artifact._key_is_virtual
     artifact.delete(permanent=True)
     shutil.rmtree("./small_dataset1.tiledbsoma")
-
-
-def test_dataframe_curator(small_dataset1_features, curator_params):
-    """Test DataFrame curator implementation."""
-    df, metadata = datasets.small_dataset1(format="df")
-    curator = ln.Curator.from_df(df, **curator_params)
-    artifact = curator.save_artifact(key="example_datasets/dataset1.parquet")
-    artifact.features.add_values(metadata)
-
-    assert set(artifact.features.get_values()["cell_type_by_expert"]) == {
-        "T cell",
-        "B cell",
-    }
-    assert set(artifact.features.get_values()["cell_type_by_model"]) == {
-        "T cell",
-        "B cell",
-    }
-
-    artifact.delete(permanent=True)

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -9,7 +9,7 @@ from lamindb.core import datasets
 
 
 @pytest.fixture(scope="module")
-def small_dataset1_features():
+def small_dataset1_schema():
     # Labels
     ln.ULabel.from_values(["DMSO", "IFNG"], create=True).save()
     ln.ULabel.from_values(
@@ -19,20 +19,37 @@ def small_dataset1_features():
 
     # Features
     # observation-level
-    ln.Feature(name="cell_medium", dtype="cat[ULabel]").save()
-    ln.Feature(name="sample_note", dtype="str").save()
-    ln.Feature(name="cell_type_by_expert", dtype="cat[bionty.CellType]").save()
-    ln.Feature(name="cell_type_by_model", dtype="cat[bionty.CellType]").save()
+    cell_medium = ln.Feature(name="cell_medium", dtype="cat[ULabel]").save()
+    sample_note = ln.Feature(name="sample_note", dtype="str").save()
+    cell_type_by_expert = ln.Feature(
+        name="cell_type_by_expert", dtype="cat[bionty.CellType]"
+    ).save()
+    cell_type_by_model = ln.Feature(
+        name="cell_type_by_model", dtype="cat[bionty.CellType]"
+    ).save()
     # dataset-level
     ln.Feature(name="temperature", dtype="float").save()
     ln.Feature(name="study", dtype="cat[ULabel]").save()
     ln.Feature(name="date_of_study", dtype="date").save()
     ln.Feature(name="study_note", dtype="str").save()
 
-    yield
+    # Schema
+    schema = ln.Schema(
+        name="small_dataset1",
+        otype="DataFrame",
+        features=[
+            cell_medium,
+            sample_note,
+            cell_type_by_expert,
+            cell_type_by_model,
+        ],
+        coerce_dtype=True,
+    ).save()
+
+    yield schema
 
     # Cleanup
-    ln.Schema.filter().delete()
+    schema.delete()
     ln.Feature.filter().delete()
     bt.Gene.filter().delete()
     ln.ULabel.filter().delete()
@@ -52,26 +69,11 @@ def curator_params():
     }
 
 
-def test_dataframe_curator(small_dataset1_features, curator_params):
+def test_dataframe_curator(small_dataset1_schema):
     """Test DataFrame curator implementation."""
 
-    features = ln.Feature.lookup()
-
-    # Schema
-    schema = ln.Schema(
-        name="small_dataset1",
-        otype="DataFrame",
-        features=[
-            features.cell_medium,
-            features.sample_note,
-            features.cell_type_by_expert,
-            features.cell_type_by_model,
-        ],
-        coerce_dtype=True,
-    ).save()
-
     df, _ = datasets.small_dataset1(format="df")
-    curator = ln.curators.DataFrameCurator(df, schema)
+    curator = ln.curators.DataFrameCurator(df, small_dataset1_schema)
     artifact = curator.save_artifact(key="example_datasets/dataset1.parquet")
 
     assert set(artifact.features.get_values()["cell_type_by_expert"]) == {
@@ -85,7 +87,7 @@ def test_dataframe_curator(small_dataset1_features, curator_params):
     artifact.delete(permanent=True)
 
 
-def test_anndata_curator(small_dataset1_features, curator_params):
+def test_anndata_curator(small_dataset1_schema, curator_params):
     """Test AnnData curator implementation."""
     adata = datasets.small_dataset1(format="anndata")
     curator = ln.Curator.from_anndata(adata, var_index=bt.Gene.symbol, **curator_params)
@@ -104,7 +106,7 @@ def test_anndata_curator(small_dataset1_features, curator_params):
     artifact.delete(permanent=True)
 
 
-def test_soma_curator(small_dataset1_features, curator_params):
+def test_soma_curator(small_dataset1_schema, curator_params):
     """Test SOMA curator implementation."""
     adata = datasets.small_dataset1(format="anndata")
     tiledbsoma.io.from_anndata(

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -10,24 +10,24 @@ from lamindb.core import datasets
 
 @pytest.fixture(scope="module")
 def small_dataset1_features():
-    """Create and save features for testing."""
-    # observation-level metadata
-    ln.Feature(name="cell_medium", dtype="cat[ULabel]").save()
-    ln.Feature(name="sample_note", dtype="str").save()
-    ln.Feature(name="cell_type_by_expert", dtype="cat[bionty.CellType]").save()
-    ln.Feature(name="cell_type_by_model", dtype="cat[bionty.CellType]").save()
-    # dataset-level metadata
-    ln.Feature(name="temperature", dtype="float").save()
-    ln.Feature(name="study", dtype="cat[ULabel]").save()
-    ln.Feature(name="date_of_study", dtype="date").save()
-    ln.Feature(name="study_note", dtype="str").save()
-
-    # Permissible values for categoricals
+    # Labels
     ln.ULabel.from_values(["DMSO", "IFNG"], create=True).save()
     ln.ULabel.from_values(
         ["Candidate marker study 1", "Candidate marker study 2"], create=True
     ).save()
     bt.CellType.from_values(["B cell", "T cell"], create=True).save()
+
+    # Features
+    # observation-level
+    ln.Feature(name="cell_medium", dtype="cat[ULabel]").save()
+    ln.Feature(name="sample_note", dtype="str").save()
+    ln.Feature(name="cell_type_by_expert", dtype="cat[bionty.CellType]").save()
+    ln.Feature(name="cell_type_by_model", dtype="cat[bionty.CellType]").save()
+    # dataset-level
+    ln.Feature(name="temperature", dtype="float").save()
+    ln.Feature(name="study", dtype="cat[ULabel]").save()
+    ln.Feature(name="date_of_study", dtype="date").save()
+    ln.Feature(name="study_note", dtype="str").save()
 
     yield
 
@@ -54,10 +54,25 @@ def curator_params():
 
 def test_dataframe_curator(small_dataset1_features, curator_params):
     """Test DataFrame curator implementation."""
-    df, metadata = datasets.small_dataset1(format="df")
-    curator = ln.Curator.from_df(df, **curator_params)
+
+    features = ln.Feature.lookup()
+
+    # Schema
+    schema = ln.Schema(
+        name="small_dataset1",
+        otype="DataFrame",
+        features=[
+            features.cell_medium,
+            features.sample_note,
+            features.cell_type_by_expert,
+            features.cell_type_by_model,
+        ],
+        coerce_dtype=True,
+    ).save()
+
+    df, _ = datasets.small_dataset1(format="df")
+    curator = ln.curators.DataFrameCurator(df, schema)
     artifact = curator.save_artifact(key="example_datasets/dataset1.parquet")
-    artifact.features.add_values(metadata)
 
     assert set(artifact.features.get_values()["cell_type_by_expert"]) == {
         "T cell",
@@ -67,7 +82,6 @@ def test_dataframe_curator(small_dataset1_features, curator_params):
         "T cell",
         "B cell",
     }
-
     artifact.delete(permanent=True)
 
 

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -89,7 +89,6 @@ def test_dataframe_curator(small_dataset1_schema):
 
 def test_anndata_curator(small_dataset1_schema: ln.Schema, curator_params):
     """Test AnnData curator implementation."""
-    datasets.small_dataset1(otype="AnnData")
 
     adata_schema = ln.Schema(
         name="small_dataset1_anndata_schema",
@@ -113,20 +112,20 @@ def test_anndata_curator(small_dataset1_schema: ln.Schema, curator_params):
     assert "small_dataset1_obs_level_metadata" in describe_output
     assert "small_dataset1_var_schema" in describe_output
 
-    # curator = ln.Curator.from_anndata(adata, var_index=bt.Gene.symbol, **curator_params)
-    # artifact = curator.save_artifact(key="example_datasets/dataset1.h5ad")
-    # artifact.features.add_values(adata.uns)
+    adata = datasets.small_dataset1(otype="AnnData")
+    curator = ln.curators.AnnDataCurator(adata, adata_schema)
+    artifact = curator.save_artifact(key="example_datasets/dataset1.h5ad")
 
-    # assert set(artifact.features.get_values()["cell_type_by_expert"]) == {
-    #     "T cell",
-    #     "B cell",
-    # }
-    # assert set(artifact.features.get_values()["cell_type_by_model"]) == {
-    #     "T cell",
-    #     "B cell",
-    # }
+    assert set(artifact.features.get_values()["cell_type_by_expert"]) == {
+        "T cell",
+        "B cell",
+    }
+    assert set(artifact.features.get_values()["cell_type_by_model"]) == {
+        "T cell",
+        "B cell",
+    }
 
-    # artifact.delete(permanent=True)
+    artifact.delete(permanent=True)
 
 
 def test_soma_curator(small_dataset1_schema, curator_params):

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -90,19 +90,16 @@ def test_anndata_curator(small_dataset1_schema: ln.Schema, curator_params):
     """Test AnnData curator implementation."""
 
     obs_schema = small_dataset1_schema
-    obs_schema.slot = "obs"
-    obs_schema.save()
     var_schema = ln.Schema(
         name="small_dataset1_var_schema",
         otype="DataFrame",
         itype="bionty.Gene.ensembl_gene_id",
         dtype="num",
-        slot="var",
     ).save()
     adata_schema = ln.Schema(
         name="small_dataset1_anndata_schema",
         otype="AnnData",
-        components=[obs_schema, var_schema],
+        components={"obs": obs_schema, "var": var_schema},
     ).save()
 
     assert adata_schema.components.get(slot="obs").composite == adata_schema

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -134,7 +134,7 @@ def test_soma_curator(small_dataset1_schema, curator_params):
         **curator_params,
     )
     artifact = curator.save_artifact(key="example_datasets/dataset1.tiledbsoma")
-    artifact.features.add_values(adata.uns)
+    # artifact.features.add_values(adata.uns)
 
     assert set(artifact.features.get_values()["cell_type_by_expert"]) == {
         "T cell",

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -48,8 +48,7 @@ def small_dataset1_schema():
 
     yield schema
 
-    # Cleanup
-    schema.delete()
+    ln.Schema.filter().delete()
     ln.Feature.filter().delete()
     bt.Gene.filter().delete()
     ln.ULabel.filter().delete()
@@ -98,7 +97,7 @@ def test_anndata_curator(small_dataset1_schema: ln.Schema, curator_params):
     obs_schema.composite = adata_schema
     obs_schema.slot = "obs"
     obs_schema.save()
-    ln.Schema(
+    var_schema = ln.Schema(
         name="small_dataset1_var_schema",
         otype="DataFrame",
         itype="bionty.Gene.ensembl_gene_id",
@@ -126,6 +125,9 @@ def test_anndata_curator(small_dataset1_schema: ln.Schema, curator_params):
     }
 
     artifact.delete(permanent=True)
+    obs_schema.delete()
+    var_schema.delete()
+    adata_schema.delete()
 
 
 def test_soma_curator(small_dataset1_schema, curator_params):
@@ -137,7 +139,7 @@ def test_soma_curator(small_dataset1_schema, curator_params):
 
     curator = ln.Curator.from_tiledbsoma(
         "./small_dataset1.tiledbsoma",
-        var_index={"RNA": ("var_id", bt.Gene.symbol)},
+        var_index={"RNA": ("var_id", bt.Gene.ensembl_gene_id)},
         **curator_params,
     )
     artifact = curator.save_artifact(key="example_datasets/dataset1.tiledbsoma")

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -96,24 +96,24 @@ def test_anndata_curator(small_dataset1_schema: ln.Schema, curator_params):
         itype="bionty.Gene.ensembl_gene_id",
         dtype="num",
     ).save()
-    adata_schema = ln.Schema(
+    anndata_schema = ln.Schema(
         name="small_dataset1_anndata_schema",
         otype="AnnData",
         components={"obs": obs_schema, "var": var_schema},
     ).save()
 
-    assert adata_schema.components.get(slot="obs").composite == adata_schema
-    assert adata_schema.components.get(slot="var").composite == adata_schema
+    assert anndata_schema.components.get(slot="obs").composite == anndata_schema
+    assert anndata_schema.components.get(slot="var").composite == anndata_schema
 
-    describe_output = adata_schema.describe(return_str=True)
+    describe_output = anndata_schema.describe(return_str=True)
     assert "small_dataset1_anndata_schema" in describe_output
     assert "small_dataset1_obs_level_metadata" in describe_output
     assert "small_dataset1_var_schema" in describe_output
 
     adata = datasets.small_dataset1(otype="AnnData")
-    curator = ln.curators.AnnDataCurator(adata, adata_schema)
+    curator = ln.curators.AnnDataCurator(adata, anndata_schema)
     artifact = curator.save_artifact(key="example_datasets/dataset1.h5ad")
-    assert artifact.schema == adata_schema
+    assert artifact.schema == anndata_schema
 
     assert set(artifact.features.get_values()["cell_type_by_expert"]) == {
         "T cell",
@@ -127,7 +127,7 @@ def test_anndata_curator(small_dataset1_schema: ln.Schema, curator_params):
     artifact.delete(permanent=True)
     obs_schema.delete()
     var_schema.delete()
-    adata_schema.delete()
+    anndata_schema.delete()
 
 
 def test_soma_curator(small_dataset1_schema, curator_params):

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -35,7 +35,7 @@ def small_dataset1_schema():
 
     # Schema
     schema = ln.Schema(
-        name="small_dataset1",
+        name="small_dataset1_obs_level_metadata",
         otype="DataFrame",
         features=[
             cell_medium,
@@ -72,7 +72,7 @@ def curator_params():
 def test_dataframe_curator(small_dataset1_schema):
     """Test DataFrame curator implementation."""
 
-    df, _ = datasets.small_dataset1(format="df")
+    df, _ = datasets.small_dataset1(otype="DataFrame")
     curator = ln.curators.DataFrameCurator(df, small_dataset1_schema)
     artifact = curator.save_artifact(key="example_datasets/dataset1.parquet")
 
@@ -87,28 +87,51 @@ def test_dataframe_curator(small_dataset1_schema):
     artifact.delete(permanent=True)
 
 
-def test_anndata_curator(small_dataset1_schema, curator_params):
+def test_anndata_curator(small_dataset1_schema: ln.Schema, curator_params):
     """Test AnnData curator implementation."""
-    adata = datasets.small_dataset1(format="anndata")
-    curator = ln.Curator.from_anndata(adata, var_index=bt.Gene.symbol, **curator_params)
-    artifact = curator.save_artifact(key="example_datasets/dataset1.h5ad")
-    artifact.features.add_values(adata.uns)
+    datasets.small_dataset1(otype="AnnData")
 
-    assert set(artifact.features.get_values()["cell_type_by_expert"]) == {
-        "T cell",
-        "B cell",
-    }
-    assert set(artifact.features.get_values()["cell_type_by_model"]) == {
-        "T cell",
-        "B cell",
-    }
+    adata_schema = ln.Schema(
+        name="small_dataset1_anndata_schema",
+        otype="AnnData",
+    ).save()
+    obs_schema = small_dataset1_schema
+    obs_schema.composite = adata_schema
+    obs_schema.slot = "obs"
+    obs_schema.save()
+    ln.Schema(
+        name="small_dataset1_var_schema",
+        otype="DataFrame",
+        itype="bionty.Gene.ensembl_gene_id",
+        dtype="num",
+        slot="var",
+        composite=adata_schema,
+    ).save()
 
-    artifact.delete(permanent=True)
+    describe_output = adata_schema.describe(return_str=True)
+    assert "small_dataset1_anndata_schema" in describe_output
+    assert "small_dataset1_obs_level_metadata" in describe_output
+    assert "small_dataset1_var_schema" in describe_output
+
+    # curator = ln.Curator.from_anndata(adata, var_index=bt.Gene.symbol, **curator_params)
+    # artifact = curator.save_artifact(key="example_datasets/dataset1.h5ad")
+    # artifact.features.add_values(adata.uns)
+
+    # assert set(artifact.features.get_values()["cell_type_by_expert"]) == {
+    #     "T cell",
+    #     "B cell",
+    # }
+    # assert set(artifact.features.get_values()["cell_type_by_model"]) == {
+    #     "T cell",
+    #     "B cell",
+    # }
+
+    # artifact.delete(permanent=True)
 
 
 def test_soma_curator(small_dataset1_schema, curator_params):
     """Test SOMA curator implementation."""
-    adata = datasets.small_dataset1(format="anndata")
+    adata = datasets.small_dataset1(otype="AnnData")
     tiledbsoma.io.from_anndata(
         "./small_dataset1.tiledbsoma", adata, measurement_name="RNA"
     )

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -71,7 +71,7 @@ def curator_params():
 def test_dataframe_curator(small_dataset1_schema):
     """Test DataFrame curator implementation."""
 
-    df, _ = datasets.small_dataset1(otype="DataFrame")
+    df = datasets.small_dataset1(otype="DataFrame")
     curator = ln.curators.DataFrameCurator(df, small_dataset1_schema)
     artifact = curator.save_artifact(key="example_datasets/dataset1.parquet")
 

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -10,38 +10,28 @@ from lamindb.core import datasets
 
 @pytest.fixture(scope="module")
 def small_dataset1_schema():
-    # Labels
-    ln.ULabel.from_values(["DMSO", "IFNG"], create=True).save()
-    ln.ULabel.from_values(
-        ["Candidate marker study 1", "Candidate marker study 2"], create=True
-    ).save()
-    bt.CellType.from_values(["B cell", "T cell"], create=True).save()
+    # define labels
+    cell_medium = ln.ULabel(name="CellMedium", is_type=True).save()
+    ln.ULabel(name="DMSO", type=cell_medium).save()
+    ln.ULabel(name="IFNG", type=cell_medium).save()
+    bt.CellType.from_source(name="B cell").save()
+    bt.CellType.from_source(name="T cell").save()
 
-    # Features
-    # observation-level
-    cell_medium = ln.Feature(name="cell_medium", dtype="cat[ULabel]").save()
-    sample_note = ln.Feature(name="sample_note", dtype="str").save()
-    cell_type_by_expert = ln.Feature(
-        name="cell_type_by_expert", dtype="cat[bionty.CellType]"
-    ).save()
-    cell_type_by_model = ln.Feature(
-        name="cell_type_by_model", dtype="cat[bionty.CellType]"
-    ).save()
-    # dataset-level
-    ln.Feature(name="temperature", dtype="float").save()
-    ln.Feature(name="study", dtype="cat[ULabel]").save()
-    ln.Feature(name="date_of_study", dtype="date").save()
-    ln.Feature(name="study_note", dtype="str").save()
+    # in next iteration for attrs
+    # ln.Feature(name="temperature", dtype="float").save()
+    # ln.Feature(name="study", dtype="cat[ULabel]").save()
+    # ln.Feature(name="date_of_study", dtype="date").save()
+    # ln.Feature(name="study_note", dtype="str").save()
 
-    # Schema
+    # define schema
     schema = ln.Schema(
         name="small_dataset1_obs_level_metadata",
         otype="DataFrame",
         features=[
-            cell_medium,
-            sample_note,
-            cell_type_by_expert,
-            cell_type_by_model,
+            ln.Feature(name="cell_medium", dtype="cat[ULabel[CellMedium]]").save(),
+            ln.Feature(name="sample_note", dtype="str").save(),
+            ln.Feature(name="cell_type_by_expert", dtype="cat[bionty.CellType]").save(),
+            ln.Feature(name="cell_type_by_model", dtype="cat[bionty.CellType]").save(),
         ],
         coerce_dtype=True,
     ).save()
@@ -51,6 +41,7 @@ def small_dataset1_schema():
     ln.Schema.filter().delete()
     ln.Feature.filter().delete()
     bt.Gene.filter().delete()
+    ln.ULabel.filter(type__isnull=False).delete()
     ln.ULabel.filter().delete()
     bt.CellType.filter().delete()
 

--- a/tests/curators/test_dataframe_curators_accounting_example.py
+++ b/tests/curators/test_dataframe_curators_accounting_example.py
@@ -9,26 +9,24 @@ import pytest
 
 @pytest.fixture(scope="module")
 def currency_labels():
-    # Create currency type and labels
     currency_type = ln.ULabel(name="Currency", is_type=True).save()
     usd = ln.ULabel(name="USD", type=currency_type).save()
     eur = ln.ULabel(name="EUR", type=currency_type).save()
 
+    assert usd.type == currency_type
+    assert eur.type == currency_type
+
     yield currency_type, usd, eur
 
-    # Cleanup
     eur.delete()
     usd.delete()
     currency_type.delete()
 
 
 @pytest.fixture(scope="module")
-def transactions_features():
-    # Create features
-    currency_feature = ln.Feature(
-        name="currency_name", dtype="cat[ULabel[Currency].name]"
-    ).save()
-    date_feature = ln.Feature(name="date", dtype="date").save()
+def transactions_features(currency_labels):
+    currency = ln.Feature(name="currency_name", dtype="cat[ULabel[Currency]]").save()
+    date = ln.Feature(name="date", dtype="date").save()
 
     transaction_type = ln.Feature(name="Transaction", is_type=True).save()
     amount_usd = ln.Feature(
@@ -38,21 +36,18 @@ def transactions_features():
         name="transaction_amount_eur_cent", dtype=int, type=transaction_type
     ).save()
 
-    yield currency_feature, date_feature, transaction_type, amount_usd, amount_eur
+    yield currency, date, amount_usd, amount_eur
 
-    # Cleanup
     amount_eur.delete()
     amount_usd.delete()
     transaction_type.delete()
-    date_feature.delete()
-    currency_feature.delete()
+    date.delete()
+    currency.delete()
 
 
 @pytest.fixture(scope="module")
 def transactions_schema(transactions_features):
-    # Create schema
-    _, date_feature, _, amount_usd, amount_eur = transactions_features
-    currency_feature = ln.Feature.get(name="currency_name")
+    currency_feature, date_feature, amount_usd, amount_eur = transactions_features
 
     schema = ln.Schema(
         name="transaction_dataframe",
@@ -67,7 +62,6 @@ def transactions_schema(transactions_features):
 
     yield schema
 
-    # Cleanup
     schema.delete()
 
 
@@ -101,22 +95,6 @@ def test_schema_creation(transactions_schema):
         "transaction_amount_eur_cent",
         "currency_name",
     ]
-
-
-def test_currency_labels(currency_labels):
-    """Test if currency labels were created properly"""
-    currency_type, usd, eur = currency_labels
-
-    # Test currency type
-    assert ln.ULabel.get(name="Currency", is_type=True) is not None
-
-    # Test currency labels
-    assert ln.ULabel.get(name="USD") is not None
-    assert ln.ULabel.get(name="EUR") is not None
-
-    # Test relationships
-    assert usd.type == currency_type
-    assert eur.type == currency_type
 
 
 def test_data_curation(transactions_schema, transactions_dataframe):

--- a/tests/curators/test_dataframe_curators_accounting_example.py
+++ b/tests/curators/test_dataframe_curators_accounting_example.py
@@ -8,7 +8,8 @@ import pytest
 
 
 @pytest.fixture(scope="module")
-def currency_labels():
+def transactions_schema():
+    # Labels
     currency_type = ln.ULabel(name="Currency", is_type=True).save()
     usd = ln.ULabel(name="USD", type=currency_type).save()
     eur = ln.ULabel(name="EUR", type=currency_type).save()
@@ -16,15 +17,7 @@ def currency_labels():
     assert usd.type == currency_type
     assert eur.type == currency_type
 
-    yield currency_type, usd, eur
-
-    eur.delete()
-    usd.delete()
-    currency_type.delete()
-
-
-@pytest.fixture(scope="module")
-def transactions_features(currency_labels):
+    # Features
     currency = ln.Feature(name="currency_name", dtype="cat[ULabel[Currency]]").save()
     date = ln.Feature(name="date", dtype="date").save()
 
@@ -36,33 +29,30 @@ def transactions_features(currency_labels):
         name="transaction_amount_eur_cent", dtype=int, type=transaction_type
     ).save()
 
-    yield currency, date, amount_usd, amount_eur
-
-    amount_eur.delete()
-    amount_usd.delete()
-    transaction_type.delete()
-    date.delete()
-    currency.delete()
-
-
-@pytest.fixture(scope="module")
-def transactions_schema(transactions_features):
-    currency_feature, date_feature, amount_usd, amount_eur = transactions_features
-
+    # Schema
     schema = ln.Schema(
         name="transaction_dataframe",
         otype="DataFrame",
         features=[
-            date_feature,
+            date,
             amount_usd,
             amount_eur,
-            currency_feature,
+            currency,
         ],
+        coerce_dtype=True,
     ).save()
 
     yield schema
 
     schema.delete()
+    amount_eur.delete()
+    amount_usd.delete()
+    transaction_type.delete()
+    date.delete()
+    currency.delete()
+    eur.delete()
+    usd.delete()
+    currency_type.delete()
 
 
 @pytest.fixture


### PR DESCRIPTION
Is part of a sequence of PRs that refactors the curators:

- https://github.com/laminlabs/lamindb/pull/2417
- https://github.com/laminlabs/lamindb/pull/2416
- https://github.com/laminlabs/lamindb/pull/2415
- https://github.com/laminlabs/lamindb/pull/2413
- https://github.com/laminlabs/lamindb/pull/2412
- https://github.com/laminlabs/lamindb/pull/2408
- https://github.com/laminlabs/lamindb/pull/2403
- https://github.com/laminlabs/lamindb/pull/2388

---

This PR introduces the counterpart to the schema-based `DataFrameCurator` introduced in:

-  https://github.com/laminlabs/lamindb/pull/2388

# The `AnnData` schema and `Curator`

```python
import lamindb as ln
import bionty as bt

# define valid labels
cell_medium = ln.ULabel(name="CellMedium", is_type=True).save()
ln.ULabel(name="DMSO", type=cell_medium).save()
ln.ULabel(name="IFNG", type=cell_medium).save()
bt.CellType.from_source(name="B cell").save()
bt.CellType.from_source(name="T cell").save()

# define obs schema
obs_schema = ln.Schema(
    name="small_dataset1_obs_level_metadata",
    otype="DataFrame",
    features=[
        ln.Feature(name="cell_medium", dtype="cat[ULabel[CellMedium]]").save(),
        ln.Feature(name="sample_note", dtype="str").save(),
        ln.Feature(name="cell_type_by_expert", dtype="cat[bionty.CellType]").save(),
        ln.Feature(name="cell_type_by_model", dtype="cat[bionty.CellType]").save(),
    ],
    coerce_dtype=True,
).save()

# define var schema
var_schema = ln.Schema(
    name="small_dataset1_var_schema",
    otype="DataFrame",
    itype="bionty.Gene.ensembl_gene_id",
    dtype="num",
).save()

# define composite schema
anndata_schema = ln.Schema(
    name="small_dataset1_anndata_schema",
    otype="AnnData",
    components={"obs": obs_schema, "var": var_schema},
).save()

# curate an AnnData
adata = datasets.small_dataset1(otype="AnnData")
curator = ln.curators.AnnDataCurator(adata, anndata_schema)
artifact = curator.save_artifact(key="example_datasets/dataset1.h5ad")
assert artifact.schema == anndata_schema
```

<details><summary>Compare with `DataFrameCurator`</summary>
<p>

```python
import lamindb as ln

# define valid labels
cell_medium = ln.ULabel(name="CellMedium", is_type=True).save()
ln.ULabel(name="DMSO", type=cell_medium).save()
ln.ULabel(name="IFNG", type=cell_medium).save()
bt.CellType.from_source(name="B cell").save()
bt.CellType.from_source(name="T cell").save()

# define schema
schema = ln.Schema(
    name="small_dataset1_obs_level_metadata",
    otype="DataFrame",
    features=[
        ln.Feature(name="cell_medium", dtype="cat[ULabel[CellMedium]]").save(),
        ln.Feature(name="sample_note", dtype="str").save(),
        ln.Feature(name="cell_type_by_expert", dtype="cat[bionty.CellType]").save(),
        ln.Feature(name="cell_type_by_model", dtype="cat[bionty.CellType]").save(),
    ],
    coerce_dtype=True,
).save()

# curate a DataFrame
df = datasets.small_dataset1(otype="DataFrame")
curator = ln.curators.DataFrameCurator(df, small_dataset1_schema)
artifact = curator.save_artifact(key="example_datasets/dataset1.parquet")
assert artifact.schema == anndata_schema
```

</p>
</details> 

# Notes

## Inferred/annotating vs. validating schema

Originally the plan was to populate `artifact.schema` with the _inferred schema_ that links/annotates by all _all features_ of a dataset in the same way `artifact._schemas_m2m` already does to make the artifact queryable by all features.

Because we decided to make `Schema.composite` a self-referential foreign key rather than a ManyToMany, every component can only be used by a single composite schema. This prohibits to use `artifact.schema` for an _inferred composite_ schema of which we'd have a high number due to variations in the detailed high-dimensional feature sets. For each combination, we'd need to create a copy of a low-cardinality feature set like the `obs` schema in the quickstart example.

With this PR we now capture both the information about the curation constraints (the "validating schema") and about the inferred/annotating schemas (what we've always done under the name "feature sets"). There might be a more parsimonious solution if we dropped `_schemas_m2m` and replace it with a good way to create and populate `artifact.schema` with an inferred schema. But we postpone this consideration to lamindb v2.

This also means that `Schema.validated_by` is **not** going to be used and should be hidden from the docs: `artifact.schema` indicates the validating schema (and not an inferred schema).

# Materials

Internal [Notion page](https://www.notion.so/laminlabs/Persist-Curator-as-Schema-re-purpose-FeatureSet-as-Schema-1782aeaa55e1801dac38de470fe6f3f9).