### PR TITLE
✨ Add auxiliary field `nullable` to `Feature`

### DIFF
--- a/docs/ehrcuration.ipynb
+++ b/docs/ehrcuration.ipynb
@@ -118,18 +118,21 @@
     "            name=\"disease\",\n",
     "            dtype=bt.Disease,\n",
     "            default_value=\"normal\",\n",
+    "            nullable=False,\n",
     "            cat_filters={\"source__uid\": disease_ontology.uid},\n",
     "        ).save(),\n",
     "        ln.Feature(\n",
     "            name=\"developmental_stage\",\n",
     "            dtype=bt.DevelopmentalStage,\n",
     "            default_value=\"unknown\",\n",
+    "            nullable=False,\n",
     "            cat_filters={\"source__uid\": developmental_stage_ontology.uid},\n",
     "        ).save(),\n",
     "        ln.Feature(\n",
     "            name=\"phenotype\",\n",
     "            dtype=bt.Phenotype,\n",
     "            default_value=\"unknown\",\n",
+    "            nullable=False,\n",
     "            cat_filters={\"source__uid\": phenotype_ontology.uid},\n",
     "        ).save(),\n",
     "    ],\n",
@@ -191,6 +194,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's validate it."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -204,6 +214,7 @@
     "try:\n",
     "    curator.validate()\n",
     "except ln.errors.ValidationError as e:\n",
+    "    assert str(e).startswith(\"column 'age' not in dataframe\")\n",
     "    print(e)"
    ]
   },
@@ -228,6 +239,7 @@
     "try:\n",
     "    curator.validate()\n",
     "except ln.errors.ValidationError as e:\n",
+    "    assert str(e).startswith(\"non-nullable series 'disease' contains null values\")\n",
     "    print(e)"
    ]
   },
@@ -248,6 +260,9 @@
     "try:\n",
     "    curator.validate()\n",
     "except ln.errors.ValidationError as e:\n",
+    "    assert str(e).startswith(\n",
+    "        \"2 terms are not validated: 'Tumor growth', 'Airway inflammation'\"\n",
+    "    )\n",
     "    print(e)"
    ]
   },

--- a/lamindb/_feature.py
+++ b/lamindb/_feature.py
@@ -218,10 +218,12 @@ def __init__(self, *args, **kwargs):
         return None
     dtype = kwargs.get("dtype", None)
     default_value = kwargs.pop("default_value", None)
+    nullable = kwargs.pop("nullable", None)
     cat_filters = kwargs.pop("cat_filters", None)
     kwargs = process_init_feature_param(args, kwargs)
     super(Feature, self).__init__(*args, **kwargs)
     self.default_value = default_value
+    self.nullable = nullable
     dtype_str = kwargs.pop("dtype", None)
     if cat_filters:
         assert "|" not in dtype_str  # noqa: S101

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -263,7 +263,7 @@ class DataFrameCurator(Curator):
                     feature.dtype if not feature.dtype.startswith("cat") else "category"
                 )
                 pandera_columns[feature.name] = pandera.Column(
-                    pandera_dtype, nullable=True
+                    pandera_dtype, nullable=feature.nullable
                 )
                 if feature.dtype.startswith("cat"):
                     categoricals[feature.name] = parse_dtype(feature.dtype)[0]["field"]

--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -1819,7 +1819,7 @@ class Feature(Record, CanCurate, TracksRun, TracksUpdates):
         unit: `str | None = None` Unit of measure, ideally SI (`"m"`, `"s"`, `"kg"`, etc.) or `"normalized"` etc.
         description: `str | None = None` A description.
         synonyms: `str | None = None` Bar-separated synonyms.
-        nullable: `bool = True` Whether the feature can have null-like values (`None`, `pd.NA`, `NaN`, etc.).
+        nullable: `bool = True` Whether the feature can have null-like values (`None`, `pd.NA`, `NaN`, etc.), see :attr:`~lamindb.Feature.nullable`.
         default_value: `Any | None = None` Default value for the feature.
         cat_filters: `dict[str, str] | None = None` Subset a registry by additional filters to define valid categories.
 
@@ -2012,7 +2012,7 @@ class Feature(Record, CanCurate, TracksRun, TracksUpdates):
 
     @property
     def default_value(self) -> Any:
