### PR TITLE
🚸 Enable to validate & annotate features *without* passing them to a schema

### DIFF
--- a/docs/faq/pydantic-pandera.ipynb
+++ b/docs/faq/pydantic-pandera.ipynb
@@ -370,6 +370,7 @@
     "property | `pydantic` | `pandera` | `lamindb`\n",
     "--- | --- | --- | ---\n",
     "define schema as code | yes, in form of a `pydantic.BaseModel` | yes, in form of a `pandera.DataFrameSchema` | yes, in form of a `lamindb.Schema`\n",
+    "define schema as a set of constraints without the need of listing fields/columns/features; e.g. useful if validating 60k genes | no | no | yes\n",
     "update labels independent of code | not possible because labels are enums/literals | not possible because labels are hard-coded in `Check` | possible by adding new terms to a registry\n",
     "built-in validation from public ontologies | no | no | yes\n",
     "sync labels with ELN/LIMS registries without code change | no | no | yes\n",

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -395,6 +395,7 @@ class DataFrameCurator(Curator):
         categoricals = []
         features = []
         if schema.mode == "validate-all-annotate-cat":
+            print(self._dataset.columns)
             features += Feature.filter(name__in=self._dataset.columns).list()
         if schema.n > 0:
             features += schema.features.all().list()
@@ -447,8 +448,6 @@ class DataFrameCurator(Curator):
                 strict=schema.maximal_set,
                 ordered=schema.ordered_set,
             )
-        else:
-            assert schema.itype is not None  # noqa: S101
         self._cat_manager = DataFrameCatManager(
             self._dataset,
             columns=parse_cat_dtype(schema.itype, is_itype=True)["field"],

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -395,7 +395,7 @@ class DataFrameCurator(Curator):
         categoricals = []
         features = []
         feature_ids: set[int] = set()
-        if schema.mode == "validate-all-annotate-cat":
+        if schema.mode == "all-itype":
             features += Feature.filter(name__in=self._dataset.keys()).list()
             feature_ids = {feature.id for feature in features}
         if schema.n > 0:

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -395,7 +395,7 @@ class DataFrameCurator(Curator):
         categoricals = []
         features = []
         feature_ids: set[int] = set()
-        if schema.mode == "all-itype":
+        if schema.itype is not None:
             features += Feature.filter(name__in=self._dataset.keys()).list()
             feature_ids = {feature.id for feature in features}
         if schema.n > 0:

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -396,7 +396,7 @@ class DataFrameCurator(Curator):
         features = []
         feature_ids: set[int] = set()
         if schema.mode == "validate-all-annotate-cat":
-            features += Feature.filter(name__in=self._dataset.columns).list()
+            features += Feature.filter(name__in=self._dataset.keys()).list()
             feature_ids = {feature.id for feature in features}
         if schema.n > 0:
             schema_features = schema.features.all().list()

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -408,6 +408,8 @@ class DataFrameCurator(Curator):
                 )
             else:
                 features.extend(schema_features)
+        else:
+            assert schema.itype is not None  # noqa: S101
         if features:
             # populate features
             pandera_columns = {}

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -395,7 +395,7 @@ class DataFrameCurator(Curator):
         categoricals = []
         features = []
         feature_ids: set[int] = set()
-        if schema.itype is not None and isinstance(dataset, pd.DataFrame):
+        if schema.flexible and isinstance(dataset, pd.DataFrame):
             features += Feature.filter(name__in=self._dataset.keys()).list()
             feature_ids = {feature.id for feature in features}
         if schema.n > 0:

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -393,12 +393,17 @@ class DataFrameCurator(Curator):
     ) -> None:
         super().__init__(dataset=dataset, schema=schema)
         categoricals = []
+        features = []
+        if schema.mode == "validate-all-annotate-cat":
+            features += Feature.filter(name__in=self._dataset.columns).list()
         if schema.n > 0:
+            features += schema.features.all().list()
+        if features:
             # populate features
             pandera_columns = {}
             if schema.minimal_set:
                 optional_feature_uids = set(schema.optionals.get_uids())
-            for feature in schema.features.all():
+            for feature in features:
                 if schema.minimal_set:
                     required = feature.uid not in optional_feature_uids
                 else:

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -394,11 +394,20 @@ class DataFrameCurator(Curator):
         super().__init__(dataset=dataset, schema=schema)
         categoricals = []
         features = []
