### PR TITLE
✨ Introduce `lamin run` with a Modal backend

### DIFF
--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import builtins
 import hashlib
+import os
 import signal
 import sys
 import threading
@@ -314,6 +315,8 @@ class Context:
         if instance_settings.dialect == "postgresql" and "read" in instance_settings.db:
             logger.warning("skipping track(), connected in read-only mode")
             return None
+        if project is None:
+            project = os.environ.get("LAMIN_CURRENT_PROJECT")
         if project is not None:
             project_record = Project.filter(
                 Q(name=project) | Q(uid=project)

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -535,27 +535,28 @@ class Context:
                 for aux_transform in transforms:
                     if aux_transform.key in self._path.as_posix():
                         key = aux_transform.key
+                        # first part of the if condition: no version bump, second part: version bump
                         if (
-                            # has to be the same user
-                            aux_transform.created_by_id == ln_setup.settings.user.id
-                            and (
-                                # if the transform source code wasn't yet saved
+                            # if a user hasn't yet saved the transform source code, needs to be same user
+                            (
                                 aux_transform.source_code is None
-                                # if the transform source code is unchanged
-                                # if aux_transform.type == "notebook", we anticipate the user makes changes to the notebook source code
-                                # in an interactive session, hence we *pro-actively bump* the version number by setting `revises`
-                                # in the second part of the if condition even though the source code is unchanged at point of running track()
-                                or (
-                                    aux_transform.hash == hash
-                                    and aux_transform.type != "notebook"
-                                )
+                                and aux_transform.created_by_id
+                                == ln_setup.settings.user.id
+                            )
+                            # if the transform source code is unchanged
+                            # if aux_transform.type == "notebook", we anticipate the user makes changes to the notebook source code
+                            # in an interactive session, hence we *pro-actively bump* the version number by setting `revises`
+                            # in the second part of the if condition even though the source code is unchanged at point of running track()
+                            or (
+                                aux_transform.hash == hash
+                                and aux_transform.type != "notebook"
                             )
                         ):
                             uid = aux_transform.uid
                             target_transform = aux_transform
                         else:
                             uid = f"{aux_transform.uid[:-4]}{increment_base62(aux_transform.uid[-4:])}"
-                            message = f"there already is a {aux_transform.type} with `key` '{aux_transform.key}'"
+                            message = f"there already is a {aux_transform.type} with key '{aux_transform.key}'"
                             if (
                                 aux_transform.hash == hash
                                 and aux_transform.type == "notebook"

--- a/lamindb/models/run.py
+++ b/lamindb/models/run.py
@@ -555,7 +555,9 @@ def delete_run_artifacts(run: Run) -> None:
         if environment._environment_of.count() == 0:
             environment.delete(permanent=True)
     if report is not None:
-        report.delete(permanent=True)
+        # only delete if there are no other runs attached to this environment
+        if report._report_of.count() == 0:
+            report.delete(permanent=True)
 
 
 class RunParamValue(BasicRecord, LinkORM):

--- a/noxfile.py
+++ b/noxfile.py
@@ -275,7 +275,9 @@ def test(session, group):
             f"pytest {coverage_args} tests/curators --durations=50",
         )
     elif group == "cli":
-        run(session, f"pytest {coverage_args} ./sub/lamin-cli/tests --durations=50")
+        run(
+            session, f"pytest {coverage_args} ./sub/lamin-cli/tests/core --durations=50"
+        )
     elif group == "permissions":
         run(session, f"pytest {coverage_args} ./tests/permissions")
     # move artifacts into right place

--- a/tests/core/test_track.py
+++ b/tests/core/test_track.py
@@ -249,7 +249,7 @@ def test_run_scripts():
 
 
 def test_run_external_script():
-    script_path = "sub/lamin-cli/tests/scripts/run-track-and-finish-sync-git.py"
+    script_path = "sub/lamin-cli/tests/core/scripts/run-track-and-finish-sync-git.py"
     result = subprocess.run(  # noqa: S602
         f"python {script_path}",
         shell=True,

--- a/tests/core/test_track.py
+++ b/tests/core/test_track.py
@@ -249,7 +249,7 @@ def test_run_scripts():
 
 
 def test_run_external_script():
-    script_path = "sub/lamin-cli/tests/core/scripts/run-track-and-finish-sync-git.py"
+    script_path = "sub/lamin-cli/tests/scripts/run-track-and-finish-sync-git.py"
     result = subprocess.run(  # noqa: S602
         f"python {script_path}",
         shell=True,


### PR DESCRIPTION
*Author:* @ragyhaddad

This PR introduces the ability to run a script on Modal through the new CLI command `lamin run`. It is documented as experimental, not meant for production usage at this point, and will not yet appear in the changelog.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/ef2b7f27-3b8d-43e9-8d36-06bf7c6e60b4" />

Needs:

- https://github.com/laminlabs/lamin-cli/pull/123 <-- see for details and follow-up TODOs
- https://github.com/laminlabs/lamindb-setup/pull/1016