### PR TITLE
♻️ Add `schema` as an argument to `Artifact.from_X()`

### DIFF
--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -395,7 +395,7 @@ class DataFrameCurator(Curator):
         categoricals = []
         features = []
         feature_ids: set[int] = set()
-        if schema.flexible and isinstance(dataset, pd.DataFrame):
+        if schema.flexible and isinstance(self._dataset, pd.DataFrame):
             features += Feature.filter(name__in=self._dataset.keys()).list()
             feature_ids = {feature.id for feature in features}
         if schema.n > 0:
@@ -551,11 +551,17 @@ class DataFrameCurator(Curator):
         if not self._is_validated:
             self.validate()  # raises ValidationError if doesn't validate
         result = parse_cat_dtype(self._schema.itype, is_itype=True)
-        self._artifact = Artifact.from_df(
-            self._dataset, key=key, description=description, revises=revises, run=run
-        )
-        self._artifact.schema = self._schema
-        self._artifact.save()
+        if self._artifact is None:
+            self._artifact = Artifact.from_df(
+                self._dataset,
+                key=key,
+                description=description,
+                revises=revises,
+                run=run,
+            )
+            self._artifact.schema = self._schema
+            self._artifact.save()
+        print("annotating with", self._cat_manager._cat_columns)
         return annotate_artifact(  # type: ignore
             self._artifact,
             index_field=result["field"],

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -241,6 +241,7 @@ class Curator:
         pass  # pragma: no cover
 
 
+# default implementation for MuDataCurator and SpatialDataCurator
 class SlotsCurator(Curator):
     """Curator for a dataset with slots.
 
@@ -290,26 +291,25 @@ class SlotsCurator(Curator):
         """{}"""  # noqa: D415
         if not self._is_validated:
             self.validate()
-
-        if data_is_mudata(self._dataset):
-            self._artifact = Artifact.from_mudata(
-                self._dataset,
-                key=key,
-                description=description,
-                revises=revises,
-                run=run,
-            )
-        elif data_is_spatialdata(self._dataset):
-            self._artifact = Artifact.from_spatialdata(
-                self._dataset,
-                key=key,
-                description=description,
-                revises=revises,
-                run=run,
-            )
-        self._artifact.schema = self._schema
-        self._artifact.save()
-        # default implementation for MuDataCurator and SpatialDataCurator
+        if self._artifact is None:
+            if data_is_mudata(self._dataset):
+                self._artifact = Artifact.from_mudata(
+                    self._dataset,
+                    key=key,
+                    description=description,
+                    revises=revises,
+                    run=run,
+                )
+            elif data_is_spatialdata(self._dataset):
+                self._artifact = Artifact.from_spatialdata(
+                    self._dataset,
+                    key=key,
+                    description=description,
+                    revises=revises,
+                    run=run,
+                )
+            self._artifact.schema = self._schema
+            self._artifact.save()
         cat_columns = {}
         for curator in self._slots.values():
             for key, cat_column in curator._cat_manager._cat_columns.items():
@@ -561,7 +561,6 @@ class DataFrameCurator(Curator):
             )
             self._artifact.schema = self._schema
             self._artifact.save()
-        print("annotating with", self._cat_manager._cat_columns)
         return annotate_artifact(  # type: ignore
             self._artifact,
             index_field=result["field"],
@@ -668,11 +667,16 @@ class AnnDataCurator(SlotsCurator):
         """{}"""  # noqa: D415
         if not self._is_validated:
             self.validate()
-        self._artifact = Artifact.from_anndata(
-            self._dataset, key=key, description=description, revises=revises, run=run
-        )
-        self._artifact.schema = self._schema
-        self._artifact.save()
+        if self._artifact is None:
+            self._artifact = Artifact.from_anndata(
+                self._dataset,
+                key=key,
+                description=description,
+                revises=revises,
+                run=run,
+            )
+            self._artifact.schema = self._schema
+            self._artifact.save()
         return annotate_artifact(  # type: ignore
             self._artifact,
             cat_columns=(

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1595,6 +1595,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
         description: str | None = None,
         run: Run | None = None,
         revises: Artifact | None = None,
+        schema: Schema | None = None,
         **kwargs,
     ) -> Artifact:
         """Create from ``AnnData``, validate & link features.
@@ -1606,6 +1607,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
             description: A description.
             revises: An old version of the artifact.
             run: The run that creates the artifact.
+            schema: A schema to validate & annotate.
 
         See Also:
 
@@ -1647,6 +1649,13 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
             # and the proper path through create_path for cloud paths
             obj_for_obs = artifact.path
         artifact.n_observations = _anndata_n_observations(obj_for_obs)
+        if schema is not None:
+            from ..curators import AnnDataCurator
+
+            curator = AnnDataCurator(artifact, schema)
+            curator.validate()
+            artifact.schema = schema
+            artifact._curator = curator
         return artifact
 
     @classmethod
@@ -1658,6 +1667,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
         description: str | None = None,
         run: Run | None = None,
         revises: Artifact | None = None,
+        schema: Schema | None = None,
         **kwargs,
     ) -> Artifact:
         """Create from ``MuData``, validate & link features.
@@ -1669,6 +1679,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
             description: A description.
             revises: An old version of the artifact.
             run: The run that creates the artifact.
+            schema: A schema to validate & annotate.
 
         See Also:
             :meth:`~lamindb.Collection`
@@ -1697,6 +1708,13 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
         )
         if not isinstance(mdata, UPathStr):
             artifact.n_observations = mdata.n_obs
+        if schema is not None:
+            from ..curators import MuDataCurator
+
+            curator = MuDataCurator(artifact, schema)
+            curator.validate()
+            artifact.schema = schema
+            artifact._curator = curator
         return artifact
 
     @classmethod
@@ -1708,6 +1726,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
         description: str | None = None,
         run: Run | None = None,
         revises: Artifact | None = None,
+        schema: Schema | None = None,
         **kwargs,
     ) -> Artifact:
         """Create from ``SpatialData``, validate & link features.
