### PR TITLE
🚸 Add space management to `ln.track()`

### DIFF
--- a/docs/track.ipynb
+++ b/docs/track.ipynb
@@ -192,6 +192,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Use spaces"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can write the entities created during a run into a space that you configure on LaminHub. This is particularly useful if you want to restrict access to a space."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "ln.track(space=\"Our team space\")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Track parameters"
    ]
   },

--- a/docs/track.ipynb
+++ b/docs/track.ipynb
@@ -199,7 +199,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can write the entities created during a run into a space that you configure on LaminHub. This is particularly useful if you want to restrict access to a space."
+    "You can write the entities created during a run into a space that you configure on LaminHub. This is particularly useful if you want to restrict access to a space. Note that this doesn't affect bionty entities who should typically be commonly accessible."
    ]
   },
   {

--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -123,8 +123,8 @@ if _check_instance_setup(from_module="lamindb"):
     from . import integrations
     from . import curators
 
-    track = context.track  # simple access
-    finish = context.finish  # simple access
+    track = context.track
+    finish = context.finish
     settings.__doc__ = """Global settings (:class:`~lamindb.core.Settings`)."""
     context.__doc__ = """Global run context (:class:`~lamindb.core.Context`).
 

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from lamindb_setup.core.types import UPathStr
 
     from lamindb.base.types import TransformType
-    from lamindb.models import Project
+    from lamindb.models import Project, Space
 
 is_run_from_ipython = getattr(builtins, "__IPYTHON__", False)
 
@@ -202,6 +202,7 @@ class Context:
         self._path: Path | None = None
         """A local path to the script that's running."""
         self._project: Project | None = None
+        self._space: Space | None = None
         self._logging_message_track: str = ""
         self._logging_message_imports: str = ""
         self._stream_tracker: LogStreamTracker = LogStreamTracker()
@@ -254,6 +255,11 @@ class Context:
         return self._project
 
     @property
+    def space(self) -> Space | None:
+        """The space in which entities are created during the run."""
+        return self._space
+
+    @property
     def run(self) -> Run | None:
         """Managed run of context."""
         return self._run
@@ -278,8 +284,9 @@ class Context:
         script-like transform exists in a git repository and links it.
 
         Args:
-            transform: A transform `uid` or record. If `None`, creates a `uid`.
+            transform: A transform `uid` or record. If `None`, manages the `transform` based on the script or notebook that calls `ln.track()`.
             project: A project `name` or `uid` for labeling entities created during the run.
+            space: A space `name` or `uid` for creating entities during the run.
             params: A dictionary of parameters to track for the run.
             new_run: If `False`, loads the latest run of transform
                 (default notebook), if `True`, creates new run (default non-notebook).
@@ -727,4 +734,4 @@ class Context:
         self._description = None
 
 
-context = Context()
+context: Context = Context()

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -269,6 +269,7 @@ class Context:
         transform: str | Transform | None = None,
         *,
         project: str | None = None,
+        space: str | None = None,
         params: dict | None = None,
         new_run: bool | None = None,
         path: str | None = None,
@@ -304,7 +305,7 @@ class Context:
             >>> ln.track("Onv04I53OgtT0000")  # example uid, the last four characters encode the version of the transform
 
         """
-        from lamindb.models import Project
+        from lamindb.models import Project, Space
 
         instance_settings = ln_setup.settings.instance
         # similar logic here: https://github.com/laminlabs/lamindb/pull/2527
@@ -321,6 +322,13 @@ class Context:
                     f"Project '{project}' not found, either create it with `ln.Project(name='...').save()` or fix typos."
                 )
             self._project = project_record
+        if space is not None:
+            space_record = Space.filter(Q(name=space) | Q(uid=space)).one_or_none()
+            if space_record is None:
+                raise InvalidArgument(
+                    f"Space '{space}', please check on the hub UI whether you have the correct `uid` or `name`."
+                )
+            self._space = space_record
         self._logging_message_track = ""
         self._logging_message_imports = ""
         if transform is not None and isinstance(transform, str):

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -274,20 +274,21 @@ class Context:
         new_run: bool | None = None,
         path: str | None = None,
     ) -> None:
-        """Track a global run of your Python session.
+        """Track a global run in your compute session.
 
         - sets :attr:`~lamindb.core.Context.transform` &
           :attr:`~lamindb.core.Context.run` by creating or loading `Transform` &
           `Run` records
-        - saves Python environment as a `requirements.txt` file: `run.environment`
+        - writes compute environment to prepare populating: `run.environment`
+        - if :attr:`~lamindb.core.Settings.sync_git_repo` is set, checks whether a script-like
+          transform exists in a git repository and links it
 
-        If :attr:`~lamindb.core.Settings.sync_git_repo` is set, checks whether a
-        script-like transform exists in a git repository and links it.
+        Guide: :doc:`/track`
 
         Args:
             transform: A transform `uid` or record. If `None`, manages the `transform` based on the script or notebook that calls `ln.track()`.
             project: A project `name` or `uid` for labeling entities created during the run.
-            space: A space `name` or `uid` for creating entities during the run.
+            space: A space `name` or `uid` for creating entities during the run. This doesn't affect bionty entities given they should typically be commonly accessible.
             params: A dictionary of parameters to track for the run.
             new_run: If `False`, loads the latest run of transform
                 (default notebook), if `True`, creates new run (default non-notebook).
@@ -296,13 +297,13 @@ class Context:
 
         Examples:
 
-            To track the run of a notebook or script, call:
+            To track the run of a notebook or script, call::
 
-            >>> ln.track()
+                ln.track()
 
-            If you want to ensure a single version history across renames of the notebook or script, pass the auto-generated `uid` that you'll find in the logs:
+            If you want to ensure a single version history across renames of the notebook or script, pass the auto-generated `uid` that you'll find in the logs::
 
-            >>> ln.track("Onv04I53OgtT0000")  # example uid, the last four characters encode the version of the transform
+                ln.track("Onv04I53OgtT0000")  # example uid, the last four characters encode the version of the transform
 
         """
         from lamindb.models import Project, Space

--- a/lamindb/models/query_set.py
+++ b/lamindb/models/query_set.py
@@ -680,7 +680,8 @@ class QuerySet(models.QuerySet):
                     )
 
         expressions = process_expressions(self, expressions)
