### PR TITLE
🚸 Show link to hub in `view_lineage()` and render lineage through graphviz also in scripts

### DIFF
--- a/lamindb/models/has_parents.py
+++ b/lamindb/models/has_parents.py
@@ -11,6 +11,8 @@ from .record import format_field_value, get_name_field
 from .run import Run
 
 if TYPE_CHECKING:
+    from graphviz import Digraph
+
     from lamindb.base.types import StrField
 
     from .artifact import Artifact
@@ -79,7 +81,7 @@ class HasParents:
         if not isinstance(field, str):
             field = field.field.name
 
-        return _view_parents(
+        return view_parents(
             record=self,  # type: ignore
             field=field,
             with_children=with_children,
@@ -102,7 +104,7 @@ def _transform_emoji(transform: Transform):
         return TRANSFORM_EMOJIS["pipeline"]
 
 
-def _view(u):
+def view_digraph(u: Digraph):
     from graphviz.backend import ExecutableNotFound
 
     try:
@@ -197,10 +199,10 @@ def view_lineage(data: Artifact | Collection, with_children: bool = True) -> Non
         shape="box",
     )
 
-    _view(u)
+    view_digraph(u)
 
 
-def _view_parents(
+def view_parents(
     record: Record,
     field: str,
     with_children: bool = False,
@@ -266,7 +268,7 @@ def _view_parents(
             u.node(row["target"], label=row["target_label"])
             u.edge(row["source"], row["target"], color="dimgrey")
 
-    _view(u)
+    view_digraph(u)
 
 
 def _get_parents(

--- a/lamindb/models/has_parents.py
+++ b/lamindb/models/has_parents.py
@@ -120,7 +120,7 @@ def view_digraph(u: Digraph):
                 # call to display()
                 display(u._repr_mimebundle_(), raw=True)
         else:
-            return u
+            return u.view()
     except (FileNotFoundError, RuntimeError, ExecutableNotFound):  # pragma: no cover
         logger.error(
             "please install the graphviz executable on your system:\n  - Ubuntu: `sudo"

--- a/lamindb/models/has_parents.py
+++ b/lamindb/models/has_parents.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import builtins
 from typing import TYPE_CHECKING, Literal
 
+import lamindb_setup as ln_setup
 from lamin_utils import logger
 
 from .record import format_field_value, get_name_field
@@ -136,6 +137,13 @@ def view_lineage(data: Artifact | Collection, with_children: bool = True) -> Non
         >>> collection.view_lineage()
         >>> artifact.view_lineage()
     """
+    if ln_setup.settings.instance.is_on_hub:
+        instance_slug = ln_setup.settings.instance.slug
+        entity_slug = data.__class__.__name__.lower()
+        logger.important(
+            f"explore at: https://lamin.ai/{instance_slug}/{entity_slug}/{data.uid}"
+        )
+
     import graphviz
 
     df_values = _get_all_parent_runs(data)

--- a/lamindb/models/transform.py
+++ b/lamindb/models/transform.py
@@ -340,9 +340,9 @@ class Transform(Record, IsVersioned):
 
     def view_lineage(self, with_successors: bool = False, distance: int = 5):
         """View lineage of transforms."""
-        from .has_parents import _view_parents
+        from .has_parents import view_parents
 
-        return _view_parents(
+        return view_parents(
             record=self,
             field="key",
             with_children=with_successors,


### PR DESCRIPTION
The below is now printed.

```python
artifact.view_lineage()
#> → explore at: https://lamin.ai/laminlabs/lamindata/artifact/qQ6DCPnSKWMvA5GC0000
```

When running the code in the regular python shell or in a script, a pdf plot is displayed and a file is written into the current working directory.