### PR TITLE
🚸 Add `uint` as a valid `dtype`, in `AnnDataCurator`, make `'obs'` schema optional and allow `'uns'` schema

### DIFF
--- a/docs/faq/key.ipynb
+++ b/docs/faq/key.ipynb
@@ -137,9 +137,7 @@
     "\n",
     "1. {class}`~lamindb.Storage`: Manages the default storage root that can be either local or in the cloud. For more details we refer to {doc}`docs:faq/storage`.\n",
     "2. {class}`~lamindb.Artifact`: Manages datasets with an optional `key` that acts as a relative path within the current default storage root (see {class}`~lamindb.Storage`). An example is a single h5 artifact.\n",
-    "3. {class}`~lamindb.Collection`: Manages a collection of datasets with an optional `key` that acts as a relative path within the current default storage root (see {class}`~lamindb.Storage`). An example is a collection of h5 artifacts.\n",
-    "\n",
-    "For more details we refer to {doc}`docs:tutorial`."
+    "3. {class}`~lamindb.Collection`: Manages a collection of datasets with an optional `key` that acts as a relative path within the current default storage root (see {class}`~lamindb.Storage`). An example is a collection of h5 artifacts."
    ]
   },
   {

--- a/lamindb/base/types.py
+++ b/lamindb/base/types.py
@@ -39,13 +39,14 @@ TransformType = Literal[
 ]
 ArtifactKind = Literal["dataset", "model"]
 FeatureDtype = Literal[
-    "cat",  # categorical variables
+    "cat",  # categoricals
     "num",  # numerical variables
-    "str",  # string variables
-    "int",  # integer variables
-    "float",  # float variables
-    "bool",  # boolean variables
-    "date",  # date variables
-    "datetime",  # datetime variables
-    "object",  # this is a pandas type, we're only using it for complicated types, not for strings
+    "str",  # string
+    "int",  # integer
+    "uint",  # unsigned integer
+    "float",  # float
+    "bool",  # boolean
+    "date",  # date
+    "datetime",  # datetime
+    "object",  # this is a pandas dtype, we're only using it for complicated types, not for strings
 ]

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -3194,8 +3194,14 @@ def save_artifact(
                 data, artifact, fields, feature_ref_is_name=_ref_is_name(index_field)
             )
         case "AnnData":
+            if "uns" in schema.slots:
+                uns_field = parse_dtype_single_cat(
+                    schema.slots["uns"].itype, is_itype=True
+                )["field"]
+            else:
+                uns_field = None
             artifact.features._add_set_from_anndata(  # type: ignore
-                var_field=index_field, **feature_kwargs
+                var_field=index_field, uns_field=uns_field, **feature_kwargs
             )
             _add_labels(
                 data, artifact, fields, feature_ref_is_name=_ref_is_name(index_field)

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -3194,7 +3194,7 @@ def save_artifact(
                 data, artifact, fields, feature_ref_is_name=_ref_is_name(index_field)
             )
         case "AnnData":
-            if "uns" in schema.slots:
+            if schema is not None and "uns" in schema.slots:
                 uns_field = parse_dtype_single_cat(
                     schema.slots["uns"].itype, is_itype=True
                 )["field"]

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -545,7 +545,7 @@ class AnnDataCurator(SlotsCurator):
                 slot_schema,
             )
             for slot, slot_schema in schema.slots.items()
-            if slot in {"obs", "var"}
+            if slot in {"obs", "var", "uns"}
         }
 
     @doc_args(SAVE_ARTIFACT_DOCSTRING)
@@ -1022,18 +1022,18 @@ class DataFrameCatManager(CatManager):
         update_registry(
             values=list(self.categoricals.keys()),
             field=self._columns_field,
-            key="columns",
+            key="columns" if isinstance(self._dataset, pd.DataFrame) else "keys",
             validated_only=False,
             source=self._sources.get("columns"),
         )
 
         # Save the rest of the columns based on validated_only