-        """A default value that overwrites missing values (default None).
+        """A default value that overwrites missing values (default `None`).
 
         This takes effect when you call `Curator.standardize()`.
         """
@@ -2031,7 +2031,24 @@ class Feature(Record, CanCurate, TracksRun, TracksUpdates):
 
     @property
     def nullable(self) -> bool:
-        """Indicates whether the feature can have nullable values (default True)."""
+        """Indicates whether the feature can have nullable values (default `True`).
+
+        Example::
+
+            import lamindb as ln
+            import pandas as pd
+
+            disease = ln.Feature(name="disease", dtype=ln.ULabel, nullable=False).save()
+            schema = ln.Schema(features=[disease]).save()
+            dataset = {"disease": pd.Categorical([pd.NA, "asthma"])}
+            df = pd.DataFrame(dataset)
+            curator = ln.curators.DataFrameCurator(df, schema)
+            try:
+                curator.validate()
+            except ln.errors.ValidationError as e:
+                assert str(e).startswith("non-nullable series 'disease' contains null values")
+
+        """
         if self._aux is not None and "af" in self._aux and "1" in self._aux["af"]:
             return self._aux["af"]["1"]
         else:

--- a/tests/core/test_record.py
+++ b/tests/core/test_record.py
@@ -232,6 +232,7 @@ def test_get_record_kwargs():
         ("unit", "str | None"),
         ("description", "str | None"),
         ("synonyms", "str | None"),
+        ("nullable", "bool"),
         (
             "default_value",
             "str | None",

--- a/tests/curators/test_curators_general.py
+++ b/tests/curators/test_curators_general.py
@@ -1,0 +1,25 @@
+import lamindb as ln
+import pandas as pd
+
+
+def test_nullable():
+    disease_feature = ln.Feature(name="disease", dtype=ln.ULabel, nullable=False).save()
+    schema = ln.Schema(features=[disease_feature]).save()
+    dataset = {"disease": pd.Categorical([pd.NA, "asthma"])}
+    df = pd.DataFrame(dataset)
+    curator = ln.curators.DataFrameCurator(df, schema)
+    try:
+        curator.validate()
+    except ln.errors.ValidationError as e:
+        assert str(e).startswith("non-nullable series 'disease' contains null values")
+    # make feature nullable
+    # (needs to throw an error if already datasets were validated with it)
+    disease_feature.nullable = True
+    disease_feature.save()
+    curator = ln.curators.DataFrameCurator(df, schema)
+    try:
+        curator.validate()
+    except ln.errors.ValidationError as e:
+        assert str(e).startswith("1 term is not validated: 'asthma'")
+    schema.delete()
+    disease_feature.delete()

--- a/tests/curators/test_curators_general.py
+++ b/tests/curators/test_curators_general.py
@@ -3,8 +3,8 @@ import pandas as pd
 
 
 def test_nullable():
-    disease_feature = ln.Feature(name="disease", dtype=ln.ULabel, nullable=False).save()
-    schema = ln.Schema(features=[disease_feature]).save()
+    disease = ln.Feature(name="disease", dtype=ln.ULabel, nullable=False).save()
+    schema = ln.Schema(features=[disease]).save()
     dataset = {"disease": pd.Categorical([pd.NA, "asthma"])}
     df = pd.DataFrame(dataset)
     curator = ln.curators.DataFrameCurator(df, schema)
@@ -14,12 +14,12 @@ def test_nullable():
         assert str(e).startswith("non-nullable series 'disease' contains null values")
     # make feature nullable
     # (needs to throw an error if already datasets were validated with it)
-    disease_feature.nullable = True
-    disease_feature.save()
+    disease.nullable = True
+    disease.save()
     curator = ln.curators.DataFrameCurator(df, schema)
     try:
         curator.validate()
     except ln.errors.ValidationError as e:
         assert str(e).startswith("1 term is not validated: 'asthma'")
     schema.delete()
-    disease_feature.delete()
+    disease.delete()


### PR DESCRIPTION
One can now set features to be non-nullable:
```python
ln.Feature(name="disease", dtype=ln.ULabel, nullable=False)
```

By default, features are `nullable`, given the abundance of datasets with missing data. This is the opposite choice compared to `pandera`, where `nullable=False` by default.

If attempting to validate it, one will get this behavior:
```python
import lamindb as ln
import pandas as pd

schema = ln.Schema(features=[ln.Feature(name="disease", dtype=ln.ULabel, nullable=False).save()]).save()
dataset = {"disease": pd.Categorical([pd.NA, "asthma"])}
df = pd.DataFrame(dataset)
curator = ln.curators.DataFrameCurator(df, schema)
curator.validate()
except ln.errors.ValidationError as e:
    assert str(e).startswith("non-nullable series 'disease' contains null values")
```

## Docs

Example for the `nullable` property:
<img width="1336" alt="image" src="https://github.com/user-attachments/assets/6fd9f280-916a-413c-8584-b8881d45b96b" />

Cross-linked in `Feature` params under href `nullable`:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/688c7773-bf5b-430f-a469-1d624fc95918" />

Part of `Feature` signature:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/29339562-3b18-4cf7-ae2d-5099db21ea13" />
