### PR TITLE
✨ Support `minimal_set`, `maximal_set`, `ordered_set` in curators

### DIFF
--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -375,6 +375,8 @@ class DataFrameCurator(Curator):
         super().__init__(dataset=dataset, schema=schema)
         categoricals = {}
         if schema.n > 0:
+            # whether all the columns are required
+            required = schema.minimal_set
             # populate features
             pandera_columns = {}
             for feature in schema.features.all():
@@ -393,6 +395,7 @@ class DataFrameCurator(Curator):
                         ),
                         nullable=feature.nullable,
                         coerce=feature.coerce_dtype,
+                        required=required,
                     )
                 else:
                     pandera_dtype = (
@@ -404,11 +407,15 @@ class DataFrameCurator(Curator):
                         pandera_dtype,
                         nullable=feature.nullable,
                         coerce=feature.coerce_dtype,
+                        required=required,
                     )
                 if feature.dtype.startswith("cat"):
                     categoricals[feature.name] = parse_dtype(feature.dtype)[0]["field"]
             self._pandera_schema = pandera.DataFrameSchema(
-                pandera_columns, coerce=schema.coerce_dtype
+                pandera_columns,
+                coerce=schema.coerce_dtype,
+                strict=schema.maximal_set,
+                ordered=schema.ordered_set,
             )
         else:
             assert schema.itype is not None  # noqa: S101


### PR DESCRIPTION
This PR adds validation of features in `DataFrameCurator` based on `schema.minimal_set`, `schema.maximal_set`, `schema.ordered_set`.

* If `minimal_set` is `False`, missing columns in a dataframe will not lead to an error (default is unchanged and `True`)
* If `maximal_set` is `True`, additional columns in a dataframe will lead to an error (default is unchanged and `False`)
* If `ordered_set` is `True`, columns in the wrong order in a dataframe lead to an error (default is unchanged and `False`)

## minimal_set
```python
df_missing_column = pd.DataFrame(
    {
        "sample_id": ["sample1", "sample2"],
        "sample_name": ["Sample 1", "Sample 2"],
    }
)

schema_minimal_set = ln.Schema(
    name = "my_schema_minimal_set",
    features = [
        ln.Feature(name="sample_id", dtype = str).save(),
        ln.Feature(name="sample_name", dtype = str).save(),
        ln.Feature(name="sample_type", dtype = str).save(),
    ],
).save()
schema_not_minimal_set = ln.Schema(
    name = "my-schema minimal_set",
    features = [
        ln.Feature(name="sample_id", dtype = str).save(),
        ln.Feature(name="sample_name", dtype = str).save(),
        ln.Feature(name="sample_type", dtype = str).save(),
    ],
    minimal_set=False,
).save()

# pass
ln.curators.DataFrameCurator(df_missing_column, schema=schema_not_minimal_set).validate()

# error
ln.curators.DataFrameCurator(df_missing_column, schema=schema_minimal_set).validate()
```

## maximal_set
```python
df_extra_column = pd.DataFrame(
    {
        "sample_id": ["sample1", "sample2"],
        "sample_name": ["Sample 1", "Sample 2"],
        "sample_type": ["Type A", "Type B"],
        "extra_column": ["Extra 1", "Extra 2"],
    }
)

schema_maximal_set = ln.Schema(
    name = "my_schema_maximal_set",
    features = [
        ln.Feature(name="sample_id", dtype = str).save(),
        ln.Feature(name="sample_name", dtype = str).save(),
        ln.Feature(name="sample_type", dtype = str).save(),
    ],
    maximal_set=True,
).save()

# error
ln.curators.DataFrameCurator(df_extra_column, schema=schema_maximal_set).validate()
```

## ordered_set
```python
df_changed_order = pd.DataFrame(
    {
        "sample_name": ["Sample 1", "Sample 2"],
        "sample_type": ["Type A", "Type B"],
        "sample_id": ["sample1", "sample2"],
    }
)

schema_ordered_set = ln.Schema(
    name = "my_schema_ordered_set",
    features = [
        ln.Feature(name="sample_id", dtype = str).save(),
        ln.Feature(name="sample_name", dtype = str).save(),
        ln.Feature(name="sample_type", dtype = str).save(),
    ],
    ordered_set=True,
).save()

# error
ln.curators.DataFrameCurator(df_changed_order, schema=schema_ordered_set).validate()
```