-        additional_columns = set(self._dataset.columns) - set(self.categoricals.keys())
+        additional_columns = set(self._dataset.keys()) - set(self.categoricals.keys())
         if additional_columns:
             update_registry(
                 values=list(additional_columns),
                 field=self._columns_field,
-                key="columns",
+                key="columns" if isinstance(self._dataset, pd.DataFrame) else "keys",
                 validated_only=validated_only,
                 df=self._dataset,  # Get the Feature type from df
                 source=self._sources.get("columns"),

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -560,10 +560,14 @@ class AnnDataCurator(SlotsCurator):
         """{}"""  # noqa: D415
         if not self._is_validated:
             self.validate()
+        if "obs" in self.slots:
+            categoricals = self.slots["obs"]._cat_manager.categoricals
+        else:
+            categoricals = {}
         return save_artifact(  # type: ignore
             self._dataset,
             description=description,
-            fields=self.slots["obs"]._cat_manager.categoricals,
+            fields=categoricals,
             index_field=(
                 parse_dtype_single_cat(self.slots["var"]._schema.itype, is_itype=True)[
                     "field"

--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -1116,6 +1116,7 @@ def _add_set_from_anndata(
     self,
     var_field: FieldAttr | None = None,
     obs_field: FieldAttr | None = Feature.name,
+    uns_field: FieldAttr | None = None,
     mute: bool = False,
     organism: str | Record | None = None,
 ):
@@ -1128,6 +1129,7 @@ def _add_set_from_anndata(
         adata,
         var_field=var_field,
         obs_field=obs_field,
+        uns_field=uns_field,
         mute=mute,
         organism=organism,
     )

--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -485,7 +485,7 @@ def parse_staged_feature_sets_from_anndata(
     adata: AnnData,
     var_field: FieldAttr | None = None,
     obs_field: FieldAttr = Feature.name,
-    uns_field: FieldAttr = Feature.name,
+    uns_field: FieldAttr | None = None,
     mute: bool = False,
     organism: str | Record | None = None,
 ) -> dict:

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -482,14 +482,14 @@ class Schema(Record, CanCurate, TracksRun):
         organism: Record | str | None = None,
         source: Record | None = None,
     ) -> Schema | None:
-        """Create feature set for validated features."""
+        """Create schema for valid columns."""
         registry = field.field.model
         validated = registry.validate(
             df.columns, field=field, mute=mute, organism=organism
         )
         if validated.sum() == 0:
-            if mute is True:
-                logger.warning("no validated features, skip creating feature set")
+            if not mute:
+                logger.warning("no validated features, skip creating schema")
             return None
         if registry == Feature:
             validated_features = Feature.from_values(  # type: ignore

--- a/tests/core/test_describe_and_df_calls.py
+++ b/tests/core/test_describe_and_df_calls.py
@@ -57,8 +57,6 @@ def test_curate_df():
     ln.Feature(name="study", dtype="cat[ULabel]").save()
     ln.Feature(name="date_of_study", dtype="date").save()
     ln.Feature(name="study_note", dtype="str").save()
-    # ad-hoc external metadata
-    # ln.Feature(name="adhoc_feature", dtype=float).save()
     ## Permissible values for categoricals
     ln.ULabel.from_values(["DMSO", "IFNG"], create=True).save()
     ln.ULabel.from_values(
@@ -79,7 +77,7 @@ def test_curate_df():
         organism="human",
     )
     artifact = curator.save_artifact(key="example_datasets/dataset1.h5ad")
-    # artifact.features.add_values({"adhoc_feature": 5.5})
+    artifact.features.add_values(adata.uns)
 
     # Ingest dataset2
     adata2 = datasets.small_dataset2(otype="AnnData")
@@ -93,6 +91,7 @@ def test_curate_df():
         organism="human",
     )
     artifact2 = curator.save_artifact(key="example_datasets/dataset2.h5ad")
+    artifact2.features.add_values(adata2.uns)
 
     # Test df(include=[...])
     df = (
@@ -126,9 +125,6 @@ def test_curate_df():
         .df(features=True)
         .drop(["uid"], axis=1)
     )
-    print(artifact.features)
-    print(artifact.features.get_values())
-    print(df.columns)
     expected_data = {
         "key": ["example_datasets/dataset2.h5ad", "example_datasets/dataset1.h5ad"],
         "description": [None, None],
@@ -144,7 +140,6 @@ def test_curate_df():
             np.nan,
         ],
         "date_of_study": [{"2024-12-01"}, np.nan],
-        "adhoc_feature": [{5.5}, np.nan],
     }
     expected_df = pd.DataFrame(expected_data)
     check_df_equality(df, expected_df)
@@ -152,12 +147,11 @@ def test_curate_df():
     # expected output has italicized elements that can't be tested
     # hence testing is restricted to section content, not headings
     description_tree = _describe_postgres(artifact)
-    from lamindb.models._describe import print_rich_tree
-
-    print_rich_tree(description_tree)
 
     # general section
-    assert len(description_tree.children) == 3  # general, dataset features, labels
+    assert (
+        len(description_tree.children) == 4
+    )  # general, internal features, external features, labels
     general_node = description_tree.children[0]
     assert general_node.label.plain == "General"
     assert general_node.children[0].label == f".uid = '{artifact.uid}'"
@@ -185,8 +179,6 @@ def test_curate_df():
         int_features_node.children[0].label.columns[1].header.plain == "[bionty.Gene]"
     )
     assert int_features_node.children[0].label.columns[1]._cells[0].plain == "int"
-
-    # obs
     assert int_features_node.children[1].label.columns[0].header.plain == "obs • 4"
     assert int_features_node.children[1].label.columns[0]._cells == [
         "cell_type_by_expert",
@@ -213,39 +205,28 @@ def test_curate_df():
         "",
     ]
 
-    # uns
-    assert int_features_node.children[2].label.columns[0].header.plain == "uns • 4"
-    assert int_features_node.children[2].label.columns[0]._cells == [
-        "study",
-        "date_of_study",
-        "study_note",
-        "temperature",
-    ]
-    assert int_features_node.children[2].label.columns[1].header.plain == "[Feature]"
-    assert (
-        int_features_node.children[2].label.columns[1]._cells[0].plain == "cat[ULabel]"
-    )
-    assert int_features_node.children[2].label.columns[1]._cells[1].plain == "date"
-    assert int_features_node.children[2].label.columns[1]._cells[2].plain == "str"
-    assert int_features_node.children[2].label.columns[1]._cells[3].plain == "float"
-    assert int_features_node.children[2].label.columns[2]._cells == [
-        "Candidate marker study 1",
-        "2024-12-01",
-        "We had a great time performing this study and the results look compelling.",
-        "21.6",
-    ]
-
     # external features section
     ext_features_node = description_tree.children[2]
     assert ext_features_node.label.plain == "Linked features"
     assert len(ext_features_node.children) == 1
     assert len(ext_features_node.children[0].label.columns) == 3
-    assert len(ext_features_node.children[0].label.rows) == 1
+    assert len(ext_features_node.children[0].label.rows) == 4
     assert ext_features_node.children[0].label.columns[0]._cells == [
-        "adhoc_feature",
+        "study",
+        "date_of_study",
+        "study_note",
+        "temperature",
     ]
-    assert ext_features_node.children[0].label.columns[1]._cells[0].plain == "float"
+    assert (
+        ext_features_node.children[0].label.columns[1]._cells[0].plain == "cat[ULabel]"
+    )
+    assert ext_features_node.children[0].label.columns[1]._cells[1].plain == "date"
+    assert ext_features_node.children[0].label.columns[1]._cells[2].plain == "str"
+    assert ext_features_node.children[0].label.columns[1]._cells[3].plain == "float"
     assert ext_features_node.children[0].label.columns[2]._cells == [
+        "Candidate marker study 1",
+        "2024-12-01",
+        "We had a great time performing this study and the results look compelling.",
         "21.6",
     ]
 


### PR DESCRIPTION
`uint` one is now a valid `dtype`.

The `AnnDataCurator` now understands validation with composite schemas that contain a slot `uns`.

```python
var_schema = ln.Schema(
    name="scRNA_seq_var_schema",
    itype=bt.Gene.ensembl_gene_id,
    dtype="num",
).save()
uns_schema = ln.Schema(
    name="flexible_uns_schema",
    itype=ln.Feature,
).save()
anndata_schema = ln.Schema(
    name="small_dataset1_anndata_schema",
    otype="AnnData",
    components={"var": var_schema, "uns": uns_schema},
).save()
```

Providing an "obs" schema is no longer required.