### PR TITLE
✨ Refresh db token on expiration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - id: set-matrix
         shell: bash
         run: |
-          BASE_GROUPS=$(jq -n -c '["unit-core", "unit-storage", "tutorial", "guide", "biology", "faq", "storage", "cli", "permissions"]')
+          BASE_GROUPS=$(jq -n -c '["permissions"]')
 
           if [[ "${{ github.event_name }}" == "push" || "${{ steps.changes.outputs.curator }}" == "true" ]]; then
             # Run everything on push or when curator paths change

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - id: set-matrix
         shell: bash
         run: |
-          BASE_GROUPS=$(jq -n -c '["permissions"]')
+          BASE_GROUPS=$(jq -n -c '["unit-core", "unit-storage", "tutorial", "guide", "biology", "faq", "storage", "cli", "permissions"]')
 
           if [[ "${{ github.event_name }}" == "push" || "${{ steps.changes.outputs.curator }}" == "true" ]]; then
             # Run everything on push or when curator paths change

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -58,9 +58,9 @@ from lamindb_setup._connect_instance import (
     update_db_using_local,
 )
 from lamindb_setup.core._docs import doc_args
-from lamindb_setup.core._hub_core import access_db, connect_instance_hub
+from lamindb_setup.core._hub_core import connect_instance_hub
 from lamindb_setup.core._settings_store import instance_settings_file
-from lamindb_setup.core.django import db_token_manager
+from lamindb_setup.core.django import DBToken, db_token_manager
 from lamindb_setup.core.upath import extract_suffix_from_path
 
 from lamindb.base.fields import (
@@ -631,7 +631,7 @@ class Registry(ModelBase):
                 iresult["fine_grained_access"] and iresult["db_permissions"] == "jwt"
             )
             # access_db can take both: the dict from connect_instance_hub and isettings
-            into_access_db = iresult
+            into_db_token = iresult
         else:
             isettings = load_instance_settings(settings_file)
             source_modules = isettings.modules
@@ -644,7 +644,7 @@ class Registry(ModelBase):
                 isettings._fine_grained_access and isettings._db_permissions == "jwt"
             )
             # access_db can take both: the dict from connect_instance_hub and isettings
-            into_access_db = isettings
+            into_db_token = isettings
 
         target_modules = setup_settings.instance.modules
         if not (missing_members := source_modules - target_modules):
@@ -655,7 +655,7 @@ class Registry(ModelBase):
 
         add_db_connection(db, instance)
         if is_fine_grained_access:
-            db_token = access_db(into_access_db)
+            db_token = DBToken(into_db_token)
             db_token_manager.set(db_token, instance)
         return QuerySet(model=cls, using=instance)
 

--- a/tests/permissions/test_permissions.py
+++ b/tests/permissions/test_permissions.py
@@ -158,7 +158,7 @@ def test_write_role():
 def test_token_reset():
     db_token_manager.reset()
 
-    ln.ULabel.filter()
+    assert ln.ULabel.filter().count() == 0
 
 
 # below is an integration test that should run last

--- a/tests/permissions/test_permissions.py
+++ b/tests/permissions/test_permissions.py
@@ -7,7 +7,7 @@ import hubmodule.models as hm
 import lamindb as ln
 import psycopg2
 import pytest
-from django.db import transaction
+from django.db import connection, transaction
 from django.db.utils import DataError, ProgrammingError
 from jwt_utils import sign_jwt
 from lamindb_setup.core.django import DBToken, db_token_manager
@@ -28,6 +28,12 @@ db_token_manager.set(db_token)
 
 
 def test_fine_grained_permissions_account():
+    # just check that the token was setup
+    with connection.cursor() as cur:
+        cur.execute("SELECT current_setting('app.account_id');")
+        account_id = cur.fetchall()[0][0]
+    assert account_id == user_uuid
+
     # check select
     assert ln.ULabel.filter().count() == 3
     assert ln.Project.filter().count() == 2

--- a/tests/permissions/test_permissions.py
+++ b/tests/permissions/test_permissions.py
@@ -163,6 +163,10 @@ def test_token_reset():
     with pytest.raises(DataError):
         ln.ULabel.filter().count()
 
+    with pytest.raises(DataError):
+        with transaction.atomic():
+            ln.ULabel.filter().count()
+
 
 # below is an integration test that should run last
 def test_lamin_dev():

--- a/tests/permissions/test_permissions.py
+++ b/tests/permissions/test_permissions.py
@@ -8,7 +8,7 @@ import lamindb as ln
 import psycopg2
 import pytest
 from django.db import transaction
-from django.db.utils import ProgrammingError
+from django.db.utils import DataError, ProgrammingError
 from jwt_utils import sign_jwt
 from lamindb_setup.core.django import DBToken, db_token_manager
 from psycopg2.extensions import adapt
@@ -158,7 +158,10 @@ def test_write_role():
 def test_token_reset():
     db_token_manager.reset()
 
-    assert ln.ULabel.filter().count() == 0
+    # app.account_id is not set
+    # invalid input syntax for type uuid: ""
+    with pytest.raises(DataError):
+        ln.ULabel.filter().count()
 
 
 # below is an integration test that should run last

--- a/tests/permissions/test_permissions.py
+++ b/tests/permissions/test_permissions.py
@@ -1,4 +1,5 @@
 import subprocess
+import time
 from pathlib import Path
 from uuid import uuid4
 
@@ -9,12 +10,21 @@ import pytest
 from django.db import transaction
 from django.db.utils import ProgrammingError
 from jwt_utils import sign_jwt
-from lamindb_setup.core.django import db_token_manager
+from lamindb_setup.core.django import DBToken, db_token_manager
+from psycopg2.extensions import adapt
 
 pgurl = "postgresql://postgres:pwd@0.0.0.0:5432/pgtest"  # admin db connection url
+
 user_uuid = ln.setup.settings.user._uuid.hex
-token = sign_jwt(pgurl, {"account_id": user_uuid})
-db_token_manager.set(token)
+expiration = time.time() + 2000
+token = sign_jwt(pgurl, {"account_id": user_uuid, "exp": expiration})
+# init an instance of DBToken manually
+db_token = DBToken({})
+db_token._token = token
+db_token._token_query = f"SELECT set_token({adapt(token).getquoted().decode()}, true);"
+db_token._expiration = expiration
+
+db_token_manager.set(db_token)
 
 
 def test_fine_grained_permissions_account():

--- a/tests/permissions/test_permissions.py
+++ b/tests/permissions/test_permissions.py
@@ -155,6 +155,12 @@ def test_write_role():
     ln.ULabel(name="new label team default space").save()
 
 
+def test_token_reset():
+    db_token_manager.reset()
+
+    ln.ULabel.filter()
+
+
 # below is an integration test that should run last
 def test_lamin_dev():
     script_path = Path(__file__).parent.resolve() / "scripts/check_lamin_dev.py"


### PR DESCRIPTION
- https://github.com/laminlabs/lamindb-setup/pull/1020

For instances with fine-grained access a db token (jwt) is set on every transaction. This token grants access to database operations. The token is received from central and has an expiration date, this PR adds a check of the expiration and requests a new token if the current one is expired.