@@ -1719,6 +1738,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
             description: A description.
             revises: An old version of the artifact.
             run: The run that creates the artifact.
+             schema: A schema to validate & annotate.
 
         See Also:
             :meth:`~lamindb.Collection`
@@ -1748,6 +1768,13 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
         )
         # ill-defined https://scverse.zulipchat.com/#narrow/channel/315824-spatial/topic/How.20to.20calculate.20the.20number.20of.20observations.3F
         # artifact.n_observations = ...
+        if schema is not None:
+            from ..curators import SpatialDataCurator
+
+            curator = SpatialDataCurator(artifact, schema)
+            curator.validate()
+            artifact.schema = schema
+            artifact._curator = curator
         return artifact
 
     @classmethod

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -477,6 +477,7 @@ class Schema(Record, CanCurate, TracksRun):
         if components:
             hash = hash_set({component.hash for component in components.values()})
         else:
+            # we do not want pure informational annotations like otype, name, type, is_type, otype to be part of the hash
             hash_args = ["dtype", "itype", "minimal_set", "ordered_set", "maximal_set"]
             union_set = {
                 str(validated_kwargs[arg])
@@ -636,7 +637,6 @@ class Schema(Record, CanCurate, TracksRun):
                 features=validated_features,
                 name=name,
                 dtype=get_type_str(dtype),
-                otype="DataFrame",
             )
         return schema
 

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -334,7 +334,9 @@ def test_anndata_curator(small_dataset1_schema: ln.Schema):
             assert isinstance(curator.slots["obs"], ln.curators.DataFrameCurator)
         if add_comp == "uns":
             assert isinstance(curator.slots["uns"], ln.curators.DataFrameCurator)
-        artifact = curator.save_artifact(key="example_datasets/dataset1.h5ad")
+        artifact = ln.Artifact.from_anndata(
+            adata, key="example_datasets/dataset1.h5ad", schema=anndata_schema
+        ).save()
         assert artifact.schema == anndata_schema
         assert artifact.features.slots["var"].n == 3  # 3 genes get linked
         if add_comp == "obs":
@@ -462,9 +464,9 @@ def test_spatialdata_curator(
         curator.validate()
     spatialdata.tables["table"].var.drop(index="ENSG00000999999", inplace=True)
 
-    # TODO: shouldn't need to re-init the curator
-    curator = ln.curators.SpatialDataCurator(spatialdata, spatialdata_schema)
-    artifact = curator.save_artifact(key="example_datasets/spatialdata1.zarr")
+    artifact = ln.Artifact.from_spatialdata(
+        spatialdata, key="example_datasets/spatialdata1.zarr", schema=spatialdata_schema
+    ).save()
     assert artifact.schema == spatialdata_schema
     assert artifact.features.slots.keys() == {
         "sample",

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -237,8 +237,9 @@ def test_dataframe_curator_validate_all_annotate_cat(small_dataset1_schema):
     schema = ln.Schema(itype=ln.Feature).save()
     assert schema.flexible
     df = datasets.small_dataset1(otype="DataFrame")
-    curator = ln.curators.DataFrameCurator(df, schema)
-    artifact = curator.save_artifact(key="example_datasets/dataset1.parquet")
+    artifact = ln.Artifact.from_df(
+        df, key="example_datasets/dataset1.parquet", schema=schema
+    ).save()
     assert set(artifact.features.get_values()["perturbation"]) == {
         "DMSO",
         "IFNG",


### PR DESCRIPTION
To ingest a validated and annotated artifact, one can now run:
```python
artifact = ln.Artifact.from_df(df, key="my_dataset.parquet", schema=schema).save()
```

The is useful if one expects standardized datasets. If one expects "messy data" or one wants to update registries during curation, one can continue to use the more explicit flow that leverages a `Curator` object.

```python
curator = ln.curators.DataFrameCurator(df, schema)
artifact = curator.save_artifact(key="my_dataset.parquet")
```