### PR TITLE
✨ Add Artifact.from_tiledbsoma with n_observations

### DIFF
--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -77,6 +77,7 @@ if TYPE_CHECKING:
     from pyarrow.dataset import Dataset as PyArrowDataset
     from tiledbsoma import Collection as SOMACollection
     from tiledbsoma import Experiment as SOMAExperiment
+    from tiledbsoma import Measurement as SOMAMeasurement
 
     from lamindb.core.storage._backed_access import AnnDataAccessor, BackedAccessor
 
@@ -989,7 +990,12 @@ inconsistent_state_msg = (
 def open(
     self, mode: str = "r", is_run_input: bool | None = None
 ) -> (
-    AnnDataAccessor | BackedAccessor | SOMACollection | SOMAExperiment | PyArrowDataset
+    AnnDataAccessor
+    | BackedAccessor
+    | SOMACollection
+    | SOMAExperiment
+    | SOMAMeasurement
+    | PyArrowDataset
 ):
     if self._overwrite_versions and not self.is_latest:
         raise ValueError(inconsistent_state_msg)

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -47,6 +47,7 @@ from .core.storage import (
 )
 from .core.storage._anndata_accessor import _anndata_n_observations
 from .core.storage._pyarrow_dataset import PYARROW_SUFFIXES
+from .core.storage._tiledbsoma import _soma_n_observations
 from .core.storage.objects import _mudata_is_installed
 from .core.storage.paths import (
     AUTO_KEY_PREFIX,
@@ -488,7 +489,7 @@ def data_is_mudata(data: MuData | UPathStr) -> bool:
         if isinstance(data, MuData):
             return True
     if isinstance(data, (str, Path)):
-        return UPath(data).suffix in {".h5mu"}
+        return UPath(data).suffix == ".h5mu"
     return False
 
 
@@ -769,6 +770,37 @@ def from_mudata(
         **kwargs,
     )
     artifact.n_observations = mdata.n_obs
+    return artifact
+
+
+@classmethod  # type: ignore
+@doc_args(Artifact.from_tiledbsoma.__doc__)
+def from_tiledbsoma(
+    cls,
+    path: UPathStr,
+    *,
+    key: str | None = None,
+    description: str | None = None,
+    run: Run | None = None,
+    revises: Artifact | None = None,
+    **kwargs,
+) -> Artifact:
+    """{}"""  # noqa: D415
+    if UPath(path).suffix != ".tiledbsoma":
+        raise ValueError(
+            "A tiledbsoma store should have .tiledbsoma suffix to be registered."
+        )
+    artifact = Artifact(  # type: ignore
+        data=path,
+        key=key,
+        run=run,
+        description=description,
+        revises=revises,
+        otype="tiledbsoma",
+        kind="dataset",
+        **kwargs,
+    )
+    artifact.n_observations = _soma_n_observations(artifact.path)
     return artifact
 
 
@@ -1287,6 +1319,7 @@ METHOD_NAMES = [
     "from_anndata",
     "from_df",
     "from_mudata",
+    "from_tiledbsoma",
     "open",
     "cache",
     "load",

--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -2861,6 +2861,33 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
         pass
 
     @classmethod
+    def from_tiledbsoma(
+        cls,
+        path: UPathStr,
+        *,
+        key: str | None = None,
+        description: str | None = None,
+        run: Run | None = None,
+        revises: Artifact | None = None,
+        **kwargs,
+    ) -> Artifact:
+        """Create from a tiledbsoma store.
+
+        Args:
+            path: A tiledbsoma store with .tiledbsoma suffix.
+            key: A relative path within default storage,
+                e.g., `"myfolder/mystore.tiledbsoma"`.
+            description: A description.
+            revises: An old version of the artifact.
+            run: The run that creates the artifact.
+
+        Examples:
+            >>> artifact = ln.Artifact.from_tiledbsoma("s3://mybucket/store.tiledbsoma", description="a tiledbsoma store")
+            >>> artifact.save()
+        """
+        pass
+
+    @classmethod
     def from_dir(
         cls,
         path: UPathStr,

--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -65,6 +65,7 @@ if TYPE_CHECKING:
     from pyarrow.dataset import Dataset as PyArrowDataset
     from tiledbsoma import Collection as SOMACollection
     from tiledbsoma import Experiment as SOMAExperiment
+    from tiledbsoma import Measurement as SOMAMeasurement
     from upath import UPath
 
     from lamindb.core import LabelManager, MappedCollection, QuerySet, RecordList
@@ -2952,6 +2953,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
         | BackedAccessor
         | SOMACollection
         | SOMAExperiment
+        | SOMAMeasurement
         | PyArrowDataset
     ):
         """Return a cloud-backed data object.

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -127,7 +127,13 @@ def test_signatures():
         pass
 
     # class methods
-    class_methods = ["from_dir", "from_df", "from_anndata", "from_mudata"]
+    class_methods = [
+        "from_dir",
+        "from_df",
+        "from_anndata",
+        "from_mudata",
+        "from_tiledbsoma",
+    ]
     for name in class_methods:
         setattr(Mock, name, getattr(_artifact, name))
         assert signature(getattr(Mock, name)) == _artifact.SIGS.pop(name)

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -398,7 +398,7 @@ def test_from_tiledbsoma():
         assert _soma_store_n_observations(store) == 30
         # dataframe
         assert _soma_store_n_observations(store.obs) == 30
-        # collection
+        # treat as unstructured collection, data + raw
         assert _soma_store_n_observations(store.ms) == 60
         # measurement
         assert _soma_store_n_observations(store.ms["RNA"]) == 30

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -383,7 +383,7 @@ def test_from_tiledbsoma():
     tiledbsoma.io.from_h5ad(soma_path, test_file, measurement_name="RNA")
     # wrong suffix
     with pytest.raises(ValueError):
-        ln.Artifact("mystore")
+        ln.Artifact.from_tiledbsoma("mystore")
 
     artifact = ln.Artifact.from_tiledbsoma(
         soma_path, description="test soma store"

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -16,6 +16,7 @@ from lamindb.core.storage._backed_access import (
     BackedAccessor,
     backed_access,
 )
+from lamindb.core.storage._tiledbsoma import _open_tiledbsoma, _soma_n_observations
 from lamindb.core.storage._zarr import load_anndata_zarr, write_adata_zarr
 from lamindb.core.storage.objects import infer_suffix, write_to_disk
 from lamindb.integrations import save_tiledbsoma_experiment
@@ -374,6 +375,35 @@ def test_write_read_tiledbsoma(storage):
 
     if storage is not None:
         ln.settings.storage = previous_storage
+
+
+def test_from_tiledbsoma():
+    test_file = ln.core.datasets.anndata_file_pbmc68k_test()
+    soma_path = "mystore.tiledbsoma"
+    tiledbsoma.io.from_h5ad(soma_path, test_file, measurement_name="RNA")
+    # wrong suffix
+    with pytest.raises(ValueError):
+        ln.Artifact("mystore")
+
+    artifact = ln.Artifact.from_tiledbsoma(
+        soma_path, description="test soma store"
+    ).save()
+    assert artifact.n_observations == 30
+
+    with _open_tiledbsoma(artifact.path, mode="r") as store:
+        # experiment
+        assert _soma_n_observations(store) == 30
+        # dataframe
+        assert _soma_n_observations(store.obs) == 30
+        # collection
+        assert _soma_n_observations(store.ms) == 30
+        # measurement
+        assert _soma_n_observations(store.ms["RNA"]) == 30
+        # array
+        assert _soma_n_observations(store.ms["RNA"]["X"]["data"]) == 30
+
+    artifact.delete(permanent=True)
+    shutil.rmtree(soma_path)
 
 
 def test_backed_pyarrow():

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -16,7 +16,10 @@ from lamindb.core.storage._backed_access import (
     BackedAccessor,
     backed_access,
 )
-from lamindb.core.storage._tiledbsoma import _open_tiledbsoma, _soma_n_observations
+from lamindb.core.storage._tiledbsoma import (
+    _open_tiledbsoma,
+    _soma_store_n_observations,
+)
 from lamindb.core.storage._zarr import load_anndata_zarr, write_adata_zarr
 from lamindb.core.storage.objects import infer_suffix, write_to_disk
 from lamindb.integrations import save_tiledbsoma_experiment
@@ -392,15 +395,15 @@ def test_from_tiledbsoma():
 
     with _open_tiledbsoma(artifact.path, mode="r") as store:
         # experiment
-        assert _soma_n_observations(store) == 30
+        assert _soma_store_n_observations(store) == 30
         # dataframe
-        assert _soma_n_observations(store.obs) == 30
+        assert _soma_store_n_observations(store.obs) == 30
         # collection
-        assert _soma_n_observations(store.ms) == 30
+        assert _soma_store_n_observations(store.ms) == 30
         # measurement
-        assert _soma_n_observations(store.ms["RNA"]) == 30
+        assert _soma_store_n_observations(store.ms["RNA"]) == 30
         # array
-        assert _soma_n_observations(store.ms["RNA"]["X"]["data"]) == 30
+        assert _soma_store_n_observations(store.ms["RNA"]["X"]["data"]) == 30
 
     artifact.delete(permanent=True)
     shutil.rmtree(soma_path)

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -399,7 +399,7 @@ def test_from_tiledbsoma():
         # dataframe
         assert _soma_store_n_observations(store.obs) == 30
         # collection
-        assert _soma_store_n_observations(store.ms) == 30
+        assert _soma_store_n_observations(store.ms) == 60
         # measurement
         assert _soma_store_n_observations(store.ms["RNA"]) == 30
         # array


### PR DESCRIPTION
Adds `Artifact.from_tiledbsoma` for registering `tiledbsoma` stores. Infers `n_observations`.
Example:
`ln.Artifact.from_tiledbsoma("s3://bucket/store.tiledbsoma")`