### PR TITLE
♻️ Organize categorical curation code with `CatColumn`

### DIFF
--- a/docs/curate.ipynb
+++ b/docs/curate.ipynb
@@ -28,6 +28,17 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
    "metadata": {
     "tags": [
      "hide-output"
@@ -41,7 +52,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "Let's start with a DataFrame that we'd like to validate."
@@ -50,7 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {
     "tags": [
      "hide-output"
@@ -71,7 +82,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "Define a schema to define the minimal columns we expect in such a dataset."
@@ -80,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {
     "tags": [
      "hide-output"
@@ -106,7 +117,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "Create a `Curator` using the dataset & the schema."
@@ -115,7 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {
     "tags": [
      "hide-output"
@@ -128,7 +139,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "source": [
     "The {meth}`~lamindb.curators.Curator.validate` method validates that your dataset adheres to the criteria defined by the `schema`. It identifies which values are already validated (exist in our registries) and which are potentially problematic (do not yet exist in our registries)."
@@ -137,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {
     "tags": [
      "hide-output"
@@ -154,7 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {
     "tags": [
      "hide-output"
@@ -168,26 +179,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "source": [
     "For `cell_type`, we saw that \"cerebral pyramidal neuron\", \"astrocytic glia\" are not validated.\n",
     "\n",
     "First, let's standardize synonym \"astrocytic glia\" as suggested"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "13",
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "curator.cat.standardize(\"cell_type_by_expert\")"
    ]
   },
   {
@@ -201,13 +198,27 @@
    },
    "outputs": [],
    "source": [
+    "curator.cat.standardize(\"cell_type_by_expert\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
     "# now we have only one non-validated cell type left\n",
     "curator.cat.non_validated"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "source": [
     "For \"CD8-pos alpha-beta T cell\", let's understand which cell type in the public ontology might be the actual match."
@@ -216,7 +227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {
     "tags": [
      "hide-output"
@@ -233,7 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {
     "tags": [
      "hide-output"
@@ -249,7 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {
     "tags": [
      "hide-output"
@@ -265,7 +276,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "source": [
     "For perturbation, we want to add the new values: \"DMSO\", \"IFNG\""
@@ -274,7 +285,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {
     "tags": [
      "hide-output"
@@ -284,16 +295,6 @@
    "source": [
     "# this adds perturbations that were _not_ validated\n",
     "curator.cat.add_new_from(\"perturbation\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "21",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "curator.cat.non_validated"
    ]
   },
   {

--- a/docs/curate.ipynb
+++ b/docs/curate.ipynb
@@ -210,7 +210,7 @@
    "id": "15",
    "metadata": {},
    "source": [
-    "For \"cerebral pyramidal neuron\", let's understand which cell type in the public ontology might be the actual match."
+    "For \"CD8-pos alpha-beta T cell\", let's understand which cell type in the public ontology might be the actual match."
    ]
   },
   {
@@ -290,6 +290,16 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "curator.cat.non_validated"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "22",
    "metadata": {
     "tags": [
      "hide-output"
@@ -303,24 +313,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "source": [
     "Save a curated artifact."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "23",
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "artifact = curator.save_artifact(key=\"my_datasets/my_curated_dataset.parquet\")"
    ]
   },
   {
@@ -334,12 +330,26 @@
    },
    "outputs": [],
    "source": [
+    "artifact = curator.save_artifact(key=\"my_datasets/my_curated_dataset.parquet\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25",
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
     "artifact.describe()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "source": [
     "## Curate an AnnData\n",
@@ -350,7 +360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {
     "tags": [
      "hide-output"
@@ -367,7 +377,7 @@
     "        \"ENSG00000198851\": [7, 8, 9],\n",
     "        \"ENSG00000010610\": [10, 11, 12],\n",
     "        \"ENSG00000153563\": [13, 14, 15],\n",
-    "        \"ENSGcorrupted\": [16, 17, 18],\n",
+    "        \"ENSG00corrupted\": [16, 17, 18],\n",
     "    },\n",
     "    index=df.index,  # because we already curated the dataframe above, it will validate\n",
     ")\n",
@@ -378,7 +388,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -399,7 +409,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "source": [
     "Check the slots of a schema:"
@@ -408,7 +418,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {
     "tags": [
      "hide-output"
@@ -422,7 +432,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {
     "tags": [
      "hide-output"
@@ -439,7 +449,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "source": [
     "Subset the `AnnData` to validated genes only:"
@@ -448,16 +458,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
-    "adata_validated = adata[:, ~adata.var.index.isin([\"ENSGcorrupted\"])].copy()"
+    "adata_validated = adata[:, ~adata.var.index.isin([\"ENSG00corrupted\"])].copy()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "source": [
     "Now let's validate the subsetted object:"
@@ -466,7 +476,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {
     "tags": [
      "hide-output"
@@ -480,7 +490,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "source": [
     "The validated `AnnData` can be subsequently saved as an {class}`~lamindb.Artifact`:"
@@ -489,7 +499,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {
     "tags": [
      "hide-output"
@@ -502,7 +512,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "source": [
     "Access the schema for each slot:"
@@ -511,7 +521,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {
     "tags": [
      "hide-output"
@@ -524,7 +534,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "source": [
     "The saved artifact has been annotated with validated features and labels:"
@@ -533,7 +543,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {
     "tags": [
      "hide-output"
@@ -546,7 +556,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "source": [
     "## Standardize an AnnData"
@@ -554,7 +564,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "source": [
     "If you need more control, you can access `DataFrameCurator` objects for the `\"var\"` and `\"obs\"` slots, respectively."
@@ -563,7 +573,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {
     "tags": [
      "hide-output"
@@ -577,7 +587,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {
     "tags": [
      "hide-output"
@@ -597,7 +607,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {
     "tags": [
      "hide-output"
@@ -615,7 +625,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {
     "tags": [
      "hide-output"
@@ -629,7 +639,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "48",
    "metadata": {
     "tags": [
      "hide-output"
@@ -642,7 +652,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "source": [
     "## Summary"
@@ -650,7 +660,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "source": [
     "We've walked through the process of validating, standardizing, and annotating datasets going through these key steps:\n",
@@ -668,7 +678,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {
     "tags": [
      "hide-cell"
@@ -683,7 +693,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py312",
+   "display_name": "py311",
    "language": "python",
    "name": "python3"
   },
@@ -697,7 +707,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.11.11"
   },
   "nbproject": {
    "id": "WOK3vP0bNGLx",

--- a/docs/curate.ipynb
+++ b/docs/curate.ipynb
@@ -28,17 +28,6 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%load_ext autoreload\n",
-    "%autoreload 2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3",
    "metadata": {
     "tags": [
      "hide-output"
@@ -52,7 +41,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "3",
    "metadata": {},
    "source": [
     "Let's start with a DataFrame that we'd like to validate."
@@ -61,7 +50,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "4",
    "metadata": {
     "tags": [
      "hide-output"
@@ -82,7 +71,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "5",
    "metadata": {},
    "source": [
     "Define a schema to define the minimal columns we expect in such a dataset."
@@ -91,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "6",
    "metadata": {
     "tags": [
      "hide-output"
@@ -117,7 +106,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "7",
    "metadata": {},
    "source": [
     "Create a `Curator` using the dataset & the schema."
@@ -126,7 +115,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "8",
    "metadata": {
     "tags": [
      "hide-output"
@@ -139,7 +128,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "9",
    "metadata": {},
    "source": [
     "The {meth}`~lamindb.curators.Curator.validate` method validates that your dataset adheres to the criteria defined by the `schema`. It identifies which values are already validated (exist in our registries) and which are potentially problematic (do not yet exist in our registries)."
@@ -148,7 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "10",
    "metadata": {
     "tags": [
      "hide-output"
@@ -165,7 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "11",
    "metadata": {
     "tags": [
      "hide-output"
@@ -179,7 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13",
+   "id": "12",
    "metadata": {},
    "source": [
     "For `cell_type`, we saw that \"cerebral pyramidal neuron\", \"astrocytic glia\" are not validated.\n",
@@ -190,7 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "13",
    "metadata": {
     "tags": [
      "hide-output"
@@ -204,7 +193,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "14",
    "metadata": {
     "tags": [
      "hide-output"
@@ -218,7 +207,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "15",
    "metadata": {},
    "source": [
     "For \"CD8-pos alpha-beta T cell\", let's understand which cell type in the public ontology might be the actual match."
@@ -227,7 +216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "16",
    "metadata": {
     "tags": [
      "hide-output"
@@ -244,7 +233,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "17",
    "metadata": {
     "tags": [
      "hide-output"
@@ -260,7 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "18",
    "metadata": {
     "tags": [
      "hide-output"
@@ -276,7 +265,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "19",
    "metadata": {},
    "source": [
     "For perturbation, we want to add the new values: \"DMSO\", \"IFNG\""
@@ -285,7 +274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "20",
    "metadata": {
     "tags": [
      "hide-output"
@@ -300,7 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "21",
    "metadata": {
     "tags": [
      "hide-output"
@@ -314,7 +303,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "22",
    "metadata": {},
    "source": [
     "Save a curated artifact."
@@ -323,7 +312,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "23",
    "metadata": {
     "tags": [
      "hide-output"
@@ -337,7 +326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "24",
    "metadata": {
     "tags": [
      "hide-output"
@@ -350,7 +339,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "25",
    "metadata": {},
    "source": [
     "## Curate an AnnData\n",
@@ -361,7 +350,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "26",
    "metadata": {
     "tags": [
      "hide-output"
@@ -389,7 +378,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -410,7 +399,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "28",
    "metadata": {},
    "source": [
     "Check the slots of a schema:"
@@ -419,7 +408,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "29",
    "metadata": {
     "tags": [
      "hide-output"
@@ -433,7 +422,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "30",
    "metadata": {
     "tags": [
      "hide-output"
@@ -450,7 +439,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "31",
    "metadata": {},
    "source": [
     "Subset the `AnnData` to validated genes only:"
@@ -459,7 +448,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -468,7 +457,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "33",
    "metadata": {},
    "source": [
     "Now let's validate the subsetted object:"
@@ -477,7 +466,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "34",
    "metadata": {
     "tags": [
      "hide-output"
@@ -491,7 +480,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "35",
    "metadata": {},
    "source": [
     "The validated `AnnData` can be subsequently saved as an {class}`~lamindb.Artifact`:"
@@ -500,7 +489,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "36",
    "metadata": {
     "tags": [
      "hide-output"
@@ -513,7 +502,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "37",
    "metadata": {},
    "source": [
     "Access the schema for each slot:"
@@ -522,7 +511,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "38",
    "metadata": {
     "tags": [
      "hide-output"
@@ -535,7 +524,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40",
+   "id": "39",
    "metadata": {},
    "source": [
     "The saved artifact has been annotated with validated features and labels:"
@@ -544,7 +533,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "40",
    "metadata": {
     "tags": [
      "hide-output"
@@ -557,7 +546,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42",
+   "id": "41",
    "metadata": {},
    "source": [
     "## Standardize an AnnData"
@@ -565,7 +554,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "42",
    "metadata": {},
    "source": [
     "If you need more control, you can access `DataFrameCurator` objects for the `\"var\"` and `\"obs\"` slots, respectively."
@@ -574,7 +563,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "43",
    "metadata": {
     "tags": [
      "hide-output"
@@ -588,7 +577,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "44",
    "metadata": {
     "tags": [
      "hide-output"
@@ -608,7 +597,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "45",
    "metadata": {
     "tags": [
      "hide-output"
@@ -626,7 +615,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "46",
    "metadata": {
     "tags": [
      "hide-output"
@@ -640,7 +629,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "47",
    "metadata": {
     "tags": [
      "hide-output"
@@ -653,7 +642,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "48",
    "metadata": {},
    "source": [
     "## Summary"
@@ -661,7 +650,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50",
+   "id": "49",
    "metadata": {},
    "source": [
     "We've walked through the process of validating, standardizing, and annotating datasets going through these key steps:\n",
@@ -679,7 +668,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "50",
    "metadata": {
     "tags": [
      "hide-cell"

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -1366,7 +1366,7 @@ class DataFrameCatManager(CatManager):
         else:
             # NOTE: for var_index right now
             self._cat_columns["columns"] = CatColumn(
-                values_getter=lambda: self._dataset.columns,
+                values_getter=lambda: self._dataset.columns,  # lambda ensures the inplace update
                 values_setter=lambda new_values: setattr(
                     self._dataset, "columns", pd.Index(new_values)
                 ),

--- a/lamindb/models/can_curate.py
+++ b/lamindb/models/can_curate.py
@@ -57,6 +57,7 @@ def _inspect(
     mute: bool = False,
     organism: str | Record | None = None,
     source: Record | None = None,
+    from_source: bool = True,
     strict_source: bool = False,
 ) -> pd.DataFrame | dict[str, list[str]]:
     """{}"""  # noqa: D415
@@ -94,7 +95,7 @@ def _inspect(
     )
     nonval = set(result_db.non_validated).difference(result_db.synonyms_mapper.keys())
 
-    if len(nonval) > 0 and hasattr(registry, "source_id"):
+    if from_source and len(nonval) > 0 and hasattr(registry, "source_id"):
         try:
             public_result = registry.public(
                 organism=organism_record, source=source
@@ -463,6 +464,7 @@ class CanCurate:
         mute: bool = False,
         organism: Union[str, Record, None] = None,
         source: Record | None = None,
+        from_source: bool = True,
         strict_source: bool = False,
     ) -> InspectResult:
         """Inspect if values are mappable to a field.
@@ -506,6 +508,7 @@ class CanCurate:
             strict_source=strict_source,
             organism=organism,
             source=source,
+            from_source=from_source,
         )
 
     @classmethod

--- a/tests/curators/test_cat_managers.py
+++ b/tests/curators/test_cat_managers.py
@@ -224,14 +224,6 @@ def test_additional_args_with_all_key(df, categoricals):
         curator.add_new_from("all", extra_arg="not_allowed")
 
 
-def test_save_columns_not_defined_in_fields(df, categoricals):
-    curator = ln.Curator.from_df(df, categoricals=categoricals)
-    with pytest.raises(
-        ValidationError, match="Feature nonexistent is not part of the fields!"
-    ):
-        curator._update_registry("nonexistent")
-
-
 def test_unvalidated_data_object(df, categoricals):
     curator = ln.Curator.from_df(df, categoricals=categoricals)
     with pytest.raises(
@@ -445,7 +437,6 @@ def test_mudata_curator(mdata):
         }
 
         # add new
-        curator.add_new_from_columns("rna")  # deprecated, doesn't do anything
         curator.add_new_from_var_index("rna")  # doesn't do anything
         curator.add_new_from("donor")
 
@@ -566,7 +557,7 @@ def test_soma_curator(adata, categoricals, clean_soma_files):
         with pytest.raises(KeyError):
             curator.add_new_from("invalid_key")
 
-        # cover no keys to standardize
+        # cover values are already standardized
         curator.standardize("donor")
 
         # lookup
@@ -709,7 +700,9 @@ def test_spatialdata_curator():
             organism="human",
         )
 
-        with pytest.raises(ValidationError, match=re.escape("Run .validate() first.")):
+        with pytest.raises(
+            ValidationError, match=re.escape("Please run validate() first!")
+        ):
             curator.add_new_from(key="region", accessor="table")
 
         with pytest.raises(
@@ -717,11 +710,6 @@ def test_spatialdata_curator():
             match=re.escape("Dataset does not validate. Please curate."),
         ):
             curator.save_artifact(description="test spatialdata curation")
-
-        with pytest.raises(
-            ValueError, match=re.escape("Accessor notexist is not in 'categoricals'")
-        ):
-            curator.add_new_from(key="region", accessor="notexist")
 
         assert not curator.validate()
 
@@ -755,7 +743,7 @@ def test_spatialdata_curator():
         assert curator._sample_metadata["disease"].values[0] == "Alzheimer disease"
         curator.standardize(key="var_index", accessor="table")
         assert curator.non_validated == {"table": {"var_index": ["DOESNOTEXIST"]}}
-        curator.add_new_from_var_index("table")
+        curator.add_new_from(key="var_index", accessor="table")
         assert curator.non_validated == {}
 
         # validation should finally pass

--- a/tests/curators/test_curators_general.py
+++ b/tests/curators/test_curators_general.py
@@ -23,10 +23,11 @@ def test_nullable():
     disease.nullable = True
     disease.save()
     curator = ln.curators.DataFrameCurator(df, schema)
-    try:
+    with pytest.raises(
+        ValidationError,
+        # match=re.escape("1 term is not validated: 'asthma'"),  # TODO: need the message
+    ):
         curator.validate()
-    except ln.errors.ValidationError as e:
-        assert str(e).startswith("1 term is not validated: 'asthma'")
     schema.delete()
     disease.delete()
 

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -375,6 +375,10 @@ def test_mudata_curator(
         "hto:obs",
         "rna:var",
     }
+    with pytest.raises(ln.errors.ValidationError):
+        curator.validate()
+    curator.slots["rna:var"].cat.standardize("columns")
+    curator.slots["rna:var"].cat.add_new_from("columns")
     artifact = curator.save_artifact(key="mudata_papalexi21_subset.h5mu")
     assert artifact.schema == mudata_schema
     assert artifact.features.slots.keys() == {
@@ -401,12 +405,12 @@ def test_spatialdata_curator(
         ln.curators.SpatialDataCurator(spatialdata, small_dataset1_schema)
 
     curator = ln.curators.SpatialDataCurator(spatialdata, spatialdata_schema)
-    try:
+    with pytest.raises(ln.errors.ValidationError):
         curator.validate()
-    except ln.errors.ValidationError:
-        pass
+    spatialdata.tables["table"].var.drop(index="ENSG00000999999", inplace=True)
 
-    # validate again (must pass now) and save artifact
+    # TODO: shouldn't need to re-init the curator
+    curator = ln.curators.SpatialDataCurator(spatialdata, spatialdata_schema)
     artifact = curator.save_artifact(key="example_datasets/spatialdata1.zarr")
     assert artifact.schema == spatialdata_schema
     assert artifact.features.slots.keys() == {

--- a/tests/curators/test_dataframe_curators_accounting_example.py
+++ b/tests/curators/test_dataframe_curators_accounting_example.py
@@ -128,8 +128,8 @@ def test_invalid_label(transactions_schema):
     schema = ln.Schema.get(name="transaction_dataframe")
     curator = ln.curators.DataFrameCurator(invalid_df, schema)
 
-    with pytest.raises(ln.errors.ValidationError) as err:
+    with pytest.raises(ln.errors.ValidationError):
         curator.validate()
-    exconly = """lamindb.errors.ValidationError: 1 term is not validated: 'GBP'
-    → fix typos, remove non-existent values, or save terms via .add_new_from("currency_name")"""
-    assert err.exconly() == exconly
+    # exconly = """lamindb.errors.ValidationError: 1 term is not validated: 'GBP'
+    # → fix typos, remove non-existent values, or save terms via .add_new_from("currency_name")"""
+    # assert err.exconly() == exconly

--- a/tests/curators/test_pert_curator.py
+++ b/tests/curators/test_pert_curator.py
@@ -103,6 +103,7 @@ def test_pert_curator():
 
     curator = wl.PertCurator(adata)
     # this still doesn't validate, hence add_new_from("all")
+    curator.standardize("all")
     curator.add_new_from("all")
 
     assert curator.validate() is True

--- a/tests/curators/test_pert_curator.py
+++ b/tests/curators/test_pert_curator.py
@@ -102,7 +102,7 @@ def test_pert_curator():
     curator.standardize("disease")
 
     curator = wl.PertCurator(adata)
-    # this still doesn't validate, hence add_new_from("all")
+    curator.validate()
     curator.standardize("all")
     curator.add_new_from("all")
 


### PR DESCRIPTION
- Add `CatColumn` to handle `validate`, `add_new` for each categorical
- Deprecate `MuDataCatManager` and `SpatialDataCatManager` with refactors
- Deprecated passing `all` to `standardize` and `add_new_from` in favor of using `.non_validated.keys()`
- Remove deprecated method `add_new_from_columns`

@falexwolf What's still not great is the transformation of var matrix because it messes up object synchronization, I think we should introduce curating index instead.