### PR TITLE
✨ Support s3-compatible endpoint urls

### DIFF
--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -116,6 +116,10 @@ def process_pathlike(
                     hf_path.path_in_repo = ""
                     new_root = "hf://" + hf_path.unresolve()
                 else:
+                    if filepath.protocol == "s3":
+                        # check that endpoint_url didn't propagate here
+                        # as a pert of the path string
+                        assert "?" not in filepath.path  # noqa: S101
                     new_root = list(filepath.parents)[-1]
                 # do not register remote storage locations on hub if the current instance
                 # is not managed on the hub

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -118,7 +118,7 @@ def process_pathlike(
                 else:
                     if filepath.protocol == "s3":
                         # check that endpoint_url didn't propagate here
-                        # as a pert of the path string
+                        # as a part of the path string
                         assert "?" not in filepath.path  # noqa: S101
                     new_root = list(filepath.parents)[-1]
                 # do not register remote storage locations on hub if the current instance

--- a/lamindb/core/storage/paths.py
+++ b/lamindb/core/storage/paths.py
@@ -55,6 +55,11 @@ def check_path_is_child_of_root(path: UPathStr, root: UPathStr) -> bool:
         return False
     path_upath = _safely_resolve(UPath(path))
     root_upath = _safely_resolve(UPath(root))
+    if path_upath.protocol == "s3":
+        endpoint_path = path_upath.storage_options.get("endpoint_url", "")
+        endpoint_root = root_upath.storage_options.get("endpoint_url", "")
+        if endpoint_path != endpoint_root:
+            return False
     # str is needed to eliminate UPath storage_options
     # which affect equality checks
     return UPath(str(root_upath)) in UPath(str(path_upath)).parents

--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -2731,7 +2731,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
 
         >>> artifact = ln.Artifact("s3://my-bucket/my-file.csv").save()
         >>> artifact.path
-        S3Path('s3://my-bucket/my-file.csv')
+        S3QueryPath('s3://my-bucket/my-file.csv')
 
         File in local storage:
 

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -719,6 +719,23 @@ def test_check_path_is_child_of_root():
         "https://raw.githubusercontent.com/laminlabs/lamindb/refs/heads/main/README.md",
         root="https://raw.githubusercontent.com",
     )
+    # s3 with endpoint
+    assert not check_path_is_child_of_root(
+        "s3://bucket/key?endpoint_url=http://localhost:8000",
+        root="s3://bucket/",
+    )
+    assert not check_path_is_child_of_root(
+        "s3://bucket/key/",
+        root="s3://bucket/?endpoint_url=http://localhost:8000",
+    )
+    assert check_path_is_child_of_root(
+        "s3://bucket/key?endpoint_url=http://localhost:8000",
+        root="s3://bucket?endpoint_url=http://localhost:8000",
+    )
+    assert check_path_is_child_of_root(
+        UPath("s3://bucket/key", endpoint_url="http://localhost:8000"),
+        root="s3://bucket?endpoint_url=http://localhost:8000",
+    )
 
 
 def test_serialize_paths():

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -370,6 +370,8 @@ def test_write_read_tiledbsoma(storage):
     assert not soma_path.exists()
     assert not ln.Artifact.filter(description="test tiledbsoma").exists()
 
+    Path("adata_to_append_2.h5ad").unlink()
+
     if storage is not None:
         ln.settings.storage = previous_storage
 


### PR DESCRIPTION
https://github.com/laminlabs/lamindb-setup/pull/958

Adds initial support for s3-compatible endpoint urls.

Now it is possible to register an instance with an endpoint like this:
`lamin init --storage s3://bucket/folder?endpoint_url=http://some/url`

And also register an `Artifact`:
`ln.Artifact("s3://bucket/key.h5ad?endpoint_url=http://some/url")`

Thanks @ap-- for showing how to create and register a subclass of `S3Path`.