### PR TITLE
✨ Write `Artifact.n_observations` in `Artifact.from_df()`

### DIFF
--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -689,6 +689,7 @@ def from_df(
         kind="dataset",
         **kwargs,
     )
+    artifact.n_observations = len(df)
     return artifact
 
 

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -290,6 +290,7 @@ def test_create_from_dataframe(df):
     assert artifact.key is None
     assert artifact.otype == "DataFrame"
     assert artifact.kind == "dataset"
+    assert artifact.n_observations == 2
     assert hasattr(artifact, "_local_filepath")
     artifact.save()
     # can do backed now, tested in test_storage.py


### PR DESCRIPTION
Populates `artifact.n_observations` when the `artifact` is created through `Artifact.from_df`.

Example:
```python
artifact = ln.Artifact.from_df(df, key="df.parquet").save()
artifact.n_observations # has len(df)
```
