### PR TITLE
🚸 Add more constructor signatures and specific inherited types

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1468,24 +1468,6 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
     def n_objects(self) -> int:
         return self.n_files
 
-    # add the below because this is what people will have in their code
-    # if they implement the recommended migration strategy
-    # - FeatureSet -> Schema
-    # - featureset -> schema
-    # - feature_set -> schema
-    # @property
-    # def schemas(self) -> QuerySet[Schema]:
-    #     """Schemas linked to artifact via many-to-many relationship.
-
-    #     Is now mediating the private `.feature_sets` relationship during
-    #     a transition period to better schema management.
-
-    #     .. versionchanged: 1.0
-    #        Was previously called `.feature_sets`.
-
-    #     """
-    #     return self.feature_sets
-
     @property
     def path(self) -> Path:
         """Path.
@@ -1521,6 +1503,34 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
         return setup_settings.paths.cloud_to_local_no_update(
             filepath, cache_key=cache_key
         )
+
+    @classmethod
+    def get(
+        cls,
+        idlike: int | str | None = None,
+        **expressions,
+    ) -> Artifact:
+        """Get a single artifact.
+
+        Args:
+            idlike: Either a uid stub, uid or an integer id.
+            expressions: Fields and values passed as Django query expressions.
+
+        Raises:
+            :exc:`docs:lamindb.errors.DoesNotExist`: In case no matching record is found.
+
+        See Also:
+            - Guide: :doc:`docs:registries`
+            - Method in `Record` base class: :meth:`~lamindb.models.Record.get`
+
+        Examples::
+
+            artifact = ln.Artifact.get("tCUkRcaEjTjhtozp0000")
+            artifact = ln.Arfifact.get(key="my_datasets/my_file.parquet")
+        """
+        from .query_set import QuerySet
+
+        return QuerySet(model=cls).get(idlike, **expressions)
 
     @classmethod
     def from_df(

--- a/lamindb/models/project.py
+++ b/lamindb/models/project.py
@@ -66,6 +66,23 @@ class Person(Record, CanCurate, TracksRun, TracksUpdates, ValidateFields):
     external: bool = BooleanField(default=True, db_index=True)
     """Whether the person is external to the organization."""
 
+    @overload
+    def __init__(
+        self,
+        name: str,
+        email: str | None = None,
+        external: bool = True,
+    ): ...
+
+    @overload
+    def __init__(
+        self,
+        *db_args,
+    ): ...
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
 
 class Reference(Record, CanCurate, TracksRun, TracksUpdates, ValidateFields):
     """References such as internal studies, papers, documents, or URLs.

--- a/lamindb/models/project.py
+++ b/lamindb/models/project.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 
 from django.core.validators import RegexValidator
 from django.db import models
@@ -240,6 +240,27 @@ class Project(Record, CanCurate, TracksRun, TracksUpdates, ValidateFields):
     """Linked references."""
     _status_code: int = models.SmallIntegerField(default=0, db_index=True)
     """Status code."""
+
+    @overload
+    def __init__(
+        self,
+        name: str,
+        type: Project | None = None,
+        is_type: bool = False,
+        abbr: str | None = None,
+        url: str | None = None,
+        start_date: DateType | None = None,
+        end_date: DateType | None = None,
+    ): ...
+
+    @overload
+    def __init__(
+        self,
+        *db_args,
+    ): ...
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class ArtifactProject(BasicRecord, LinkORM, TracksRun):

--- a/lamindb/models/project.py
+++ b/lamindb/models/project.py
@@ -94,12 +94,6 @@ class Reference(Record, CanCurate, TracksRun, TracksUpdates, ValidateFields):
     """Universal id, valid across DB instances."""
     name: str = CharField(db_index=True)
     """Title or name of the reference document."""
-    abbr: str | None = CharField(
-        max_length=32,
-        db_index=True,
-        null=True,
-    )
-    """An abbreviation for the reference."""
     type: Reference | None = ForeignKey(
         "self", PROTECT, null=True, related_name="records"
     )
@@ -111,6 +105,12 @@ class Reference(Record, CanCurate, TracksRun, TracksUpdates, ValidateFields):
     """Records of this type."""
     is_type: bool = BooleanField(default=False, db_index=True, null=True)
     """Distinguish types from instances of the type."""
+    abbr: str | None = CharField(
+        max_length=32,
+        db_index=True,
+        null=True,
+    )
+    """An abbreviation for the reference."""
     url: str | None = URLField(null=True)
     """URL linking to the reference."""
     pubmed_id: int | None = BigIntegerField(null=True, db_index=True)
@@ -146,6 +146,30 @@ class Reference(Record, CanCurate, TracksRun, TracksUpdates, ValidateFields):
         Collection, through="CollectionReference", related_name="references"
     )
     """Collections associated with this reference."""
+
+    @overload
+    def __init__(
+        self,
+        name: str,
+        type: Reference | None = None,
+        is_type: bool = False,
+        abbr: str | None = None,
+        url: str | None = None,
+        pubmed_id: int | None = None,
+        doi: str | None = None,
+        description: str | None = None,
+        text: str | None = None,
+        date: DateType | None = None,
+    ): ...
+
+    @overload
+    def __init__(
+        self,
+        *db_args,
+    ): ...
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
 
 class Project(Record, CanCurate, TracksRun, TracksUpdates, ValidateFields):

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -13,6 +13,7 @@ from typing import (
     Any,
     Literal,
     NamedTuple,
+    TypeVar,
     Union,
     overload,
 )
@@ -89,6 +90,7 @@ if TYPE_CHECKING:
     from .transform import Transform
 
 
