### PR TITLE
✨ Define optional features on a per-schema level & improve schema hash calculation

### DIFF
--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -380,15 +380,12 @@ class DataFrameCurator(Curator):
         if schema.n > 0:
             # populate features
             pandera_columns = {}
-            optional_feature_uids = schema.optional.list("uid")
+            optional_feature_uids = schema.get_optional().list("uid")
             for feature in schema.features.all():
-                feature = feature.with_config(
-                    optional=feature.uid in optional_feature_uids
-                )
                 required = (
-                    not feature.optional
-                    if feature.optional is not None
-                    else schema.minimal_set
+                    feature.uid not in optional_feature_uids
+                    if schema.minimal_set
+                    else feature.uid in optional_feature_uids
                 )
                 if feature.dtype in {"int", "float", "num"}:
                     dtype = (

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -380,13 +380,9 @@ class DataFrameCurator(Curator):
         if schema.n > 0:
             # populate features
             pandera_columns = {}
-            optional_feature_uids = schema.get_optional().list("uid")
+            optional_feature_uids = schema.optionals.get().list("uid")
             for feature in schema.features.all():
-                required = (
-                    feature.uid not in optional_feature_uids
-                    if schema.minimal_set
-                    else feature.uid in optional_feature_uids
-                )
+                required = feature.uid not in optional_feature_uids
                 if feature.dtype in {"int", "float", "num"}:
                     dtype = (
                         self._dataset[feature.name].dtype

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -380,7 +380,12 @@ class DataFrameCurator(Curator):
         if schema.n > 0:
             # populate features
             pandera_columns = {}
+            required_feature_uids = schema.required.list("uid")
             for feature in schema.features.all():
+                feature = feature.with_config(
+                    required=feature.uid in required_feature_uids
+                )
+                required = True if schema.minimal_set else feature.required
                 if feature.dtype in {"int", "float", "num"}:
                     dtype = (
                         self._dataset[feature.name].dtype
@@ -396,7 +401,7 @@ class DataFrameCurator(Curator):
                         ),
                         nullable=feature.nullable,
                         coerce=feature.coerce_dtype,
-                        required=True if schema.minimal_set else feature.required,
+                        required=required,
                     )
                 else:
                     pandera_dtype = (
@@ -408,7 +413,7 @@ class DataFrameCurator(Curator):
                         pandera_dtype,
                         nullable=feature.nullable,
                         coerce=feature.coerce_dtype,
-                        required=True if schema.minimal_set else feature.required,
+                        required=required,
                     )
                 if feature.dtype.startswith("cat"):
                     # validate categoricals if the column is required or if the column is present

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -377,8 +377,6 @@ class DataFrameCurator(Curator):
         super().__init__(dataset=dataset, schema=schema)
         categoricals = {}
         if schema.n > 0:
-            # whether all the columns are required
-            required = schema.minimal_set
             # populate features
             pandera_columns = {}
             for feature in schema.features.all():
@@ -397,7 +395,7 @@ class DataFrameCurator(Curator):
                         ),
                         nullable=feature.nullable,
                         coerce=feature.coerce_dtype,
-                        required=required,
+                        required=True if schema.minimal_set else feature.required,
                     )
                 else:
                     pandera_dtype = (
@@ -409,7 +407,7 @@ class DataFrameCurator(Curator):
                         pandera_dtype,
                         nullable=feature.nullable,
                         coerce=feature.coerce_dtype,
-                        required=required,
+                        required=True if schema.minimal_set else feature.required,
                     )
                 if feature.dtype.startswith("cat"):
                     categoricals[feature.name] = parse_dtype(feature.dtype)[0]["field"]

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -380,12 +380,16 @@ class DataFrameCurator(Curator):
         if schema.n > 0:
             # populate features
             pandera_columns = {}
-            required_feature_uids = schema.required.list("uid")
+            optional_feature_uids = schema.optional.list("uid")
             for feature in schema.features.all():
                 feature = feature.with_config(
-                    required=feature.uid in required_feature_uids
+                    optional=feature.uid in optional_feature_uids
                 )
