### PR TITLE
🐛 Automatically add missing columns upon `.standardize()` if `nullable` is `True`

### DIFF
--- a/lamindb/_feature.py
+++ b/lamindb/_feature.py
@@ -218,7 +218,7 @@ def __init__(self, *args, **kwargs):
         return None
     dtype = kwargs.get("dtype", None)
     default_value = kwargs.pop("default_value", None)
-    nullable = kwargs.pop("nullable", None)
+    nullable = kwargs.pop("nullable", True)  # default value of nullable
     cat_filters = kwargs.pop("cat_filters", None)
     kwargs = process_init_feature_param(args, kwargs)
     super(Feature, self).__init__(*args, **kwargs)

--- a/lamindb/_tracked.py
+++ b/lamindb/_tracked.py
@@ -32,13 +32,15 @@ def tracked(uid: str | None = None) -> Callable[[Callable[P, R]], Callable[P, R]
 
     Guide: :doc:`/track`
 
-    .. versionadded: 1.1.0
+    .. versionadded:: 1.1.0
         This is still in beta and will be refined in future releases.
 
     Args:
         uid: Persist the uid to identify this transform across renames.
 
     Example::
+
+        import lamindb as ln
 
         @ln.tracked()
         def subset_dataframe(
@@ -48,9 +50,9 @@ def tracked(uid: str | None = None) -> Callable[[Callable[P, R]], Callable[P, R]
             subset_cols: int = 2,
         ) -> None:
             artifact = ln.Artifact.get(key=input_artifact_key)
-            dataset = artifact.load()  # auto-tracked as input
-            new_data = dataset.iloc[:subset_rows, :subset_cols]
-            ln.Artifact.from_df(new_data, key=output_artifact_key).save()  # auto-tracked as output
+            df = artifact.load()  # auto-tracked as input
+            new_df = df.iloc[:subset_rows, :subset_cols]
+            ln.Artifact.from_df(new_df, key=output_artifact_key).save()  # auto-tracked as output
     """
 
     def decorator_tracked(func: Callable[P, R]) -> Callable[P, R]:

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -291,16 +291,29 @@ class DataFrameCurator(Curator):
     def standardize(self) -> None:
         """Standardize the dataset.
 
-        - Adds missing columns if a default value for a feature is defined.
-        - Fills missing values with the default value if a default value for a feature is defined.
+        - Adds missing columns for features
+        - Fills missing values for features with default values
         """
         for feature in self._schema.members:
             if feature.name not in self._dataset.columns:
-                if feature.default_value is not None:
-                    self._dataset[feature.name] = feature.default_value
+                if feature.default_value is not None or feature.nullable:
+                    fill_value = (
+                        feature.default_value
+                        if feature.default_value is not None
+                        else pd.NA
+                    )
+                    if feature.dtype.startswith("cat"):
+                        self._dataset[feature.name] = pd.Categorical(
+                            [fill_value] * len(self._dataset)
+                        )
+                    else:
+                        self._dataset[feature.name] = fill_value
+                    logger.important(
+                        f"added column {feature.name} with fill value {fill_value}"
+                    )
                 else:
                     raise ValidationError(
-                        f"Missing column {feature.name} cannot be added because no default value is defined for this feature"
+                        f"Missing column {feature.name} cannot be added because is not nullable and has no default value"
                     )
             else:
                 if feature.default_value is not None:
@@ -3423,7 +3436,7 @@ def save_artifact(
             filter_kwargs_current = get_current_filter_kwargs(registry, filter_kwargs)
             df = data if isinstance(data, pd.DataFrame) else data.obs
             # multi-value columns are separated by "|"
-            if df[key].str.contains("|").any():
+            if not df[key].isna().all() and df[key].str.contains("|").any():
                 values = df[key].str.split("|").explode().unique()
             else:
                 values = df[key].unique()

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -1,6 +1,6 @@
 """Curators.
 
-.. versionadded: 1.1.0
+.. versionadded:: 1.1.0
 
 .. autosummary::
    :toctree: .
@@ -172,7 +172,7 @@ class Curator:
 
     A `Curator` object makes it easy to validate, standardize & annotate datasets.
 
-    .. versionadded: 1.1.0
+    .. versionadded:: 1.1.0
 
     See:
         - :class:`~lamindb.curators.DataFrameCurator`
@@ -216,7 +216,7 @@ class DataFrameCurator(Curator):
 
     See also :class:`~lamindb.Curator` and :class:`~lamindb.Schema`.
 
-    .. versionadded: 1.1.0
+    .. versionadded:: 1.1.0
 
     Args:
         dataset: The DataFrame-like object to validate & annotate.
@@ -391,7 +391,7 @@ class AnnDataCurator(Curator):
 
     See also :class:`~lamindb.Curator` and :class:`~lamindb.Schema`.
 
-    .. versionadded: 1.1.0
+    .. versionadded:: 1.1.0
 
     Args:
         dataset: The AnnData-like object to validate & annotate.

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -335,9 +335,11 @@ class DataFrameCurator(Curator):
     def validate(self) -> None:
         """{}"""  # noqa: D415
         if self._schema.n > 0:
-            self._cat_manager.validate()
             try:
+                # first validate through pandera
                 self._pandera_schema.validate(self._dataset)
+                # then validate lamindb categoricals
+                self._cat_manager.validate()
                 if self._cat_manager._is_validated:
                     self._is_validated = True
                 else:

--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -2052,12 +2052,14 @@ class Feature(Record, CanCurate, TracksRun, TracksUpdates):
 
         """
         if self._aux is not None and "af" in self._aux and "1" in self._aux["af"]:
-            return self._aux["af"]["1"]
+            value = self._aux["af"]["1"]
+            return True if value is None else value
         else:
             return True
 
     @nullable.setter
     def nullable(self, value: bool) -> None:
+        assert isinstance(value, bool), value  # noqa: S101
         if self._aux is None:
             self._aux = {}
         if "af" not in self._aux:

--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -2015,6 +2015,8 @@ class Feature(Record, CanCurate, TracksRun, TracksUpdates):
         """A default value that overwrites missing values (default `None`).
 
         This takes effect when you call `Curator.standardize()`.
+
+        If `default_value = None`, missing values like `pd.NA` or `np.nan` are kept.
         """
         if self._aux is not None and "af" in self._aux and "0" in self._aux["af"]:
             return self._aux["af"]["0"]

--- a/tests/core/test_schema.py
+++ b/tests/core/test_schema.py
@@ -218,6 +218,14 @@ def test_schema_components(small_dataset1_schema: ln.Schema):
         dtype="num",
     ).save()
 
+    # test recreation of schema based on name lookup
+    var_schema2 = ln.Schema(
+        name="scRNA_seq_var_schema",
+        itype=bt.Gene.ensembl_gene_id,
+        dtype="num",
+    ).save()
+    assert var_schema == var_schema2
+
     try:
         ln.Schema(
             name="small_dataset1_anndata_schema",

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -72,6 +72,17 @@ def test_dataframe_curator(small_dataset1_schema):
         "T cell",
         "B cell",
     }
+
+    # a second dataset with missing values
+    df = ln.core.datasets.small_dataset2(otype="DataFrame", gene_symbols_in_index=True)
+    curator = ln.curators.DataFrameCurator(df, small_dataset1_schema)
+    try:
+        curator.validate()
+    except ln.errors.ValidationError as error:
+        assert str(error).startswith("column 'sample_note' not in dataframe")
+    curator.standardize()
+    curator.validate()
+
     artifact.delete(permanent=True)
 
 


### PR DESCRIPTION
After | Before
--- | ---
`DataFrameCurator.standardize()` failed saying: "feature doesn't have a default value". | If the `feature` is `nullable`, `.standardize()` will add columns and fill them with `pd.NA`.

This PR adds a few more other tests of edge cases and makes fixes in the docs.