+        feature_ids: set[int] = set()
         if schema.mode == "validate-all-annotate-cat":
-            print(self._dataset.columns)
             features += Feature.filter(name__in=self._dataset.columns).list()
+            feature_ids = {feature.id for feature in features}
         if schema.n > 0:
-            features += schema.features.all().list()
+            schema_features = schema.features.all().list()
+            if feature_ids:
+                features.extend(
+                    feature
+                    for feature in schema_features
+                    if feature.id not in feature_ids
+                )
+            else:
+                features.extend(schema_features)
         if features:
             # populate features
             pandera_columns = {}

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -395,7 +395,7 @@ class DataFrameCurator(Curator):
         categoricals = []
         features = []
         feature_ids: set[int] = set()
-        if schema.itype is not None:
+        if schema.itype is not None and isinstance(dataset, pd.DataFrame):
             features += Feature.filter(name__in=self._dataset.keys()).list()
             feature_ids = {feature.id for feature in features}
         if schema.n > 0:

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -170,7 +170,7 @@ class Schema(Record, CanCurate, TracksRun):
         description: `str | None = None` A description.
         itype: `str | None = None` The feature identifier type (e.g. :class:`~lamindb.Feature`, :class:`~bionty.Gene`, ...).
         flexible: `bool | None = None` Whether to include any feature of the same `itype` in validation
