### PR TITLE
🚸 Improve `ln.tracked()` user experience

### DIFF
--- a/docs/track.ipynb
+++ b/docs/track.ipynb
@@ -456,13 +456,12 @@
     "    artifact: ln.Artifact,\n",
     "    subset_rows: int = 2,\n",
     "    subset_cols: int = 2,\n",
-    "    run: ln.Run | None = None,  # keyword argument is managed by decorator\n",
     ") -> ln.Artifact:\n",
-    "    dataset = artifact.load(is_run_input=run)  # pass run to mark as input\n",
+    "    dataset = artifact.load()  # pass run to mark as input\n",
     "    new_data = dataset.iloc[:subset_rows, :subset_cols]\n",
     "    new_key = artifact.key.replace(\".parquet\", \"_subsetted.parquet\")\n",
     "    return ln.Artifact.from_df(\n",
-    "        new_data, key=new_key, run=run\n",
+    "        new_data, key=new_key\n",
     "    ).save()  # pass run to mark as output"
    ]
   },

--- a/docs/track.ipynb
+++ b/docs/track.ipynb
@@ -422,6 +422,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you want more-fined-grained data lineage tracking, use the `tracked()` decorator."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### In a notebook"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -430,7 +444,7 @@
     "import lamindb as ln\n",
     "\n",
     "ln.track()  # track this notebook\n",
-    "ln.Param(name=\"subset_rows\", dtype=\"int\").save()  # define run parameters\n",
+    "ln.Param(name=\"subset_rows\", dtype=\"int\").save()  # define parameters\n",
     "ln.Param(name=\"subset_cols\", dtype=\"int\").save()\n",
     "ln.Param(name=\"input_artifact_key\", dtype=\"str\").save()\n",
     "ln.Param(name=\"output_artifact_key\", dtype=\"str\").save()"
@@ -470,6 +484,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Prepare a test dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = ln.core.datasets.small_dataset1(otype=\"DataFrame\")\n",
+    "input_artifact_key = \"my_analysis/dataset.parquet\"\n",
+    "artifact = ln.Artifact.from_df(df, key=input_artifact_key).save()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Run the function with default params:"
    ]
   },