-                required = True if schema.minimal_set else feature.required
+                required = (
+                    feature.optional
+                    if feature.optional is not None
+                    else schema.minimal_set
+                )
                 if feature.dtype in {"int", "float", "num"}:
                     dtype = (
                         self._dataset[feature.name].dtype

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -386,7 +386,7 @@ class DataFrameCurator(Curator):
                     optional=feature.uid in optional_feature_uids
                 )
                 required = (
-                    feature.optional
+                    not feature.optional
                     if feature.optional is not None
                     else schema.minimal_set
                 )

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -396,9 +396,13 @@ class DataFrameCurator(Curator):
         if schema.n > 0:
             # populate features
             pandera_columns = {}
-            optional_feature_uids = schema.optionals.get().list("uid")
+            if schema.minimal_set:
+                optional_feature_uids = set(schema.optionals.get_uids())
             for feature in schema.features.all():
-                required = feature.uid not in optional_feature_uids
+                if schema.minimal_set:
+                    required = feature.uid not in optional_feature_uids
+                else:
+                    required = False
                 if feature.dtype in {"int", "float", "num"}:
                     dtype = (
                         self._dataset[feature.name].dtype

--- a/lamindb/models/__init__.py
+++ b/lamindb/models/__init__.py
@@ -21,6 +21,7 @@
    FeatureValue
    InspectResult
    ValidateFields
+   SchemaOptionals
 
 """
 
@@ -75,5 +76,11 @@ from .project import (
 )
 from .record import Migration
 from .run import RunParamValue
-from .schema import SchemaFeature, SchemaParam, ArtifactSchema, SchemaComponent
+from .schema import (
+    SchemaFeature,
+    SchemaParam,
+    ArtifactSchema,
+    SchemaComponent,
+    SchemaOptionals,
+)
 from .ulabel import ArtifactULabel, TransformULabel, RunULabel, CollectionULabel

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -454,7 +454,7 @@ class Feature(Record, CanCurate, TracksRun, TracksUpdates):
         self.default_value = default_value
         self.nullable = nullable
         self.coerce_dtype = coerce_dtype
-        self.required: bool = False
+        self.optional: bool | None = None
         dtype_str = kwargs.pop("dtype", None)
         if cat_filters:
             assert "|" not in dtype_str  # noqa: S101
@@ -500,9 +500,9 @@ class Feature(Record, CanCurate, TracksRun, TracksUpdates):
         super().save(*args, **kwargs)
         return self
 
-    def with_config(self, required: bool = False) -> Feature:
+    def with_config(self, optional: bool | None = None) -> Feature:
         """Set required flag."""
-        self.required = required
+        self.optional = optional
         return self
 
     @property

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -501,7 +501,9 @@ class Feature(Record, CanCurate, TracksRun, TracksUpdates):
 
     def with_config(self, optional: bool | None = None) -> tuple[Feature, dict]:
         """Pass addtional configurations to the schema."""
-        return self, {"optional": optional}
+        if optional is not None:
+            return self, {"optional": optional}
+        return self, {}
 
     @property
     def default_value(self) -> Any:

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -449,11 +449,13 @@ class Feature(Record, CanCurate, TracksRun, TracksUpdates):
         nullable = kwargs.pop("nullable", True)  # default value of nullable
         cat_filters = kwargs.pop("cat_filters", None)
         coerce_dtype = kwargs.pop("coerce_dtype", False)
+        required = kwargs.pop("required", False)
         kwargs = process_init_feature_param(args, kwargs)
         super().__init__(*args, **kwargs)
         self.default_value = default_value
         self.nullable = nullable
         self.coerce_dtype = coerce_dtype
+        self.required = required
         dtype_str = kwargs.pop("dtype", None)
         if cat_filters:
             assert "|" not in dtype_str  # noqa: S101
@@ -500,25 +502,6 @@ class Feature(Record, CanCurate, TracksRun, TracksUpdates):
         return self
 
     @property
-    def coerce_dtype(self) -> bool:
-        """Whether dtypes should be coerced during validation.
-
-        For example, a `objects`-dtyped pandas column can be coerced to `categorical` and would pass validation if this is true.
-        """
-        if self._aux is not None and "af" in self._aux and "2" in self._aux["af"]:  # type: ignore
-            return self._aux["af"]["2"]  # type: ignore
-        else:
-            return False
-
-    @coerce_dtype.setter
-    def coerce_dtype(self, value: bool) -> None:
-        if self._aux is None:  # type: ignore
-            self._aux = {}  # type: ignore
-        if "af" not in self._aux:
-            self._aux["af"] = {}
-        self._aux["af"]["2"] = value
-
-    @property
     def default_value(self) -> Any:
         """A default value that overwrites missing values (default `None`).
 
@@ -533,11 +516,8 @@ class Feature(Record, CanCurate, TracksRun, TracksUpdates):
 
     @default_value.setter
     def default_value(self, value: bool) -> None:
-        if self._aux is None:  # type: ignore
-            self._aux = {}  # type: ignore
-        if "af" not in self._aux:
-            self._aux["af"] = {}
-        self._aux["af"]["0"] = value
+        self._aux = self._aux or {}
+        self._aux.setdefault("af", {})["0"] = value
 
     @property
     def nullable(self) -> bool:
@@ -568,11 +548,37 @@ class Feature(Record, CanCurate, TracksRun, TracksUpdates):
     @nullable.setter
     def nullable(self, value: bool) -> None:
         assert isinstance(value, bool), value  # noqa: S101
-        if self._aux is None:
-            self._aux = {}
-        if "af" not in self._aux:
-            self._aux["af"] = {}
-        self._aux["af"]["1"] = value
+        self._aux = self._aux or {}
+        self._aux.setdefault("af", {})["1"] = value
+
+    @property
+    def coerce_dtype(self) -> bool:
+        """Whether dtypes should be coerced during validation.
+
+        For example, a `objects`-dtyped pandas column can be coerced to `categorical` and would pass validation if this is true.
+        """
+        if self._aux is not None and "af" in self._aux and "2" in self._aux["af"]:  # type: ignore
+            return self._aux["af"]["2"]  # type: ignore
+        else:
+            return False
+
+    @coerce_dtype.setter
+    def coerce_dtype(self, value: bool) -> None:
+        self._aux = self._aux or {}
+        self._aux.setdefault("af", {})["2"] = value
+
+    @property
+    def required(self) -> bool:
+        """Whether the field is required."""
+        if self._aux is not None and "af" in self._aux and "3" in self._aux["af"]:  # type: ignore
+            return self._aux["af"]["3"]  # type: ignore
+        else:
+            return False
+
+    @required.setter
+    def required(self, value: bool) -> None:
+        self._aux = self._aux or {}
+        self._aux.setdefault("af", {})["3"] = value
 
 
 class FeatureValue(Record, TracksRun):

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -454,7 +454,6 @@ class Feature(Record, CanCurate, TracksRun, TracksUpdates):
         self.default_value = default_value
         self.nullable = nullable
         self.coerce_dtype = coerce_dtype
-        self.optional: bool | None = None
         dtype_str = kwargs.pop("dtype", None)
         if cat_filters:
             assert "|" not in dtype_str  # noqa: S101
@@ -500,10 +499,9 @@ class Feature(Record, CanCurate, TracksRun, TracksUpdates):
         super().save(*args, **kwargs)
         return self
 
-    def with_config(self, optional: bool | None = None) -> Feature:
-        """Set required flag."""
-        self.optional = optional
-        return self
+    def with_config(self, optional: bool | None = None) -> tuple[Feature, dict]:
+        """Pass addtional configurations to the schema."""
+        return self, {"optional": optional}
 
     @property
     def default_value(self) -> Any:

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -213,7 +213,8 @@ class Schema(Record, CanCurate, TracksRun):
     For a composite schema, the hash of hashes.
     """
     minimal_set: bool = BooleanField(default=True, db_index=True, editable=False)
-    """Deprecated. Use `required` instead.
+    """Deprecated. Use `optional` instead.
+
     Whether the schema contains a minimal set of linked features (default `True`).
 
     If `False`, no features are linked to this schema.
@@ -399,7 +400,7 @@ class Schema(Record, CanCurate, TracksRun):
         validated_kwargs["uid"] = ids.base62_20()
         super().__init__(**validated_kwargs)
         if features_registry == Feature:
-            self.required = [f for f in features if f.required]
+            self.optional = [f for f in features if not f.required]
 
     @classmethod
     def from_values(  # type: ignore
@@ -586,8 +587,8 @@ class Schema(Record, CanCurate, TracksRun):
         self._aux.setdefault("af", {})["0"] = value
 
     @property
-    def required(self) -> QuerySet:
-        """Required features."""
+    def optional(self) -> QuerySet:
+        """Optional features."""
         if self._aux is not None and "af" in self._aux and "1" in self._aux["af"]:  # type: ignore
             feature_uids = self._aux["af"]["1"]
             return (
@@ -598,9 +599,9 @@ class Schema(Record, CanCurate, TracksRun):
         else:
             return Feature.objects.none()  # empty QuerySet
 
-    @required.setter
-    def required(self, value: list[Record]) -> None:
-        """Set required features."""
+    @optional.setter
+    def optional(self, value: list[Record]) -> None:
+        """Set optional features."""
         self._aux = self._aux or {}
         self._aux.setdefault("af", {})["1"] = [feature.uid for feature in value]
 

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -343,7 +343,7 @@ class Schema(Record, CanCurate, TracksRun):
                 itype = itype_compare
             n_features = len(features)
             if features_registry == Feature:
-                [f for f in features if f.optional]
+                [f for f in features if hasattr(f, "optional") and f.optional]
         else:
             n_features = -1
         if dtype is None:

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -118,6 +118,10 @@ class SchemaOptionals:
 
     def set(self, features: list[Feature]) -> None:
         """Set the optional features."""
+        if not isinstance(features, list) or not all(
+            isinstance(f, Feature) for f in features
+        ):
+            raise TypeError("features must be a list of Feature records!")
         self.schema._aux = self.schema._aux or {}
         if len(features) > 0:
             self.schema._aux.setdefault("af", {})["1"] = [f.uid for f in features]
@@ -127,6 +131,8 @@ class SchemaOptionals:
         self.schema._aux = self.schema._aux or {}
         if not isinstance(features, list):
             features = [features]
+        if not all(isinstance(f, Feature) for f in features):
+            raise TypeError("features must be a list of Feature records!")
         if len(features) > 0:
             if "1" not in self.schema._aux.setdefault("af", {}):
                 self.set(features)
@@ -157,7 +163,6 @@ class Schema(Record, CanCurate, TracksRun):
         type: `Schema | None = None` A type.
         is_type: `bool = False` Distinguish types from instances of the type.
         otype: `str | None = None` An object type to define the structure of a composite schema.
-        minimal_set: `bool = True` Whether all features linked to the schema are required.
         ordered_set: `bool = False` Whether features are required to be ordered.
         maximal_set: `bool = False` If `True`, no additional features are allowed to be present in the dataset.
         slot: `str | None = None` The slot name when this schema is used as a component in a
@@ -289,7 +294,6 @@ class Schema(Record, CanCurate, TracksRun):
     For a composite schema, the hash of hashes.
     """
     minimal_set: bool = BooleanField(default=True, db_index=True, editable=False)
-    """Whether all features linked to the schema are required (default `True`)."""
     ordered_set: bool = BooleanField(default=False, db_index=True, editable=False)
     """Whether features are required to be ordered (default `False`)."""
     maximal_set: bool = BooleanField(default=False, db_index=True, editable=False)
@@ -353,7 +357,6 @@ class Schema(Record, CanCurate, TracksRun):
         type: Schema | None = None,
         is_type: bool = False,
         otype: str | None = None,
-        minimal_set: bool = True,
         ordered_set: bool = False,
         maximal_set: bool = False,
         slot: str | None = None,
@@ -391,7 +394,6 @@ class Schema(Record, CanCurate, TracksRun):
         type: Feature | None = kwargs.pop("type", None)
         is_type: bool = kwargs.pop("is_type", False)
         otype: str | None = kwargs.pop("otype", None)
-        minimal_set: bool = kwargs.pop("minimal_set", True)
         ordered_set: bool = kwargs.pop("ordered_set", False)
         maximal_set: bool = kwargs.pop("maximal_set", False)
         slot: str | None = kwargs.pop("slot", None)
@@ -402,7 +404,7 @@ class Schema(Record, CanCurate, TracksRun):
             raise ValueError(
                 f"Unexpected keyword arguments: {', '.join(kwargs.keys())}\n"
                 "Valid arguments are: features, description, dtype, itype, type, "
-                "is_type, otype, minimal_set, ordered_set, maximal_set, "
+                "is_type, otype, ordered_set, maximal_set, "
                 "slot, validated_by, coerce_dtype"
             )
 
@@ -443,7 +445,6 @@ class Schema(Record, CanCurate, TracksRun):
             "otype": otype,
             "n": n_features,
             "itype": itype_str,
-            "minimal_set": minimal_set,
             "ordered_set": ordered_set,
             "maximal_set": maximal_set,
         }

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -342,6 +342,8 @@ class Schema(Record, CanCurate, TracksRun):
             else:
                 itype = itype_compare
             n_features = len(features)
