### PR TITLE
♻️ Remove `organism` argument on `CatManager` level

### DIFF
--- a/tests/curators/test_cat_managers.py
+++ b/tests/curators/test_cat_managers.py
@@ -232,15 +232,6 @@ def test_unvalidated_data_object(df, categoricals):
         curator.save_artifact()
 
 
-def test_invalid_organism_type(df, categoricals):
-    with pytest.raises(
-        ValueError, match="organism must be a string such as 'human' or 'mouse'!"
-    ):
-        ln.Curator.from_df(
-            df, categoricals=categoricals, organism=bt.Organism.filter(name="human")
-        )
-
-
 def test_clean_up_failed_runs():
     mock_transform = ln.Transform()
     mock_transform.save()
@@ -273,15 +264,6 @@ def test_clean_up_failed_runs():
 @pytest.mark.parametrize("to_add", ["donor", "all"])
 def test_anndata_curator(adata, categoricals, to_add):
     try:
-        # must pass an organism
-        with pytest.raises(bt._organism.OrganismNotSet):
-            bt.settings._organism = None  # make sure organism is not set globally
-            ln.Curator.from_anndata(
-                adata,
-                categoricals=categoricals,
-                var_index=bt.Gene.symbol,
-            ).validate()
-
         curator = ln.Curator.from_anndata(
             adata,
             categoricals=categoricals,

--- a/tests/curators/test_cxg_curator.py
+++ b/tests/curators/test_cxg_curator.py
@@ -4,17 +4,15 @@ import numpy as np
 
 def test_cxg_curator():
     schema_version = "5.2.0"
-    organism = "human"
     adata = ln.core.datasets.small_dataset3_cellxgene()
     curator = ln.curators.CellxGeneAnnDataCatManager(
-        adata, organism=organism, schema_version=schema_version
+        adata, schema_version=schema_version
     )
 
     adata.obs.rename(columns={"donor": "donor_id"}, inplace=True)
     curator = ln.curators.CellxGeneAnnDataCatManager(
         adata,
         defaults=ln.curators.CellxGeneAnnDataCatManager.cxg_categoricals_defaults,
-        organism=organism,
         schema_version=schema_version,
     )
     assert not curator.validate()
@@ -22,7 +20,7 @@ def test_cxg_curator():
     adata = adata[:, ~adata.var.index.isin(curator.non_validated["var_index"])]
     adata.obs["tissue"] = adata.obs["tissue"].cat.rename_categories({"lungg": "lung"})
     curator = ln.curators.CellxGeneAnnDataCatManager(
-        adata, organism=organism, schema_version=schema_version
+        adata, schema_version=schema_version
     )
     assert curator.validate()
 


### PR DESCRIPTION
Organisms should be defined on the `dtype` or `itype` level, not on the curator level. Eliminating all this legacy code enables downstream simplifications.

A user of the _legacy_ curators, all of which still have the `organism` argument, will now see that this argument is no longer respected. They can use `bt.settinigs.organism` instead.

Requires:

- https://github.com/laminlabs/bionty/pull/242
