### PR TITLE
🩹 Do not overwrite `._state_db` of models when the current instance is passed to `.using`

### DIFF
--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -595,9 +595,11 @@ class Registry(ModelBase):
 
         if instance is None:
             return QuerySet(model=cls, using=None)
+
         owner, name = get_owner_name_from_identifier(instance)
         if f"{owner}/{name}" == setup_settings.instance.slug:
             return QuerySet(model=cls, using=None)
+
         settings_file = instance_settings_file(name, owner)
         cache_filepath = (
             ln_setup.settings.cache_dir / f"instance--{owner}--{name}--uid.txt"

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -49,6 +49,7 @@ from django.db.models.lookups import (
 )
 from lamin_utils import colors, logger
 from lamin_utils._lookup import Lookup
+from lamindb_setup import settings as setup_settings
 from lamindb_setup._connect_instance import (
     get_owner_name_from_identifier,
     load_instance_settings,
@@ -595,6 +596,8 @@ class Registry(ModelBase):
         if instance is None:
             return QuerySet(model=cls, using=None)
         owner, name = get_owner_name_from_identifier(instance)
+        if f"{owner}/{name}" == setup_settings.instance.slug:
+            return QuerySet(model=cls, using=None)
         settings_file = instance_settings_file(name, owner)
         cache_filepath = (
             ln_setup.settings.cache_dir / f"instance--{owner}--{name}--uid.txt"

--- a/tests/core/test_record.py
+++ b/tests/core/test_record.py
@@ -198,6 +198,12 @@ def test_using():
         .first()
     )
     assert artifact == artifact_ref
+    # check that .using provided with the current intance does nothing
+    assert ln.User.using("lamindb-unit-tests-core").first()._state.db == "default"
+    user = ln.setup.settings.user
+    assert (
+        ln.User.using(f"{user}/lamindb-unit-tests-core").first()._state.db == "default"
+    )
 
 
 def test_get_record_kwargs():


### PR DESCRIPTION
Passing the current instance to `.using` causes problems downstream.