### PR TITLE
🐛 Fix caching logic in `Artifact.open()`

### DIFF
--- a/docs/storage/add-replace-cache.ipynb
+++ b/docs/storage/add-replace-cache.ipynb
@@ -834,8 +834,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "shutil.rmtree(\"./test-files/pbmc68k.zarr\")\n",
-    "shutil.rmtree(\"./test-files/pbmc68k_new.zarr\")"
+    "# checks that .open above opened the cloud path without syncing\n",
+    "assert not artifact._cache_path.exists()"
    ]
   },
   {
@@ -845,13 +845,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact.delete(permanent=True, storage=True)"
+    "shutil.rmtree(\"./test-files/pbmc68k.zarr\")\n",
+    "shutil.rmtree(\"./test-files/pbmc68k_new.zarr\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "81",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact.delete(permanent=True, storage=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82",
    "metadata": {
     "tags": []
    },

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -1017,7 +1017,13 @@ def open(
     localpath = setup_settings.paths.cloud_to_local_no_update(
         filepath, cache_key=cache_key
     )
-    if not is_tiledbsoma_w and localpath.exists():
+    if is_tiledbsoma_w:
+        open_cache = False
+    else:
+        open_cache = not isinstance(
+            filepath, LocalPathClasses
+        ) and not filepath.synchronize(localpath, just_check=True)
+    if open_cache:
         try:
             access = backed_access(localpath, mode, using_key)
         except Exception as e:


### PR DESCRIPTION
Before this fix `Artifact.open` opened a cached store even if it was outdated. Now it opens the original cloud path in this case.

Fixes https://github.com/laminlabs/lamindb/issues/2452