### PR TITLE
🎨 Integrate SDC `save_artifact` with general `save_artifact`

### DIFF
--- a/lamindb/core/storage/objects.py
+++ b/lamindb/core/storage/objects.py
@@ -45,8 +45,7 @@ def infer_suffix(dmem: SupportedDataTypes, format: str | None = None):
         dmem,
         "SpatialData",
         "spatialdata",
-        lambda obj: "."
-        + (
+        lambda obj: (
             format
             if format is not None and format in {"spatialdata.zarr", "zarr"}
             else ".zarr"

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -47,7 +47,7 @@ def parse_dtype_single_cat(
     dtype_str: str,
     related_registries: dict[str, Record] | None = None,
     is_itype: bool = False,
-) -> dict:
+) -> dict[str, Any]:
     from .artifact import Artifact
 
     assert isinstance(dtype_str, str)  # noqa: S101


### PR DESCRIPTION
Fixes https://github.com/laminlabs/lamindb/issues/2538

Another step to tier 1 SpatialData support.

- consolidates the `save_artifact` code
- fixes a bad bug where SpatialData zarr files got saved with one extra `.` --> `..zarr` instead of `.zarr`