### PR TITLE
✨ Allow to specify `fsspec` upload options in `Artifact.save`

### DIFF
--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -1238,6 +1238,7 @@ def _delete_skip_storage(artifact, *args, **kwargs) -> None:
 def save(self, upload: bool | None = None, **kwargs) -> Artifact:
     state_was_adding = self._state.adding
     print_progress = kwargs.pop("print_progress", True)
+    store_kwargs = kwargs.pop("store_kwargs", {})  # kwargs for .upload_from in the end
     access_token = kwargs.pop("access_token", None)
     local_path = None
     if upload and setup_settings.instance.keep_artifacts_local:
@@ -1259,7 +1260,11 @@ def save(self, upload: bool | None = None, **kwargs) -> Artifact:
     if "using" in kwargs:
         using_key = kwargs["using"]
     exception_upload = check_and_attempt_upload(
-        self, using_key, access_token=access_token, print_progress=print_progress
+        self,
+        using_key,
+        access_token=access_token,
+        print_progress=print_progress,
+        **store_kwargs,
     )
     if exception_upload is not None:
         # we do not want to raise file not found on cleanup if upload of a file failed

--- a/lamindb/_save.py
+++ b/lamindb/_save.py
@@ -133,7 +133,9 @@ def check_and_attempt_upload(
     using_key: str | None = None,
     access_token: str | None = None,
     print_progress: bool = True,
+    **kwargs,
 ) -> Exception | None:
+    # kwargs are propagated to .upload_from in the end
     # if Artifact object is either newly instantiated or replace() was called on
     # a local env it will have a _local_filepath and needs to be uploaded
     if hasattr(artifact, "_local_filepath"):
@@ -143,6 +145,7 @@ def check_and_attempt_upload(
                 using_key,
                 access_token=access_token,
                 print_progress=print_progress,
+                **kwargs,
             )
         except Exception as exception:
             logger.warning(f"could not upload artifact: {artifact}")
@@ -316,8 +319,10 @@ def upload_artifact(
     using_key: str | None = None,
     access_token: str | None = None,
     print_progress: bool = True,
+    **kwargs,
 ) -> tuple[UPath, UPath | None]:
     """Store and add file and its linked entries."""
+    # kwargs are propagated to .upload_from in the end
     # can't currently use  filepath_from_artifact here because it resolves to ._local_filepath
     storage_key = auto_storage_key_from_artifact(artifact)
     storage_path, storage_settings = attempt_accessing_path(
@@ -326,7 +331,10 @@ def upload_artifact(
     if hasattr(artifact, "_to_store") and artifact._to_store:
         logger.save(f"storing artifact '{artifact.uid}' at '{storage_path}'")
         store_file_or_folder(
-            artifact._local_filepath, storage_path, print_progress=print_progress
+            artifact._local_filepath,
+            storage_path,
+            print_progress=print_progress,
+            **kwargs,
         )
 
     if isinstance(storage_path, LocalPathClasses):

--- a/lamindb/core/storage/paths.py
+++ b/lamindb/core/storage/paths.py
@@ -134,7 +134,7 @@ def filepath_cache_key_from_artifact(
 
 
 def store_file_or_folder(
-    local_path: UPathStr, storage_path: UPath, print_progress: bool = True
+    local_path: UPathStr, storage_path: UPath, print_progress: bool = True, **kwargs
 ) -> None:
     """Store file or folder (localpath) at storagepath."""
     local_path = UPath(local_path)
@@ -155,7 +155,10 @@ def store_file_or_folder(
         else:
             create_folder = None
         storage_path.upload_from(
-            local_path, create_folder=create_folder, print_progress=print_progress
+            local_path,
+            create_folder=create_folder,
+            print_progress=print_progress,
+            **kwargs,
         )
     else:  # storage path is local
         if local_path.resolve().as_posix() == storage_path.resolve().as_posix():


### PR DESCRIPTION
This is needed in some edge cases like uploading large files in an unstable network or uploading a very large folder.

Example:
```python
# uploading a very large folder on an unstable network
Artifact.save(store_kwargs={"batch_size": 64}) 
```