### PR TITLE
🐛 Fix notebook re-run with same hash

### DIFF
--- a/lamindb/_query_set.py
+++ b/lamindb/_query_set.py
@@ -226,14 +226,15 @@ def get(
             # handle the case in which the is_latest injection led to a missed query
             if "is_latest" in expressions and is_latest_was_not_in_expressions:
                 expressions.pop("is_latest")
-                return (
+                result = (
                     registry.objects.using(qs.db)
                     .filter(**expressions)
                     .order_by("-created_at")
                     .first()
                 )
-            else:
-                raise registry.DoesNotExist from registry.DoesNotExist
+                if result is not None:
+                    return result
+            raise registry.DoesNotExist from registry.DoesNotExist
 
 
 class RecordList(UserList, Generic[T]):

--- a/lamindb/_query_set.py
+++ b/lamindb/_query_set.py
@@ -214,10 +214,26 @@ def get(
     else:
         assert idlike is None  # noqa: S101
         expressions = process_expressions(qs, expressions)
+        # don't want _branch_code here in .get(), only in .filter()
+        expressions.pop("_branch_code", None)
         # inject is_latest for consistency with idlike
-        if issubclass(registry, IsVersioned) and "is_latest" not in expressions:
+        is_latest_was_not_in_expressions = "is_latest" not in expressions
+        if issubclass(registry, IsVersioned) and is_latest_was_not_in_expressions:
             expressions["is_latest"] = True
-        return registry.objects.using(qs.db).get(**expressions)
+        try:
+            return registry.objects.using(qs.db).get(**expressions)
+        except registry.DoesNotExist:
+            # handle the case in which the is_latest injection led to a missed query
+            if "is_latest" in expressions and is_latest_was_not_in_expressions:
+                expressions.pop("is_latest")
+                return (
+                    registry.objects.using(qs.db)
+                    .filter(**expressions)
+                    .order_by("-created_at")
+                    .first()
+                )
+            else:
+                raise registry.DoesNotExist from registry.DoesNotExist
 
 
 class RecordList(UserList, Generic[T]):

--- a/lamindb/base/users.py
+++ b/lamindb/base/users.py
@@ -12,12 +12,9 @@ def current_user_id() -> int:
         if ln_setup.core.django.IS_MIGRATING:
             return 1
         else:
-            exc_attr = (
-                "DoesNotExist" if hasattr(User, "DoesNotExist") else "_DoesNotExist"
-            )
             try:
                 user_id = User.objects.get(uid=settings.user.uid).id
-            except getattr(User, exc_attr):
+            except User.DoesNotExist:
                 register_user(settings.user)
                 user_id = User.objects.get(uid=settings.user.uid).id
             return user_id

--- a/tests/core/test_notebooks.py
+++ b/tests/core/test_notebooks.py
@@ -11,5 +11,9 @@ def test_all_notebooks():
     env = os.environ
     env["LAMIN_TESTING"] = "true"
     nbproject_test.execute_notebooks(notebook_dir)
+    # re-run one of the notebooks to trigger hash lookup
+    nbproject_test.execute_notebooks(
+        notebook_dir / "with-title-initialized-consecutive-finish-not-last-cell.ipynb"
+    )
     nbproject_test.execute_notebooks(notebook_dir_duplicate)
     del env["LAMIN_TESTING"]

--- a/tests/core/test_record.py
+++ b/tests/core/test_record.py
@@ -126,7 +126,7 @@ def test_search_and_get(get_search_test_filepaths):
 
     # because we're rendering Artifact.DoesNotExist private
     # in some use cases, we're not testing for it
-    with pytest.raises(ln.Artifact._DoesNotExist):
+    with pytest.raises(ln.Artifact.DoesNotExist):
         ln.Artifact.get(description="test-search1000000")
 
     #

--- a/tests/core/test_record.py
+++ b/tests/core/test_record.py
@@ -124,12 +124,9 @@ def test_search_and_get(get_search_test_filepaths):
     artifact = ln.Artifact.get(description="test-search4")
     assert artifact == artifact4
 
-    # because we're rendering Artifact.DoesNotExist private
-    # in some use cases, we're not testing for it
     with pytest.raises(ln.Artifact.DoesNotExist):
-        ln.Artifact.get(description="test-search1000000")
+        ln.Artifact.get(description="test-does-not-exist")
 
-    #
     artifact0.delete(permanent=True, storage=True)
     artifact1.delete(permanent=True, storage=True)
     artifact2.delete(permanent=True, storage=True)


### PR DESCRIPTION
Since the below PR, we disallow hash duplications in `Transform`, `Artifact` & `Collection`:

- https://github.com/laminlabs/lamindb/pull/2432

While the clashing of hashes was resolved, for versioned entities like `Transform`, it was possible that the hash look up would fail because a record with the same hash might not have been marked as the latest version.

This opens the question whether a transform without `source_code` yet attached should act as `is_latest`, but we'll not resolve it in this PR.