### PR TITLE
✨ Add `Collection.open()` that returns `pyarrow` dataset

### DIFF
--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -1262,7 +1262,7 @@ def save(self, upload: bool | None = None, **kwargs) -> Artifact:
     )
     if exception_upload is not None:
         # we do not want to raise file not found on cleanup if upload of a file failed
-        # often it is ACID in the filesytsem itself
+        # often it is ACID in the filesystem itself
         # for example, s3 won't have the failed file, so just skip the delete in this case
         raise_file_not_found_error = False
         self._delete_skip_storage()

--- a/lamindb/_collection.py
+++ b/lamindb/_collection.py
@@ -236,7 +236,7 @@ def open(self, is_run_input: bool | None = None) -> PyArrowDataset:
     for path in paths[1:]:
         # this assumes that the filesystems are cached by fsspec
         if path.fs is not fs:
-            return ValueError(
+            raise ValueError(
                 "The collection has artifacts with different filesystems, this is not supported."
             )
     if not _is_pyarrow_dataset(paths):

--- a/lamindb/core/storage/_backed_access.py
+++ b/lamindb/core/storage/_backed_access.py
@@ -94,8 +94,8 @@ def backed_access(
         return _open_pyarrow_dataset(objectpath)
     else:
         raise ValueError(
-            "object should have .h5, .hdf5, .h5ad, .zarr, .tiledbsoma suffix, not"
-            f" {suffix}."
+            "The object should have .h5, .hdf5, .h5ad, .zarr, .tiledbsoma suffix "
+            f"or be compatible with pyarrow.dataset.dataset, instead of being {suffix} object."
         )
 
     is_anndata = suffix == ".h5ad" or get_spec(storage).encoding_type == "anndata"

--- a/lamindb/core/storage/_pyarrow_dataset.py
+++ b/lamindb/core/storage/_pyarrow_dataset.py
@@ -6,10 +6,11 @@ import pyarrow.dataset
 from lamindb_setup.core.upath import LocalPathClasses
 
 if TYPE_CHECKING:
+    from pyarrow.dataset import Dataset as PyArrowDataset
     from upath import UPath
 
 
-PYARROW_SUFFIXES = (".parquet", ".csv", ".json", ".orc", ".arrow", ".feather")
+PYARROW_SUFFIXES = (".parquet", ".csv", ".json", ".orc", ".arrow", ".feather", ".ipc")
 
 
 def _is_pyarrow_dataset(paths: UPath | list[UPath]) -> bool:
@@ -25,7 +26,7 @@ def _is_pyarrow_dataset(paths: UPath | list[UPath]) -> bool:
     return len(suffixes) == 1 and suffixes.pop() in PYARROW_SUFFIXES
 
 
-def _open_pyarrow_dataset(paths: UPath | list[UPath]) -> pyarrow.dataset.Dataset:
+def _open_pyarrow_dataset(paths: UPath | list[UPath]) -> PyArrowDataset:
     if isinstance(paths, list):
         path0 = paths[0]
         if isinstance(path0, LocalPathClasses):

--- a/lamindb/core/storage/_pyarrow_dataset.py
+++ b/lamindb/core/storage/_pyarrow_dataset.py
@@ -14,6 +14,8 @@ PYARROW_SUFFIXES = (".parquet", ".csv", ".json", ".orc", ".arrow", ".feather")
 
 def _is_pyarrow_dataset(paths: UPath | list[UPath]) -> bool:
     # it is assumed here that the paths exist
+    # we don't check here that the filesystem is the same
+    # but this is a requirement for pyarrow.dataset.dataset
     if isinstance(paths, list):
         suffixes = {path.suffix for path in paths}
     elif paths.is_file():

--- a/lamindb/core/storage/_pyarrow_dataset.py
+++ b/lamindb/core/storage/_pyarrow_dataset.py
@@ -12,20 +12,27 @@ if TYPE_CHECKING:
 PYARROW_SUFFIXES = (".parquet", ".csv", ".json", ".orc", ".arrow", ".feather")
 
 
-def _is_pyarrow_dataset(path: UPath) -> bool:
-    # it is assumed here that path exists
-    if path.is_file():
-        return path.suffix in PYARROW_SUFFIXES
+def _is_pyarrow_dataset(paths: UPath | list[UPath]) -> bool:
+    # it is assumed here that the paths exist
+    if isinstance(paths, list):
+        suffixes = {path.suffix for path in paths}
+    elif paths.is_file():
+        suffixes = {paths.suffix}
     else:
-        objects = path.rglob("*")
-        suffixes = {object.suffix for object in objects if object.suffix != ""}
-        return len(suffixes) == 1 and suffixes.pop() in PYARROW_SUFFIXES
+        suffixes = {path.suffix for path in paths.rglob("*") if path.suffix != ""}
+    return len(suffixes) == 1 and suffixes.pop() in PYARROW_SUFFIXES
 
 
-def _open_pyarrow_dataset(path: UPath) -> pyarrow.dataset.Dataset:
-    if isinstance(path, LocalPathClasses):
-        path_str, filesystem = path.as_posix(), None
+def _open_pyarrow_dataset(paths: UPath | list[UPath]) -> pyarrow.dataset.Dataset:
+    if isinstance(paths, list):
+        path0 = paths[0]
+        if isinstance(path0, LocalPathClasses):
+            paths_str, filesystem = [path.as_posix() for path in paths], None
+        else:
+            paths_str, filesystem = [path.path for path in paths], path0.fs
+    elif isinstance(paths, LocalPathClasses):
+        paths_str, filesystem = paths.as_posix(), None
     else:
-        path_str, filesystem = path.path, path.fs
+        paths_str, filesystem = paths.path, paths.fs
 
-    return pyarrow.dataset.dataset(path_str, filesystem=filesystem)
+    return pyarrow.dataset.dataset(paths_str, filesystem=filesystem)

--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -3259,6 +3259,16 @@ class Collection(Record, IsVersioned, TracksRun, TracksUpdates):
         """
         pass
 
+    def open(self, is_run_input: bool | None = None) -> PyArrowDataset:
+        """Return a cloud-backed pyarrow Dataset.
+
+        Works for `pyarrow` compatible formats.
+
+        Notes:
+            For more info, see tutorial: :doc:`/arrays`.
+        """
+        pass
+
     def mapped(
         self,
         layers_keys: str | list[str] | None = None,

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -482,7 +482,7 @@ def test_backed_pyarrow_collection():
     with pytest.raises(ValueError) as err:
         collection2.open()
     assert err.exconly().endswith(
-        "This collection is not compatible with pyarrow.dataset.dataset."
+        "This collection is not compatible with pyarrow.dataset.dataset()"
     )
 
     collection3 = ln.Collection([artifact1, artifact4], key="s3_http_col").save()

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -481,15 +481,15 @@ def test_backed_pyarrow_collection():
     collection2 = ln.Collection([artifact1, artifact3], key="parquet_csv_col").save()
     with pytest.raises(ValueError) as err:
         collection2.open()
-    assert err.exconly().endswith(
-        "This collection is not compatible with pyarrow.dataset.dataset()"
+    assert err.exconly().startswith(
+        "ValueError: This collection is not compatible with pyarrow.dataset.dataset()"
     )
 
     collection3 = ln.Collection([artifact1, artifact4], key="s3_http_col").save()
     with pytest.raises(ValueError) as err:
         collection3.open()
-    assert err.exconly().endswith(
-        "The collection has artifacts with different filesystems, this is not supported."
+    assert err.exconly().startswith(
+        "ValueError: The collection has artifacts with different filesystems, this is not supported."
     )
 
     shard1.unlink()

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -481,14 +481,15 @@ def test_backed_pyarrow_collection():
     collection2 = ln.Collection([artifact1, artifact3], key="parquet_csv_col").save()
     with pytest.raises(ValueError) as err:
         collection2.open()
-    assert str(err) == "This collection is not compatible with pyarrow.dataset.dataset."
+    assert err.exconly().endswith(
+        "This collection is not compatible with pyarrow.dataset.dataset."
+    )
 
     collection3 = ln.Collection([artifact1, artifact4], key="s3_http_col").save()
     with pytest.raises(ValueError) as err:
         collection3.open()
-    assert (
-        str(err)
-        == "The collection has artifacts with different filesystems, this is not supported."
+    assert err.exconly().endswith(
+        "The collection has artifacts with different filesystems, this is not supported."
     )
 
     shard1.unlink()


### PR DESCRIPTION
Adds `Collection.open()` that can open a collection of files supported by `pyarrow` via `pyarrow.dataset.dataset()`.
See also [here](https://arrow.apache.org/docs/python/generated/pyarrow.dataset.dataset.html).

Example:
```python
import lamindb as ln
import pandas as pd

df = pd.DataFrame({"feat1": [0, 0, 1, 1], "feat2": [6, 7, 8, 9]})
df[:2].to_parquet("df1.parquet", engine="pyarrow")
df[2:].to_parquet("df2.parquet", engine="pyarrow")

artifact1 = ln.Artifact(shard1, key="df1.parquet").save()
artifact2 = ln.Artifact(shard2, key="df2.parquet").save()
collection = ln.Collection([artifact1, artifact2], key="parquet_col")

dataset = collection.open() # backed by files in the cloud storage
dataset.to_table().to_pandas().head()
```