-        if queries or len(expressions) > 0:
+        # need to run a query if queries or expressions are not empty
+        if queries or expressions:
             try:
                 return super().filter(*queries, **expressions)
             except FieldError as e:

--- a/lamindb/models/query_set.py
+++ b/lamindb/models/query_set.py
@@ -680,7 +680,7 @@ class QuerySet(models.QuerySet):
                     )
 
         expressions = process_expressions(self, expressions)
-        if len(expressions) > 0:
+        if queries or len(expressions) > 0:
             try:
                 return super().filter(*queries, **expressions)
             except FieldError as e:

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -62,7 +62,6 @@ from lamindb_setup.core._hub_core import connect_instance_hub
 from lamindb_setup.core._settings_store import instance_settings_file
 from lamindb_setup.core.upath import extract_suffix_from_path
 
-from lamindb import context as run_context
 from lamindb.base import deprecated
 from lamindb.base.fields import (
     CharField,
@@ -671,6 +670,8 @@ class BasicRecord(models.Model, metaclass=Registry):
         abstract = True
 
     def __init__(self, *args, **kwargs):
+        from lamindb import context as run_context
+
         skip_validation = kwargs.pop("_skip_validation", False)
         if not args:
             if run_context.space is not None:

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -670,12 +670,13 @@ class BasicRecord(models.Model, metaclass=Registry):
         abstract = True
 
     def __init__(self, *args, **kwargs):
-        from lamindb import context as run_context
-
         skip_validation = kwargs.pop("_skip_validation", False)
         if not args:
-            if run_context.space is not None:
-                kwargs["space"] = run_context.space
+            if self.__class__ is Record and not self.__class__.__name__ == "Storage":
+                from lamindb import context as run_context
+
+                if run_context.space is not None:
+                    kwargs["space"] = run_context.space
             if skip_validation:
                 super().__init__(**kwargs)
             else:
@@ -686,9 +687,6 @@ class BasicRecord(models.Model, metaclass=Registry):
                 from .transform import Transform
 
                 validate_fields(self, kwargs)
-
-                if run_context.space is not None:
-                    kwargs["space"] = run_context.space
 
                 # do not search for names if an id is passed; this is important
                 # e.g. when synching ids from the notebook store to lamindb

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -841,16 +841,20 @@ class BasicRecord(models.Model, metaclass=Registry):
                 if k != "run":
                     logger.important(f"{k} records: {', '.join(v)}")
 
-        if self.__class__.__name__ in {
-            "Artifact",
-            "Transform",
-            "Run",
-            "ULabel",
-            "Feature",
-            "Schema",
-            "Collection",
-            "Reference",
-        }:
+        if (
+            self.__class__.__name__
+            in {
+                "Artifact",
+                "Transform",
+                "Run",
+                "ULabel",
+                "Feature",
+                "Schema",
+                "Collection",
+                "Reference",
+            }
+            and self._branch_code >= 1
+        ):
             import lamindb as ln
 
             if ln.context.project is not None:

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -675,6 +675,8 @@ class BasicRecord(models.Model, metaclass=Registry):
             if (
                 issubclass(self.__class__, Record)
                 and not self.__class__.__name__ == "Storage"
+                # do not save bionty entities in restricted spaces by default
+                and self.__class__.__module__ != "bionty.models"
             ):
                 from lamindb import context as run_context
 

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -672,7 +672,10 @@ class BasicRecord(models.Model, metaclass=Registry):
     def __init__(self, *args, **kwargs):
         skip_validation = kwargs.pop("_skip_validation", False)
         if not args:
-            if self.__class__ is Record and not self.__class__.__name__ == "Storage":
+            if (
+                issubclass(self.__class__, Record)
+                and not self.__class__.__name__ == "Storage"
+            ):
                 from lamindb import context as run_context
 
                 if run_context.space is not None:

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -62,6 +62,7 @@ from lamindb_setup.core._hub_core import connect_instance_hub
 from lamindb_setup.core._settings_store import instance_settings_file
 from lamindb_setup.core.upath import extract_suffix_from_path
 
+from lamindb import context as run_context
 from lamindb.base import deprecated
 from lamindb.base.fields import (
     CharField,
@@ -671,75 +672,81 @@ class BasicRecord(models.Model, metaclass=Registry):
 
     def __init__(self, *args, **kwargs):
         skip_validation = kwargs.pop("_skip_validation", False)
-        if not args and skip_validation:
-            super().__init__(**kwargs)
-        elif not args and not skip_validation:
-            from ..core._settings import settings
-            from .can_curate import CanCurate
-            from .collection import Collection
-            from .schema import Schema
-            from .transform import Transform
+        if not args:
+            if run_context.space is not None:
+                kwargs["space"] = run_context.space
+            if skip_validation:
+                super().__init__(**kwargs)
+            else:
+                from ..core._settings import settings
+                from .can_curate import CanCurate
+                from .collection import Collection
+                from .schema import Schema
+                from .transform import Transform
 
-            validate_fields(self, kwargs)
+                validate_fields(self, kwargs)
 
-            # do not search for names if an id is passed; this is important
-            # e.g. when synching ids from the notebook store to lamindb
-            has_consciously_provided_uid = False
-            if "_has_consciously_provided_uid" in kwargs:
-                has_consciously_provided_uid = kwargs.pop(
-                    "_has_consciously_provided_uid"
-                )
-            if (
-                isinstance(self, (CanCurate, Collection, Transform))
-                and settings.creation.search_names
-                and not has_consciously_provided_uid
-            ):
-                name_field = getattr(self, "_name_field", "name")
-                exact_match = suggest_records_with_similar_names(
-                    self, name_field, kwargs
-                )
-                if exact_match is not None:
-                    if "version" in kwargs:
-                        if kwargs["version"] is not None:
-                            version_comment = " and version"
-                            existing_record = self.__class__.filter(
-                                **{
-                                    name_field: kwargs[name_field],
-                                    "version": kwargs["version"],
-                                }
-                            ).one_or_none()
+                if run_context.space is not None:
+                    kwargs["space"] = run_context.space
+
+                # do not search for names if an id is passed; this is important
+                # e.g. when synching ids from the notebook store to lamindb
+                has_consciously_provided_uid = False
+                if "_has_consciously_provided_uid" in kwargs:
+                    has_consciously_provided_uid = kwargs.pop(
+                        "_has_consciously_provided_uid"
+                    )
+                if (
+                    isinstance(self, (CanCurate, Collection, Transform))
+                    and settings.creation.search_names
+                    and not has_consciously_provided_uid
+                ):
+                    name_field = getattr(self, "_name_field", "name")
+                    exact_match = suggest_records_with_similar_names(
+                        self, name_field, kwargs
+                    )
+                    if exact_match is not None:
+                        if "version" in kwargs:
+                            if kwargs["version"] is not None:
+                                version_comment = " and version"
+                                existing_record = self.__class__.filter(
+                                    **{
+                                        name_field: kwargs[name_field],
+                                        "version": kwargs["version"],
+                                    }
+                                ).one_or_none()
+                            else:
+                                # for a versioned record, an exact name match is not a criterion
+                                # for retrieving a record in case `version` isn't passed -
+                                # we'd always pull out many records with exactly the same name
+                                existing_record = None
                         else:
-                            # for a versioned record, an exact name match is not a criterion
-                            # for retrieving a record in case `version` isn't passed -
-                            # we'd always pull out many records with exactly the same name
-                            existing_record = None
-                    else:
-                        version_comment = ""
-                        existing_record = exact_match
-                    if existing_record is not None:
-                        logger.important(
-                            f"returning existing {self.__class__.__name__} record with same"
-                            f" {name_field}{version_comment}: '{kwargs[name_field]}'"
-                        )
-                        if isinstance(self, Schema):
-                            if existing_record.hash != kwargs["hash"]:
-                                raise ValueError(
-                                    f"Schema name is already in use by schema with uid '{existing_record.uid}', please choose a different name."
-                                )
-                        init_self_from_db(self, existing_record)
-                        update_attributes(self, kwargs)
-                        return None
-            super().__init__(**kwargs)
-            if isinstance(self, ValidateFields):
-                # this will trigger validation against django validators
-                try:
-                    if hasattr(self, "clean_fields"):
-                        self.clean_fields()
-                    else:
-                        self._Model__clean_fields()
-                except DjangoValidationError as e:
-                    message = _format_django_validation_error(self, e)
-                    raise FieldValidationError(message) from e
+                            version_comment = ""
+                            existing_record = exact_match
+                        if existing_record is not None:
+                            logger.important(
+                                f"returning existing {self.__class__.__name__} record with same"
+                                f" {name_field}{version_comment}: '{kwargs[name_field]}'"
+                            )
+                            if isinstance(self, Schema):
+                                if existing_record.hash != kwargs["hash"]:
+                                    raise ValueError(
+                                        f"Schema name is already in use by schema with uid '{existing_record.uid}', please choose a different name."
+                                    )
+                            init_self_from_db(self, existing_record)
+                            update_attributes(self, kwargs)
+                            return None
+                super().__init__(**kwargs)
+                if isinstance(self, ValidateFields):
+                    # this will trigger validation against django validators
+                    try:
+                        if hasattr(self, "clean_fields"):
+                            self.clean_fields()
+                        else:
+                            self._Model__clean_fields()
+                    except DjangoValidationError as e:
+                        message = _format_django_validation_error(self, e)
+                        raise FieldValidationError(message) from e
         elif len(args) != len(self._meta.concrete_fields):
             raise FieldValidationError(
                 f"Use keyword arguments instead of positional arguments, e.g.: {self.__class__.__name__}(name='...')."

--- a/tests/core/test_track.py
+++ b/tests/core/test_track.py
@@ -19,15 +19,15 @@ def test_track_basic_invocation():
     with pytest.raises(ln.errors.InvalidArgument) as error:
         ln.context.track(project=project)
     assert (
-        str(error)
-        == f"Project '{project}' not found, either create it with `ln.Project(name='...').save()` or fix typos."
+        error.exconly()
+        == f"lamindb.errors.InvalidArgument: Project '{project}' not found, either create it with `ln.Project(name='...').save()` or fix typos."
     )
     space = "non-existing space"
     with pytest.raises(ln.errors.InvalidArgument) as error:
         ln.context.track(space=space)
     assert (
-        str(error)
-        == f"Space '{space}', please check on the hub UI whether you have the correct `uid` or `name`."
+        error.exconly()
+        == f"lamindb.errors.InvalidArgument: Space '{space}', please check on the hub UI whether you have the correct `uid` or `name`."
     )
 
     predecessor1 = ln.Transform(key="parent 1").save()

--- a/tests/core/test_track.py
+++ b/tests/core/test_track.py
@@ -16,13 +16,19 @@ NOTEBOOKS_DIR = Path(__file__).parent.resolve() / "notebooks"
 
 def test_track_basic_invocation():
     project = "non-existing project"
-    try:
+    with pytest.raises(ln.errors.InvalidArgument) as error:
         ln.context.track(project=project)
-    except ln.errors.InvalidArgument as error:
-        assert (
-            str(error)
-            == f"Project '{project}' not found, either create it with `ln.Project(name='...').save()` or fix typos."
-        )
+    assert (
+        str(error)
+        == f"Project '{project}' not found, either create it with `ln.Project(name='...').save()` or fix typos."
+    )
+    space = "non-existing space"
+    with pytest.raises(ln.errors.InvalidArgument) as error:
+        ln.context.track(space=space)
+    assert (
+        str(error)
+        == f"Space '{space}', please check on the hub UI whether you have the correct `uid` or `name`."
+    )
 
     predecessor1 = ln.Transform(key="parent 1").save()
     predecessor2 = ln.Transform(key="parent 2").save()

--- a/tests/permissions/scripts/example_script.py
+++ b/tests/permissions/scripts/example_script.py
@@ -1,0 +1,24 @@
+import lamindb_setup as ln_setup
+
+AUTO_CONNECT = ln_setup.settings.auto_connect
+ln_setup.settings.auto_connect = False
+
+import lamindb as ln
+
+assert ln.setup.settings.user.handle == "testuser1"
+ln.connect("laminlabs/lamin-dev")
+space_name = "Our test space for CI"
+ln.track(space=space_name)
+
+assert ln.context.space.name == space_name
+
+ulabel = ln.ULabel(name="My test ulabel in test space").save()
+
+print(ln.context.space.name)
+print(ulabel.space.name)
+
+assert ulabel.space.name == space_name
+
+ulabel.delete()
+
+ln.context.transform.delete()

--- a/tests/permissions/scripts/example_script.py
+++ b/tests/permissions/scripts/example_script.py
@@ -1,6 +1,5 @@
 import lamindb_setup as ln_setup
 
-AUTO_CONNECT = ln_setup.settings.auto_connect
 ln_setup.settings.auto_connect = False
 
 import lamindb as ln
@@ -9,16 +8,8 @@ assert ln.setup.settings.user.handle == "testuser1"
 ln.connect("laminlabs/lamin-dev")
 space_name = "Our test space for CI"
 ln.track(space=space_name)
-
 assert ln.context.space.name == space_name
-
 ulabel = ln.ULabel(name="My test ulabel in test space").save()
-
-print(ln.context.space.name)
-print(ulabel.space.name)
-
 assert ulabel.space.name == space_name
-
-ulabel.delete()
-
+ulabel.delete()  # delete silently passes in case another worker deleted the ulabel
 ln.context.transform.delete()

--- a/tests/permissions/test_permissions.py
+++ b/tests/permissions/test_permissions.py
@@ -1,6 +1,9 @@
 from uuid import uuid4
 
 import hubmodule.models as hm
+import subprocess
+from pathlib import Path
+
 import lamindb as ln
 import psycopg2
 import pytest
@@ -114,3 +117,16 @@ def test_write_role():
         )
 
     ln.ULabel(name="new label default space").save()
+
+
+def test_lamin_dev():
+    script_path = Path(__file__).parent.resolve() / "scripts/example_script.py"
+
+    result = subprocess.run(  # noqa: S602
+        f"python {script_path}",
+        shell=True,
+        capture_output=True,
+    )
+    print(result.stdout.decode())
+    print(result.stderr.decode())
+    assert result.returncode == 0

--- a/tests/permissions/test_permissions.py
+++ b/tests/permissions/test_permissions.py
@@ -121,7 +121,7 @@ def test_write_role():
 # below is an integration test that should run last
 def test_lamin_dev():
     script_path = Path(__file__).parent.resolve() / "scripts/example_script.py"
-    result = subprocess.run(  # noqa: S602
+    subprocess.run(  # noqa: S602
         f"python {script_path}",
         shell=True,
         check=True,

--- a/tests/permissions/test_permissions.py
+++ b/tests/permissions/test_permissions.py
@@ -118,9 +118,9 @@ def test_write_role():
     ln.ULabel(name="new label default space").save()
 
 
+# below is an integration test that should run last
 def test_lamin_dev():
     script_path = Path(__file__).parent.resolve() / "scripts/example_script.py"
-
     result = subprocess.run(  # noqa: S602
         f"python {script_path}",
         shell=True,

--- a/tests/permissions/test_permissions.py
+++ b/tests/permissions/test_permissions.py
@@ -124,8 +124,5 @@ def test_lamin_dev():
     result = subprocess.run(  # noqa: S602
         f"python {script_path}",
         shell=True,
-        capture_output=True,
+        check=True,
     )
-    print(result.stdout.decode())
-    print(result.stderr.decode())
-    assert result.returncode == 0

--- a/tests/permissions/test_permissions.py
+++ b/tests/permissions/test_permissions.py
@@ -1,9 +1,8 @@
+import subprocess
+from pathlib import Path
 from uuid import uuid4
 
 import hubmodule.models as hm
-import subprocess
-from pathlib import Path
-
 import lamindb as ln
 import psycopg2
 import pytest


### PR DESCRIPTION
Assigning spaces to records was possible before, but to conveniently add all entities written during a run to a desired space, you can now pass `space` to `ln.track()`.

```python
ln.track(space="My space")
```

This parallels what we do for labeling entities with projects with `ln.track(project="My project")`.

Note that `bionty` entities are -- for now -- excluded from this because in most use cases they should be saved in the`"All"` space of an instance and be accessible to all instance collaborators.