+T = TypeVar("T", bound="Record")
 IPYTHON = getattr(builtins, "__IPYTHON__", False)
 
 
@@ -468,10 +470,10 @@ class Registry(ModelBase):
         return QuerySet(model=cls, using=_using_key).filter(*queries, **expressions)
 
     def get(
-        cls,
+        cls: type[T],
         idlike: int | str | None = None,
         **expressions,
-    ) -> Record:
+    ) -> T:
         """Get a single record.
 
         Args:

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -478,9 +478,6 @@ class Registry(ModelBase):
             idlike: Either a uid stub, uid or an integer id.
             expressions: Fields and values passed as Django query expressions.
 
-        Returns:
-            A record.
-
         Raises:
             :exc:`docs:lamindb.errors.DoesNotExist`: In case no matching record is found.
 
@@ -488,9 +485,10 @@ class Registry(ModelBase):
             - Guide: :doc:`docs:registries`
             - Django documentation: `Queries <https://docs.djangoproject.com/en/stable/topics/db/queries/>`__
 
-        Examples:
-            >>> ulabel = ln.ULabel.get("FvtpPJLJ")
-            >>> ulabel = ln.ULabel.get(name="my-label")
+        Examples::
+
+            ulabel = ln.ULabel.get("FvtpPJLJ")
+            ulabel = ln.ULabel.get(name="my-label")
         """
         from .query_set import QuerySet
 

--- a/lamindb/models/run.py
+++ b/lamindb/models/run.py
@@ -23,10 +23,12 @@ from lamindb.errors import ValidationError
 
 from ..base.ids import base62_20
 from .can_curate import CanCurate
-from .record import BasicRecord, LinkORM, Record
+from .record import BasicRecord, LinkORM, Record, Registry
 
 if TYPE_CHECKING:
     from datetime import datetime
+
+    from lamindb.base.types import FeatureDtype, FieldAttr
 
     from .artifact import Artifact
     from .collection import Collection
@@ -234,6 +236,21 @@ class Param(Record, CanCurate, TracksRun, TracksUpdates):
     # backward fields
     values: ParamValue
     """Values for this parameter."""
+
+    @overload
+    def __init__(
+        self,
+        name: str,
+        dtype: FeatureDtype | Registry | list[Registry] | FieldAttr,
+        type: Param | None = None,
+        is_type: bool = False,
+    ): ...
+
+    @overload
+    def __init__(
+        self,
+        *db_args,
+    ): ...
 
     def __init__(self, *args, **kwargs):
         from .feature import process_init_feature_param

--- a/tests/permissions/scripts/setup_access.py
+++ b/tests/permissions/scripts/setup_access.py
@@ -2,9 +2,9 @@ import lamindb as ln  # noqa
 import hubmodule.models as hm
 from laminhub_rest.core.db import DbRoleHandler
 
-full_access = ln.models.Space(name="full access", uid="00000001").save()
-select_access = ln.models.Space(name="select access", uid="00000002").save()
-no_access = ln.models.Space(name="no access", uid="00000003").save()
+full_access = ln.models.Space(name="full access", uid="00000001").save()  # type: ignore
+select_access = ln.models.Space(name="select access", uid="00000002").save()  # type: ignore
+no_access = ln.models.Space(name="no access", uid="00000003").save()  # type: ignore
 
 account = hm.Account(id=ln.setup.settings.user._uuid.hex).save()
 


### PR DESCRIPTION
## Constructor signatures

Before | After
--- | ---
<img width="709" alt="image" src="https://github.com/user-attachments/assets/821b5752-1a44-4032-83bb-14473412f3f1" /> | <img width="628" alt="image" src="https://github.com/user-attachments/assets/0ffde496-ed57-41f6-95b2-62116f76350b" />

## `Artifact.get()` signature

Before | After
--- | ---
<img width="1107" alt="image" src="https://github.com/user-attachments/assets/a2d4a9a9-c164-4499-a90b-21d91e88397c" /> | <img width="1116" alt="image" src="https://github.com/user-attachments/assets/62fc87c9-dcf9-4a5a-b374-851fa2b9ba23" />

## `Registry.get()` signature

Now returns the inherited type for all registries and thereby we have auto-complete right away:

<img width="296" alt="image" src="https://github.com/user-attachments/assets/dd48bdf3-6d99-4923-a240-17397c097d0c" />

Claude [helped](https://claude.ai/share/338cc542-8d19-43c6-935b-df598783cc9e).

## Future work

We'll add similar typing improvements for other functionality in the future. Here is what we could add for `filter()`.

```python
from typing import TypeVar, Type, Optional, Union, Any, Generic
from django.db.models.base import ModelBase

T = TypeVar('T', bound='Record')

# Make QuerySet generic
class QuerySet(Generic[T]):
    # Your QuerySet implementation here
    pass

class Registry(ModelBase):
    def filter(
        cls: Type[T], 
        *queries: Any, 
        **expressions: Any
    ) -> QuerySet[T]:
        """Query records.

        Args:
            queries: One or multiple `Q` objects.
            expressions: Fields and values passed as Django query expressions.

        Returns:
            A :class:`~lamindb.models.QuerySet`.

        See Also:
            - Guide: :doc:`docs:registries`
            - Django documentation: `Queries <https://docs.djangoproject.com/en/stable/topics/db/queries/>`__

        Examples:
            >>> ln.ULabel(name="my label").save()
            >>> ln.ULabel.filter(name__startswith="my").df()
        """
        from .query_set import QuerySet

        return QuerySet[T](model=cls).filter(*queries, **expressions)


class Record(metaclass=Registry):
    """Base record class."""
    pass
```


