### PR TITLE
🐛 Do not delete version family if user wants to retain store by passing `storage=False` to `artifact.delete()`

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -2456,8 +2456,10 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
                 and self.is_latest
                 and (storage is None or storage)
             ):
-                # includes self
-                for version in self.versions.all():
+                logger.important(
+                    "deleting the entire version family because all versions of this artifact share the same store"
+                )
+                for version in self.versions.all():  # includes self
                     _delete_skip_storage(version)
             else:
                 self._delete_skip_storage()

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -2399,6 +2399,9 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
             artifact = ln.Artifact.get(key="some.tiledbsoma". is_latest=True)
             artiact.delete() # delete all versions, the data will be deleted or prompted for deletion.
         """
+        # we're *not* running the line below because the case `storage is None` triggers user feedback in one case
+        # storage = True if storage is None else storage
+
         # this first check means an invalid delete fails fast rather than cascading through
         # database and storage permission errors
         if os.getenv("LAMINDB_MULTI_INSTANCE") is None:
@@ -2448,7 +2451,11 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
                 storage = False
             # only delete in storage if DB delete is successful
             # DB delete might error because of a foreign key constraint violated etc.
-            if self._overwrite_versions and self.is_latest:
+            if (
+                self._overwrite_versions
+                and self.is_latest
+                and (storage is None or storage)
+            ):
                 # includes self
                 for version in self.versions.all():
                     _delete_skip_storage(version)


### PR DESCRIPTION
In case `artifact._overwrite_versions` was `True`, before this PR, the following call deleted all records of the version family:

```python
artifact.delete(storage=False)
```

Now it only deletes the selected record.