+            if features_registry == Feature:
+                [f for f in features if f.optional]
         else:
             n_features = -1
         if dtype is None:
@@ -399,8 +401,7 @@ class Schema(Record, CanCurate, TracksRun):
             self._slots = components
         validated_kwargs["uid"] = ids.base62_20()
         super().__init__(**validated_kwargs)
-        if features_registry == Feature:
-            self.optional = [f for f in features if f.optional]
+        self.optional = Feature.objects.none()
 
     @classmethod
     def from_values(  # type: ignore
@@ -603,7 +604,8 @@ class Schema(Record, CanCurate, TracksRun):
     def optional(self, value: list[Record]) -> None:
         """Set optional features."""
         self._aux = self._aux or {}
-        self._aux.setdefault("af", {})["1"] = [feature.uid for feature in value]
+        if len(value) > 0:
+            self._aux.setdefault("af", {})["1"] = [feature.uid for feature in value]
 
     # @property
     # def index_feature(self) -> None | Feature:

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -400,7 +400,7 @@ class Schema(Record, CanCurate, TracksRun):
         validated_kwargs["uid"] = ids.base62_20()
         super().__init__(**validated_kwargs)
         if features_registry == Feature:
-            self.optional = [f for f in features if not f.required]
+            self.optional = [f for f in features if f.optional]
 
     @classmethod
     def from_values(  # type: ignore

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -310,7 +310,7 @@ class Schema(Record, CanCurate, TracksRun):
     """Whether all passed features are to be considered required by default (default `True`).
 
     Note that features that are explicitly marked as `optional` via `feature.with_config(optional=True)`
-    are **not* required even if this `minimal_set` is true.
+    are **not** required even if this `minimal_set` is true.
     """
     ordered_set: bool = BooleanField(default=False, db_index=True, editable=False)
     """Whether features are required to be ordered (default `False`)."""

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -205,22 +205,22 @@ class Schema(Record, CanCurate, TracksRun):
             import lamindb as ln
             import bionty as bt
             import pandas as pd
-    
+
             # Create a schema (feature set) from df with types:
             df = pd.DataFrame({"feat1": [1, 2], "feat2": [3.1, 4.2], "feat3": ["cond1", "cond2"]})
             schema = ln.Schema.from_df(df)
-    
+
             # Create a schema (feature set) from features
             features = [ln.Feature(name=feat, dtype="float").save() for feat in ["feat1", "feat2"]]
             schema = ln.Schema(features)
-    
+
             # Create a schema (feature set) from identifier values
             schema = ln.Schema.from_values(
                 adata.var["ensemble_id"],
                 field=Gene.ensembl_gene_id,
                 organism="mouse",
             ).save()
-    
+
             # Create a schema with required features
             schema = ln.Schema(
                 name="my-schema",
@@ -230,7 +230,7 @@ class Schema(Record, CanCurate, TracksRun):
                     ln.Feature(name="feat3", dtype=bt.CellType).save(),
                 ],
             ).save()
-    
+
             # Create a schema with an optional feature feat2
             schema = ln.Schema(
                 name="my-schema",

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -198,46 +198,48 @@ class Schema(Record, CanCurate, TracksRun):
         :meth:`~lamindb.Schema.from_df`
             Create from dataframe columns.
 
-    Example::
+    Example:
 
-        import lamindb as ln
-        import bionty as bt
-        import pandas as pd
+        ::
 
-        # Create a schema (feature set) from df with types:
-        df = pd.DataFrame({"feat1": [1, 2], "feat2": [3.1, 4.2], "feat3": ["cond1", "cond2"]})
-        schema = ln.Schema.from_df(df)
-
-        # Create a schema (feature set) from features
-        features = [ln.Feature(name=feat, dtype="float").save() for feat in ["feat1", "feat2"]]
-        schema = ln.Schema(features)
-
-        # Create a schema (feature set) from identifier values
-        schema = ln.Schema.from_values(
-            adata.var["ensemble_id"],
-            field=Gene.ensembl_gene_id,
-            organism="mouse",
-        ).save()
-
-        # Create a schema with required features
-        schema = ln.Schema(
-            name="my-schema",
-            features=[
-                ln.Feature(name="feat1", dtype=str).save(),
-                ln.Feature(name="feat2", dtype=int).save(),
-                ln.Feature(name="feat3", dtype=bt.CellType).save(),
-            ],
-        ).save()
-
-        # Create a schema with an optional feature feat2
-        schema = ln.Schema(
-            name="my-schema",
-            features=[
-                ln.Feature(name="feat1", dtype=str).save(),
-                ln.Feature(name="feat2", dtype=int).save().with_config(optional=True),
-                ln.Feature(name="feat3", dtype=bt.CellType).save(),
-            ],
-        ).save()
+            import lamindb as ln
+            import bionty as bt
+            import pandas as pd
+    
+            # Create a schema (feature set) from df with types:
+            df = pd.DataFrame({"feat1": [1, 2], "feat2": [3.1, 4.2], "feat3": ["cond1", "cond2"]})
+            schema = ln.Schema.from_df(df)
+    
+            # Create a schema (feature set) from features
+            features = [ln.Feature(name=feat, dtype="float").save() for feat in ["feat1", "feat2"]]
+            schema = ln.Schema(features)
+    
+            # Create a schema (feature set) from identifier values
+            schema = ln.Schema.from_values(
+                adata.var["ensemble_id"],
+                field=Gene.ensembl_gene_id,
+                organism="mouse",
+            ).save()
+    
+            # Create a schema with required features
+            schema = ln.Schema(
+                name="my-schema",
+                features=[
+                    ln.Feature(name="feat1", dtype=str).save(),
+                    ln.Feature(name="feat2", dtype=int).save(),
+                    ln.Feature(name="feat3", dtype=bt.CellType).save(),
+                ],
+            ).save()
+    
+            # Create a schema with an optional feature feat2
+            schema = ln.Schema(
+                name="my-schema",
+                features=[
+                    ln.Feature(name="feat1", dtype=str).save(),
+                    ln.Feature(name="feat2", dtype=int).save().with_config(optional=True),
+                    ln.Feature(name="feat3", dtype=bt.CellType).save(),
+                ],
+            ).save()
     """
 
     class Meta(Record.Meta, TracksRun.Meta, TracksUpdates.Meta):

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -297,6 +297,8 @@ class Schema(Record, CanCurate, TracksRun):
     For a composite schema, the hash of hashes.
     """
     minimal_set: bool = BooleanField(default=True, db_index=True, editable=False)
+    """Deprecated. Use `feature.with_config(optional=True)` to specify non-required features.
+    Whether all features present in the dataset must be in the schema (default `True`)."""
     ordered_set: bool = BooleanField(default=False, db_index=True, editable=False)
     """Whether features are required to be ordered (default `False`)."""
     maximal_set: bool = BooleanField(default=False, db_index=True, editable=False)
@@ -397,6 +399,12 @@ class Schema(Record, CanCurate, TracksRun):
         type: Feature | None = kwargs.pop("type", None)
         is_type: bool = kwargs.pop("is_type", False)
         otype: str | None = kwargs.pop("otype", None)
+        # minimal_set is deprecated
+        if "minimal_set" in kwargs:
+            logger.warning(
+                "the argument `minimal_set` is deprecated and ignored! Use `feature.with_config(optional=True)` to specify non-required features."
+            )
+        kwargs.pop("minimal_set", True)
         ordered_set: bool = kwargs.pop("ordered_set", False)
         maximal_set: bool = kwargs.pop("maximal_set", False)
         slot: str | None = kwargs.pop("slot", None)

--- a/tests/curators/test_curators_general.py
+++ b/tests/curators/test_curators_general.py
@@ -150,14 +150,12 @@ def test_pandera_dataframe_schema(
     # extra column is fine
     ln.curators.DataFrameCurator(df_extra_column, schema=schema_minimal_set).validate()
 
-    # minimal_set=False
+    # minimal_set=False, maximal_set=True
     with pytest.raises(ValidationError):
         ln.curators.DataFrameCurator(
-            df_extra_column, schema=schema_maximal_set
+            df_extra_column,
+            schema=schema_maximal_set,  # extra column is not allowed
         ).validate()
-    ln.curators.DataFrameCurator(
-        df_missing_sample_type_column, schema=schema_maximal_set
-    ).validate()
 
     # ordered_set=True
     with pytest.raises(ValidationError):
@@ -168,7 +166,7 @@ def test_pandera_dataframe_schema(
     # default=True (require) for a single feature when minimal_set=False
     # note this modifies the "sample_type" feature to be required
     schema_optional_sample_name = ln.Schema(
-        name="my-schema minimal_set require sample_type",
+        name="my-schema optional sample_name",
         features=[
             ln.Feature(name="sample_id", dtype=str).save(),
             ln.Feature(name="sample_name", dtype=str).save().with_config(optional=True),
@@ -181,7 +179,7 @@ def test_pandera_dataframe_schema(
             df_missing_sample_type_column,
             schema=schema_optional_sample_name,
         ).validate()
-    # missing a optional column is fine
+    # missing optional column "sample_name" is fine
     ln.curators.DataFrameCurator(
         df_missing_sample_name_column, schema=schema_optional_sample_name
     ).validate()

--- a/tests/curators/test_curators_general.py
+++ b/tests/curators/test_curators_general.py
@@ -167,24 +167,23 @@ def test_pandera_dataframe_schema(
 
     # default=True (require) for a single feature when minimal_set=False
     # note this modifies the "sample_type" feature to be required
-    schema_not_minimal_set_require_sample_type = ln.Schema(
+    schema_optional_sample_name = ln.Schema(
         name="my-schema minimal_set require sample_type",
         features=[
             ln.Feature(name="sample_id", dtype=str).save(),
-            ln.Feature(name="sample_name", dtype=str).save(),
-            ln.Feature(name="sample_type", dtype=str).with_config(required=True),
+            ln.Feature(name="sample_name", dtype=str).save().with_config(optional=True),
+            ln.Feature(name="sample_type", dtype=str).save(),
         ],
-        minimal_set=False,
     ).save()
-    # missing "sample_type" column now raises an error
+    # missing required "sample_type" column raises an error
     with pytest.raises(ValidationError):
         ln.curators.DataFrameCurator(
             df_missing_sample_type_column,
-            schema=schema_not_minimal_set_require_sample_type,
+            schema=schema_optional_sample_name,
         ).validate()
-    # missing a non-required column is fine
+    # missing a optional column is fine
     ln.curators.DataFrameCurator(
-        df_missing_sample_name_column, schema=schema_not_minimal_set_require_sample_type
+        df_missing_sample_name_column, schema=schema_optional_sample_name
     ).validate()
 
     # clean up

--- a/tests/curators/test_curators_general.py
+++ b/tests/curators/test_curators_general.py
@@ -111,6 +111,7 @@ def test_pandera_dataframe_schema(
             ln.Feature(name="sample_name", dtype=str).save(),
             ln.Feature(name="sample_type", dtype=str).save(),
         ],
+        minimal_set=False,
         maximal_set=True,
     ).save()
     schema_ordered_set = ln.Schema(
@@ -123,7 +124,7 @@ def test_pandera_dataframe_schema(
         ordered_set=True,
     ).save()
 
-    # all three columns are required
+    # minimal_set=True, all three columns are required
     ln.curators.DataFrameCurator(df, schema=schema_all_required).validate()
     # can't miss a required column
     with pytest.raises(ValidationError):
@@ -143,6 +144,10 @@ def test_pandera_dataframe_schema(
             df_extra_column,
             schema=schema_maximal_set,  # extra column is not allowed
         ).validate()
+    # minimal_set=False, missing column is allowed
+    ln.curators.DataFrameCurator(
+        df_missing_sample_type_column, schema=schema_maximal_set
+    ).validate()
 
     # ordered_set=True, order matters
     with pytest.raises(ValidationError):

--- a/tests/curators/test_curators_general.py
+++ b/tests/curators/test_curators_general.py
@@ -1,3 +1,5 @@
+import re
+
 import lamindb as ln
 import pandas as pd
 import pytest


### PR DESCRIPTION
This PR adds `Feature.with_config(optional: bool)` to define schema-specific optional features.

It also updates the hash calculation for the schema hash to account for the schema configuration in all cases. Previously, if features were defined, the hash calculation disregarded the schema configuration.

<img width="700" alt="image" src="https://github.com/user-attachments/assets/21ecf66d-a437-4835-a805-9ae357a71636" />

Interacting with optionals:

- Get optional features via `schema.optionals.get()`
- Set optional features via `schema.optionals.set()`
- Add an additional optional feature via `schema.optionals.add()`

Internal [Notion page](https://www.notion.so/laminlabs/Overhaul-the-Schema-design-1ca2aeaa55e1803cb3fed41f955fcc7c).