-            and annotation. If no features are passed, defaults to `True`, otherwise to `False.
+            and annotation. If no features are passed, defaults to `True`, otherwise to `False`.
         type: `Schema | None = None` A type.
         is_type: `bool = False` Distinguish types from instances of the type.
         otype: `str | None = None` An object type to define the structure of a composite schema.

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -485,7 +485,7 @@ class Schema(Record, CanCurate, TracksRun):
                 if validated_kwargs[arg] is not None
             }
             if mode != "passed-only":
-                union_set.add(mode)
+                union_set.add(f"mode:{SCHEMA_MODE_ENCODE[mode]}")
             if features:
                 union_set = union_set.union({feature.uid for feature in features})
             if optional_features:

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -168,8 +168,8 @@ class Schema(Record, CanCurate, TracksRun):
             their corresponding :class:`~lamindb.Schema` objects for composite schemas.
         name: `str | None = None` A name.
         description: `str | None = None` A description.
-        mode: `Literal["validate-passed", "validate-all-annotate-all-cat"] | None = None`
-            If `None`, uses `"validate-passed"` if features are passed and `"validate-all-annotate-all-cat"` otherwise.
+        mode: `Literal["validate-passed", "validate-all-annotate-cat"] | None = None`
+            If `None`, uses `"validate-passed"` if features are passed and `"validate-all-annotate-cat"` otherwise.
         itype: `str | None = None` The feature identifier type (e.g. :class:`~lamindb.Feature`, :class:`~bionty.Gene`, ...).
         type: `Schema | None = None` A type.
         is_type: `bool = False` Distinguish types from instances of the type.
@@ -362,7 +362,7 @@ class Schema(Record, CanCurate, TracksRun):
         components: dict[str, Schema] | None = None,
         name: str | None = None,
         description: str | None = None,
-        mode: Literal["validate-passed", "validate-all-annotate-all-cat"] | None = None,
+        mode: Literal["validate-passed", "validate-all-annotate-cat"] | None = None,
         dtype: str | None = None,
         itype: str | Registry | FieldAttr | None = None,
         type: Schema | None = None,
@@ -400,7 +400,7 @@ class Schema(Record, CanCurate, TracksRun):
         components: dict[str, Schema] = kwargs.pop("components", {})
         name: str | None = kwargs.pop("name", None)
         description: str | None = kwargs.pop("description", None)
-        mode: Literal["validate-passed", "validate-all-annotate-all-cat"] | None = (
+        mode: Literal["validate-passed", "validate-all-annotate-cat"] | None = (
             kwargs.pop("mode", None)
         )
         itype: str | Record | DeferredAttribute | None = kwargs.pop("itype", None)
@@ -455,7 +455,7 @@ class Schema(Record, CanCurate, TracksRun):
             if features:
                 mode = "validate-passed"
             else:
-                mode = "validate-all-annotate-all-cat"
+                mode = "validate-all-annotate-cat"
         validated_kwargs = {
             "name": name,
             "description": description,
@@ -704,7 +704,7 @@ class Schema(Record, CanCurate, TracksRun):
         self._aux.setdefault("af", {})["0"] = value
 
     @property
-    def mode(self) -> Literal["validate-passed", "validate-all-annotate-all-cat"]:
+    def mode(self) -> Literal["validate-passed", "validate-all-annotate-cat"]:
         """Indicates how to handle validation and annotation in case features are not defined."""
         if self._aux is not None and "af" in self._aux and "0" in self._aux["af"]:  # type: ignore
             return self._aux["af"]["2"]  # type: ignore
@@ -713,13 +713,13 @@ class Schema(Record, CanCurate, TracksRun):
 
     @mode.setter
     def mode(
-        self, value: Literal["validate-passed", "validate-all-annotate-all-cat"]
+        self, value: Literal["validate-passed", "validate-all-annotate-cat"]
     ) -> None:
-        if value not in ["validate-passed", "validate-all-annotate-all-cat"]:
+        if value not in ["validate-passed", "validate-all-annotate-cat"]:
             raise ValueError(
-                "mode must be either 'validate-passed' or 'validate-all-annotate-all-cat'"
+                "mode must be either 'validate-passed' or 'validate-all-annotate-cat'"
             )
-        if value == "validate-all-annotate-all-cat":
+        if value == "validate-all-annotate-cat":
             self._aux = self._aux or {}
             self._aux.setdefault("af", {})["2"] = value
 

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -170,7 +170,7 @@ class Schema(Record, CanCurate, TracksRun):
         description: `str | None = None` A description.
         mode: `Literal["validate-passed", "validate-all-annotate-cat"] | None = None`
             If `None`, uses `"validate-passed"` if features are passed and `"validate-all-annotate-cat"` otherwise.
-        itype: `str | None = None` The feature identifier type (e.g. :class:`~lamindb.Feature`, :class:`~bionty.Gene`, ...).
+        itype: `str | None = "Feature"` The feature identifier type (e.g. :class:`~lamindb.Feature`, :class:`~bionty.Gene`, ...).
         type: `Schema | None = None` A type.
         is_type: `bool = False` Distinguish types from instances of the type.
         otype: `str | None = None` An object type to define the structure of a composite schema.
@@ -364,7 +364,7 @@ class Schema(Record, CanCurate, TracksRun):
         description: str | None = None,
         mode: Literal["validate-passed", "validate-all-annotate-cat"] | None = None,
         dtype: str | None = None,
-        itype: str | Registry | FieldAttr | None = None,
+        itype: str | Registry | FieldAttr | None = "Feature",
         type: Schema | None = None,
         is_type: bool = False,
         otype: str | None = None,
@@ -403,7 +403,7 @@ class Schema(Record, CanCurate, TracksRun):
         mode: Literal["validate-passed", "validate-all-annotate-cat"] | None = (
             kwargs.pop("mode", None)
         )
-        itype: str | Record | DeferredAttribute | None = kwargs.pop("itype", None)
+        itype: str | Record | DeferredAttribute | None = kwargs.pop("itype", "Feature")
         type: Feature | None = kwargs.pop("type", None)
         is_type: bool = kwargs.pop("is_type", False)
         otype: str | None = kwargs.pop("otype", None)
@@ -706,7 +706,7 @@ class Schema(Record, CanCurate, TracksRun):
     @property
     def mode(self) -> Literal["validate-passed", "validate-all-annotate-cat"]:
         """Indicates how to handle validation and annotation in case features are not defined."""
-        if self._aux is not None and "af" in self._aux and "0" in self._aux["af"]:  # type: ignore
+        if self._aux is not None and "af" in self._aux and "2" in self._aux["af"]:  # type: ignore
             return self._aux["af"]["2"]  # type: ignore
         else:
             return "validate-passed"

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -98,6 +98,10 @@ def get_features_config(
         return features, configs  # type: ignore
 
 
+SCHEMA_MODE_ENCODE = {"passed-only": 0, "all-itype": 1}
+SCHEMA_MODE_DECODE = {0: "passed-only", 1: "all-itype"}
+
+
 class SchemaOptionals:
     """Manage and access optional features in a schema."""
 
@@ -250,7 +254,7 @@ class Schema(Record, CanCurate, TracksRun):
     _aux_fields: dict[str, tuple[str, type]] = {
         "0": ("coerce_dtype", bool),
         "1": ("optionals", list[str]),
-        "2": ("mode", str),
+        "2": ("mode_code", int),  # encoding of schema mode
     }
 
     id: int = models.AutoField(primary_key=True)
@@ -707,7 +711,7 @@ class Schema(Record, CanCurate, TracksRun):
     def mode(self) -> Literal["passed-only", "all-itype"]:
         """Indicates how to handle validation and annotation in case features are not defined."""
         if self._aux is not None and "af" in self._aux and "2" in self._aux["af"]:  # type: ignore
-            return self._aux["af"]["2"]  # type: ignore
+            return SCHEMA_MODE_DECODE[self._aux["af"]["2"]]  # type: ignore
         else:
             return "passed-only"
 
@@ -717,7 +721,7 @@ class Schema(Record, CanCurate, TracksRun):
             raise ValueError("mode must be either 'passed-only' or 'all-itype'")
         if value == "all-itype":
             self._aux = self._aux or {}
-            self._aux.setdefault("af", {})["2"] = value
+            self._aux.setdefault("af", {})["2"] = SCHEMA_MODE_ENCODE[value]
 
     # @property
     # def index_feature(self) -> None | Feature:

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -247,7 +247,7 @@ class Schema(Record, CanCurate, TracksRun):
     _name_field: str = "name"
     _aux_fields: dict[str, tuple[str, type]] = {
         "0": ("coerce_dtype", bool),
-        "1": ("optionals", str),
+        "1": ("optionals", list[str]),
         "2": ("mode", str),
     }
 

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -744,7 +744,7 @@ class Schema(Record, CanCurate, TracksRun):
 
     @flexible.setter
     def flexible(self, value: bool) -> None:
-        if value != self.n < 0:
+        if value != (self.n < 0):
             self._aux = self._aux or {}
             self._aux.setdefault("af", {})["2"] = value
 

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -170,7 +170,7 @@ class Schema(Record, CanCurate, TracksRun):
         description: `str | None = None` A description.
         mode: `Literal["validate-passed", "validate-all-annotate-cat"] | None = None`
             If `None`, uses `"validate-passed"` if features are passed and `"validate-all-annotate-cat"` otherwise.
-        itype: `str | None = "Feature"` The feature identifier type (e.g. :class:`~lamindb.Feature`, :class:`~bionty.Gene`, ...).
+        itype: `str | None = None` The feature identifier type (e.g. :class:`~lamindb.Feature`, :class:`~bionty.Gene`, ...).
         type: `Schema | None = None` A type.
         is_type: `bool = False` Distinguish types from instances of the type.
         otype: `str | None = None` An object type to define the structure of a composite schema.
@@ -364,7 +364,7 @@ class Schema(Record, CanCurate, TracksRun):
         description: str | None = None,
         mode: Literal["validate-passed", "validate-all-annotate-cat"] | None = None,
         dtype: str | None = None,
-        itype: str | Registry | FieldAttr | None = "Feature",
+        itype: str | Registry | FieldAttr | None = None,
         type: Schema | None = None,
         is_type: bool = False,
         otype: str | None = None,
@@ -403,7 +403,7 @@ class Schema(Record, CanCurate, TracksRun):
         mode: Literal["validate-passed", "validate-all-annotate-cat"] | None = (
             kwargs.pop("mode", None)
         )
-        itype: str | Record | DeferredAttribute | None = kwargs.pop("itype", "Feature")
+        itype: str | Record | DeferredAttribute | None = kwargs.pop("itype", None)
         type: Feature | None = kwargs.pop("type", None)
         is_type: bool = kwargs.pop("is_type", False)
         otype: str | None = kwargs.pop("otype", None)

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -206,46 +206,46 @@ class Schema(Record, CanCurate, TracksRun):
 
     Examples:
 
-        ::
+        Create schemas::
 
             import lamindb as ln
             import bionty as bt
             import pandas as pd
 
-            # Create a schema from a dataframe
+            # From a dataframe
             df = pd.DataFrame({"feat1": [1, 2], "feat2": [3.1, 4.2], "feat3": ["cond1", "cond2"]})
             schema = ln.Schema.from_df(df)
 
-            # Create a schema from features
+            # From explicitly defined features
             schema = ln.Schema(
                 features=[
                     ln.Feature(name="required_feature", dtype=str).save(),
                 ],
             ).save()
 
-            # Create a schema by merely defining an identifier type
+            # By merely constraining an identifier type
             schema = ln.Schema(itype=bt.Gene.ensembl_gene_id)
 
-            # Create a schema with a required features but also validate features that match the identifier type
+            # A combination of the above
             schema = ln.Schema(
                 features=[
                     ln.Feature(name="required_feature", dtype=str).save(),
                 ],
-                itype=ln.Feature,
+                flexible=True,
             ).save()
 
-            # Create a schema by parsing & validating identifier values
+            # By parsing & validating identifier values
             schema = ln.Schema.from_values(
                 adata.var["ensemble_id"],
                 field=bt.Gene.ensembl_gene_id,
                 organism="mouse",
             ).save()
 
-            # Create a schema and mark a feature as optional
+            # Mark a single feature as optional and ignore other features of the same identifier type
             schema = ln.Schema(
                 features=[
                     ln.Feature(name="required_feature", dtype=str).save(),
-                    ln.Feature(name="feat2", dtype=int).save().with_config(optional=True),
+                    ln.Feature(name="feature2", dtype=int).save().with_config(optional=True),
                 ],
             ).save()
     """

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -168,8 +168,8 @@ class Schema(Record, CanCurate, TracksRun):
             their corresponding :class:`~lamindb.Schema` objects for composite schemas.
         name: `str | None = None` A name.
         description: `str | None = None` A description.
-        mode: `Literal["validate-passed", "validate-all-annotate-cat"] | None = None`
-            If `None`, uses `"validate-passed"` if features are passed and `"validate-all-annotate-cat"` otherwise.
+        mode: `Literal["passed-only", "all-itype"] | None = None`
+            If `None`, uses `"passed-only"` if features are passed and `"all-itype"` otherwise.
         itype: `str | None = None` The feature identifier type (e.g. :class:`~lamindb.Feature`, :class:`~bionty.Gene`, ...).
         type: `Schema | None = None` A type.
         is_type: `bool = False` Distinguish types from instances of the type.
@@ -362,7 +362,7 @@ class Schema(Record, CanCurate, TracksRun):
         components: dict[str, Schema] | None = None,
         name: str | None = None,
         description: str | None = None,
-        mode: Literal["validate-passed", "validate-all-annotate-cat"] | None = None,
+        mode: Literal["passed-only", "all-itype"] | None = None,
         dtype: str | None = None,
         itype: str | Registry | FieldAttr | None = None,
         type: Schema | None = None,
@@ -400,9 +400,7 @@ class Schema(Record, CanCurate, TracksRun):
         components: dict[str, Schema] = kwargs.pop("components", {})
         name: str | None = kwargs.pop("name", None)
         description: str | None = kwargs.pop("description", None)
-        mode: Literal["validate-passed", "validate-all-annotate-cat"] | None = (
-            kwargs.pop("mode", None)
-        )
+        mode: Literal["passed-only", "all-itype"] | None = kwargs.pop("mode", None)
         itype: str | Record | DeferredAttribute | None = kwargs.pop("itype", None)
         type: Feature | None = kwargs.pop("type", None)
         is_type: bool = kwargs.pop("is_type", False)
@@ -453,9 +451,9 @@ class Schema(Record, CanCurate, TracksRun):
             itype_str = itype
         if mode is None:
             if features:
-                mode = "validate-passed"
+                mode = "passed-only"
             else:
-                mode = "validate-all-annotate-cat"
+                mode = "all-itype"
         validated_kwargs = {
             "name": name,
             "description": description,
@@ -480,7 +478,7 @@ class Schema(Record, CanCurate, TracksRun):
                 for arg in hash_args
                 if validated_kwargs[arg] is not None
             }
-            if mode != "validate-passed":
+            if mode != "passed-only":
                 union_set.add(mode)
             if features:
                 union_set = union_set.union({feature.uid for feature in features})
@@ -704,22 +702,18 @@ class Schema(Record, CanCurate, TracksRun):
         self._aux.setdefault("af", {})["0"] = value
 
     @property
-    def mode(self) -> Literal["validate-passed", "validate-all-annotate-cat"]:
+    def mode(self) -> Literal["passed-only", "all-itype"]:
         """Indicates how to handle validation and annotation in case features are not defined."""
         if self._aux is not None and "af" in self._aux and "2" in self._aux["af"]:  # type: ignore
             return self._aux["af"]["2"]  # type: ignore
         else:
-            return "validate-passed"
+            return "passed-only"
 
     @mode.setter
-    def mode(
-        self, value: Literal["validate-passed", "validate-all-annotate-cat"]
-    ) -> None:
-        if value not in ["validate-passed", "validate-all-annotate-cat"]:
-            raise ValueError(
-                "mode must be either 'validate-passed' or 'validate-all-annotate-cat'"
-            )
-        if value == "validate-all-annotate-cat":
+    def mode(self, value: Literal["passed-only", "all-itype"]) -> None:
+        if value not in ["passed-only", "all-itype"]:
+            raise ValueError("mode must be either 'passed-only' or 'all-itype'")
+        if value == "all-itype":
             self._aux = self._aux or {}
             self._aux.setdefault("af", {})["2"] = value
 

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -169,7 +169,9 @@ class Schema(Record, CanCurate, TracksRun):
         name: `str | None = None` A name.
         description: `str | None = None` A description.
         mode: `Literal["passed-only", "all-itype"] | None = None`
-            If `None`, uses `"passed-only"` if features are passed and `"all-itype"` otherwise.
+            If `None`, uses `"validate-passed"` if features are passed and `"all-itype"` otherwise.
+            If `"passed-only"`, only those features that are passed in the schema construction are validated and annotated.
+            If `"all-itype"`, all features with compliant feature identifiers are validated, and all categorical features among these are annotated.
         itype: `str | None = None` The feature identifier type (e.g. :class:`~lamindb.Feature`, :class:`~bionty.Gene`, ...).
         type: `Schema | None = None` A type.
         is_type: `bool = False` Distinguish types from instances of the type.

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -707,7 +707,36 @@ class Schema(Record, CanCurate, TracksRun):
 
     @property
     def flexible(self) -> bool:
-        """Indicates how to handle validation and annotation in case features are not defined."""
+        """Indicates how to handle validation and annotation in case features are not defined.
+
+        Examples:
+
+            Make a rigid schema flexible::
+
+                schema = ln.Schema.get(name="my_schema")
+                schema.flexible = True
+                schema.save()
+
+            During schema creation::
+
+                # if you're not passing features but just defining the itype, defaults to flexible = True
+                schema = ln.Schema(itype=ln.Feature).save()
+                assert not schema.flexible
+
+                # if you're passing features, defaults to flexible = False
+                schema = ln.Schema(
+                    features=[ln.Feature(name="my_required_feature", dtype=int).save()],
+                )
+                assert not schema.flexible
+
+                # you can also validate & annotate features in addition to those that you're explicitly defining:
+                schema = ln.Schema(
+                    features=[ln.Feature(name="my_required_feature", dtype=int).save()],
+                    flexible=True,
+                )
+                assert schema.flexible
+
+        """
         if self._aux is not None and "af" in self._aux and "2" in self._aux["af"]:  # type: ignore
             return self._aux["af"]["2"]  # type: ignore
         else:

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -221,11 +221,22 @@ class Schema(Record, CanCurate, TracksRun):
             schema = ln.Schema.from_df(df)
 
             # Create a schema from features
-            features = [ln.Feature(name=feat, dtype="float").save() for feat in ["feat1", "feat2"]]
-            schema = ln.Schema(features)
+            schema = ln.Schema(
+                features=[
+                    ln.Feature(name="required_feature", dtype=str).save(),
+                ],
+            ).save()
 
             # Create a schema by merely defining an identifier type
             schema = ln.Schema(itype=bt.Gene.ensembl_gene_id)
+
+            # Create a schema with a required features but also validate features that match the identifier type
+            schema = ln.Schema(
+                features=[
+                    ln.Feature(name="required_feature", dtype=str).save(),
+                ],
+                itype=ln.Feature,
+            ).save()
 
             # Create a schema by parsing & validating identifier values
             schema = ln.Schema.from_values(
@@ -237,7 +248,7 @@ class Schema(Record, CanCurate, TracksRun):
             # Create a schema and mark a feature as optional
             schema = ln.Schema(
                 features=[
-                    ln.Feature(name="feat1", dtype=str).save(),
+                    ln.Feature(name="required_feature", dtype=str).save(),
                     ln.Feature(name="feat2", dtype=int).save().with_config(optional=True),
                 ],
             ).save()

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -260,6 +260,7 @@ def test_dataframe_curator_validate_all_annotate_cat2(small_dataset1_schema):
     schema = ln.Schema(
         itype=ln.Feature,
         features=[ln.Feature.get(name="perturbation")],
+        flexible=True,
     ).save()
     df = datasets.small_dataset1(otype="DataFrame")
     curator = ln.curators.DataFrameCurator(df, schema)

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -300,6 +300,7 @@ def test_anndata_curator(small_dataset1_schema: ln.Schema):
             uns_schema = ln.Schema(
                 name="flexible_uns_schema",
                 itype=ln.Feature,
+                mode="validate-passed",
             ).save()
             components["uns"] = uns_schema
 

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -300,7 +300,6 @@ def test_anndata_curator(small_dataset1_schema: ln.Schema):
             uns_schema = ln.Schema(
                 name="flexible_uns_schema",
                 itype=ln.Feature,
-                mode="passed-only",
             ).save()
             components["uns"] = uns_schema
 

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -234,7 +234,7 @@ def test_dataframe_curator(small_dataset1_schema: ln.Schema):
 def test_dataframe_curator_validate_all_annotate_cat(small_dataset1_schema):
     """Do not pass any features."""
 
-    schema = ln.Schema(mode="validate-all-annotate-cat").save()
+    schema = ln.Schema(mode="validate-all-annotate-cat", itype=ln.Feature).save()
     df = datasets.small_dataset1(otype="DataFrame")
     curator = ln.curators.DataFrameCurator(df, schema)
     artifact = curator.save_artifact(key="example_datasets/dataset1.parquet")

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -231,6 +231,33 @@ def test_dataframe_curator(small_dataset1_schema: ln.Schema):
     artifact.delete(permanent=True)
 
 
+def test_dataframe_curator_validate_all_annotate_cat(small_dataset1_schema):
+    """Test DataFrame curator implementation."""
+
+    schema = ln.Schema(
+        name="validate-all-annotate-cat", mode="validate-all-annotate-cat"
+    ).save()
+    assert schema.mode == "validate-all-annotate-cat"
+    df = datasets.small_dataset1(otype="DataFrame")
+    curator = ln.curators.DataFrameCurator(df, schema)
+    artifact = curator.save_artifact(key="example_datasets/dataset1.parquet")
+
+    assert set(artifact.features.get_values()["perturbation"]) == {
+        "DMSO",
+        "IFNG",
+    }
+    assert set(artifact.features.get_values()["cell_type_by_expert"]) == {
+        "CD8-positive, alpha-beta T cell",
+        "B cell",
+    }
+    assert set(artifact.features.get_values()["cell_type_by_model"]) == {
+        "T cell",
+        "B cell",
+    }
+
+    artifact.delete(permanent=True)
+
+
 def test_anndata_curator(small_dataset1_schema: ln.Schema):
     """Test AnnData curator implementation."""
 

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -235,6 +235,7 @@ def test_dataframe_curator_validate_all_annotate_cat(small_dataset1_schema):
     """Do not pass any features."""
 
     schema = ln.Schema(itype=ln.Feature).save()
+    assert schema.flexible
     df = datasets.small_dataset1(otype="DataFrame")
     curator = ln.curators.DataFrameCurator(df, schema)
     artifact = curator.save_artifact(key="example_datasets/dataset1.parquet")
@@ -262,6 +263,7 @@ def test_dataframe_curator_validate_all_annotate_cat2(small_dataset1_schema):
         features=[ln.Feature.get(name="perturbation")],
         flexible=True,
     ).save()
+    assert schema.flexible
     df = datasets.small_dataset1(otype="DataFrame")
     curator = ln.curators.DataFrameCurator(df, schema)
     artifact = curator.save_artifact(key="example_datasets/dataset1.parquet")

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -234,7 +234,7 @@ def test_dataframe_curator(small_dataset1_schema: ln.Schema):
 def test_dataframe_curator_validate_all_annotate_cat(small_dataset1_schema):
     """Do not pass any features."""
 
-    schema = ln.Schema(mode="validate-all-annotate-cat", itype=ln.Feature).save()
+    schema = ln.Schema(mode="all-itype", itype=ln.Feature).save()
     df = datasets.small_dataset1(otype="DataFrame")
     curator = ln.curators.DataFrameCurator(df, schema)
     artifact = curator.save_artifact(key="example_datasets/dataset1.parquet")
@@ -258,7 +258,7 @@ def test_dataframe_curator_validate_all_annotate_cat2(small_dataset1_schema):
     """Combine half-specifying features, half not."""
 
     schema = ln.Schema(
-        mode="validate-all-annotate-cat",
+        mode="all-itype",
         features=[ln.Feature.get(name="perturbation")],
     ).save()
     df = datasets.small_dataset1(otype="DataFrame")
@@ -300,7 +300,7 @@ def test_anndata_curator(small_dataset1_schema: ln.Schema):
             uns_schema = ln.Schema(
                 name="flexible_uns_schema",
                 itype=ln.Feature,
-                mode="validate-passed",
+                mode="passed-only",
             ).save()
             components["uns"] = uns_schema
 

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -234,7 +234,7 @@ def test_dataframe_curator(small_dataset1_schema: ln.Schema):
 def test_dataframe_curator_validate_all_annotate_cat(small_dataset1_schema):
     """Do not pass any features."""
 
-    schema = ln.Schema(mode="all-itype", itype=ln.Feature).save()
+    schema = ln.Schema(itype=ln.Feature).save()
     df = datasets.small_dataset1(otype="DataFrame")
     curator = ln.curators.DataFrameCurator(df, schema)
     artifact = curator.save_artifact(key="example_datasets/dataset1.parquet")
@@ -258,7 +258,7 @@ def test_dataframe_curator_validate_all_annotate_cat2(small_dataset1_schema):
     """Combine half-specifying features, half not."""
 
     schema = ln.Schema(
-        mode="all-itype",
+        itype=ln.Feature,
         features=[ln.Feature.get(name="perturbation")],
     ).save()
     df = datasets.small_dataset1(otype="DataFrame")


### PR DESCRIPTION
## Summary

This PR introduces a simple way to validate & annotate datasets without having to spell out all involved features. A schema with `flexible == True` will validate all known features matching the `itype` and automatically annotate categoricals. Before this PR, in such cases, only the feature identifiers themselves were validated and no annotation with labels took place.

```python
schema = ln.Schema(itype=ln.Feature).save()  # <-- if you're just defining the itype, this sets flexible = True
curator = ln.curators.DataFrameCurator(df, schema)
curator.save_artifact(key="my_dataset.parquet")
```

You can also validate & annotate features in addition to those that you're explicitly defining:
```python
schema = ln.Schema(
    features=[ln.Feature(name="my_required_feature", dtype=int).save()],
    flexible=True,
)
```

If you don't pass `flexible=True`, the curator will disregard features that aren't part of the schema
```python
schema = ln.Schema(
    features=[ln.Feature(name="my_required_feature", dtype=int).save()],
)
```

## Context

Avoiding to spell out features is important because it frees the user from updating schemas with new features. While the previous PR enabled the later it still means considerable work for the user that's only justified for a highly-curated dataset; not for a dataset that a user wants to "quickly validate & annotate" in daily operations.

- https://github.com/laminlabs/lamindb/pull/2635

## Outlook

In the future, for users who work with well-organized data that should typically pass validation, this could make it very easy to indicate ingestion of a validated & annotated artifact via:

```python
ln.Artifact.from_df(..., schema=schema).save()
```

## Docs changes

Before | After
--- | ---
<img width="777" alt="image" src="https://github.com/user-attachments/assets/1e726769-db9d-4658-a516-36ed32e9b226" /> | <img width="782" alt="image" src="https://github.com/user-attachments/assets/c3b42338-fba5-4cd3-a84f-357d8bdaa60c" />
/ | <img width="783" alt="image" src="https://github.com/user-attachments/assets/5193e422-bfe3-43c7-ba6c-bd6d9cda69e3" />

## Materials

Internal [Notion page](https://www.notion.so/laminlabs/Overhaul-the-Schema-design-1ca2aeaa55e1803cb3fed41f955fcc7c).