### PR TITLE
🚸 Raise `NotImplementedError` in `Artifact.load()` if there is no loader

### DIFF
--- a/docs/faq/key.ipynb
+++ b/docs/faq/key.ipynb
@@ -333,7 +333,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "loaded_artifact = artifact_key_3.load()"
+    "loaded_artifact = artifact_key_3.cache()"
    ]
   },
   {
@@ -368,7 +368,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact_3 = artifact_key_3.load()"
+    "artifact_3 = artifact_key_3.cache()"
    ]
   },
   {
@@ -442,7 +442,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact_4 = artifact_key_4.load()"
+    "artifact_4 = artifact_key_4.cache()"
    ]
   },
   {
@@ -944,7 +944,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "lamindb",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -958,7 +958,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,

--- a/lamindb/_artifact.py
+++ b/lamindb/_artifact.py
@@ -1117,8 +1117,11 @@ def load(self, is_run_input: bool | None = None, **kwargs) -> Any:
             # cache_path is local so doesn't trigger any sync in load_to_memory
             access_memory = load_to_memory(cache_path, **kwargs)
         except Exception as e:
-            # just raise the exception if the original path is local
-            if isinstance(filepath, LocalPathClasses):
+            # raise the exception if it comes from not having a correct loader
+            # or if the original path is local
+            if isinstance(e, NotImplementedError) or isinstance(
+                filepath, LocalPathClasses
+            ):
                 raise e
             logger.warning(
                 f"The cache might be corrupted: {e}. Retrying to synchronize."

--- a/lamindb/core/loaders.py
+++ b/lamindb/core/loaders.py
@@ -179,8 +179,6 @@ def load_to_memory(filepath: UPathStr, **kwargs):
     """
     filepath = create_path(filepath)
 
-    filepath = settings._storage_settings.cloud_to_local(filepath, print_progress=True)
-
     # infer the correct suffix when .gz is present
     suffixes = filepath.suffixes
     suffix = (
@@ -189,8 +187,11 @@ def load_to_memory(filepath: UPathStr, **kwargs):
         else filepath.suffix
     )
 
-    loader = FILE_LOADERS.get(suffix)
+    loader = FILE_LOADERS.get(suffix, None)
     if loader is None:
-        return filepath
-    else:
-        return loader(filepath, **kwargs)
+        raise NotImplementedError(
+            f"There is no loader for {suffix} files. Use .cache() to get the path."
+        )
+
+    filepath = settings._storage_settings.cloud_to_local(filepath, print_progress=True)
+    return loader(filepath, **kwargs)

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -798,8 +798,9 @@ def test_load_to_memory(tsv_file, zip_file, fcs_file, yaml_file):
     # fcs
     adata = load_fcs(str(fcs_file))
     assert isinstance(adata, ad.AnnData)
-    # none
-    load_to_memory(zip_file)
+    # error
+    with pytest.raises(NotImplementedError):
+        load_to_memory(zip_file)
     # check that it is a path
     assert isinstance(load_to_memory("./somefile.rds"), UPath)
     # yaml

--- a/tests/core/test_load.py
+++ b/tests/core/test_load.py
@@ -6,6 +6,15 @@ import pytest
 
 
 @pytest.fixture(scope="module")
+def zip_file():
+    filepath = Path("test.zip")
+    with open(filepath, "w") as f:
+        f.write("some")
+    yield filepath
+    filepath.unlink()
+
+
+@pytest.fixture(scope="module")
 def local_filepath():
     return ln.core.datasets.anndata_file_pbmc68k_test().resolve()
 
@@ -54,3 +63,9 @@ def test_load_json(json_filepath):
     artifact = ln.Artifact(json_filepath, key=str(json_filepath))
     dictionary = artifact.load()
     assert dictionary["a"] == 1
+
+
+def test_no_loader(zip_file):
+    artifact = ln.Artifact(zip_file, key=str(zip_file))
+    with pytest.raises(NotImplementedError):
+        artifact.load()


### PR DESCRIPTION
Fix https://github.com/laminlabs/lamindb/issues/2504

Raise `NotImplementedError` on `artifact.load()` call when no loader is registered for the suffix.