### PR TITLE
🐛 Allow filtering on np.nan in obs_filter of MappedCollection

### DIFF
--- a/lamindb/core/_mapped_collection.py
+++ b/lamindb/core/_mapped_collection.py
@@ -186,7 +186,7 @@ class MappedCollection:
                     for obs_filter_key, obs_filter_values in obs_filter.items():
                         obs_labels = self._get_labels(store, obs_filter_key)
                         obs_filter_mask = np.isin(obs_labels, obs_filter_values)
-                        if np.nan in obs_filter_values:
+                        if np.isnan(obs_filter_values).any():
                             obs_filter_mask |= np.isnan(obs_labels)
                         if indices_storage_mask is None:
                             indices_storage_mask = obs_filter_mask

--- a/lamindb/core/_mapped_collection.py
+++ b/lamindb/core/_mapped_collection.py
@@ -184,9 +184,10 @@ class MappedCollection:
                 if self.filtered:
                     indices_storage_mask = None
                     for obs_filter_key, obs_filter_values in obs_filter.items():
-                        obs_filter_mask = np.isin(
-                            self._get_labels(store, obs_filter_key), obs_filter_values
-                        )
+                        obs_labels = self._get_labels(store, obs_filter_key)
+                        obs_filter_mask = np.isin(obs_labels, obs_filter_values)
+                        if np.nan in obs_filter_values:
+                            obs_filter_mask |= np.isnan(obs_labels)
                         if indices_storage_mask is None:
                             indices_storage_mask = obs_filter_mask
                         else:

--- a/tests/core/test_collection.py
+++ b/tests/core/test_collection.py
@@ -380,6 +380,19 @@ def test_collection_mapped(adata, adata2):
         weights = ls_ds.get_label_weights("feat2")
         assert len(weights) == 2
         assert all(weights == 0.5)
+    # nan in filtering values
+    with collection_outer.mapped(obs_filter={"feat1": np.nan}) as ls_ds:
+        assert ls_ds.shape == (1, 6)
+    with collection_outer.mapped(
+        obs_filter={"feat1": (np.nan,), "feat2": ("A", "B")}
+    ) as ls_ds:
+        assert ls_ds.shape == (1, 6)
+    with collection_outer.mapped(obs_filter={"feat1": (np.nan, "A", "B")}) as ls_ds:
+        assert ls_ds.shape == (6, 6)
+    with collection_outer.mapped(obs_filter={"feat1": ("A", "B")}) as ls_ds:
+        assert ls_ds.shape == (5, 6)
+    with collection_outer.mapped(obs_filter={"feat1": ("A", np.nan)}) as ls_ds:
+        assert ls_ds.shape == (3, 6)
 
     collection.delete(permanent=True)
     collection_outer.delete(permanent=True)


### PR DESCRIPTION
So `collection.mapped(obs_filter={"feat1": np.nan})`
correctly filters on `np.nan` values in `.obs["feat1"] `