@@ -483,22 +515,169 @@
    },
    "outputs": [],
    "source": [
-    "df = ln.core.datasets.small_dataset1(otype=\"DataFrame\")\n",
-    "input_artifact_key = \"my_analysis/dataset.parquet\"\n",
-    "artifact = ln.Artifact.from_df(df, key=input_artifact_key).save()\n",
-    "\n",
     "ouput_artifact_key = input_artifact_key.replace(\".parquet\", \"_subsetted.parquet\")\n",
-    "subset_dataframe(input_artifact_key, ouput_artifact_key)\n",
-    "\n",
+    "subset_dataframe(input_artifact_key, ouput_artifact_key)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Query for the output:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "subsetted_artifact = ln.Artifact.get(key=ouput_artifact_key)\n",
-    "subsetted_artifact.view_lineage()\n",
-    "\n",
-    "print(subsetted_artifact.run.initiated_by_run.transform)  # notebook\n",
-    "print(subsetted_artifact.run.transform)  # function\n",
-    "print(subsetted_artifact.run)  # run\n",
-    "print(subsetted_artifact.run.params.get_values())  # params\n",
-    "display(subsetted_artifact.run.input_artifacts.df())  # input artifacts\n",
-    "display(subsetted_artifact.run.output_artifacts.df())  # output artifacts"
+    "subsetted_artifact.view_lineage()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is the run that created the subsetted_artifact:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subsetted_artifact.run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is the function that created it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subsetted_artifact.run.transform"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is the source code of this function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subsetted_artifact.run.transform.source_code"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These are all versions of this function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subsetted_artifact.run.transform.versions.df()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is the initating run that triggered the function call:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subsetted_artifact.run.initiated_by_run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is the `transform` of the initiating run:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subsetted_artifact.run.initiated_by_run.transform"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These are the parameters of the run:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subsetted_artifact.run.params.get_values()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These input artifacts:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subsetted_artifact.run.input_artifacts.df()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These are output artifacts:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subsetted_artifact.run.output_artifacts.df()"
    ]
   },
   {
@@ -521,16 +700,56 @@
     "subsetted_artifact = subset_dataframe(\n",
     "    input_artifact_key, ouput_artifact_key, subset_cols=3\n",
     ")\n",
-    "\n",
     "subsetted_artifact = ln.Artifact.get(key=ouput_artifact_key)\n",
-    "subsetted_artifact.view_lineage()\n",
-    "\n",
-    "print(subsetted_artifact.run.initiated_by_run.transform)  # notebook\n",
-    "print(subsetted_artifact.run.transform)  # function\n",
-    "print(subsetted_artifact.run)  # run\n",
-    "print(subsetted_artifact.run.params.get_values())  # params\n",
-    "display(subsetted_artifact.run.input_artifacts.df())  # input artifacts\n",
-    "display(subsetted_artifact.run.output_artifacts.df())  # output artifacts"
+    "subsetted_artifact.view_lineage()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We created a new run:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subsetted_artifact.run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With new parameters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subsetted_artifact.run.params.get_values()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And a new version of the output artifact:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subsetted_artifact.run.output_artifacts.df()"
    ]
   },
   {
@@ -557,7 +776,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Towards a workflow"
+    "### In a script"
    ]
   },
   {

--- a/docs/track.ipynb
+++ b/docs/track.ipynb
@@ -431,7 +431,9 @@
     "\n",
     "ln.track()  # track this notebook\n",
     "ln.Param(name=\"subset_rows\", dtype=\"int\").save()  # define run parameters\n",
-    "ln.Param(name=\"subset_cols\", dtype=\"int\").save()"
+    "ln.Param(name=\"subset_cols\", dtype=\"int\").save()\n",
+    "ln.Param(name=\"input_artifact_key\", dtype=\"str\").save()\n",
+    "ln.Param(name=\"output_artifact_key\", dtype=\"str\").save()"
    ]
   },
   {

--- a/docs/track.ipynb
+++ b/docs/track.ipynb
@@ -453,16 +453,15 @@
    "source": [
     "@ln.tracked()\n",
     "def subset_dataframe(\n",
-    "    artifact: ln.Artifact,\n",
+    "    input_artifact_key: str,\n",
+    "    output_artifact_key: str,\n",
     "    subset_rows: int = 2,\n",
     "    subset_cols: int = 2,\n",
-    ") -> ln.Artifact:\n",
-    "    dataset = artifact.load()  # pass run to mark as input\n",
+    ") -> None:\n",
+    "    artifact = ln.Artifact.get(key=input_artifact_key)\n",
+    "    dataset = artifact.load()\n",
     "    new_data = dataset.iloc[:subset_rows, :subset_cols]\n",
-    "    new_key = artifact.key.replace(\".parquet\", \"_subsetted.parquet\")\n",
-    "    return ln.Artifact.from_df(\n",
-    "        new_data, key=new_key\n",
-    "    ).save()  # pass run to mark as output"
+    "    ln.Artifact.from_df(new_data, key=output_artifact_key).save()"
    ]
   },
   {
@@ -483,9 +482,13 @@
    "outputs": [],
    "source": [
     "df = ln.core.datasets.small_dataset1(otype=\"DataFrame\")\n",
-    "artifact = ln.Artifact.from_df(df, key=\"my_analysis/dataset.parquet\").save()\n",
-    "subsetted_artifact = subset_dataframe(artifact)\n",
+    "input_artifact_key = \"my_analysis/dataset.parquet\"\n",
+    "artifact = ln.Artifact.from_df(df, key=input_artifact_key).save()\n",
     "\n",
+    "ouput_artifact_key = input_artifact_key.replace(\".parquet\", \"_subsetted.parquet\")\n",
+    "subset_dataframe(input_artifact_key, ouput_artifact_key)\n",
+    "\n",
+    "subsetted_artifact = ln.Artifact.get(key=ouput_artifact_key)\n",
     "subsetted_artifact.view_lineage()\n",
     "\n",
     "print(subsetted_artifact.run.initiated_by_run.transform)  # notebook\n",
@@ -500,7 +503,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Re-run the function:"
+    "Re-run the function with a different parameter:"
    ]
   },
   {
@@ -513,10 +516,11 @@
    },
    "outputs": [],
    "source": [
-    "df = ln.core.datasets.small_dataset1(otype=\"DataFrame\")\n",
-    "artifact = ln.Artifact.from_df(df, key=\"my_analysis/dataset.parquet\").save()\n",
-    "subsetted_artifact = subset_dataframe(artifact, subset_cols=3)\n",
+    "subsetted_artifact = subset_dataframe(\n",
+    "    input_artifact_key, ouput_artifact_key, subset_cols=3\n",
+    ")\n",
     "\n",
+    "subsetted_artifact = ln.Artifact.get(key=ouput_artifact_key)\n",
     "subsetted_artifact.view_lineage()\n",
     "\n",
     "print(subsetted_artifact.run.initiated_by_run.transform)  # notebook\n",

--- a/lamindb/_query_set.py
+++ b/lamindb/_query_set.py
@@ -216,6 +216,9 @@ def get(
     else:
         assert idlike is None  # noqa: S101
         expressions = process_expressions(qs, expressions)
+        # inject is_latest for consistency with idlike
+        if issubclass(registry, IsVersioned) and "is_latest" not in expressions:
+            expressions["is_latest"] = True
         return registry.objects.using(qs.db).get(**expressions)
 
 

--- a/lamindb/_tracked.py
+++ b/lamindb/_tracked.py
@@ -74,8 +74,10 @@ def tracked(uid: str | None = None) -> Callable[[Callable[P, R]], Callable[P, R]
             # Deal with non-trivial parameter values
             filtered_params = {}
             for key, value in params.items():
-                dtype, _, _ = infer_feature_type_convert_json(key, value)
-                if dtype == "?" or dtype.startswith("cat"):
+                dtype, _, _ = infer_feature_type_convert_json(
+                    key, value, str_as_ulabel=False
+                )
+                if (dtype == "?" or dtype.startswith("cat")) and dtype != "cat ? str":
                     continue
                 filtered_params[key] = value
 

--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -153,8 +153,13 @@ def current_run() -> Run | None:
         _TRACKING_READY = _check_instance_setup()
     if _TRACKING_READY:
         import lamindb.core
+        from lamindb._tracked import get_current_tracked_run
 
-        return lamindb.context.run
+        # also see get_run() in core._data
+        run = get_current_tracked_run()
+        if run is None:
+            run = lamindb.context.run
+        return run
     else:
         return None
 

--- a/tests/core/test_versioning.py
+++ b/tests/core/test_versioning.py
@@ -113,8 +113,7 @@ def test_latest_version_and_get():
     assert len(ln.Transform.filter(description="Introduction").all()) == 3
     assert len(ln.Transform.filter(description="Introduction").latest_version()) == 2
     transform_v4.delete()
-    with pytest.raises(Exception):  # noqa: B017 should be MultipleResultsFound
-        ln.Transform.get(description="Introduction")
+    assert ln.Transform.get(description="Introduction") == transform_v3
     assert (
         ln.Transform.filter(description="Introduction").latest_version().one()
         == transform_v3


### PR DESCRIPTION
Iterates on the `ln.tracked()` decorator introduced below:

- https://github.com/laminlabs/lamindb/pull/2422

Eliminate the need to handle `run` manually by the user for consistency with tracking runs on the global scope.

## Before

```python
@ln.tracked()
def subset_dataframe(
    input_artifact_key: str,  # all arguments tracked as parameters of the function run
    output_artifact_key: str,
    subset_rows: int = 2,
    subset_cols: int = 2,
    run: ln.Run | None = None,  # keyword argument is managed by decorator
) -> None:
    artifact = ln.Artifact.get(artifact_key)
    df = artifact.load(is_run_input=run)  # pass run to mark as input
    new_df = df.iloc[:subset_rows, :subset_cols]
    new_key = artifact.key.replace(".parquet", "_subsetted.parquet")
    ln.Artifact.from_df(new_df, key=new_key, run=run).save()  # pass run to mark as output
```

## After

```python
@ln.tracked()
def subset_dataframe(
    input_artifact_key: str,  # all arguments tracked as parameters of the function run
    output_artifact_key: str,
    subset_rows: int = 2,
    subset_cols: int = 2,
) -> None:
    artifact = ln.Artifact.get(key=input_artifact_key)
    dataset = artifact.load()  # auto-tracked as input
    new_data = dataset.iloc[:subset_rows, :subset_cols]
    ln.Artifact.from_df(new_data, key=output_artifact_key).save()  # auto-tracked as output
```