### PR TITLE
✨ Enable executing notebooks via `jupyter nbconvert --execute`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ gcp = [
     "lamindb_setup[gcp]",
 ]
 jupyter = [
-    "nbproject==0.10.6",  # keep pinning
+    "nbproject==0.11.0",  # keep pinning
     "jupytext",
     "nbconvert>=7.2.1", # avoid lxml[html_clean] dependency
     "mistune!=3.1.0",  # there is a bug in it


### PR DESCRIPTION
Enables `ln.track()` without passing the notebook path when run through `nbconvert`:
```
jupyter nbconvert --to notebook --execute test-nbconvert.ipynb
```

Resolves:

- https://github.com/laminlabs/lamindb/issues/1625

Needs:

- https://github.com/laminlabs/nbproject/pull/288
- https://github.com/laminlabs/lamin-cli/pull/128