### PR TITLE
🚸 Raise consistency error if a source path suffix doesn't match the artifact `key` suffix

### DIFF
--- a/docs/registries.ipynb
+++ b/docs/registries.ipynb
@@ -56,7 +56,7 @@
     "\n",
     "# Create non-curated datasets\n",
     "ln.Artifact(datasets.file_jpg_paradisi05(), key=\"images/my_image.jpg\").save()\n",
-    "ln.Artifact(datasets.file_fastq(), key=\"raw/my_fastq.fastq\").save()\n",
+    "ln.Artifact(datasets.file_fastq(), key=\"raw/my_fastq.fastq.gz\").save()\n",
     "ln.Artifact.from_df(datasets.df_iris(), key=\"iris/iris_collection.parquet\").save()\n",
     "\n",
     "# Create a more complex case\n",

--- a/docs/storage/add-replace-cache.ipynb
+++ b/docs/storage/add-replace-cache.ipynb
@@ -89,23 +89,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact = ln.Artifact(\"./test-files/iris.csv\", description=\"iris.csv\")"
+    "artifact = ln.Artifact(\"./test-files/iris.csv\", description=\"iris.csv\").save()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "artifact.save()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,7 +106,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,7 +118,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +139,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "12",
    "metadata": {},
    "source": [
     "The suffix changed:"
@@ -158,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,7 +161,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,7 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +183,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "16",
    "metadata": {},
    "source": [
     "## Save with manually passed real `key`"
@@ -202,7 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,27 +202,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact = ln.Artifact(\"./test-files/iris.csv\", key=\"iris.csv\").save()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "19",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "artifact = ln.Artifact(\"./test-files/iris.csv\", key=\"iris.csv\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "20",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "artifact.save()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,7 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -252,7 +232,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,7 +242,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -271,7 +251,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "23",
    "metadata": {},
    "source": [
     "Check paths: no changes here, as the suffix didn't change."
@@ -280,7 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,7 +271,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -301,11 +281,38 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
     "new_key_path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert old_key_path.exists()\n",
+    "assert not new_key_path.exists()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    artifact.replace(\"./test-files/iris.data\")\n",
+    "except ln.errors.InvalidArgument as error:\n",
+    "    assert (\n",
+    "        str(error)\n",
+    "        == \"The suffix '.data' of the provided path is inconsistent, it should be '.csv'\"\n",
+    "    )"
    ]
   },
   {
@@ -326,24 +333,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "try:\n",
-    "    artifact.replace(\"./test-files/iris.data\")\n",
-    "except ln.errors.InvalidArgument as error:\n",
-    "    assert (\n",
-    "        str(error)\n",
-    "        == \"The suffix '.data' of the provided path is inconsistent, it should be '.csv'\"\n",
-    "    )"
+    "artifact.delete(permanent=True, storage=True)"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "31",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "assert old_key_path.exists()\n",
-    "assert not new_key_path.exists()"
+    "## Save from memory"
    ]
   },
   {
@@ -353,31 +351,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact.delete(permanent=True, storage=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "33",
-   "metadata": {},
-   "source": [
-    "## Save from memory"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "34",
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import pandas as pd"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -387,7 +367,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -397,7 +377,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -407,7 +387,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -417,7 +397,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -427,7 +407,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -437,7 +417,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -447,7 +427,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -457,7 +437,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -467,7 +447,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -483,7 +463,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -497,21 +477,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
+    "# raises this error because the (vitual) key in artifact is not the same as the (inferred) key of path_in_storage\n",
     "with pytest.raises(ln.errors.InvalidArgument) as err:\n",
     "    artifact.replace(path_in_storage)\n",
     "assert err.exconly().startswith(\n",
     "    \"lamindb.errors.InvalidArgument: The path 's3://lamindb-ci/test-add-replace-cache/iris2.parquet' is already in registered storage\"\n",
-    ")\n",
-    "path_in_storage.unlink()"
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "45",
    "metadata": {},
    "source": [
     "## Save with manually passed virtual `key`"
@@ -520,7 +500,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -530,27 +510,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact = ln.Artifact(\"./test-files/iris.csv\", key=\"iris.csv\")"
+    "artifact = ln.Artifact(\"./test-files/iris.csv\", key=\"iris.csv\").save()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "artifact.save()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "51",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -561,7 +531,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -572,7 +542,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -588,7 +558,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -599,11 +569,50 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
     "artifact.delete(permanent=True, storage=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# use the same key as the inferred key of path_in_storage\n",
+    "artifact = ln.Artifact.from_df(\n",
+    "    iris, description=\"iris_store\", key=\"iris2.parquet\"\n",
+    ").save()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# raises this error because the (vitual) key in artifact is the same as the (inferred) key of path_in_storage\n",
+    "with pytest.raises(ValueError) as err:\n",
+    "    artifact.replace(path_in_storage)\n",
+    "assert err.exconly().startswith(\n",
+    "    \"ValueError: Can only replace with a local path not in any Storage.\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact.delete(permanent=True, storage=True)\n",
+    "path_in_storage.unlink()"
    ]
   },
   {
@@ -766,7 +775,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py312",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -780,7 +789,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.10.16"
   },
   "nbproject": {
    "id": "uBQMCcdYwEjA",

--- a/docs/storage/add-replace-cache.ipynb
+++ b/docs/storage/add-replace-cache.ipynb
@@ -329,7 +329,7 @@
     "except ln.errors.InvalidArgument as error:\n",
     "    assert (\n",
     "        str(error)\n",
-    "        == \"The suffix '.data' of the provided path is inconsistent, it should be '.csv'\"\n",
+    "        == \"The suffix '.data' of the path is inconsistent, it should be '.csv'\"\n",
     "    )"
    ]
   },
@@ -622,7 +622,7 @@
     "except ln.errors.InvalidArgument as error:\n",
     "    assert (\n",
     "        str(error)\n",
-    "        == \"The suffix '.data' of the provided path is inconsistent, it should be '.csv'\"\n",
+    "        == \"The suffix '.data' of the path is inconsistent, it should be '.csv'\"\n",
     "    )"
    ]
   },

--- a/docs/storage/add-replace-cache.ipynb
+++ b/docs/storage/add-replace-cache.ipynb
@@ -329,7 +329,7 @@
     "except ln.errors.InvalidArgument as error:\n",
     "    assert (\n",
     "        str(error)\n",
-    "        == \"The suffix '.data' of the path is inconsistent, it should be '.csv'\"\n",
+    "        == \"The suffix '.data' of the provided path is inconsistent, it should be '.csv'\"\n",
     "    )"
    ]
   },
@@ -622,7 +622,7 @@
     "except ln.errors.InvalidArgument as error:\n",
     "    assert (\n",
     "        str(error)\n",
-    "        == \"The suffix '.data' of the path is inconsistent, it should be '.csv'\"\n",
+    "        == \"The suffix '.data' of the provided path is inconsistent, it should be '.csv'\"\n",
     "    )"
    ]
   },

