### PR TITLE
✏️ Improve installation hint for zarr

### DIFF
--- a/lamindb/core/loaders.py
+++ b/lamindb/core/loaders.py
@@ -44,7 +44,7 @@ try:
 except ImportError:
 
     def load_zarr(storepath):  # type: ignore
-        raise ImportError("Please install zarr: pip install zarr<=2.18.4")
+        raise ImportError("Please install zarr: pip install 'zarr<=2.18.4'")
 
 
 is_run_from_ipython = getattr(builtins, "__IPYTHON__", False)


### PR DESCRIPTION
This PR fixes the installation instruction for `zarr` by adding quotes around the package and version specifier. The installation command without quotes caused shell interpretation issues.
