### PR TITLE
✨ Allow to use `Artifact.open()` and `Artifact.load()` for `.gz` files

### DIFF
--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -458,7 +458,7 @@ def data_is_anndata(data: AnnData | UPathStr) -> bool:
         return True
     if isinstance(data, (str, Path, UPath)):
         data_path = UPath(data)
-        if data_path.suffix == ".h5ad":
+        if ".h5ad" in data_path.suffixes:  # ".h5ad.gz" is a valid suffix
             return True
         elif data_path.suffix == ".zarr":
             # ".anndata.zarr" is a valid suffix (core.storage._valid_suffixes)

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -990,16 +990,21 @@ def open(
 ):
     if self._overwrite_versions and not self.is_latest:
         raise ValueError(inconsistent_state_msg)
+    # all hdf5 suffixes including gzipped
+    h5_suffixes = [".h5", ".hdf5", ".h5ad"]
+    h5_suffixes += [s + ".gz" for s in h5_suffixes]
     # ignore empty suffix for now
     suffixes = (
-        "",
-        ".h5",
-        ".hdf5",
-        ".h5ad",
-        ".zarr",
-        ".anndata.zarr",
-        ".tiledbsoma",
-    ) + PYARROW_SUFFIXES
+        (
+            "",
+            ".zarr",
+            ".anndata.zarr",
+            ".tiledbsoma",
+        )
+        + tuple(h5_suffixes)
+        + PYARROW_SUFFIXES
+        + tuple(s + ".gz" for s in PYARROW_SUFFIXES)
+    )
     if self.suffix not in suffixes:
         raise ValueError(
             "Artifact should have a zarr, h5, tiledbsoma object"
@@ -1017,7 +1022,7 @@ def open(
     using_key = settings._using_key
     filepath, cache_key = filepath_cache_key_from_artifact(self, using_key=using_key)
     is_tiledbsoma_w = (
-        filepath.name == "soma" or filepath.suffix == ".tiledbsoma"
+        filepath.name == "soma" or self.suffix == ".tiledbsoma"
     ) and mode == "w"
     # consider the case where an object is already locally cached
     localpath = setup_settings.paths.cloud_to_local_no_update(

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -1003,7 +1003,9 @@ def open(
         )
         + tuple(h5_suffixes)
         + PYARROW_SUFFIXES
-        + tuple(s + ".gz" for s in PYARROW_SUFFIXES)
+        + tuple(
+            s + ".gz" for s in PYARROW_SUFFIXES
+        )  # this doesn't work for extranally gzipped files, REMOVE LATER
     )
     if self.suffix not in suffixes:
         raise ValueError(

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -1003,7 +1003,6 @@ def open(
         )
         + tuple(h5_suffixes)
         + PYARROW_SUFFIXES
-        + tuple(s + ".gz" for s in PYARROW_SUFFIXES)
     )
     if self.suffix not in suffixes:
         raise ValueError(

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -1003,6 +1003,7 @@ def open(
         )
         + tuple(h5_suffixes)
         + PYARROW_SUFFIXES
+        + tuple(s + ".gz" for s in PYARROW_SUFFIXES)
     )
     if self.suffix not in suffixes:
         raise ValueError(

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -979,7 +979,7 @@ inconsistent_state_msg = (
 
 # docstring handled through attach_func_to_class_method
 def open(
-    self, mode: str = "r", is_run_input: bool | None = None
+    self, mode: str = "r", is_run_input: bool | None = None, **kwargs
 ) -> (
     AnnDataAccessor
     | BackedAccessor
@@ -1036,14 +1036,14 @@ def open(
         ) and not filepath.synchronize(localpath, just_check=True)
     if open_cache:
         try:
-            access = backed_access(localpath, mode, using_key)
+            access = backed_access(localpath, mode, using_key, **kwargs)
         except Exception as e:
             if isinstance(filepath, LocalPathClasses):
                 raise e
             logger.warning(
                 f"The cache might be corrupted: {e}. Trying to open directly."
             )
-            access = backed_access(filepath, mode, using_key)
+            access = backed_access(filepath, mode, using_key, **kwargs)
             # happens only if backed_access has been successful
             # delete the corrupted cache
             if localpath.is_dir():
@@ -1051,7 +1051,7 @@ def open(
             else:
                 localpath.unlink(missing_ok=True)
     else:
-        access = backed_access(filepath, mode, using_key)
+        access = backed_access(filepath, mode, using_key, **kwargs)
         if is_tiledbsoma_w:
 
             def finalize():

--- a/lamindb/_collection.py
+++ b/lamindb/_collection.py
@@ -235,7 +235,7 @@ def open(self, is_run_input: bool | None = None) -> PyArrowDataset:
                 "The collection has artifacts with different filesystems, this is not supported."
             )
     if not _is_pyarrow_dataset(paths):
-        suffixes = {path.suffix for path in paths}
+        suffixes = {"".join(path.suffixes).replace(".gz", "") for path in paths}
         suffixes_str = ", ".join(suffixes)
         err_msg = "This collection is not compatible with pyarrow.dataset.dataset(), "
         err_msg += (

--- a/lamindb/_collection.py
+++ b/lamindb/_collection.py
@@ -235,7 +235,7 @@ def open(self, is_run_input: bool | None = None) -> PyArrowDataset:
                 "The collection has artifacts with different filesystems, this is not supported."
             )
     if not _is_pyarrow_dataset(paths):
-        suffixes = {"".join(path.suffixes).replace(".gz", "") for path in paths}
+        suffixes = {path.suffix for path in paths}
         suffixes_str = ", ".join(suffixes)
         err_msg = "This collection is not compatible with pyarrow.dataset.dataset(), "
         err_msg += (

--- a/lamindb/_collection.py
+++ b/lamindb/_collection.py
@@ -273,7 +273,7 @@ def mapped(
     else:
         artifacts = self.ordered_artifacts.all()
     for artifact in artifacts:
-        if artifact.suffix not in {".h5ad", ".zarr"}:
+        if ".h5ad" not in artifact.suffix and ".zarr" not in artifact.suffix:
             logger.warning(f"ignoring artifact with suffix {artifact.suffix}")
             continue
         elif not stream:

--- a/lamindb/core/loaders.py
+++ b/lamindb/core/loaders.py
@@ -65,7 +65,8 @@ def load_tsv(path: UPathStr, **kwargs) -> pd.DataFrame:
 def load_h5ad(filepath, **kwargs) -> ad.AnnData:
     """Load an `.h5ad` file to `AnnData`."""
     fs, filepath = infer_filesystem(filepath)
-    with fs.open(filepath, mode="rb", compression="infer") as file:
+    compression = kwargs.pop("compression", "infer")
+    with fs.open(filepath, mode="rb", compression=compression) as file:
         adata = ad.read_h5ad(file, backed=False, **kwargs)
         return adata
 

--- a/lamindb/core/loaders.py
+++ b/lamindb/core/loaders.py
@@ -65,8 +65,7 @@ def load_tsv(path: UPathStr, **kwargs) -> pd.DataFrame:
 def load_h5ad(filepath, **kwargs) -> ad.AnnData:
     """Load an `.h5ad` file to `AnnData`."""
     fs, filepath = infer_filesystem(filepath)
-    compression = "gzip" if filepath.endswith(".gz") else None
-    with fs.open(filepath, mode="rb", compression=compression) as file:
+    with fs.open(filepath, mode="rb", compression="infer") as file:
         adata = ad.read_h5ad(file, backed=False, **kwargs)
         return adata
 

--- a/lamindb/core/loaders.py
+++ b/lamindb/core/loaders.py
@@ -65,8 +65,8 @@ def load_tsv(path: UPathStr, **kwargs) -> pd.DataFrame:
 def load_h5ad(filepath, **kwargs) -> ad.AnnData:
     """Load an `.h5ad` file to `AnnData`."""
     fs, filepath = infer_filesystem(filepath)
-
-    with fs.open(filepath, mode="rb") as file:
+    compression = "gzip" if filepath.endswith(".gz") else None
+    with fs.open(filepath, mode="rb", compression=compression) as file:
         adata = ad.read_h5ad(file, backed=False, **kwargs)
         return adata
 

--- a/lamindb/core/loaders.py
+++ b/lamindb/core/loaders.py
@@ -181,8 +181,8 @@ def load_to_memory(filepath: UPathStr, **kwargs):
 
     filepath = settings._storage_settings.cloud_to_local(filepath, print_progress=True)
 
-    suffixes = filepath.suffixes
     # infer the correct suffix when .gz is present
+    suffixes = filepath.suffixes
     suffix = (
         "".join(suffixes[-2:])
         if len(suffixes) > 1 and ".gz" in suffixes

--- a/lamindb/core/loaders.py
+++ b/lamindb/core/loaders.py
@@ -154,7 +154,6 @@ FILE_LOADERS = {
     ".h5ad": load_h5ad,
     ".h5ad.gz": load_h5ad,
     ".parquet": pd.read_parquet,
-    ".parquet.gz": pd.read_parquet,
     ".fcs": load_fcs,
     ".zarr": load_anndata_zarr,
     ".html": load_html,

--- a/lamindb/core/loaders.py
+++ b/lamindb/core/loaders.py
@@ -154,6 +154,7 @@ FILE_LOADERS = {
     ".h5ad": load_h5ad,
     ".h5ad.gz": load_h5ad,
     ".parquet": pd.read_parquet,
+    ".parquet.gz": pd.read_parquet,  # this doesn't work for extranally gzipped files, REMOVE LATER
     ".fcs": load_fcs,
     ".zarr": load_anndata_zarr,
     ".html": load_html,

--- a/lamindb/core/loaders.py
+++ b/lamindb/core/loaders.py
@@ -148,9 +148,13 @@ def load_rds(path: UPathStr) -> UPathStr:
 
 FILE_LOADERS = {
     ".csv": pd.read_csv,
+    ".csv.gz": pd.read_csv,
     ".tsv": load_tsv,
+    ".tsv.gz": load_tsv,
     ".h5ad": load_h5ad,
+    ".h5ad.gz": load_h5ad,
     ".parquet": pd.read_parquet,
+    ".parquet.gz": pd.read_parquet,
     ".fcs": load_fcs,
     ".zarr": load_anndata_zarr,
     ".html": load_html,
@@ -177,7 +181,15 @@ def load_to_memory(filepath: UPathStr, **kwargs):
 
     filepath = settings._storage_settings.cloud_to_local(filepath, print_progress=True)
 
-    loader = FILE_LOADERS.get(filepath.suffix)
+    suffixes = filepath.suffixes
+    # infer the correct suffix when .gz is present
+    suffix = (
+        "".join(suffixes[-2:])
+        if len(suffixes) > 1 and ".gz" in suffixes
+        else filepath.suffix
+    )
+
+    loader = FILE_LOADERS.get(suffix)
     if loader is None:
         return filepath
     else:

--- a/lamindb/core/storage/_anndata_accessor.py
+++ b/lamindb/core/storage/_anndata_accessor.py
@@ -154,7 +154,7 @@ registry = AccessRegistry()
 @registry.register_open("h5py")
 def open(filepath: UPathStr, mode: str = "r"):
     fs, file_path_str = infer_filesystem(filepath)
-    if isinstance(fs, LocalFileSystem):
+    if isinstance(fs, LocalFileSystem) and not file_path_str.endswith(".gz"):
         assert mode in {"r", "r+", "a", "w", "w-"}, f"Unknown mode {mode}!"  #  noqa: S101
         return None, h5py.File(file_path_str, mode=mode)
     if mode == "r":

--- a/lamindb/core/storage/_backed_access.py
+++ b/lamindb/core/storage/_backed_access.py
@@ -70,6 +70,7 @@ def backed_access(
     artifact_or_filepath: Artifact | UPath,
     mode: str = "r",
     using_key: str | None = None,
+    **kwargs,
 ) -> (
     AnnDataAccessor | BackedAccessor | SOMACollection | SOMAExperiment | PyArrowDataset
 ):
@@ -89,13 +90,13 @@ def backed_access(
     if name == "soma" or suffix == ".tiledbsoma":
         if mode not in {"r", "w"}:
             raise ValueError("`mode` should be either 'r' or 'w' for tiledbsoma.")
-        return _open_tiledbsoma(objectpath, mode=mode)  # type: ignore
+        return _open_tiledbsoma(objectpath, mode=mode, **kwargs)  # type: ignore
     elif suffix in {".h5", ".hdf5", ".h5ad"}:
-        conn, storage = registry.open("h5py", objectpath, mode=mode)
+        conn, storage = registry.open("h5py", objectpath, mode=mode, **kwargs)
     elif suffix == ".zarr":
-        conn, storage = registry.open("zarr", objectpath, mode=mode)
+        conn, storage = registry.open("zarr", objectpath, mode=mode, **kwargs)
     elif _is_pyarrow_dataset(objectpath):
-        return _open_pyarrow_dataset(objectpath)
+        return _open_pyarrow_dataset(objectpath, **kwargs)
     else:
         raise ValueError(
             "The object should have .h5, .hdf5, .h5ad, .zarr, .tiledbsoma suffix "

--- a/lamindb/core/storage/_backed_access.py
+++ b/lamindb/core/storage/_backed_access.py
@@ -80,10 +80,10 @@ def backed_access(
     else:
         objectpath = artifact_or_filepath
     name = objectpath.name
+    # ignore .gz, only check the real suffix
+    suffixes = objectpath.suffixes
     suffix = (
-        objectpath.suffixes[-2]
-        if len(objectpath.suffixes) > 1 and ".gz" in objectpath.suffixes
-        else objectpath.suffix
+        suffixes[-2] if len(suffixes) > 1 and ".gz" in suffixes else objectpath.suffix
     )
 
     if name == "soma" or suffix == ".tiledbsoma":

--- a/lamindb/core/storage/_backed_access.py
+++ b/lamindb/core/storage/_backed_access.py
@@ -77,16 +77,21 @@ def backed_access(
         objectpath, _ = filepath_from_artifact(
             artifact_or_filepath, using_key=using_key
         )
+        suffix = artifact_or_filepath.suffix
     else:
         objectpath = artifact_or_filepath
+        suffix = "".join(objectpath.suffixes)
     name = objectpath.name
-    suffix = objectpath.suffix
+
+    # all hdf5 suffixes including gzipped
+    h5_suffixes = [".h5", ".hdf5", ".h5ad"]
+    h5_suffixes += [s + ".gz" for s in h5_suffixes]
 
     if name == "soma" or suffix == ".tiledbsoma":
         if mode not in {"r", "w"}:
             raise ValueError("`mode` should be either 'r' or 'w' for tiledbsoma.")
         return _open_tiledbsoma(objectpath, mode=mode)  # type: ignore
-    elif suffix in {".h5", ".hdf5", ".h5ad"}:
+    elif suffix in h5_suffixes:
         conn, storage = registry.open("h5py", objectpath, mode=mode)
     elif suffix == ".zarr":
         conn, storage = registry.open("zarr", objectpath, mode=mode)
@@ -98,7 +103,7 @@ def backed_access(
             f"or be compatible with pyarrow.dataset.dataset, instead of being {suffix} object."
         )
 
-    is_anndata = suffix == ".h5ad" or get_spec(storage).encoding_type == "anndata"
+    is_anndata = ".h5ad" in suffix or get_spec(storage).encoding_type == "anndata"
     if is_anndata:
         if mode != "r":
             raise ValueError("Can only access `AnnData` with mode='r'.")

--- a/lamindb/core/storage/_pyarrow_dataset.py
+++ b/lamindb/core/storage/_pyarrow_dataset.py
@@ -27,9 +27,9 @@ def _is_pyarrow_dataset(paths: UPath | list[UPath]) -> bool:
     for path in path_list:
         # ignore .gz, only check the real suffix
         path_suffix = (
-            path.suffix
-            if len(path.suffixes) == 1
-            else "".join(path.suffixes).replace(".gz", "")
+            path.suffixes[-2]
+            if len(path.suffixes) > 1 and ".gz" in path.suffixes
+            else path.suffix
         )
         if path_suffix not in PYARROW_SUFFIXES:
             return False

--- a/lamindb/core/storage/_pyarrow_dataset.py
+++ b/lamindb/core/storage/_pyarrow_dataset.py
@@ -26,9 +26,10 @@ def _is_pyarrow_dataset(paths: UPath | list[UPath]) -> bool:
     suffix = None
     for path in path_list:
         # ignore .gz, only check the real suffix
+        path_suffixes = path.suffixes
         path_suffix = (
-            path.suffixes[-2]
-            if len(path.suffixes) > 1 and ".gz" in path.suffixes
+            path_suffixes[-2]
+            if len(path_suffixes) > 1 and ".gz" in path_suffixes
             else path.suffix
         )
         if path_suffix not in PYARROW_SUFFIXES:

--- a/lamindb/core/storage/_pyarrow_dataset.py
+++ b/lamindb/core/storage/_pyarrow_dataset.py
@@ -25,13 +25,7 @@ def _is_pyarrow_dataset(paths: UPath | list[UPath]) -> bool:
         path_list = [paths]
     suffix = None
     for path in path_list:
-        # ignore .gz, only check the real suffix
-        path_suffixes = path.suffixes
-        path_suffix = (
-            path_suffixes[-2]
-            if len(path_suffixes) > 1 and ".gz" in path_suffixes
-            else path.suffix
-        )
+        path_suffix = path.suffix
         if path_suffix not in PYARROW_SUFFIXES:
             return False
         elif suffix is None:

--- a/lamindb/core/storage/_pyarrow_dataset.py
+++ b/lamindb/core/storage/_pyarrow_dataset.py
@@ -25,7 +25,13 @@ def _is_pyarrow_dataset(paths: UPath | list[UPath]) -> bool:
         path_list = [paths]
     suffix = None
     for path in path_list:
-        path_suffix = path.suffix
+        path_suffixes = path.suffixes
+        # this doesn't work for extranally gzipped files, REMOVE LATER
+        path_suffix = (
+            path_suffixes[-2]
+            if len(path_suffixes) > 1 and ".gz" in path_suffixes
+            else path.suffix
+        )
         if path_suffix not in PYARROW_SUFFIXES:
             return False
         elif suffix is None:

--- a/lamindb/core/storage/_pyarrow_dataset.py
+++ b/lamindb/core/storage/_pyarrow_dataset.py
@@ -19,10 +19,10 @@ def _is_pyarrow_dataset(paths: UPath | list[UPath]) -> bool:
     # but this is a requirement for pyarrow.dataset.dataset
     if isinstance(paths, list):
         path_list = paths
-    elif paths.is_file():
-        path_list = [paths]
-    else:
+    elif paths.is_dir():
         path_list = [path for path in paths.rglob("*") if path.suffix != ""]
+    else:
+        path_list = [paths]
     suffix = None
     for path in path_list:
         # ignore .gz, only check the real suffix

--- a/lamindb/models.py
+++ b/lamindb/models.py
@@ -3061,7 +3061,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
         pass
 
     def open(
-        self, mode: str = "r", is_run_input: bool | None = None
+        self, mode: str = "r", is_run_input: bool | None = None, **kwargs
     ) -> (
         AnnDataAccessor
         | BackedAccessor

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -571,5 +571,8 @@ def test_compressed():
         assert isinstance(store, AnnDataAccessor)
     assert isinstance(artifact.load(), ad.AnnData)
 
+    with pytest.raises(OSError):
+        artifact.open(compression=None)
+
     artifact.delete(permanent=True)
     adata_gz.unlink()

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -1,6 +1,8 @@
+import gzip
 import shutil
 from pathlib import Path
 
+import anndata as ad
 import h5py
 import lamindb as ln
 import numpy as np
@@ -168,8 +170,6 @@ def test_backed_access(adata_format):
 
 
 def test_infer_suffix():
-    import anndata as ad
-
     adata = ad.AnnData()
     assert infer_suffix(adata, adata_format="h5ad") == ".h5ad"
     with pytest.raises(ValueError):
@@ -553,3 +553,23 @@ def test_anndata_n_observations(bad_adata_path):
     assert _anndata_n_observations(zarr_path) == adata.n_obs
 
     shutil.rmtree(zarr_path)
+
+
+def _compress(input_filepath, output_filepath):
+    with open(input_filepath, "rb") as f_in:
+        with gzip.open(output_filepath, "wb") as f_out:
+            shutil.copyfileobj(f_in, f_out)
+
+
+def test_compressed():
+    adata_f = ln.core.datasets.anndata_file_pbmc68k_test()
+    adata_gz = adata_f.with_suffix(adata_f.suffix + ".gz")
+    _compress(adata_f, adata_gz)
+
+    artifact = ln.Artifact(adata_gz, key="adata.h5ad.gz").save()
+    with artifact.open() as store:
+        assert isinstance(store, AnnDataAccessor)
+    assert isinstance(artifact.load(), ad.AnnData)
+
+    artifact.delete(permanent=True)
+    adata_gz.unlink()

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -566,7 +566,7 @@ def test_compressed():
     adata_gz = adata_f.with_suffix(adata_f.suffix + ".gz")
     _compress(adata_f, adata_gz)
 
-    artifact = ln.Artifact(adata_gz, key="adata.h5ad.gz").save()
+    artifact = ln.Artifact.from_anndata(adata_gz, key="adata.h5ad.gz").save()
     with artifact.open() as store:
         assert isinstance(store, AnnDataAccessor)
     assert isinstance(artifact.load(), ad.AnnData)


### PR DESCRIPTION
Allows to read gzipped `anndata` and `h5` files

Example:
```python
artifact = ln.Artifact.from_anndata("./adata.h5ad.gz", description="gzipped adata").save()
artifact.open()
artifact.load()
```