--- a/docs/storage/add-replace-cache.ipynb
+++ b/docs/storage/add-replace-cache.ipynb
@@ -469,65 +469,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact.replace(\"./test-files/new_iris.csv\")"
+    "try:\n",
+    "    artifact.replace(\"./test-files/iris.csv\")\n",
+    "except ln.errors.InvalidArgument as error:\n",
+    "    assert (\n",
+    "        str(error)\n",
+    "        == \"The suffix '.csv' of the provided path is inconsistent, it should be '.parquet'\"\n",
+    "    )"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "45",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "artifact.save()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "46",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "old_key_path = key_path\n",
-    "new_key_path = root / \"iris.csv\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "47",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "old_key_path"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "48",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "new_key_path"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "49",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "assert not old_key_path.exists()\n",
-    "assert new_key_path.exists()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,7 +492,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "46",
    "metadata": {},
    "source": [
     "## Save with manually passed virtual `key`"
@@ -547,7 +501,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -557,7 +511,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -567,7 +521,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -577,7 +531,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -591,7 +545,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -602,7 +556,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -613,7 +567,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -629,7 +583,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -640,7 +594,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -650,7 +604,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -659,7 +613,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62",
+   "id": "57",
    "metadata": {},
    "source": [
     "## Replace with folder artifacts"
@@ -668,7 +622,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -680,7 +634,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -692,7 +646,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -704,7 +658,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -715,7 +669,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -727,7 +681,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -738,7 +692,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -751,7 +705,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -761,7 +715,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -772,7 +726,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -783,7 +737,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -794,7 +748,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -804,7 +758,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "70",
    "metadata": {
     "tags": []
    },

--- a/docs/storage/add-replace-cache.ipynb
+++ b/docs/storage/add-replace-cache.ipynb
@@ -58,7 +58,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.setup.init(storage=\"s3://lamindb-ci/test-add-replace-cache\")"
+    "ln.setup.init(storage=\"s3://lamindb-ci/test-add-replace-cache\")\n",
+    "ln.settings.track_run_inputs = False\n",
+    "ln.settings.creation.artifact_silence_missing_run_warning = False"
    ]
   },
   {
@@ -485,27 +487,34 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# we use the path in the next section\n",
-    "path_in_storage = artifact.path\n",
-    "artifact.delete(permanent=True, storage=False)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "46",
-   "metadata": {},
-   "source": [
-    "## Save with manually passed virtual `key`"
+    "artifact2 = ln.Artifact.from_df(\n",
+    "    iris[:-2], description=\"iris_store2\", key=\"iris2.parquet\"\n",
+    ").save()\n",
+    "path_in_storage = artifact2.path\n",
+    "artifact2.delete(permanent=True, storage=False)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.settings.creation._artifact_use_virtual_keys = True"
+    "with pytest.raises(ln.errors.InvalidArgument) as err:\n",
+    "    artifact.replace(path_in_storage)\n",
+    "assert err.exconly().startswith(\n",
+    "    \"lamindb.errors.InvalidArgument: The path 's3://lamindb-ci/test-add-replace-cache/iris2.parquet' is already in registered storage\"\n",
+    ")\n",
+    "path_in_storage.unlink()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47",
+   "metadata": {},
+   "source": [
+    "## Save with manually passed virtual `key`"
    ]
   },
   {
@@ -515,7 +524,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact = ln.Artifact(\"./test-files/iris.csv\", key=\"iris.csv\")"
+    "ln.settings.creation._artifact_use_virtual_keys = True"
    ]
   },
   {
@@ -525,7 +534,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact.save()"
+    "artifact = ln.Artifact(\"./test-files/iris.csv\", key=\"iris.csv\")"
    ]
   },
   {
@@ -535,11 +544,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with pytest.raises(ValueError) as err:\n",
-    "    artifact.replace(path_in_storage)\n",
-    "assert err.exconly().startswith(\n",
-    "    \"ValueError: Can only replace with a local path not in any Storage.\"\n",
-    ")"
+    "artifact.save()"
    ]
   },
   {
@@ -602,18 +607,8 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "56",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "path_in_storage.unlink()"
-   ]
-  },
-  {
    "cell_type": "markdown",
-   "id": "57",
+   "id": "56",
    "metadata": {},
    "source": [
     "## Replace with folder artifacts"
@@ -622,7 +617,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -634,7 +629,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -646,19 +641,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
+    "!cp ./test-files/iris.csv ./test-files/iris.zarr\n",
     "with pytest.raises(ValueError) as err:\n",
-    "    artifact.replace(\"./test-files/iris.csv\")\n",
+    "    artifact.replace(\"./test-files/iris.zarr\")\n",
     "assert err.exconly().endswith(\"It is not allowed to replace a folder with a file.\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -669,7 +665,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -681,7 +677,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -692,7 +688,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -705,7 +701,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -715,7 +711,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -726,7 +722,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -737,7 +733,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -748,7 +744,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -758,7 +754,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "69",
    "metadata": {
     "tags": []
    },
@@ -770,7 +766,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "py312",
    "language": "python",
    "name": "python3"
   },
@@ -784,7 +780,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.12.8"
   },
   "nbproject": {
    "id": "uBQMCcdYwEjA",

--- a/docs/storage/add-replace-cache.ipynb
+++ b/docs/storage/add-replace-cache.ipynb
@@ -324,7 +324,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact.replace(\"./test-files/iris.data\")"
+    "try:\n",
+    "    artifact.replace(\"./test-files/iris.data\")\n",
+    "except ln.errors.InvalidArgument as error:\n",
+    "    assert (\n",
+    "        str(error)\n",
+    "        == \"The suffix '.data' of the provided path is inconsistent, it should be '.csv'\"\n",
+    "    )"
    ]
   },
   {
@@ -334,7 +340,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact.save()"
+    "assert old_key_path.exists()\n",
+    "assert not new_key_path.exists()"
    ]
   },
   {
@@ -344,17 +351,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "new_key_path = root / \"iris.data\""
+    "artifact.delete(permanent=True, storage=True)"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "33",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "old_key_path"
+    "## Save from memory"
    ]
   },
   {
@@ -364,7 +369,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "new_key_path"
+    "import pandas as pd"
    ]
   },
   {
@@ -374,8 +379,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert not old_key_path.exists()\n",
-    "assert new_key_path.exists()"
+    "iris = pd.read_csv(\"./test-files/iris.csv\")"
    ]
   },
   {
@@ -385,51 +389,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact.delete(permanent=True, storage=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "37",
-   "metadata": {},
-   "source": [
-    "## Save from memory"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "38",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pandas as pd"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "39",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "iris = pd.read_csv(\"./test-files/iris.csv\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "40",
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "artifact = ln.Artifact.from_df(iris, description=\"iris_store\", key=\"iris.parquet\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -439,11 +405,51 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
     "key_path = root / \"iris.parquet\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "39",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert key_path.exists()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact.replace(data=iris[:-1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert artifact.key == \"iris.parquet\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact.save()"
    ]
   },
   {
@@ -463,7 +469,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact.replace(data=iris[:-1])"
+    "artifact.replace(\"./test-files/new_iris.csv\")"
    ]
   },
   {
@@ -473,53 +479,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert artifact.key == \"iris.parquet\""
+    "artifact.save()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "46",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "artifact.save()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "47",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "assert key_path.exists()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "48",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "artifact.replace(\"./test-files/new_iris.csv\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "49",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "artifact.save()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -530,7 +496,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -540,7 +506,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -550,7 +516,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -561,7 +527,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -572,7 +538,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55",
+   "id": "51",
    "metadata": {},
    "source": [
     "## Save with manually passed virtual `key`"
@@ -581,7 +547,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -591,7 +557,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -601,7 +567,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -611,7 +577,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -625,7 +591,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -636,7 +602,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -647,58 +613,34 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact.replace(\"./test-files/iris.data\")"
+    "try:\n",
+    "    artifact.replace(\"./test-files/iris.data\")\n",
+    "except ln.errors.InvalidArgument as error:\n",
+    "    assert (\n",
+    "        str(error)\n",
+    "        == \"The suffix '.data' of the provided path is inconsistent, it should be '.csv'\"\n",
+    "    )"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "artifact.save()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "64",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "assert artifact.key == \"iris.data\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "65",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "assert not fpath.exists()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "66",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
     "fpath = artifact.path\n",
-    "assert fpath.suffix == \".data\" and fpath.stem == artifact.uid"
+    "assert fpath.suffix == \".csv\" and fpath.stem == artifact.uid"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -708,7 +650,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -717,7 +659,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69",
+   "id": "62",
    "metadata": {},
    "source": [
     "## Replace with folder artifacts"
@@ -726,7 +668,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -738,7 +680,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -750,7 +692,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -762,7 +704,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -773,7 +715,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -785,7 +727,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -796,7 +738,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -809,7 +751,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -819,7 +761,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -830,7 +772,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -841,7 +783,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -852,7 +794,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -862,7 +804,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82",
+   "id": "75",
    "metadata": {
     "tags": []
    },

--- a/docs/storage/add-replace-cache.ipynb
+++ b/docs/storage/add-replace-cache.ipynb
@@ -58,9 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.setup.init(storage=\"s3://lamindb-ci/test-add-replace-cache\")\n",
-    "ln.settings.track_run_inputs = False\n",
-    "ln.settings.creation.artifact_silence_missing_run_warning = False"
+    "ln.setup.init(storage=\"s3://lamindb-ci/test-add-replace-cache\")"
    ]
   },
   {
@@ -89,13 +87,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact = ln.Artifact(\"./test-files/iris.csv\", description=\"iris.csv\").save()"
+    "artifact = ln.Artifact(\"./test-files/iris.csv\", description=\"iris.csv\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact.save()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,7 +114,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,7 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +147,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "source": [
     "The suffix changed:"
@@ -148,7 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -161,7 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,20 +191,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "## Save with manually passed real `key`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "17",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ln.settings.creation._artifact_use_virtual_keys = False"
    ]
   },
   {
@@ -206,7 +204,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact = ln.Artifact(\"./test-files/iris.csv\", key=\"iris.csv\").save()"
+    "ln.settings.creation._artifact_use_virtual_keys = False"
    ]
   },
   {
@@ -216,7 +214,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key_path = root / \"iris.csv\""
+    "artifact = ln.Artifact(\"./test-files/iris.csv\", key=\"iris.csv\")"
    ]
   },
   {
@@ -226,7 +224,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert key_path.exists()"
+    "artifact.save()"
    ]
   },
   {
@@ -236,7 +234,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact.replace(\"./test-files/new_iris.csv\")"
+    "key_path = root / \"iris.csv\""
    ]
   },
   {
@@ -246,12 +244,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "assert key_path.exists()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact.replace(\"./test-files/new_iris.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "artifact.save()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "25",
    "metadata": {},
    "source": [
     "Check paths: no changes here, as the suffix didn't change."
@@ -260,7 +278,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -271,7 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -281,38 +299,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "new_key_path"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "27",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "assert old_key_path.exists()\n",
-    "assert not new_key_path.exists()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
-    "try:\n",
-    "    artifact.replace(\"./test-files/iris.data\")\n",
-    "except ln.errors.InvalidArgument as error:\n",
-    "    assert (\n",
-    "        str(error)\n",
-    "        == \"The suffix '.data' of the provided path is inconsistent, it should be '.csv'\"\n",
-    "    )"
+    "new_key_path"
    ]
   },
   {
@@ -333,15 +324,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact.delete(permanent=True, storage=True)"
+    "artifact.replace(\"./test-files/iris.data\")"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "31",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "## Save from memory"
+    "artifact.save()"
    ]
   },
   {
@@ -351,7 +344,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pandas as pd"
+    "new_key_path = root / \"iris.data\""
    ]
   },
   {
@@ -361,7 +354,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "iris = pd.read_csv(\"./test-files/iris.csv\")"
+    "old_key_path"
    ]
   },
   {
@@ -371,7 +364,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact = ln.Artifact.from_df(iris, description=\"iris_store\", key=\"iris.parquet\")"
+    "new_key_path"
    ]
   },
   {
@@ -381,7 +374,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact.save()"
+    "assert not old_key_path.exists()\n",
+    "assert new_key_path.exists()"
    ]
   },
   {
@@ -391,17 +385,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "key_path = root / \"iris.parquet\""
+    "artifact.delete(permanent=True, storage=True)"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "37",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "assert key_path.exists()"
+    "## Save from memory"
    ]
   },
   {
@@ -411,7 +403,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact.replace(data=iris[:-1])"
+    "import pandas as pd"
    ]
   },
   {
@@ -421,7 +413,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert artifact.key == \"iris.parquet\""
+    "iris = pd.read_csv(\"./test-files/iris.csv\")"
    ]
   },
   {
@@ -431,7 +423,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact.save()"
+    "artifact = ln.Artifact.from_df(iris, description=\"iris_store\", key=\"iris.parquet\")"
    ]
   },
   {
@@ -441,7 +433,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert key_path.exists()"
+    "artifact.save()"
    ]
   },
   {
@@ -451,13 +443,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "try:\n",
-    "    artifact.replace(\"./test-files/iris.csv\")\n",
-    "except ln.errors.InvalidArgument as error:\n",
-    "    assert (\n",
-    "        str(error)\n",
-    "        == \"The suffix '.csv' of the provided path is inconsistent, it should be '.parquet'\"\n",
-    "    )"
+    "key_path = root / \"iris.parquet\""
    ]
   },
   {
@@ -467,11 +453,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact2 = ln.Artifact.from_df(\n",
-    "    iris[:-2], description=\"iris_store2\", key=\"iris2.parquet\"\n",
-    ").save()\n",
-    "path_in_storage = artifact2.path\n",
-    "artifact2.delete(permanent=True, storage=False)"
+    "assert key_path.exists()"
    ]
   },
   {
@@ -481,20 +463,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# raises this error because the (vitual) key in artifact is not the same as the (inferred) key of path_in_storage\n",
-    "with pytest.raises(ln.errors.InvalidArgument) as err:\n",
-    "    artifact.replace(path_in_storage)\n",
-    "assert err.exconly().startswith(\n",
-    "    \"lamindb.errors.InvalidArgument: The path 's3://lamindb-ci/test-add-replace-cache/iris2.parquet' is already in registered storage\"\n",
-    ")"
+    "artifact.replace(data=iris[:-1])"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "45",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "## Save with manually passed virtual `key`"
+    "assert artifact.key == \"iris.parquet\""
    ]
   },
   {
@@ -504,7 +483,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ln.settings.creation._artifact_use_virtual_keys = True"
+    "artifact.save()"
    ]
   },
   {
@@ -514,7 +493,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact = ln.Artifact(\"./test-files/iris.csv\", key=\"iris.csv\").save()"
+    "assert key_path.exists()"
    ]
   },
   {
@@ -524,8 +503,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# return an existing artifact if the hash is the same\n",
-    "assert artifact == artifact.replace(\"./test-files/iris.csv\")"
+    "artifact.replace(\"./test-files/new_iris.csv\")"
    ]
   },
   {
@@ -535,8 +513,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fpath = artifact.path\n",
-    "assert fpath.suffix == \".csv\" and fpath.stem == artifact.uid"
+    "artifact.save()"
    ]
   },
   {
@@ -546,13 +523,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "try:\n",
-    "    artifact.replace(\"./test-files/iris.data\")\n",
-    "except ln.errors.InvalidArgument as error:\n",
-    "    assert (\n",
-    "        str(error)\n",
-    "        == \"The suffix '.data' of the provided path is inconsistent, it should be '.csv'\"\n",
-    "    )"
+    "old_key_path = key_path\n",
+    "new_key_path = root / \"iris.csv\""
    ]
   },
   {
@@ -562,8 +534,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fpath = artifact.path\n",
-    "assert fpath.suffix == \".csv\" and fpath.stem == artifact.uid"
+    "old_key_path"
    ]
   },
   {
@@ -573,7 +544,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact.delete(permanent=True, storage=True)"
+    "new_key_path"
    ]
   },
   {
@@ -583,10 +554,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# use the same key as the inferred key of path_in_storage\n",
-    "artifact = ln.Artifact.from_df(\n",
-    "    iris, description=\"iris_store\", key=\"iris2.parquet\"\n",
-    ").save()"
+    "assert not old_key_path.exists()\n",
+    "assert new_key_path.exists()"
    ]
   },
   {
@@ -596,7 +565,56 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# raises this error because the (vitual) key in artifact is the same as the (inferred) key of path_in_storage\n",
+    "# we use the path in the next section\n",
+    "path_in_storage = artifact.path\n",
+    "artifact.delete(permanent=True, storage=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55",
+   "metadata": {},
+   "source": [
+    "## Save with manually passed virtual `key`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln.settings.creation._artifact_use_virtual_keys = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact = ln.Artifact(\"./test-files/iris.csv\", key=\"iris.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact.save()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "with pytest.raises(ValueError) as err:\n",
     "    artifact.replace(path_in_storage)\n",
     "assert err.exconly().startswith(\n",
@@ -607,17 +625,99 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact.delete(permanent=True, storage=True)\n",
+    "# return an existing artifact if the hash is the same\n",
+    "assert artifact == artifact.replace(\"./test-files/iris.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "61",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fpath = artifact.path\n",
+    "assert fpath.suffix == \".csv\" and fpath.stem == artifact.uid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact.replace(\"./test-files/iris.data\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact.save()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert artifact.key == \"iris.data\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert not fpath.exists()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fpath = artifact.path\n",
+    "assert fpath.suffix == \".data\" and fpath.stem == artifact.uid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "67",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact.delete(permanent=True, storage=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "path_in_storage.unlink()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "56",
+   "id": "69",
    "metadata": {},
    "source": [
     "## Replace with folder artifacts"
@@ -626,7 +726,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -638,7 +738,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -650,20 +750,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
-    "!cp ./test-files/iris.csv ./test-files/iris.zarr\n",
     "with pytest.raises(ValueError) as err:\n",
-    "    artifact.replace(\"./test-files/iris.zarr\")\n",
+    "    artifact.replace(\"./test-files/iris.csv\")\n",
     "assert err.exconly().endswith(\"It is not allowed to replace a folder with a file.\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -674,7 +773,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -686,7 +785,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -697,7 +796,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -710,7 +809,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -720,7 +819,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -731,7 +830,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -742,7 +841,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -753,7 +852,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -763,7 +862,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69",
+   "id": "82",
    "metadata": {
     "tags": []
    },

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -152,6 +152,7 @@ def process_data(
     default_storage: Storage,
     using_key: str | None,
     skip_existence_check: bool = False,
+    is_replace: bool = False,
 ) -> tuple[Any, Path | UPath, str, Storage, bool]:
     """Serialize a data object that's provided as file or in memory."""
     # if not overwritten, data gets stored in default storage
@@ -191,7 +192,7 @@ def process_data(
         raise NotImplementedError(
             f"Do not know how to create a artifact object from {data}, pass a path instead!"
         )
-    if key_suffix is not None and key_suffix != suffix:
+    if key_suffix is not None and key_suffix != suffix and not is_replace:
         # consciously omitting a trailing period
         if isinstance(data, (str, Path, UPath)):
             message = f"The suffix '{suffix}' of the provided path is inconsistent, it should be '{key_suffix}'"
@@ -320,6 +321,7 @@ def get_artifact_kwargs_from_data(
         default_storage,
         using_key,
         skip_check_exists,
+        is_replace=is_replace,
     )
     stat_or_artifact = get_stat_or_artifact(
         path=path,

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -193,7 +193,7 @@ def process_data(
         )
     if key_suffix is not None and key_suffix != suffix:
         raise InvalidArgument(
-            f"The suffix '{key_suffix}' of the provided key is incorrect, it should"
+            f"The suffix '{key_suffix}' of the provided key is inconsistent, it should"
             f" be '{suffix}'"  # consciously omitting a trailing period
         )
     # in case we have an in-memory representation, we need to write it to disk

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -192,10 +192,12 @@ def process_data(
             f"Do not know how to create a artifact object from {data}, pass a path instead!"
         )
     if key_suffix is not None and key_suffix != suffix:
-        raise InvalidArgument(
-            f"The suffix '{key_suffix}' of the provided key is inconsistent, it should"
-            f" be '{suffix}'"  # consciously omitting a trailing period
-        )
+        # consciously omitting a trailing period
+        if isinstance(data, (str, Path, UPath)):
+            message = f"The suffix '{suffix}' of the provided path is inconsistent, it should be '{key_suffix}'"
+        else:
+            message = f"The suffix '{key_suffix}' of the provided key is inconsistent, it should be '{suffix}'"
+        raise InvalidArgument(message)
     # in case we have an in-memory representation, we need to write it to disk
     if isinstance(data, data_types):
         path = settings.cache_dir / f"{provisional_uid}{suffix}"

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -194,7 +194,7 @@ def process_data(
     if key_suffix is not None and key_suffix != suffix:
         raise InvalidArgument(
             f"The suffix '{key_suffix}' of the provided key is incorrect, it should"
-            f" be '{suffix}'."
+            f" be '{suffix}'"  # consciously omitting a trailing period
         )
     # in case we have an in-memory representation, we need to write it to disk
     if isinstance(data, data_types):

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -92,7 +92,7 @@ def get_test_filepaths(request):  # -> Tuple[bool, Path, Path, Path, str]
             ln.Storage.filter(root=root_dir.resolve().as_posix()).one_or_none() is None
         )
     test_dirpath = root_dir / "my_dir/"
-    test_dirpath.mkdir(parents=True)
+    test_dirpath.mkdir(parents=True, exist_ok=True)
     # create a first file
     test_filepath0 = test_dirpath / f"my_file{suffix}"
     test_filepath0.write_text("0")

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -867,6 +867,27 @@ def test_zarr_upload_cache(adata):
     ln.settings.storage = previous_storage
 
 
+def test_path_suffix(df):
+    artifact = ln.Artifact("README.md", key="README.md")
+    assert artifact.suffix == ".md"
+    assert artifact.key == "README.md"
+    artifact = ln.Artifact("LICENSE", key="LICENSE")
+    assert artifact.suffix == ""
+    assert artifact.key == "LICENSE"
+    try:
+        artifact = ln.Artifact("README.md", key="README.inconsistent")
+    except InvalidArgument as error:
+        assert str(error).startswith(
+            "The suffix '.inconsistent' of the provided key is incorrect, it should be '.md'."
+        )
+    try:
+        artifact = ln.Artifact("LICENSE", key="LICENSE.txt")
+    except InvalidArgument as error:
+        assert str(error).startswith(
+            "The suffix '.txt' of the provided key is incorrect, it should be ''."
+        )
+
+
 def test_df_suffix(df):
     artifact = ln.Artifact.from_df(df, key="test_.parquet")
     assert artifact.suffix == ".parquet"

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -430,7 +430,7 @@ def test_create_from_local_filepath(
             artifact = ln.Artifact(test_filepath, key=key, description=description)
         except InvalidArgument as error:
             assert str(error) == (
-                f"The suffix '{key_suffix}' of the provided key is incorrect, it should be '{suffix}'"
+                f"The suffix '{key_suffix}' of the provided key is inconsistent, it should be '{suffix}'"
             )
         return None
     elif key is not None and is_in_registered_storage:
@@ -892,13 +892,13 @@ def test_path_suffix(df):
         artifact = ln.Artifact("README.md", key="README.inconsistent")
     except InvalidArgument as error:
         assert str(error) == (
-            "The suffix '.inconsistent' of the provided key is incorrect, it should be '.md'"
+            "The suffix '.inconsistent' of the provided key is inconsistent, it should be '.md'"
         )
     try:
         artifact = ln.Artifact("LICENSE", key="LICENSE.txt")
     except InvalidArgument as error:
         assert str(error) == (
-            "The suffix '.txt' of the provided key is incorrect, it should be ''"
+            "The suffix '.txt' of the provided key is inconsistent, it should be ''"
         )
 
 
@@ -910,7 +910,7 @@ def test_df_suffix(df):
         artifact = ln.Artifact.from_df(df, key="test_.def")
     assert (
         error.exconly().partition(",")[0]
-        == "lamindb.errors.InvalidArgument: The suffix '.def' of the provided key is incorrect"
+        == "lamindb.errors.InvalidArgument: The suffix '.def' of the provided key is inconsistent"
     )
 
 
@@ -933,7 +933,7 @@ def test_adata_suffix(adata):
         artifact = ln.Artifact.from_anndata(adata, key="test_")
     assert (
         error.exconly().partition(",")[0]
-        == "lamindb.errors.InvalidArgument: The suffix '' of the provided key is incorrect"
+        == "lamindb.errors.InvalidArgument: The suffix '' of the provided key is inconsistent"
     )
 
 

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -430,7 +430,7 @@ def test_create_from_local_filepath(
             artifact = ln.Artifact(test_filepath, key=key, description=description)
         except InvalidArgument as error:
             assert str(error) == (
-                f"The suffix '{key_suffix}' of the provided key is inconsistent, it should be '{suffix}'"
+                f"The suffix '{suffix}' of the provided path is inconsistent, it should be '{key_suffix}'"
             )
         return None
     elif key is not None and is_in_registered_storage:

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -881,27 +881,6 @@ def test_zarr_upload_cache(adata):
     ln.settings.storage = previous_storage
 
 
-def test_path_suffix(df):
-    artifact = ln.Artifact("README.md", key="README.md")
-    assert artifact.suffix == ".md"
-    assert artifact.key == "README.md"
-    artifact = ln.Artifact("LICENSE", key="LICENSE")
-    assert artifact.suffix == ""
-    assert artifact.key == "LICENSE"
-    try:
-        artifact = ln.Artifact("README.md", key="README.inconsistent")
-    except InvalidArgument as error:
-        assert str(error) == (
-            "The suffix '.inconsistent' of the provided key is inconsistent, it should be '.md'"
-        )
-    try:
-        artifact = ln.Artifact("LICENSE", key="LICENSE.txt")
-    except InvalidArgument as error:
-        assert str(error) == (
-            "The suffix '.txt' of the provided key is inconsistent, it should be ''"
-        )
-
-
 def test_df_suffix(df):
     artifact = ln.Artifact.from_df(df, key="test_.parquet")
     assert artifact.suffix == ".parquet"

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -6,7 +6,7 @@ Also see `test_artifact_folders.py` for tests of folder-like artifacts.
 
 import shutil
 from inspect import signature
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import anndata as ad
 import bionty as bt
@@ -40,6 +40,7 @@ from lamindb_setup.core.upath import (
     CloudPath,
     LocalPathClasses,
     UPath,
+    extract_suffix_from_path,
 )
 
 # how do we properly abstract out the default storage variable?
@@ -405,7 +406,13 @@ def test_create_from_local_filepath(
     is_in_registered_storage = get_test_filepaths[0]
     root_dir = get_test_filepaths[1]
     test_filepath = get_test_filepaths[3]
-    suffix = get_test_filepaths[4]
+    suffix = get_test_filepaths[4]  # path suffix
+    if key is not None:
+        key_suffix = extract_suffix_from_path(
+            PurePosixPath(key), arg_name="key"
+        )  # key suffix
+    else:
+        key_suffix = None
     # this tests if insufficient information is being provided
     if key is None and not is_in_registered_storage and description is None:
         # this can fail because ln.track() might set a global run context
@@ -418,20 +425,27 @@ def test_create_from_local_filepath(
             == "ValueError: Pass one of key, run or description as a parameter"
         )
         return None
+    elif key is not None and suffix != key_suffix:
+        try:
+            artifact = ln.Artifact(test_filepath, key=key, description=description)
+        except InvalidArgument as error:
+            assert str(error) == (
+                f"The suffix '{key_suffix}' of the provided key is incorrect, it should be '{suffix}'"
+            )
+        return None
     elif key is not None and is_in_registered_storage:
         inferred_key = get_relative_path_to_directory(
             path=test_filepath, directory=root_dir
         ).as_posix()
-        with pytest.raises(InvalidArgument) as error:
+        try:
             artifact = ln.Artifact(test_filepath, key=key, description=description)
-        assert (
-            error.exconly()
-            == f"lamindb.errors.InvalidArgument: The path '{test_filepath}' is already in registered"
-            " storage"
-            f" '{root_dir.resolve().as_posix()}' with key '{inferred_key}'\nYou"
-            f" passed conflicting key '{key}': please move the file before"
-            " registering it."
-        )
+        except InvalidArgument as error:
+            assert str(error) == (
+                f"The path '{test_filepath}' is already in registered storage"
+                f" '{root_dir.resolve().as_posix()}' with key '{inferred_key}'\nYou"
+                f" passed conflicting key '{key}': please move the file before"
+                " registering it."
+            )
         return None
     else:
         artifact = ln.Artifact(test_filepath, key=key, description=description)
@@ -467,7 +481,7 @@ def test_create_from_local_filepath(
         assert artifact._key_is_virtual == key_is_virtual
         # changing non-virtual key is not allowed
         if not key_is_virtual:
-            with pytest.raises(InvalidArgument) as error:
+            with pytest.raises(InvalidArgument):
                 artifact.key = "new_key"
                 artifact.save()
             # need to change the key back to the original key
@@ -877,14 +891,14 @@ def test_path_suffix(df):
     try:
         artifact = ln.Artifact("README.md", key="README.inconsistent")
     except InvalidArgument as error:
-        assert str(error).startswith(
-            "The suffix '.inconsistent' of the provided key is incorrect, it should be '.md'."
+        assert str(error) == (
+            "The suffix '.inconsistent' of the provided key is incorrect, it should be '.md'"
         )
     try:
         artifact = ln.Artifact("LICENSE", key="LICENSE.txt")
     except InvalidArgument as error:
-        assert str(error).startswith(
-            "The suffix '.txt' of the provided key is incorrect, it should be ''."
+        assert str(error) == (
+            "The suffix '.txt' of the provided key is incorrect, it should be ''"
         )
 
 

--- a/tests/core/test_cache.py
+++ b/tests/core/test_cache.py
@@ -42,8 +42,7 @@ def test_local_cache():
     adata.write_zarr(adata_zarr_pth)
     assert adata_zarr_pth.exists()
 
-    artifact = ln.Artifact(adata_zarr_pth, key="test_cache.zarr")
-    artifact.save()
+    artifact = ln.Artifact(adata_zarr_pth, key="test_cache.zarr").save()
     assert adata_zarr_pth.exists()
     assert artifact.path.exists()
     assert artifact.path.name != artifact.key


### PR DESCRIPTION
We've so far supported the case in which source path and target key in `Artifact()` have different suffixes.

While all functionality worked as expected there are two risks:

1. A user might provide an erroneous suffix either through the passed filepath or the passed key and because the suffix gets persisted as part of the S3 key it can't be easily changed
2. The user might get confused because the storage suffix and the suffix of the virtual path don't agree

Hence we're now throwing this error:
```python
try:
    artifact = ln.Artifact("my_source_file.suffix1", key="my_target_file.suffix2")
except InvalidArgument as error:
    assert str(error).startswith(
        "The suffix '.inconsistent' of the provided key is incorrect, it should be '.md'."
    )
```

Before this PR, the above silently passed.

What remains possible is to call `artifact.replace("my_source_file.suffix2")` if `artifact.suffix == ".suffix1", which will lead to `artifact` having the suffix `.suffix2`.

Resolves:

- https://github.com/laminlabs/lamindb/issues/2488