### PR TITLE
🐛 Fix SpatialData and MuData check

### DIFF
--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -42,6 +42,8 @@ from lamindb_setup.core import deprecated
 from lamindb_setup.core._docs import doc_args
 from lamindb_setup.core.upath import UPath
 
+from lamindb.core._compat import is_package_installed
+
 if TYPE_CHECKING:
     from lamindb_setup.core.types import UPathStr
     from mudata import MuData
@@ -3512,6 +3514,9 @@ def from_mudata(
     verbosity: str = "hint",
     organism: str | None = None,
 ) -> MuDataCatManager:
+    if not is_package_installed("mudata"):
+        raise ImportError("Please install mudata: pip install mudata")
+
     return MuDataCatManager(
         mdata=mdata,
         var_index=var_index,
@@ -3553,10 +3558,8 @@ def from_spatialdata(
     *,
     sample_metadata_key: str = "sample",
 ):
-    try:
-        import spatialdata
-    except ImportError as e:
-        raise ImportError("Please install spatialdata: pip install spatialdata") from e
+    if not is_package_installed("spatialdata"):
+        raise ImportError("Please install spatialdata: pip install spatialdata")
 
     return SpatialDataCatManager(
         sdata=sdata,

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -253,7 +253,7 @@ def process_data(
     # Check for suffix consistency
     if key_suffix is not None and key_suffix != suffix and not is_replace:
         # consciously omitting a trailing period
-        if isinstance(data, (str, Path, UPath)):
+        if isinstance(data, (str, Path, UPath)):  # UPathStr, spelled out
             message = f"The suffix '{suffix}' of the provided path is inconsistent, it should be '{key_suffix}'"
         else:
             message = f"The suffix '{key_suffix}' of the provided key is inconsistent, it should be '{suffix}'"

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -38,7 +38,6 @@ from lamindb.errors import FieldValidationError
 from lamindb.models.query_set import QuerySet
 
 from ..base.users import current_user_id
-from ..core._compat import is_package_installed
 from ..core.loaders import load_to_memory
 from ..core.storage import (
     LocalPathClasses,
@@ -209,35 +208,24 @@ def process_data(
 
     if not overwritten, data gets stored in default storage
     """
-    supported_data_types = [pd.DataFrame, AnnData]
-    if is_package_installed("mudata"):
-        from mudata import MuData
-
-        supported_data_types.append(MuData)
-    if is_package_installed("spatialdata"):
-        from spatialdata import SpatialData
-
-        supported_data_types.append(SpatialData)
-    supported_data_types = tuple(supported_data_types)  # type: ignore
-
     if key is not None:
         key_suffix = extract_suffix_from_path(PurePosixPath(key), arg_name="key")
-        # use suffix as the (adata) format if the format is not provided
         if isinstance(data, AnnData) and format is None and len(key_suffix) > 0:
             format = key_suffix[1:]
     else:
         key_suffix = None
-    if isinstance(data, (str, Path, UPath)):  # UPathStr, spelled out
+
+    if isinstance(data, (str, Path, UPath)):
         access_token = (
             default_storage._access_token
             if hasattr(default_storage, "_access_token")
             else None
         )
         path = create_path(data, access_token=access_token)
-        # we don't resolve http links because they can resolve into a different domain
-        # for example into a temporary url
+
         if path.protocol not in {"http", "https"}:
             path = path.resolve()
+
         storage, use_existing_storage_key = process_pathlike(
             path,
             default_storage=default_storage,
@@ -246,28 +234,36 @@ def process_data(
         )
         suffix = extract_suffix_from_path(path)
         memory_rep = None
-    elif isinstance(data, supported_data_types):
+    elif (
+        isinstance(data, pd.DataFrame)
+        or isinstance(data, AnnData)
+        or data_is_mudata(data)
+        or data_is_spatialdata(data)
+    ):
         storage = default_storage
         memory_rep = data
         suffix = infer_suffix(data, format)
     else:
         raise NotImplementedError(
-            f"Do not know how to create a artifact object from {data}, pass a path instead!"
+            f"Do not know how to create an Artifact from {data}, pass a path instead."
         )
+
+    # Check for suffix consistency
     if key_suffix is not None and key_suffix != suffix and not is_replace:
-        # consciously omitting a trailing period
         if isinstance(data, (str, Path, UPath)):
             message = f"The suffix '{suffix}' of the provided path is inconsistent, it should be '{key_suffix}'"
         else:
             message = f"The suffix '{key_suffix}' of the provided key is inconsistent, it should be '{suffix}'"
         raise InvalidArgument(message)
-    # in case we have an in-memory representation, we need to write it to disk
-    from lamindb import settings
 
-    if isinstance(data, supported_data_types):
+    # Handle in-memory data serialization
+    if memory_rep is not None:
+        from lamindb import settings
+
         path = settings.cache_dir / f"{provisional_uid}{suffix}"
         write_to_disk(data, path)
         use_existing_storage_key = False
+
     return memory_rep, path, suffix, storage, use_existing_storage_key
 
 
@@ -532,28 +528,24 @@ def data_is_anndata(data: AnnData | UPathStr) -> bool:
 
 
 def data_is_mudata(data: MuData | UPathStr) -> bool:
-    if is_package_installed("mudata"):
-        from mudata import MuData
-
-        if isinstance(data, MuData):
-            return True
+    # We are not importing MuData here to keep loaded modules minimal
+    if hasattr(data, "__class__") and data.__class__.__name__ == "MuData":
+        return True
     if isinstance(data, (str, Path)):
         return UPath(data).suffix == ".h5mu"
     return False
 
 
 def data_is_spatialdata(data: SpatialData | UPathStr) -> bool:
-    if is_package_installed("spatialdata"):
-        from spatialdata import SpatialData
-
-        if isinstance(data, SpatialData):
-            return True
-        if isinstance(data, (str, Path)):
-            if UPath(data).suffix == ".zarr":
-                # TODO: inconsistent with anndata, where we run the storage
-                # check only for local, expensive for cloud
-                return identify_zarr_type(data, check=False) == "spatialdata"
-        return False
+    # We are not importing SpatialData here to keep loaded modules minimal
+    if hasattr(data, "__class__") and data.__class__.__name__ == "SpatialData":
+        return True
+    if isinstance(data, (str, Path)):
+        if UPath(data).suffix == ".zarr":
+            # TODO: inconsistent with anndata, where we run the storage
+            # check only for local, expensive for cloud
+            return identify_zarr_type(data, check=False) == "spatialdata"
+    return False
 
 
 def _check_otype_artifact(

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -1149,3 +1149,5 @@ def test_no_unnecessary_imports(df, module_name: str) -> None:
 
     # Cleanup and restore imports to ensure that other tests still run smoothly
     af.delete(permanent=True)
+    import mudata  # noqa
+    import spatialdata  # noqa

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -1148,4 +1148,4 @@ def test_no_unnecessary_imports(df, module_name: str) -> None:
     assert module_name not in sorted(loaded_packages)
 
     # Cleanup and restore imports to ensure that other tests still run smoothly
-    af.delete(permament=True)
+    af.delete(permanent=True)


### PR DESCRIPTION
We were previously loading both mudata and spatialdata if they were installed and users were trying to create ANY Artifact. With this PR we check for types using class names instead of instance checks so that we do no longer need these imports.

To test:

```python
import lamindb as ln
import sys
from types import ModuleType

def get_loaded_packages() -> list[str]:
    modules = []
    for name, module in sys.modules.items():
        if isinstance(module, ModuleType) and not name.startswith('_'):
            if '.' not in name:
                modules.append(name)
    return sorted(modules)

ln.Artifact("LICENSE").save()

loaded_packages = get_loaded_packages()

assert not "mudata" in loaded_packages
assert not "spatialdata" in loaded_packages
```