### PR TITLE
🐛 Run pip freeze with current python interpreter

### DIFF
--- a/lamindb/core/_track_environment.py
+++ b/lamindb/core/_track_environment.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from typing import TYPE_CHECKING
 
 import lamindb_setup as ln_setup
@@ -17,7 +18,7 @@ def track_environment(run: Run) -> None:
     try:
         with open(filepath, "w") as f:
             result = subprocess.run(
-                ["pip", "freeze"],
+                [sys.executable, "-m", "pip", "freeze"],
                 stdout=f,
             )
     except OSError as e:


### PR DESCRIPTION
Hey Lamins,

The way you gather a `requirements.txt` can return incorrect results under some edge cases. _(I just ran into one)_

https://github.com/laminlabs/lamindb/blob/f576cd12f8357fa6a7b8fe0abbcde5c74403f2dd/lamindb/core/_track_environment.py#L18-L22

When running with a python interpreter in a virtual env without activating the venv, (and under other edge cases like a user-site pip install, or nested activated conda envs) this can lead to requirements gathered from the wrong env.

This PR uses the correct interpreter in the subprocess run call to fix the issue.

Cheers,
Andreas 😃 
