### PR TITLE
🚸 Refactor `organism` constraints during validation

### DIFF
--- a/lamindb/models/_from_values.py
+++ b/lamindb/models/_from_values.py
@@ -385,7 +385,7 @@ def _get_organism_record(  # type: ignore
     check = not _is_simple_field_unique(field=field) or organism is not None
 
     if field_str == "ensembl_gene_id" and len(values) > 0 and organism is None:  # type: ignore
-        return _organism_from_ensembl_id(values[0])  # type: ignore
+        return _organism_from_ensembl_id(values[0], registry)  # type: ignore
 
     if _require_organism(registry) and check:
         from bionty._bionty import create_or_get_organism_record
@@ -393,12 +393,10 @@ def _get_organism_record(  # type: ignore
         organism_record = create_or_get_organism_record(
             organism=organism, registry=registry, field=field_str
         )
-        if organism_record and organism_record._state.adding:
-            organism_record.save()
-        return organism_record
+        return organism_record.save()
 
 
-def _organism_from_ensembl_id(id: str) -> Record | None:  # type: ignore
+def _organism_from_ensembl_id(id: str, registry: type[Record]) -> Record | None:  # type: ignore
     import bionty as bt
 
     from .artifact import Artifact  # has to be here to avoid circular imports
@@ -413,4 +411,4 @@ def _organism_from_ensembl_id(id: str) -> Record | None:  # type: ignore
     if prefix in ensembl_prefixes.index:
         sname = ensembl_prefixes.loc[prefix, "scientific_name"]
 
-        return bt.Organism.from_source(scientific_name=sname)
+        return bt.Organism.from_source(scientific_name=sname).save()

--- a/lamindb/models/_from_values.py
+++ b/lamindb/models/_from_values.py
@@ -393,10 +393,11 @@ def _get_organism_record(  # type: ignore
         organism_record = create_or_get_organism_record(
             organism=organism, registry=registry, field=field_str
         )
-        return organism_record.save()
+        if organism_record is not None:
+            return organism_record.save()
 
 
-def _organism_from_ensembl_id(id: str, registry: type[Record]) -> Record | None:  # type: ignore
+def _organism_from_ensembl_id(id: str) -> Record | None:  # type: ignore
     import bionty as bt
 
     from .artifact import Artifact  # has to be here to avoid circular imports
@@ -411,4 +412,6 @@ def _organism_from_ensembl_id(id: str, registry: type[Record]) -> Record | None:
     if prefix in ensembl_prefixes.index:
         sname = ensembl_prefixes.loc[prefix, "scientific_name"]
 
-        return bt.Organism.from_source(scientific_name=sname).save()
+        organism_record = bt.Organism.from_source(scientific_name=sname)
+        if organism_record is not None:
+            return organism_record.save()

--- a/lamindb/models/_from_values.py
+++ b/lamindb/models/_from_values.py
@@ -10,28 +10,26 @@ from lamin_utils import colors, logger
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from lamindb.base.types import FieldAttr, ListLike, StrField
+    from lamindb.base.types import FieldAttr, ListLike
 
     from .query_set import RecordList
     from .record import Record
 
 
 # The base function for `from_values`
-def get_or_create_records(
+def _from_values(
     iterable: ListLike,
-    field: StrField,
+    field: FieldAttr,
     *,
     create: bool = False,
     organism: Record | str | None = None,
     source: Record | None = None,
     mute: bool = False,
-    _from_source: bool = False,
 ) -> RecordList:
     """Get or create records from iterables."""
     from .query_set import RecordList
 
     registry = field.field.model  # type: ignore
-    field = registry._meta.get_field(field) if isinstance(field, str) else field
     organism_record = _get_organism_record(field, organism, values=iterable)
     # TODO: the create is problematic if field is not a name field
     if create:
@@ -57,7 +55,7 @@ def get_or_create_records(
 
     # new records to be created based on new values
     if len(nonexist_values) > 0:
-        if _from_source and hasattr(registry, "source_id"):
+        if hasattr(registry, "source_id"):
             # if can and needed, get organism record from the existing records
             if (
                 organism_record is None

--- a/lamindb/models/_from_values.py
+++ b/lamindb/models/_from_values.py
@@ -244,11 +244,11 @@ def create_records_from_source(
             df=bionty_df,
         )
 
-        # this here is needed when the organism is required to create new records
-        if organism is None:
-            organism = _get_organism_record(
-                field, source.organism, values=mapped_values
-            )
+        # # this here is needed when the organism is required to create new records
+        # if organism is None:
+        #     organism = _get_organism_record(
+        #         field, source.organism, values=mapped_values
+        #     )
 
         create_kwargs = (
             {"organism": organism, "source": source}
@@ -384,11 +384,11 @@ def _get_organism_record(  # type: ignore
     field_str = field.field.name
     check = not _is_simple_field_unique(field=field) or organism is not None
 
+    if field_str == "ensembl_gene_id" and len(values) > 0 and organism is None:  # type: ignore
+        return _organism_from_ensembl_id(values[0])  # type: ignore
+
     if _require_organism(registry) and check:
         from bionty._bionty import create_or_get_organism_record
-
-        if field_str == "ensembl_gene_id" and len(values) > 0:  # type: ignore
-            organism = _organism_from_ensembl_id(values[0])  # type: ignore
 
         organism_record = create_or_get_organism_record(
             organism=organism, registry=registry, field=field_str

--- a/lamindb/models/_from_values.py
+++ b/lamindb/models/_from_values.py
@@ -410,7 +410,7 @@ def _organism_from_ensembl_id(id: str, using_key: str | None) -> Record | None: 
 
     ensembl_prefixes = (
         Artifact.using("laminlabs/bionty-assets")
-        .get(key="ensembl_prefixes.parquet")
+        .get(key="ensembl_prefixes.parquet", is_latest=True)
         .load(is_run_input=False)
         .set_index("gene_prefix")
     )
@@ -421,9 +421,7 @@ def _organism_from_ensembl_id(id: str, using_key: str | None) -> Record | None: 
         using_key = None if using_key == "default" else using_key
 
         organism_record = (
-            bt.Organism.using(using_key)
-            .filter(name=organism_name, is_latest=True)
-            .one_or_none()
+            bt.Organism.using(using_key).filter(name=organism_name).one_or_none()
         )
         if organism_record is None:
             organism_record = bt.Organism.from_source(name=organism_name)

--- a/lamindb/models/_from_values.py
+++ b/lamindb/models/_from_values.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 import pandas as pd
@@ -11,7 +12,7 @@ from .record import Record
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from lamindb.base.types import ListLike, StrField
+    from lamindb.base.types import FieldAttr, ListLike, StrField
 
     from .query_set import RecordList
 
@@ -22,55 +23,68 @@ def get_or_create_records(
     field: StrField,
     *,
     create: bool = False,
-    from_source: bool = False,
     organism: Record | str | None = None,
     source: Record | None = None,
     mute: bool = False,
+    _from_source: bool = False,
 ) -> RecordList:
     """Get or create records from iterables."""
     from .query_set import RecordList
 
     registry = field.field.model  # type: ignore
+    if isinstance(field, str):
+        field = registry._meta.get_field(field)
+    organism_record = _get_organism_record(field, organism, values=iterable)
+    # TODO: the create is problematic if field is not a name field
     if create:
-        return RecordList([registry(**{field.field.name: value}) for value in iterable])  # type: ignore
-    organism = _get_organism_record(field, organism)
+        if organism_record:
+            create_kwargs = {"organism": organism_record}
+        return RecordList(
+            [
+                registry(**{field.field.name: value}, **create_kwargs)
+                for value in iterable
+            ]
+        )  # type: ignore
+
     iterable_idx = index_iterable(iterable)
 
     # returns existing records & non-existing values
     records, nonexist_values, msg = get_existing_records(
         iterable_idx=iterable_idx,
         field=field,
-        organism=organism,
+        organism=organism_record,
         mute=mute,
     )
 
     # new records to be created based on new values
     if len(nonexist_values) > 0:
         source_record = None
-        if from_source:
+        if _from_source:
             if isinstance(source, Record):
                 source_record = source
-        if not source_record and hasattr(registry, "public"):
-            if organism is None:
-                organism = _ensembl_prefix(nonexist_values[0], field, organism)
-                organism = _get_organism_record(field, organism, force=True)
 
         if source_record:
             from bionty.core._add_ontology import check_source_in_db
 
             check_source_in_db(registry=registry, source=source_record)
 
-            from_source = not source_record.in_db
+            _from_source = not source_record.in_db
         elif hasattr(registry, "source_id"):
-            from_source = True
+            _from_source = True
         else:
-            from_source = False
+            _from_source = False
 
-        if from_source:
+        if _from_source:
+            if (
+                organism_record is None
+                and len(records) > 0
+                and _require_organism(registry)
+            ):
+                organism_record = records[0].organism
             records_bionty, unmapped_values = create_records_from_source(
                 iterable_idx=nonexist_values,
                 field=field,
-                organism=organism,
+                organism=organism_record,
                 source=source_record,
                 msg=msg,
                 mute=mute,
@@ -100,25 +114,20 @@ def get_or_create_records(
 
 def get_existing_records(
     iterable_idx: pd.Index,
-    field: StrField,
+    field: FieldAttr,
     organism: Record | None = None,
     mute: bool = False,
-):
+) -> tuple[list, pd.Index, str]:
     # NOTE: existing records matching is agnostic to the source
     model = field.field.model  # type: ignore
-    if organism is None and field.field.name == "ensembl_gene_id":  # type: ignore
-        if len(iterable_idx) > 0:
-            organism = _ensembl_prefix(iterable_idx[0], field, organism)  # type: ignore
-            organism = _get_organism_record(field, organism, force=True)
 
-    # standardize based on the DB reference
     # log synonyms mapped terms
     syn_mapper = model.standardize(
         iterable_idx,
         field=field,
         organism=organism,
         mute=True,
-        public_aware=False,
+        public_aware=False,  # standardize only based on the DB reference
         return_mapper=True,
     )
     iterable_idx = iterable_idx.to_frame().rename(index=syn_mapper).index
@@ -137,7 +146,6 @@ def get_existing_records(
     is_validated = model.validate(
         iterable_idx, field=field, organism=organism, mute=True
     )
-
     if len(is_validated) > 0:
         validated = iterable_idx[is_validated]
     else:
@@ -151,7 +159,7 @@ def get_existing_records(
             msg = (
                 "loaded"
                 f" {colors.green(f'{len(validated)} {model.__name__} record{s}')}"
-                f" matching {colors.italic(f'{field.field.name}')}: {print_values}"  # type: ignore
+                f" matching {colors.italic(f'{field.field.name}')}: {print_values}"
             )
         if len(syn_mapper) > 0:
             s = "" if len(syn_mapper) == 1 else "s"
@@ -181,7 +189,7 @@ def get_existing_records(
     records = model.filter(**query).list()
 
     if len(validated) == len(iterable_idx):
-        return records, [], msg
+        return records, pd.Index([]), msg
     else:
         nonval_values = iterable_idx.difference(validated)
         return records, nonval_values, msg
@@ -189,12 +197,12 @@ def get_existing_records(
 
 def create_records_from_source(
     iterable_idx: pd.Index,
-    field: StrField,
+    field: FieldAttr,
     organism: Record | None = None,
     source: Record | None = None,
     msg: str = "",
     mute: bool = False,
-):
+) -> tuple[list, pd.Index]:
     model = field.field.model  # type: ignore
     records: list = []
     # populate additional fields from bionty
@@ -253,8 +261,11 @@ def create_records_from_source(
             df=bionty_df,
         )
 
-        if hasattr(model, "organism_id") and organism is None:
-            organism = _get_organism_record(field, source.organism, force=True)
+        # this here is needed when the organism is required to create new records
+        if organism is None:
+            organism = _get_organism_record(
+                field, source.organism, values=mapped_values
+            )
 
         create_kwargs = (
             {"organism": organism, "source": source}
@@ -345,50 +356,66 @@ def _bulk_create_dicts_from_df(
     return df.reset_index().to_dict(orient="records"), multi_msg
 
 
-def _has_organism_field(registry: type[Record]) -> bool:
+def _require_organism(registry: type[Record]) -> bool:
+    """Check if the registry has an organism field and is required.
+
+    Returns:
+        True if the registry has an organism field and is required, False otherwise.
+    """
     try:
-        registry._meta.get_field("organism")
-        return True
+        organism_field = registry._meta.get_field("organism")
+        if organism_field.null:  # organism is not required
+            return False
+        else:
+            return True
     except FieldDoesNotExist:
         return False
 
 
 def _get_organism_record(  # type: ignore
-    field: StrField, organism: str | Record, force: bool = False
-) -> Record:
+    field: FieldAttr,
+    organism: str | Record | None = None,
+    values: Iterable = [],
+) -> Record | None:
     """Get organism record.
 
     Args:
         field: the field to get the organism record for
         organism: the organism to get the record for
-        force: whether to force fetching the organism record
-    """
-    registry = field.field.model  # type: ignore
-    check = True
-    if not force and hasattr(registry, "_ontology_id_field"):
-        check = field.field.name != registry._ontology_id_field  # type: ignore
-        # e.g. bionty.CellMarker has "name" as _ontology_id_field
-        if not registry._ontology_id_field.endswith("id"):
-            check = True
 
-    if _has_organism_field(registry) and check:
+    Returns:
+        The organism record if:
+            The organism is required for the registry
+            The field is not unique or the organism is not None
+    """
+    registry = field.field.model
+    check = not field.field.unique or organism is not None
+
+    if _require_organism(registry) and check:
         from bionty._bionty import create_or_get_organism_record
 
-        if field and not isinstance(field, str):
-            field = field.field.name
+        if field.field.name == "ensembl_gene_id" and len(values) > 0:  # type: ignore
+            organism = _organism_from_ensembl_id(values[0])  # type: ignore
 
         organism_record = create_or_get_organism_record(
-            organism=organism, registry=registry, field=field
+            organism=organism, registry=registry, field=field.field.name
         )
-        if organism_record is not None:
-            return organism_record
+        if organism_record._state.adding:
+            organism_record.save()
+        return organism_record
 
 
-def _ensembl_prefix(id: str, field: StrField, organism: Record | None) -> str | None:
-    if field.field.name == "ensembl_gene_id" and organism is None:  # type: ignore
-        if id.startswith("ENSG"):
-            organism = "human"  # type: ignore
-        elif id.startswith("ENSMUSG"):
-            organism = "mouse"  # type: ignore
+def _organism_from_ensembl_id(id: str) -> Record | None:
+    import bionty as bt
 
-    return organism
+    from .artifact import Artifact  # has to be here to avoid circular imports
+
+    ensembl_prefixes = (
+        Artifact.using("laminlabs/bionty-assets")
+        .get(key="ensembl_prefixes.parquet")
+        .load(is_run_input=False)
+    )
+    prefix = re.sub(r"\d+", "", id)
+    sname = ensembl_prefixes.set_index("gene_prefix").loc[prefix, "scientific_name"]
+
+    return bt.Organism.from_source(scientific_name=sname)

--- a/lamindb/models/_from_values.py
+++ b/lamindb/models/_from_values.py
@@ -347,7 +347,8 @@ def _require_organism(registry: type[Record]) -> bool:
     """
     try:
         organism_field = registry._meta.get_field("organism")
-        if organism_field.null:  # organism is not required
+        # organism is not required or not a relation
+        if organism_field.null or not organism_field.is_relation:
             return False
         else:
             return True
@@ -385,7 +386,7 @@ def _get_organism_record(  # type: ignore
     check = not _is_simple_field_unique(field=field) or organism is not None
 
     if field_str == "ensembl_gene_id" and len(values) > 0 and organism is None:  # type: ignore
-        return _organism_from_ensembl_id(values[0], registry)  # type: ignore
+        return _organism_from_ensembl_id(values[0])  # type: ignore
 
     if _require_organism(registry) and check:
         from bionty._bionty import create_or_get_organism_record

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -127,7 +127,7 @@ if TYPE_CHECKING:
 INCONSISTENT_STATE_MSG = (
     "Trying to read a folder artifact from an outdated version, "
     "this can result in an incosistent state.\n"
-    "Read from the latest version: artifact.versions.filter(is_latest=True).one()"
+    "Read from the latest version: artifact.versions.get(is_latest=True)"
 )
 
 
@@ -1502,7 +1502,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
             # File in local storage:
             ln.Artifact("./myfile.csv", key="myfile.csv").save()
             artifact.path
-            #PosixPath('/home/runner/work/lamindb/lamindb/docs/guide/mydata/myfile.csv')
+            #> PosixPath('/home/runner/work/lamindb/lamindb/docs/guide/mydata/myfile.csv')
         """
         from lamindb import settings
 
@@ -1555,14 +1555,13 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
 
             df = ln.core.datasets.df_iris_in_meter_batch1()
             df.head()
-            #   sepal_length sepal_width petal_length petal_width iris_organism_code
-            # 0        0.051       0.035        0.014       0.002                 0
-            # 1        0.049       0.030        0.014       0.002                 0
-            # 2        0.047       0.032        0.013       0.002                 0
-            # 3        0.046       0.031        0.015       0.002                 0
-            # 4        0.050       0.036        0.014       0.002                 0
-            artifact = ln.Artifact.from_df(df, key="iris/result_batch1.parquet")
-            artifact.save()
+            #>   sepal_length sepal_width petal_length petal_width iris_organism_code
+            #> 0        0.051       0.035        0.014       0.002                 0
+            #> 1        0.049       0.030        0.014       0.002                 0
+            #> 2        0.047       0.032        0.013       0.002                 0
+            #> 3        0.046       0.031        0.015       0.002                 0
+            #> 4        0.050       0.036        0.014       0.002                 0
+            artifact = ln.Artifact.from_df(df, key="iris/result_batch1.parquet").save()
         """
         artifact = Artifact(  # type: ignore
             data=df,
@@ -1610,8 +1609,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
             import lamindb as ln
 
             adata = ln.core.datasets.anndata_with_obs()
-            artifact = ln.Artifact.from_anndata(adata, key="mini_anndata_with_obs.h5ad")
-            artifact.save()
+            artifact = ln.Artifact.from_anndata(adata, key="mini_anndata_with_obs.h5ad").save()
         """
         if not data_is_anndata(adata):
             raise ValueError(
@@ -1673,8 +1671,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
             import lamindb as ln
 
             mdata = ln.core.datasets.mudata_papalexi21_subset()
-            artifact = ln.Artifact.from_mudata(mdata, key="mudata_papalexi21_subset.h5mu")
-            artifact.save()
+            artifact = ln.Artifact.from_mudata(mdata, key="mudata_papalexi21_subset.h5mu").save()
         """
         if not data_is_mudata(mdata):
             raise ValueError("data has to be a MuData object or a path to MuData-like")
@@ -1723,8 +1720,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
 
             import lamindb as ln
 
-            artifact = ln.Artifact.from_spatialdata(sdata, key="my_dataset.zarr")
-            artifact.save()
+            artifact = ln.Artifact.from_spatialdata(sdata, key="my_dataset.zarr").save()
         """
         if not data_is_spatialdata(sdata):
             raise ValueError(
@@ -1769,8 +1765,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
 
             import lamindb as ln
 
-            artifact = ln.Artifact.from_tiledbsoma("s3://mybucket/store.tiledbsoma", description="a tiledbsoma store")
-            artifact.save()
+            artifact = ln.Artifact.from_tiledbsoma("s3://mybucket/store.tiledbsoma", description="a tiledbsoma store").save()
         """
         if UPath(path).suffix != ".tiledbsoma":
             raise ValueError(
@@ -2038,9 +2033,9 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
 
             artifact = ln.Artifact.get(key="lndb-storage/pbmc68k.h5ad")
             artifact.open()
-            # AnnDataAccessor object with n_obs × n_vars = 70 × 765
-            #     constructed for the AnnData object pbmc68k.h5ad
-            #     ...
+            #> AnnDataAccessor object with n_obs × n_vars = 70 × 765
+            #>     constructed for the AnnData object pbmc68k.h5ad
+            #>     ...
         """
         if self._overwrite_versions and not self.is_latest:
             raise ValueError(INCONSISTENT_STATE_MSG)
@@ -2226,7 +2221,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
 
             # Sync file from cloud and return the local path of the cache
             artifact.cache()
-            # PosixPath('/home/runner/work/Caches/lamindb/lamindb-ci/lndb-storage/pbmc68k.h5ad')
+            #> PosixPath('/home/runner/work/Caches/lamindb/lamindb-ci/lndb-storage/pbmc68k.h5ad')
         """
         from lamindb import settings
 
@@ -2268,13 +2263,13 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
             import lamindb as ln
 
             # For an `Artifact` object `artifact`, call:
-            artifact = ln.Artifact.filter(key="some.csv").one()
+            artifact = ln.Artifact.get(key="some.csv")
             artifact.delete() # delete a single file artifact
 
             artifact = ln.Artifact.filter(key="some.tiledbsoma". is_latest=False).first()
             artiact.delete() # delete an old version, the data will not be deleted
 
-            artifact = ln.Artifact.filter(key="some.tiledbsoma". is_latest=True).one()
+            artifact = ln.Artifact.get(key="some.tiledbsoma". is_latest=True)
             artiact.delete() # delete all versions, the data will be deleted or prompted for deletion.
         """
         # this first check means an invalid delete fails fast rather than cascading through
@@ -2373,8 +2368,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
 
             import lamindb as ln
 
-            artifact = ln.Artifact("./myfile.csv", key="myfile.parquet")
-            artifact.save()
+            artifact = ln.Artifact("./myfile.csv", key="myfile.parquet").save()
         """
         state_was_adding = self._state.adding
         print_progress = kwargs.pop("print_progress", True)

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1490,17 +1490,19 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
     def path(self) -> Path:
         """Path.
 
-        File in cloud storage, here AWS S3:
+        Example::
 
-        >>> artifact = ln.Artifact("s3://my-bucket/my-file.csv").save()
-        >>> artifact.path
-        S3QueryPath('s3://my-bucket/my-file.csv')
+            import lamindb as ln
 
-        File in local storage:
+            # File in cloud storage, here AWS S3:
+            artifact = ln.Artifact("s3://my-bucket/my-file.csv").save()
+            artifact.path
+            #S3QueryPath('s3://my-bucket/my-file.csv')
 
-        >>> ln.Artifact("./myfile.csv", key="myfile.csv").save()
-        >>> artifact.path
-        PosixPath('/home/runner/work/lamindb/lamindb/docs/guide/mydata/myfile.csv')
+            # File in local storage:
+            ln.Artifact("./myfile.csv", key="myfile.csv").save()
+            artifact.path
+            #PosixPath('/home/runner/work/lamindb/lamindb/docs/guide/mydata/myfile.csv')
         """
         from lamindb import settings
 
@@ -1547,17 +1549,20 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
             :class:`~lamindb.Feature`
                 Track features.
 
-        Examples:
-            >>> df = ln.core.datasets.df_iris_in_meter_batch1()
-            >>> df.head()
-              sepal_length sepal_width petal_length petal_width iris_organism_code
-            0        0.051       0.035        0.014       0.002                 0
-            1        0.049       0.030        0.014       0.002                 0
-            2        0.047       0.032        0.013       0.002                 0
-            3        0.046       0.031        0.015       0.002                 0
-            4        0.050       0.036        0.014       0.002                 0
-            >>> artifact = ln.Artifact.from_df(df, description="Iris flower collection batch1")
-            >>> artifact.save()
+        Example::
+
+            import lamindb as ln
+
+            df = ln.core.datasets.df_iris_in_meter_batch1()
+            df.head()
+            #   sepal_length sepal_width petal_length petal_width iris_organism_code
+            # 0        0.051       0.035        0.014       0.002                 0
+            # 1        0.049       0.030        0.014       0.002                 0
+            # 2        0.047       0.032        0.013       0.002                 0
+            # 3        0.046       0.031        0.015       0.002                 0
+            # 4        0.050       0.036        0.014       0.002                 0
+            artifact = ln.Artifact.from_df(df, key="iris/result_batch1.parquet")
+            artifact.save()
         """
         artifact = Artifact(  # type: ignore
             data=df,
@@ -1600,12 +1605,13 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
             :class:`~lamindb.Feature`
                 Track features.
 
-        Examples:
-            >>> import bionty as bt
-            >>> bt.settings.organism = "human"
-            >>> adata = ln.core.datasets.anndata_with_obs()
-            >>> artifact = ln.Artifact.from_anndata(adata, description="mini anndata with obs")
-            >>> artifact.save()
+        Example::
+
+            import lamindb as ln
+
+            adata = ln.core.datasets.anndata_with_obs()
+            artifact = ln.Artifact.from_anndata(adata, key="mini_anndata_with_obs.h5ad")
+            artifact.save()
         """
         if not data_is_anndata(adata):
             raise ValueError(
@@ -1662,12 +1668,13 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
             :class:`~lamindb.Feature`
                 Track features.
 
-        Examples:
-            >>> import bionty as bt
-            >>> bt.settings.organism = "human"
-            >>> mdata = ln.core.datasets.mudata_papalexi21_subset()
-            >>> artifact = ln.Artifact.from_mudata(mdata, description="a mudata object")
-            >>> artifact.save()
+        Example::
+
+            import lamindb as ln
+
+            mdata = ln.core.datasets.mudata_papalexi21_subset()
+            artifact = ln.Artifact.from_mudata(mdata, key="mudata_papalexi21_subset.h5mu")
+            artifact.save()
         """
         if not data_is_mudata(mdata):
             raise ValueError("data has to be a MuData object or a path to MuData-like")
@@ -1712,8 +1719,12 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
             :class:`~lamindb.Feature`
                 Track features.
 
-        Examples:
-            >>> artifact = ln.Artifact.from_spatialdata(sdata, key="my_dataset.zarr")
+        Example::
+
+            import lamindb as ln
+
+            artifact = ln.Artifact.from_spatialdata(sdata, key="my_dataset.zarr")
+            artifact.save()
         """
         if not data_is_spatialdata(sdata):
             raise ValueError(
@@ -1754,9 +1765,12 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
             revises: An old version of the artifact.
             run: The run that creates the artifact.
 
-        Examples:
-            >>> artifact = ln.Artifact.from_tiledbsoma("s3://mybucket/store.tiledbsoma", description="a tiledbsoma store")
-            >>> artifact.save()
+        Example::
+
+            import lamindb as ln
+
+            artifact = ln.Artifact.from_tiledbsoma("s3://mybucket/store.tiledbsoma", description="a tiledbsoma store")
+            artifact.save()
         """
         if UPath(path).suffix != ".tiledbsoma":
             raise ValueError(
@@ -1798,10 +1812,13 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
                 of a registered storage location, the inferred key defaults to `path.name`.
             run: A `Run` object.
 
-        Examples:
-            >>> dir_path = ln.core.datasets.generate_cell_ranger_files("sample_001", ln.settings.storage)
-            >>> artifacts = ln.Artifact.from_dir(dir_path)
-            >>> ln.save(artifacts)
+        Example::
+
+            import lamindb as ln
+
+            dir_path = ln.core.datasets.generate_cell_ranger_files("sample_001", ln.settings.storage)
+            artifacts = ln.Artifact.from_dir(dir_path)
+            ln.save(artifacts)
         """
         from lamindb import settings
 
@@ -2010,15 +2027,17 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
         Notes:
             For more info, see tutorial: :doc:`/arrays`.
 
-        Examples:
+        Example::
 
-            Read AnnData in backed mode from cloud:
+            import lamindb as ln
 
-            >>> artifact = ln.Artifact.get(key="lndb-storage/pbmc68k.h5ad")
-            >>> artifact.open()
-            AnnDataAccessor object with n_obs × n_vars = 70 × 765
-                constructed for the AnnData object pbmc68k.h5ad
-                ...
+            # Read AnnData in backed mode from cloud
+
+            artifact = ln.Artifact.get(key="lndb-storage/pbmc68k.h5ad")
+            artifact.open()
+            # AnnDataAccessor object with n_obs × n_vars = 70 × 765
+            #     constructed for the AnnData object pbmc68k.h5ad
+            #     ...
         """
         if self._overwrite_versions and not self.is_latest:
             raise ValueError(INCONSISTENT_STATE_MSG)
@@ -2192,12 +2211,11 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
 
         Returns a path to a locally cached on-disk object (say a `.jpg` file).
 
-        Examples:
+        Example::
 
-            Sync file from cloud and return the local path of the cache:
-
-            >>> artifact.cache()
-            PosixPath('/home/runner/work/Caches/lamindb/lamindb-ci/lndb-storage/pbmc68k.h5ad')
+            # Sync file from cloud and return the local path of the cache
+            artifact.cache()
+            # PosixPath('/home/runner/work/Caches/lamindb/lamindb-ci/lndb-storage/pbmc68k.h5ad')
         """
         from lamindb import settings
 
@@ -2232,18 +2250,19 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
             permanent: Permanently delete the artifact (skip trash).
             storage: Indicate whether you want to delete the artifact in storage.
 
-        Examples:
+        Example::
 
-            For an `Artifact` object `artifact`, call:
+            import lamindb as ln
 
-            >>> artifact = ln.Artifact.filter(key="some.csv").one()
-            >>> artifact.delete() # delete a single file artifact
+            # For an `Artifact` object `artifact`, call:
+            artifact = ln.Artifact.filter(key="some.csv").one()
+            artifact.delete() # delete a single file artifact
 
-            >>> artifact = ln.Artifact.filter(key="some.tiledbsoma". is_latest=False).first()
-            >>> artiact.delete() # delete an old version, the data will not be deleted
+            artifact = ln.Artifact.filter(key="some.tiledbsoma". is_latest=False).first()
+            artiact.delete() # delete an old version, the data will not be deleted
 
-            >>> artifact = ln.Artifact.filter(key="some.tiledbsoma". is_latest=True).one()
-            >>> artiact.delete() # delete all versions, the data will be deleted or prompted for deletion.
+            artifact = ln.Artifact.filter(key="some.tiledbsoma". is_latest=True).one()
+            artiact.delete() # delete all versions, the data will be deleted or prompted for deletion.
         """
         # this first check means an invalid delete fails fast rather than cascading through
         # database and storage permission errors
@@ -2337,9 +2356,12 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
         Args:
             upload: Trigger upload to cloud storage in instances with hybrid storage mode.
 
-        Examples:
-            >>> artifact = ln.Artifact("./myfile.csv", description="myfile")
-            >>> artifact.save()
+        Example::
+
+            import lamindb as ln
+
+            artifact = ln.Artifact("./myfile.csv", key="myfile.parquet")
+            artifact.save()
         """
         state_was_adding = self._state.adding
         print_progress = kwargs.pop("print_progress", True)
@@ -2408,8 +2430,9 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
     def restore(self) -> None:
         """Restore from trash.
 
-        Examples:
-            >>> artifact.restore()
+        Example::
+
+            artifact.restore()
         """
         self._branch_code = 1
         self.save()
@@ -2417,8 +2440,9 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
     def describe(self) -> None:
         """Describe relations of record.
 
-        Examples:
-            >>> artifact.describe()
+        Example::
+
+            artifact.describe()
         """
         return describe_artifact_collection(self)
 
@@ -2478,8 +2502,9 @@ class ArtifactParamValue(BasicRecord, LinkORM, TracksRun):
 
 
 def _track_run_input(
-    data: Artifact
-    | Iterable[Artifact],  # can also be Collection | Iterable[Collection]
+    data: (
+        Artifact | Iterable[Artifact]
+    ),  # can also be Collection | Iterable[Collection]
     is_run_input: bool | Run | None = None,
     run: Run | None = None,
 ):

--- a/lamindb/models/can_curate.py
+++ b/lamindb/models/can_curate.py
@@ -75,7 +75,7 @@ def _inspect(
         if strict_source:
             queryset = queryset.filter(source=source)
     organism_record = _get_organism_record(
-        getattr(registry, field_str), organism, values
+        getattr(registry, field_str), organism, values, queryset.db
     )
     _check_record_db(organism_record, queryset.db)
 
@@ -177,7 +177,7 @@ def _validate(
             queryset = queryset.filter(source=source)
 
     organism_record = _get_organism_record(
-        getattr(registry, field_str), organism, values
+        getattr(registry, field_str), organism, values, queryset.db
     )
     _check_record_db(organism_record, queryset.db)
     field_values = pd.Series(
@@ -244,7 +244,7 @@ def _standardize(
         if strict_source:
             queryset = queryset.filter(source=source)
     organism_record = _get_organism_record(
-        getattr(registry, field_str), organism, values
+        getattr(registry, field_str), organism, values, queryset.db
     )
     _check_record_db(organism_record, queryset.db)
 

--- a/lamindb/models/can_curate.py
+++ b/lamindb/models/can_curate.py
@@ -11,8 +11,8 @@ from lamin_utils import colors, logger
 from ..errors import ValidationError
 from ._from_values import (
     _format_values,
+    _from_values,
     _get_organism_record,
-    get_or_create_records,
 )
 from .record import Record, get_name_field
 
@@ -604,15 +604,13 @@ class CanCurate:
             # Bulk create records from public reference
             bt.CellType.from_values(["T cell", "B cell"]).save()
         """
-        field_str = get_name_field(cls, field=field)
-        return get_or_create_records(
+        return _from_values(
             iterable=values,
-            field=getattr(cls, field_str),
+            field=getattr(cls, get_name_field(cls, field=field)),
             create=create,
             organism=organism,
             source=source,
             mute=mute,
-            _from_source=True if cls.__module__.startswith("bionty.") else False,
         )
 
     @classmethod

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -1042,13 +1042,14 @@ def _search(
     field: StrField | list[StrField] | None = None,
     limit: int | None = 20,
     case_sensitive: bool = False,
-    using_key: str | None = None,
     truncate_string: bool = False,
 ) -> QuerySet:
     if string is None:
         raise ValueError("Cannot search for None value! Please pass a valid string.")
 
-    input_queryset = _queryset(cls, using_key=using_key)
+    input_queryset = (
+        cls.all() if isinstance(cls, (QuerySet, Manager)) else cls.objects.all()
+    )
     registry = input_queryset.model
     name_field = getattr(registry, "_name_field", "name")
     if field is None:
@@ -1157,7 +1158,7 @@ def _lookup(
     using_key: str | None = None,
 ) -> NamedTuple:
     """{}"""  # noqa: D415
-    queryset = _queryset(cls, using_key=using_key)
+    queryset = cls.all() if isinstance(cls, (QuerySet, Manager)) else cls.objects.all()
     field = get_name_field(registry=queryset.model, field=field)
 
     return Lookup(
@@ -1215,16 +1216,6 @@ def get_name_field(
             ) from None
 
     return field
-
-
-def _queryset(cls: Record | QuerySet | Manager, using_key: str) -> QuerySet:
-    if isinstance(cls, (QuerySet, Manager)):
-        return cls.all()
-    elif using_key is None or using_key == "default":
-        return cls.objects.all()
-    else:
-        # using must be called on cls, otherwise the connection isn't found
-        return cls.using(using_key).all()
 
 
 def add_db_connection(db: str, using: str):

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -1177,7 +1177,7 @@ def _lookup(
 def get_name_field(
     registry: type[Record] | QuerySet | Manager,
     *,
-    field: str | StrField | None = None,
+    field: StrField | None = None,
 ) -> str:
     """Get the 1st char or text field from the registry."""
     if isinstance(registry, (QuerySet, Manager)):

--- a/tests/core/test_can_curate.py
+++ b/tests/core/test_can_curate.py
@@ -75,8 +75,8 @@ def test_standardize():
     assert bt.Gene.standardize(["LMN1"], return_mapper=True) == {"LMN1": "LMNA"}
 
 
-def test_standardize_public_aware():
-    result = bt.Gene.standardize(["ABC1", "PDCD1"], public_aware=False)
+def test_standardize_source_aware():
+    result = bt.Gene.standardize(["ABC1", "PDCD1"], source_aware=False)
     assert result == ["ABC1", "PDCD1"]
 
 

--- a/tests/storage/test_transfer.py
+++ b/tests/storage/test_transfer.py
@@ -167,6 +167,6 @@ def test_using_record_organism():
             source=release_110,
         )
     assert (
-        "source must be a bionty.Source record from instance 'laminlabs/lamin-dev'"
+        "record must be a bionty.Source record from instance 'laminlabs/lamin-dev'"
         in str(error.value)
     )


### PR DESCRIPTION
Before | After
--- | ---
Passing `organism` was required in cases in which it didn't make sense. | Passing `organism` is only required in few cases.
<img width="503" alt="Screenshot 2025-03-13 at 11 07 44" src="https://github.com/user-attachments/assets/168f67ed-c6b5-4c06-9ea1-a2d8d30731b3" /> | <img width="571" alt="Screenshot 2025-03-13 at 11 06 54" src="https://github.com/user-attachments/assets/506a59fc-bd3c-41b0-b609-3fc28d468c8b" />

Changes:

- Passing `organism` to `CanCurate.validate()` is now only required if:
  1. registry has a REQUIRED `organism` FK (e.g. won't check nullable [wetlab.Biosample.organism](https://github.com/laminlabs/wetlab/blob/main/wetlab/models.py#L746))
  2. AND `field` used for validating and creating records is NOT unique (won't check for `ontology_id`, `ensembl_gene_id`, `uid`, ...)
- Robust mapping of ensembl prefix to organism via: [curated mapper](https://lamin.ai/laminlabs/bionty-assets/transform/iySVjI9UouaX).
- Removed all `using_key` logic in `CanCurate`, since users can call curate functions from `QuerySet`

