### PR TITLE
🚸 Avoid requiring `coerce_dtype` for `"int"` and `"float"` in case an integer or float `pd.Series.dtype` only deviates by numerical precision/range

### DIFF
--- a/docs/curate.ipynb
+++ b/docs/curate.ipynb
@@ -97,7 +97,7 @@
     "        ln.Feature(name=\"assay_oid\", dtype=bt.ExperimentalFactor.ontology_id).save(),\n",
     "        ln.Feature(name=\"donor\", dtype=str, nullable=True).save(),\n",
     "        ln.Feature(name=\"concentration\", dtype=str).save(),\n",
-    "        ln.Feature(name=\"treatment_time_h\", dtype=float, coerce_dtype=True).save(),\n",
+    "        ln.Feature(name=\"treatment_time_h\", dtype=\"num\", coerce_dtype=True).save(),\n",
     "    ],\n",
     ").save()\n",
     "# display the associated features as a dataframe\n",

--- a/lamindb/_view.py
+++ b/lamindb/_view.py
@@ -11,7 +11,7 @@ from lamindb_setup._init_instance import get_schema_module_name
 
 from lamindb.models import Feature, FeatureValue, ParamValue, Record
 
-from .models.feature import convert_pandas_dtype_to_lamin_dtype
+from .models.feature import serialize_pandas_dtype
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -114,7 +114,7 @@ def view(
     """
     if df is not None:
         descriptions = {
-            col_name: convert_pandas_dtype_to_lamin_dtype(dtype)
+            col_name: serialize_pandas_dtype(dtype)
             for col_name, dtype in df.dtypes.to_dict().items()
         }
         feature_dtypes = dict(Feature.objects.values_list("name", "dtype"))

--- a/lamindb/base/types.py
+++ b/lamindb/base/types.py
@@ -38,6 +38,8 @@ TransformType = Literal[
     "pipeline", "notebook", "upload", "script", "function", "linker"
 ]
 ArtifactKind = Literal["dataset", "model"]
+
+# below is used for Feature.dtype and Param.dtype
 Dtype = Literal[
     "cat",  # categoricals
     "num",  # numericals
@@ -47,17 +49,42 @@ Dtype = Literal[
     "bool",  # boolean
     "date",  # date
     "datetime",  # datetime
-    "object",  # this is a pandas dtype, we're only using it for complicated types, not for strings
+    "object",  # this is a pandas input dtype, we're only using it for complicated types, not for strings
 ]
 """Data type.
 
-============  =================================================
-lamindb       numpy / pandas
-============  =================================================
-`"cat"`       `category`
-`"num"`       `int | float`
-`"int"`       `int64 | int32 | int16 | int8 | uint | ...`
-`"float"`     `float64 | float32 | float16 | float8 | ...`
-============  =================================================
+Data types in lamindb are a string-serialized abstraction of common data types.
+
+Overview
+========
+
+============  ============  =================================================
+description   lamindb       pandas
+============  ============  =================================================
+categorical   `"cat"`       `category`
+numerical     `"num"`       `int | float`
+integer       `"int"`       `int64 | int32 | int16 | int8 | uint | ...`
+float         `"float"`     `float64 | float32 | float16 | float8 | ...`
+string        `"str"`       `object`
+datetime      `"datetime"`  `datetime`
+date          `"date"`      `date`
+============  ============  =================================================
+
+Categoricals
+============
+
+Beyond indicating that a feature is a categorical, `lamindb` allows you to define the registry to which values are restricted.
+
+For example, `'cat[ULabel]'` or `'cat[bionty.CellType]'` indicate that permissible values are from the `ULabel` or `CellType` registry, respectively.
+
+You can also reference multiple registries, e.g., `'cat[ULabel|bionty.CellType]'` indicates that values can be from either registry.
+
+You can also restrict to sub-types defined in registries via the `type` column, e.g., `'cat[ULabel[CellMedium]]'` indicates that values must be of type `CellMedium` within the `ULabel` registry.
+
+Literal
+=======
+
+A `Dtype` object in `lamindb` is a `Literal` up to further specification of `"cat"`.
+
 """
 FeatureDtype = Dtype  # backward compat

--- a/lamindb/base/types.py
+++ b/lamindb/base/types.py
@@ -49,3 +49,13 @@ FeatureDtype = Literal[
     "datetime",  # datetime
     "object",  # this is a pandas dtype, we're only using it for complicated types, not for strings
 ]
+"""Data types.
+
+============  ===================================
+lamindb dtype  numpy / pandas dtype
+============  ===================================
+int            `Union[int64, int32, int16, int8, uint, ...]`
+float          `Union[float64, float32, float16, float8, ...]`
+num            `Union[int, float]`
+============  ===================================
+"""

--- a/lamindb/base/types.py
+++ b/lamindb/base/types.py
@@ -7,7 +7,7 @@ Central object types.
 
    ArtifactKind
    TransformType
-   FeatureDtype
+   Dtype
 
 Basic types.
 
@@ -38,24 +38,26 @@ TransformType = Literal[
     "pipeline", "notebook", "upload", "script", "function", "linker"
 ]
 ArtifactKind = Literal["dataset", "model"]
-FeatureDtype = Literal[
+Dtype = Literal[
     "cat",  # categoricals
-    "num",  # numerical variables
+    "num",  # numericals
     "str",  # string
-    "int",  # integer
+    "int",  # integer / numpy.integer
     "float",  # float
     "bool",  # boolean
     "date",  # date
     "datetime",  # datetime
     "object",  # this is a pandas dtype, we're only using it for complicated types, not for strings
 ]
-"""Data types.
+"""Data type.
 
-============  ===================================
-lamindb dtype  numpy / pandas dtype
-============  ===================================
-int            `Union[int64, int32, int16, int8, uint, ...]`
-float          `Union[float64, float32, float16, float8, ...]`
-num            `Union[int, float]`
-============  ===================================
+============  =================================================
+lamindb       numpy / pandas
+============  =================================================
+`"cat"`       `category`
+`"num"`       `int | float`
+`"int"`       `int64 | int32 | int16 | int8 | uint | ...`
+`"float"`     `float64 | float32 | float16 | float8 | ...`
+============  =================================================
 """
+FeatureDtype = Dtype  # backward compat

--- a/lamindb/base/types.py
+++ b/lamindb/base/types.py
@@ -43,7 +43,6 @@ FeatureDtype = Literal[
     "num",  # numerical variables
     "str",  # string
     "int",  # integer
-    "uint",  # unsigned integer
     "float",  # float
     "bool",  # boolean
     "date",  # date

--- a/lamindb/core/types.py
+++ b/lamindb/core/types.py
@@ -6,7 +6,7 @@ from anndata import AnnData
 from lamindb_setup.core.types import UPathStr
 
 from lamindb.base.types import (
-    FeatureDtype,
+    Dtype,
     FieldAttr,
     ListLike,
     StrField,

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -380,7 +380,7 @@ class DataFrameCurator(Curator):
                 if feature.dtype in DTYPE_CHECK_MAP:
                     pandera_columns[feature.name] = pandera.Column(
                         dtype=None,
-                        checks=pa.Check(
+                        checks=pandera.Check(
                             DTYPE_CHECK_MAP[feature.dtype], element_wise=False
                         ),
                         nullable=feature.nullable,

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -379,12 +379,17 @@ class DataFrameCurator(Curator):
             pandera_columns = {}
             for feature in schema.features.all():
                 if feature.dtype in {"int", "float", "num"}:
+                    dtype = (
+                        self._dataset[feature.name].dtype
+                        if feature.name in self._dataset.columns
+                        else None
+                    )
                     pandera_columns[feature.name] = pandera.Column(
                         dtype=None,
                         checks=pandera.Check(
                             check_dtype(feature.dtype),
                             element_wise=False,
-                            error=f"Column '{feature.name}' failed dtype check for '{feature.dtype}': got {self._dataset[feature.name].dtype}",
+                            error=f"Column '{feature.name}' failed dtype check for '{feature.dtype}': got {dtype}",
                         ),
                         nullable=feature.nullable,
                         coerce=feature.coerce_dtype,

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -312,15 +312,25 @@ def is_any_float_type(series):
 
 
 def is_any_num_type(series):
-    return pd.api.types.is_float_dtype(series.dtype) or pd.api.types.is_integer_dtype(
-        series.dtype
-    )
+    return pd.api.types.is_numeric_dtype(series.dtype)
+
+
+def create_type_check(check_function, type_name):
+    def check_with_error_msg(series):
+        result = check_function(series)
+        if not result:
+            raise ValidationError(
+                f"Column {series.name} failed dtype check for {type_name}:, got {series.dtype}"
+            )
+        return result
+
+    return check_with_error_msg
 
 
 DTYPE_CHECK_MAP = {
-    "int": is_any_integer_type,
-    "float": is_any_float_type,
-    "num": is_any_num_type,
+    "int": create_type_check(is_any_integer_type, "int"),
+    "float": create_type_check(is_any_float_type, "float"),
+    "num": create_type_check(is_any_num_type, "numeric"),
 }
 
 

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import copy
 import re
 from itertools import chain
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Callable, Literal
 
 import anndata as ad
 import lamindb_setup as ln_setup
@@ -315,7 +315,7 @@ def is_any_num_type(series):
     return pd.api.types.is_numeric_dtype(series.dtype)
 
 
-def create_type_check(check_function, type_name):
+def create_type_check(check_function: Callable, type_name: str):
     def check_with_error_msg(series):
         result = check_function(series)
         if not result:
@@ -330,7 +330,7 @@ def create_type_check(check_function, type_name):
 DTYPE_CHECK_MAP = {
     "int": create_type_check(is_any_integer_type, "int"),
     "float": create_type_check(is_any_float_type, "float"),
-    "num": create_type_check(is_any_num_type, "numeric"),
+    "num": create_type_check(is_any_num_type, "num"),
 }
 
 

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -65,7 +65,7 @@ from lamindb.models.artifact import (
     data_is_mudata,
     data_is_spatialdata,
 )
-from lamindb.models.feature import parse_dtype, parse_dtype_single_cat
+from lamindb.models.feature import parse_dtype, parse_cat_dtype
 from lamindb.models._from_values import _format_values
 
 from ..errors import InvalidArgument, ValidationError
@@ -406,7 +406,7 @@ class DataFrameCurator(Curator):
             assert schema.itype is not None  # noqa: S101
         self._cat_manager = DataFrameCatManager(
             self._dataset,
-            columns=parse_dtype_single_cat(schema.itype, is_itype=True)["field"],
+            columns=parse_cat_dtype(schema.itype, is_itype=True)["field"],
             categoricals=categoricals,
         )
 
@@ -495,7 +495,7 @@ class DataFrameCurator(Curator):
         """{}"""  # noqa: D415
         if not self._is_validated:
             self.validate()  # raises ValidationError if doesn't validate
-        result = parse_dtype_single_cat(self._schema.itype, is_itype=True)
+        result = parse_cat_dtype(self._schema.itype, is_itype=True)
         return save_artifact(  # type: ignore
             self._dataset,
             description=description,
@@ -610,9 +610,7 @@ class AnnDataCurator(SlotsCurator):
             description=description,
             fields=categoricals,
             index_field=(
-                parse_dtype_single_cat(self.slots["var"]._schema.itype, is_itype=True)[
-                    "field"
-                ]
+                parse_cat_dtype(self.slots["var"]._schema.itype, is_itype=True)["field"]
                 if "var" in self._slots
                 else None
             ),
@@ -640,7 +638,7 @@ def _assign_var_fields_categoricals_multimodal(
         categoricals[modality] = {}
 
     if slot_type == "var":
-        var_field = parse_dtype_single_cat(slot_schema.itype, is_itype=True)["field"]
+        var_field = parse_cat_dtype(slot_schema.itype, is_itype=True)["field"]
         if modality is None:
             # This should rarely/never be used since tables should have different var fields
             var_fields[slot] = var_field  # pragma: no cover
@@ -3202,9 +3200,9 @@ def save_artifact(
             )
         case "AnnData":
             if schema is not None and "uns" in schema.slots:
-                uns_field = parse_dtype_single_cat(
-                    schema.slots["uns"].itype, is_itype=True
-                )["field"]
+                uns_field = parse_cat_dtype(schema.slots["uns"].itype, is_itype=True)[
+                    "field"
+                ]
             else:
                 uns_field = None
             artifact.features._add_set_from_anndata(  # type: ignore

--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -24,7 +24,7 @@ from lamindb.core.storage import LocalPathClasses
 from lamindb.errors import DoesNotExist, ValidationError
 from lamindb.models._from_values import _format_values
 from lamindb.models.feature import (
-    convert_pandas_dtype_to_lamin_dtype,
+    serialize_pandas_dtype,
     suggest_categorical_for_str_iterable,
 )
 from lamindb.models.record import (
@@ -502,11 +502,7 @@ def parse_staged_feature_sets_from_anndata(
             data_parse = ad.read_h5ad(filepath, backed="r")
         type = "float"
     else:
-        type = (
-            "float"
-            if adata.X is None
-            else convert_pandas_dtype_to_lamin_dtype(adata.X.dtype)
-        )
+        type = "float" if adata.X is None else serialize_pandas_dtype(adata.X.dtype)
     feature_sets = {}
     if var_field is not None:
         schema_var = Schema.from_values(
@@ -571,7 +567,7 @@ def infer_feature_type_convert_json(
             return "cat ? str", value, message
     elif isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
         if isinstance(value, (pd.Series, np.ndarray, pd.Categorical)):
-            dtype = convert_pandas_dtype_to_lamin_dtype(value.dtype)
+            dtype = serialize_pandas_dtype(value.dtype)
             if dtype == "str":
                 # ndarray doesn't know categorical, so there was no conscious choice
                 # offer both options

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 from typing import TYPE_CHECKING, Any, get_args, overload
 
+import numpy as np
 import pandas as pd
 from django.db import models
 from django.db.models import CASCADE, PROTECT, Q
@@ -12,6 +13,7 @@ from lamin_utils import logger
 from lamindb_setup._init_instance import get_schema_module_name
 from lamindb_setup.core.hashing import HASH_LENGTH, hash_dict
 from pandas.api.types import CategoricalDtype, is_string_dtype
+from pandas.core.dtypes.base import ExtensionDtype
 
 from lamindb.base.fields import (
     BooleanField,
@@ -35,8 +37,6 @@ from .run import (
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-
-    from pandas.core.dtypes.base import ExtensionDtype
 
     from .schema import Schema
 
@@ -152,6 +152,8 @@ def get_dtype_str_from_dtype(
         and dtype.__name__ in FEATURE_DTYPES
     ):
         dtype_str = dtype.__name__
+    elif isinstance(dtype, (ExtensionDtype, np.dtype)):
+        dtype_str = convert_pandas_dtype_to_lamin_dtype(dtype)
     else:
         error_message = (
             "dtype has to be a record, a record field, or a list of records, not {}"

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -142,7 +142,7 @@ def parse_dtype(dtype_str: str, is_param: bool = False) -> list[dict[str, str]]:
     return result
 
 
-def get_dtype_str_from_dtype(
+def serialize_dtype(
     dtype: Record | FieldAttr | list[Record], is_itype: bool = False
 ) -> str:
     """Converts a data type object into its string representation."""
@@ -229,7 +229,7 @@ def process_init_feature_param(args, kwargs, is_param: bool = False):
     dtype_str = None
     if dtype is not None:
         if not isinstance(dtype, str):
-            dtype_str = get_dtype_str_from_dtype(dtype)
+            dtype_str = serialize_dtype(dtype)
         else:
             dtype_str = dtype
             parse_dtype(dtype_str, is_param=is_param)

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -22,7 +22,7 @@ from lamindb.base.fields import (
     JSONField,
     TextField,
 )
-from lamindb.base.types import FeatureDtype, FieldAttr
+from lamindb.base.types import Dtype, FieldAttr
 from lamindb.errors import FieldValidationError, ValidationError
 
 from ..base.ids import base62_12
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
     from .schema import Schema
 
-FEATURE_DTYPES = set(get_args(FeatureDtype))
+FEATURE_DTYPES = set(get_args(Dtype))
 
 
 def parse_dtype(dtype_str: str, is_param: bool = False) -> list[dict[str, str]]:
@@ -256,7 +256,7 @@ class Feature(Record, CanCurate, TracksRun, TracksUpdates):
 
     Args:
         name: `str` Name of the feature, typically.  column name.
-        dtype: `FeatureDtype | Registry | list[Registry] | FieldAttr` See :class:`~lamindb.base.types.FeatureDtype`.
+        dtype: `Dtype | Registry | list[Registry] | FieldAttr` See :class:`~lamindb.base.types.Dtype`.
             For categorical types, can define from which registry values are
             sampled, e.g., `ULabel` or `[ULabel, bionty.CellType]`.
         unit: `str | None = None` Unit of measure, ideally SI (`"m"`, `"s"`, `"kg"`, etc.) or `"normalized"` etc.
@@ -345,8 +345,8 @@ class Feature(Record, CanCurate, TracksRun, TracksUpdates):
     """Universal id, valid across DB instances."""
     name: str = CharField(max_length=150, db_index=True, unique=True)
     """Name of feature (hard unique constraint `unique=True`)."""
-    dtype: FeatureDtype | None = CharField(db_index=True, null=True)
-    """Data type (:class:`~lamindb.base.types.FeatureDtype`).
+    dtype: Dtype | None = CharField(db_index=True, null=True)
+    """Data type (:class:`~lamindb.base.types.Dtype`).
 
     For categorical types, can define from which registry values are
     sampled, e.g., `'cat[ULabel]'` or `'cat[bionty.CellType]'`. Unions are also
@@ -393,7 +393,7 @@ class Feature(Record, CanCurate, TracksRun, TracksUpdates):
 
     Is stored as a list rather than a tuple because it's serialized as JSON.
     """
-    proxy_dtype: FeatureDtype | None = CharField(default=None, null=True)
+    proxy_dtype: Dtype | None = CharField(default=None, null=True)
     """Proxy data type.
 
     If the feature is an image it's often stored via a path to the image file. Hence, while the dtype might be
@@ -423,7 +423,7 @@ class Feature(Record, CanCurate, TracksRun, TracksUpdates):
     def __init__(
         self,
         name: str,
-        dtype: FeatureDtype | Registry | list[Registry] | FieldAttr,
+        dtype: Dtype | Registry | list[Registry] | FieldAttr,
         type: Feature | None = None,
         is_type: bool = False,
         unit: str | None = None,

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -194,6 +194,8 @@ def convert_pandas_dtype_to_lamin_dtype(pandas_dtype: ExtensionDtype) -> str:
     else:
         # strip precision qualifiers
         dtype = "".join(dt for dt in pandas_dtype.name if not dt.isdigit())
+        if dtype == "uint":
+            dtype = "int"
     if dtype.startswith("datetime"):
         dtype = dtype.split("[")[0]
     assert dtype in FEATURE_DTYPES  # noqa: S101

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -153,7 +153,7 @@ def serialize_dtype(
     ):
         dtype_str = dtype.__name__
     elif isinstance(dtype, (ExtensionDtype, np.dtype)):
-        dtype_str = convert_pandas_dtype_to_lamin_dtype(dtype)
+        dtype_str = serialize_pandas_dtype(dtype)
     else:
         error_message = (
             "dtype has to be a record, a record field, or a list of records, not {}"
@@ -184,7 +184,7 @@ def serialize_dtype(
     return dtype_str
 
 
-def convert_pandas_dtype_to_lamin_dtype(pandas_dtype: ExtensionDtype) -> str:
+def serialize_pandas_dtype(pandas_dtype: ExtensionDtype) -> str:
     if is_string_dtype(pandas_dtype):
         if not isinstance(pandas_dtype, CategoricalDtype):
             dtype = "str"
@@ -491,7 +491,7 @@ class Feature(Record, CanCurate, TracksRun, TracksUpdates):
             if name in categoricals:
                 dtypes[name] = "cat"
             else:
-                dtypes[name] = convert_pandas_dtype_to_lamin_dtype(col.dtype)
+                dtypes[name] = serialize_pandas_dtype(col.dtype)
         with logger.mute():  # silence the warning "loaded record with exact same name "
             features = [
                 Feature(name=name, dtype=dtype) for name, dtype in dtypes.items()

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -257,8 +257,8 @@ class Feature(Record, CanCurate, TracksRun, TracksUpdates):
     Args:
         name: `str` Name of the feature, typically.  column name.
         dtype: `Dtype | Registry | list[Registry] | FieldAttr` See :class:`~lamindb.base.types.Dtype`.
-            For categorical types, can define from which registry values are
-            sampled, e.g., `ULabel` or `[ULabel, bionty.CellType]`.
+            For categorical types, you can define to which registry values are
+            restricted, e.g., `ULabel` or `[ULabel, bionty.CellType]`.
         unit: `str | None = None` Unit of measure, ideally SI (`"m"`, `"s"`, `"kg"`, etc.) or `"normalized"` etc.
         description: `str | None = None` A description.
         synonyms: `str | None = None` Bar-separated synonyms.
@@ -346,12 +346,7 @@ class Feature(Record, CanCurate, TracksRun, TracksUpdates):
     name: str = CharField(max_length=150, db_index=True, unique=True)
     """Name of feature (hard unique constraint `unique=True`)."""
     dtype: Dtype | None = CharField(db_index=True, null=True)
-    """Data type (:class:`~lamindb.base.types.Dtype`).
-
-    For categorical types, can define from which registry values are
-    sampled, e.g., `'cat[ULabel]'` or `'cat[bionty.CellType]'`. Unions are also
-    allowed if the feature samples from two registries, e.g., `'cat[ULabel|bionty.CellType]'`
-    """
+    """Data type (:class:`~lamindb.base.types.Dtype`)."""
     type: Feature | None = ForeignKey(
         "self", PROTECT, null=True, related_name="records"
     )

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -206,12 +206,12 @@ def validate_literal_fields(record: Record, kwargs) -> None:
         return None
     if record.__class__.__name__ in "Feature":
         return None
-    from lamindb.base.types import FeatureDtype, TransformType
+    from lamindb.base.types import Dtype, TransformType
 
     types = {
         "TransformType": TransformType,
-        "ArtifactKind": FeatureDtype,
-        "FeatureDtype": FeatureDtype,
+        "ArtifactKind": Dtype,
+        "Dtype": Dtype,
     }
     errors = {}
     annotations = getattr(record.__class__, "__annotations__", {})

--- a/lamindb/models/run.py
+++ b/lamindb/models/run.py
@@ -208,12 +208,8 @@ class Param(Record, CanCurate, TracksRun, TracksUpdates):
     _name_field: str = "name"
 
     name: str = CharField(max_length=100, db_index=True)
-    dtype: str | None = CharField(db_index=True, null=True)
-    """Data type ("num", "cat", "int", "float", "bool", "datetime").
-
-    For categorical types, can define from which registry values are
-    sampled, e.g., `cat[ULabel]` or `cat[bionty.CellType]`.
-    """
+    dtype: Dtype | None = CharField(db_index=True, null=True)
+    """Data type (:class:`~lamindb.base.types.Dtype`)."""
     type: Param | None = ForeignKey("self", PROTECT, null=True, related_name="records")
     """Type of param (e.g., 'Pipeline', 'ModelTraining', 'PostProcessing').
 

--- a/lamindb/models/run.py
+++ b/lamindb/models/run.py
@@ -28,7 +28,7 @@ from .record import BasicRecord, LinkORM, Record, Registry
 if TYPE_CHECKING:
     from datetime import datetime
 
-    from lamindb.base.types import FeatureDtype, FieldAttr
+    from lamindb.base.types import Dtype, FieldAttr
 
     from .artifact import Artifact
     from .collection import Collection
@@ -241,7 +241,7 @@ class Param(Record, CanCurate, TracksRun, TracksUpdates):
     def __init__(
         self,
         name: str,
-        dtype: FeatureDtype | Registry | list[Registry] | FieldAttr,
+        dtype: Dtype | Registry | list[Registry] | FieldAttr,
         type: Param | None = None,
         is_type: bool = False,
     ): ...

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -28,8 +28,8 @@ from ._relations import (
 from .can_curate import CanCurate
 from .feature import (
     Feature,
-    convert_pandas_dtype_to_lamin_dtype,
     serialize_dtype,
+    serialize_pandas_dtype,
 )
 from .record import (
     BasicRecord,
@@ -502,7 +502,7 @@ class Schema(Record, CanCurate, TracksRun):
             dtypes = [col.dtype for (_, col) in df.loc[:, validated].items()]
             if len(set(dtypes)) != 1:
                 raise ValueError(f"data types are heterogeneous: {set(dtypes)}")
-            dtype = convert_pandas_dtype_to_lamin_dtype(dtypes[0])
+            dtype = serialize_pandas_dtype(dtypes[0])
             validated_features = registry.from_values(
                 df.columns[validated],
                 field=field,

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -29,7 +29,7 @@ from .can_curate import CanCurate
 from .feature import (
     Feature,
     convert_pandas_dtype_to_lamin_dtype,
-    get_dtype_str_from_dtype,
+    serialize_dtype,
 )
 from .record import (
     BasicRecord,
@@ -352,7 +352,7 @@ class Schema(Record, CanCurate, TracksRun):
             if otype is None:
                 raise InvalidArgument("Please pass otype != None for composite schemas")
         if itype is not None and not isinstance(itype, str):
-            itype_str = get_dtype_str_from_dtype(itype, is_itype=True)
+            itype_str = serialize_dtype(itype, is_itype=True)
         else:
             itype_str = itype
         validated_kwargs = {

--- a/tests/core/test_dtype.py
+++ b/tests/core/test_dtype.py
@@ -1,8 +1,28 @@
 import bionty
+import pandas as pd
 import pytest
 from lamindb import ULabel
 from lamindb.errors import ValidationError
-from lamindb.models.feature import parse_dtype
+from lamindb.models.feature import get_dtype_str_from_dtype, parse_dtype
+
+# -----------------------------------------------------------------------------
+# serializing dtypes
+# -----------------------------------------------------------------------------
+
+
+def test_seralize_dtypes():
+    df = pd.DataFrame(
+        {
+            "column1": pd.Series([1, 4, 0, 10, 9], dtype="uint"),
+        }
+    )
+    assert df.column1.dtype.name == "uint64"
+    assert get_dtype_str_from_dtype(df.column1.dtype) == "int"
+
+
+# -----------------------------------------------------------------------------
+# parsing serialized dtypes
+# -----------------------------------------------------------------------------
 
 
 def test_simple_ulabel_with_subtype_and_field():

--- a/tests/core/test_dtype.py
+++ b/tests/core/test_dtype.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 from lamindb import ULabel
 from lamindb.errors import ValidationError
-from lamindb.models.feature import get_dtype_str_from_dtype, parse_dtype
+from lamindb.models.feature import parse_dtype, serialize_dtype
 
 # -----------------------------------------------------------------------------
 # serializing dtypes
@@ -17,7 +17,7 @@ def test_seralize_dtypes():
         }
     )
     assert df.column1.dtype.name == "uint64"
-    assert get_dtype_str_from_dtype(df.column1.dtype) == "int"
+    assert serialize_dtype(df.column1.dtype) == "int"
 
 
 # -----------------------------------------------------------------------------

--- a/tests/core/test_feature.py
+++ b/tests/core/test_feature.py
@@ -3,7 +3,7 @@ import lamindb as ln
 import pandas as pd
 import pytest
 from lamindb.errors import ValidationError
-from lamindb.models.feature import convert_pandas_dtype_to_lamin_dtype
+from lamindb.models.feature import serialize_pandas_dtype
 from pandas.api.types import is_string_dtype
 
 
@@ -78,7 +78,7 @@ def test_feature_from_df(df):
             assert feature.dtype == "cat"
         else:
             orig_type = df[feature.name].dtype
-            assert feature.dtype == convert_pandas_dtype_to_lamin_dtype(orig_type)
+            assert feature.dtype == serialize_pandas_dtype(orig_type)
     for feature in features:
         feature.save()
     labels = [ln.ULabel(name=name) for name in df["feat3"].unique()]

--- a/tests/core/test_record.py
+++ b/tests/core/test_record.py
@@ -208,7 +208,7 @@ def test_using():
 def test_get_record_kwargs():
     assert _get_record_kwargs(ln.Feature) == [
         ("name", "str"),
-        ("dtype", "FeatureDtype | Registry | list[Registry] | FieldAttr"),
+        ("dtype", "Dtype | Registry | list[Registry] | FieldAttr"),
         ("type", "Feature | None"),
         ("is_type", "bool"),
         ("unit", "str | None"),

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -95,7 +95,7 @@ def mudata_papalexi21_subset_schema():
     obs_schema_hto = ln.Schema(
         name="mudata_papalexi21_subset_hto_obs_schema",
         features=[
-            ln.Feature(name="nCount_HTO", dtype=int).save(),
+            ln.Feature(name="nCount_HTO", dtype=float).save(),
             ln.Feature(name="nFeature_HTO", dtype=int).save(),
             ln.Feature(name="technique", dtype=bt.ExperimentalFactor).save(),
         ],

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -184,7 +184,28 @@ def spatialdata_blobs_schema():
 def test_dataframe_curator(small_dataset1_schema: ln.Schema):
     """Test DataFrame curator implementation."""
 
+    feature_to_fail = ln.Feature(name="treatment_time_h", dtype=float).save()
+    schema = ln.Schema(
+        name="small_dataset1_obs_level_metadata_v2",
+        features=[
+            ln.Feature(name="perturbation", dtype="cat[ULabel[Perturbation]]").save(),
+            ln.Feature(name="sample_note", dtype=str).save(),
+            ln.Feature(name="cell_type_by_expert", dtype=bt.CellType).save(),
+            ln.Feature(name="cell_type_by_model", dtype=bt.CellType).save(),
+            feature_to_fail,
+        ],
+    ).save()
+
     df = datasets.small_dataset1(otype="DataFrame")
+    curator = ln.curators.DataFrameCurator(df, schema)
+    with pytest.raises(ln.errors.ValidationError) as error:
+        curator.validate()
+    assert (
+        error.exconly()
+        == "lamindb.errors.ValidationError: Column 'treatment_time_h' failed series or dataframe validator 0: <Check check_function: Column 'treatment_time_h' failed dtype check for 'float': got int64>"
+    )
+    schema.delete()
+    feature_to_fail.delete()
     curator = ln.curators.DataFrameCurator(df, small_dataset1_schema)
     artifact = curator.save_artifact(key="example_datasets/dataset1.parquet")
 


### PR DESCRIPTION
To avoid requiring `coerce_dtype` for `"int"` and `"float"` in case an integer or float `pd.Series.dtype` only deviates by numerical precision/range, we now interpret `"int"` / `"float"` / `"num"` dtypes as unions of their underlying numerical `dtype` families as documented below.

Before | After
--- | ---
<img width="881" alt="image" src="https://github.com/user-attachments/assets/465b8ada-5ee1-488e-8fb6-4b0d078a97fc" /> | <img width="887" alt="image" src="https://github.com/user-attachments/assets/8e1fdb27-6f32-4072-9fbf-d2bfcaacb3ef" />

According to the sources and AI I consulted, it is known behavior that pandera doesn't have a built-in way to express an `AnyInt` dtype. pandera interprets `int` as `np.int64`, _not_ as `np.integer`. `np.integer` would provide the correct behavior but doesn't have a counterpart in a validation library or another context where it'd be serialized.

Specifically, I've found this [related comment](https://github.com/unionai-oss/pandera/issues/726#issuecomment-1511391725) on the pandera repo, and had [this](https://claude.ai/share/a37cf745-5256-463f-995e-cd96aa06b7bf) and [this](https://claude.ai/share/3990d0b2-9e72-4d96-9feb-5f437ae4d656) chats with Claude. Citing from the comment:

> The default generic Int type shold allow any of int8, int16, int32 or int64. It is just Int. There are other IntN classes for the specific bid widths. But if I have a Schema with just column: int I'm not too interested in pandera checking for bid width. Perhaps, the rules in the Int class should be relaxed?

This comment did not find a response in the past two years.

The implementation here follows the suggestion in the second Claude chat. I thought about not using pandera for this at all, but then one would need to come up with custom "delayed Check" logic in our codebase.
