### PR TITLE
🚸 Fix RemovedInDjango60Warning: CheckConstraint.check is deprecated

### DIFF
--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -3681,7 +3681,7 @@ class RunData(BasicRecord, DataMixin):
     class Meta:
         constraints = [
             models.CheckConstraint(
-                check=(
+                condition=(
                     models.Q(feature__isnull=False, param__isnull=True)
                     | models.Q(feature__isnull=True, param__isnull=False)
                 ),
@@ -3731,7 +3731,7 @@ class FlexTableData(BasicRecord, DataMixin):
     class Meta:
         constraints = [
             models.CheckConstraint(
-                check=(
+                condition=(
                     models.Q(feature__isnull=False, param__isnull=True)
                     | models.Q(feature__isnull=True, param__isnull=False)
                 ),


### PR DESCRIPTION
```
tests/test_ingest.py::test_individual_ingest
  /home/lukas/code/lamindb/lamindb/models.py:3683: RemovedInDjango60Warning: CheckConstraint.check is deprecated in favor of `.condition`.
    models.CheckConstraint(

tests/test_ingest.py::test_individual_ingest
  /home/lukas/code/lamindb/lamindb/models.py:3733: RemovedInDjango60Warning: CheckConstraint.check is deprecated in favor of `.condition`.
    models.CheckConstraint(
```

should be gone