### PR TITLE
✨ Allow passing `artifact` to `Curator`

### DIFF
--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -1790,6 +1790,8 @@ class SpatialDataCatCurator(CatCurator):
         if isinstance(sdata, Artifact):
             # TODO: load() doesn't yet work
             self._sdata = sdata.load()
+        else:
+            self._sdata = self._dataset
         self._sample_metadata_key = sample_metadata_key
         self._var_fields = var_index
         self._verify_accessor_exists(self._var_fields.keys())

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -840,6 +840,8 @@ class AnnDataCatCurator(CatCurator):
 
         if sources is None:
             sources = {}
+        if not data_is_anndata(data):
+            raise TypeError("data has to be an AnnData object")
 
         if "symbol" in str(var_index):
             logger.warning(

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -482,7 +482,7 @@ class CatCurator(Curator):
         self._validate_category_error_messages: str = ""
 
     @property
-    def non_validated(self) -> dict[str, list[str]] | dict[str, dict[str, list[str]]]:
+    def non_validated(self) -> dict[str, list[str]]:
         """Return the non-validated features and labels."""
         if self._non_validated is None:
             raise ValidationError("Please run validate() first!")

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -842,7 +842,7 @@ class AnnDataCatCurator(CatCurator):
 
         if sources is None:
             sources = {}
-        if not data_is_anndata(data):
+        if not data_is_anndata(data) and not isinstance(data, Artifact):
             raise TypeError(
                 "data has to be an AnnData object or a path to AnnData-like"
             )

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -1042,18 +1042,18 @@ class MuDataCatCurator(CatCurator):
         self._organism = organism
         self._var_fields = var_index
         self._columns_field = var_index  # this is for consistency with BaseCatCurator
-        self._verify_modality(self._var_fields.keys())
-        self._obs_fields = self._parse_categoricals(categoricals)
-        self._modalities = set(self._var_fields.keys()) | set(self._obs_fields.keys())
-        self._verbosity = verbosity
-        self._obs_df_curator = None
-        self._organism = organism
         if isinstance(mdata, Artifact):
             self._artifact = mdata
             self._dataset = mdata.load()
         else:
             self._artifact = None
             self._dataset = mdata
+        self._verify_modality(self._var_fields.keys())
+        self._obs_fields = self._parse_categoricals(categoricals)
+        self._modalities = set(self._var_fields.keys()) | set(self._obs_fields.keys())
+        self._verbosity = verbosity
+        self._obs_df_curator = None
+        self._organism = organism
         if "obs" in self._modalities:
             self._obs_df_curator = DataFrameCatCurator(
                 df=self._dataset.obs,

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -863,13 +863,15 @@ class AnnDataCatCurator(CatCurator):
         self._obs_fields = categoricals or {}
         self._var_field = var_index
         super().__init__(
-            dataset=data,
+            dataset=self._dataset,
             categoricals=categoricals,
             sources=sources,
             organism=organism,
             exclude=exclude,
             columns_field=var_index,
         )
+        if isinstance(data, Artifact):
+            self._artifact = data
         self._obs_df_curator = DataFrameCatCurator(
             df=self._adata.obs,
             categoricals=self.categoricals,

--- a/tests/curators/test_cat_curators.py
+++ b/tests/curators/test_cat_curators.py
@@ -384,6 +384,7 @@ def test_mudata_curator(mdata):
     }
 
     try:
+        artifact = None
         curator = ln.Curator.from_mudata(
             mdata,
             categoricals=categoricals,
@@ -431,7 +432,8 @@ def test_mudata_curator(mdata):
         artifact = curator.save_artifact(description="test MuData")
     finally:
         # clean up
-        artifact.delete(permanent=True)
+        if artifact:
+            artifact.delete(permanent=True)
         ln.ULabel.filter().delete()
         bt.ExperimentalFactor.filter().delete()
         bt.CellType.filter().delete()
@@ -481,6 +483,7 @@ def test_soma_curator(adata, categoricals, clean_soma_files):
         )
 
     try:
+        artifact = None
         curator = ln.Curator.from_tiledbsoma(
             "curate.tiledbsoma",
             {"RNA": ("var_id", bt.Gene.symbol)},
@@ -578,7 +581,8 @@ def test_soma_curator(adata, categoricals, clean_soma_files):
         }
     finally:
         # clean up
-        artifact.delete(permanent=True)
+        if artifact:
+            artifact.delete(permanent=True)
         ln.ULabel.filter().delete()
         bt.ExperimentalFactor.filter().delete()
         bt.CellType.filter().delete()

--- a/tests/curators/test_cat_curators.py
+++ b/tests/curators/test_cat_curators.py
@@ -192,6 +192,21 @@ def test_df_curator(df, categoricals):
         ln.Schema.filter().delete()
 
 
+def test_pass_artifact(df):
+    try:
+        artifact = ln.Artifact.from_df(df, key="test_cat_curators/df").save()
+        curator = ln.Curator.from_df(artifact, categoricals={"donor": ln.ULabel.name})
+        curator.validate()
+        curator.add_new_from("donor")
+        artifact_2 = curator.save_artifact()
+        assert artifact == artifact_2
+    finally:
+        # clean up
+        artifact.delete(permanent=True)
+        ln.ULabel.filter().delete()
+        ln.Schema.filter().delete()
+
+
 def test_custom_using_invalid_field_lookup(curate_lookup):
     with pytest.raises(
         AttributeError, match='"CurateLookup" object has no attribute "invalid_field"'

--- a/tests/curators/test_cat_curators.py
+++ b/tests/curators/test_cat_curators.py
@@ -197,6 +197,10 @@ def test_pass_artifact(df):
         artifact = ln.Artifact.from_df(df, key="test_cat_curators/df.parquet").save()
         curator = ln.Curator.from_df(artifact, categoricals={"donor": ln.ULabel.name})
         curator.validate()
+        with pytest.raises(
+            RuntimeError, match="can't mutate the dataset when an artifact is passed!"
+        ):
+            curator.standardize("all")
         curator.add_new_from("donor")
         artifact_2 = curator.save_artifact()
         assert artifact == artifact_2

--- a/tests/curators/test_cat_curators.py
+++ b/tests/curators/test_cat_curators.py
@@ -194,7 +194,7 @@ def test_df_curator(df, categoricals):
 
 def test_pass_artifact(df):
     try:
-        artifact = ln.Artifact.from_df(df, key="test_cat_curators/df").save()
+        artifact = ln.Artifact.from_df(df, key="test_cat_curators/df.parquet").save()
         curator = ln.Curator.from_df(artifact, categoricals={"donor": ln.ULabel.name})
         curator.validate()
         curator.add_new_from("donor")


### PR DESCRIPTION
This PR enables passing an `Artifact` object to `Curator`.

If an `artifact` is passed, `.save_artifact` will not re-upload the artifact, but merely link all metadata records to it.

Calling `standardize()` errors when an artifact is passed, because this will mutate the dataset and therefore no longer matches the saved artifact.

(Note: passing `artifact` was already possible for `TiledbsomaCatCurator` before this PR).