### PR TITLE
✨ Enable curating the index of a dataframe

### DIFF
--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -399,7 +399,14 @@ class DataFrameCurator(Curator):
             features += Feature.filter(name__in=self._dataset.keys()).list()
             feature_ids = {feature.id for feature in features}
         if schema.n > 0:
-            schema_features = schema.features.all().list()
+            if schema._index_feature_uid is not None:
+                schema_features = [
+                    feature
+                    for feature in schema.features.all().list()
+                    if feature.uid != schema._index_feature_uid
+                ]
+            else:
+                schema_features = schema.features.all().list()
             if feature_ids:
                 features.extend(
                     feature
@@ -410,7 +417,7 @@ class DataFrameCurator(Curator):
                 features.extend(schema_features)
         else:
             assert schema.itype is not None  # noqa: S101
-        if features:
+        if features or schema._index_feature_uid is not None:
             # populate features
             pandera_columns = {}
             if schema.minimal_set:
@@ -453,16 +460,25 @@ class DataFrameCurator(Curator):
                     # validate categoricals if the column is required or if the column is present
                     if required or feature.name in self._dataset.columns:
                         categoricals.append(feature)
+            if schema._index_feature_uid is not None:
+                # in almost no case, an index should be a categorical dtype in a DataFrame
+                index = pandera.Index(
+                    schema.index.dtype if not feature.dtype.startswith("cat") else str
+                )
+            else:
+                index = None
             self._pandera_schema = pandera.DataFrameSchema(
                 pandera_columns,
                 coerce=schema.coerce_dtype,
                 strict=schema.maximal_set,
                 ordered=schema.ordered_set,
+                index=index,
             )
         self._cat_manager = DataFrameCatManager(
             self._dataset,
             columns=parse_cat_dtype(schema.itype, is_itype=True)["field"],
             categoricals=categoricals,
+            index=schema.index,
         )
 
     @property
@@ -1391,6 +1407,7 @@ class DataFrameCatManager(CatManager):
         columns: FieldAttr = Feature.name,
         categoricals: list[Feature] | dict[str, FieldAttr] | None = None,
         sources: dict[str, Record] | None = None,
+        index: Feature | None = None,
     ) -> None:
         self._non_validated = None
         super().__init__(
@@ -1440,6 +1457,15 @@ class DataFrameCatManager(CatManager):
                     key=key,
                     source=self._sources.get(key),
                     feature=feature,
+                )
+            if index is not None and index.dtype.startswith("cat"):
+                result = parse_dtype(index.dtype)[0]
+                field = result["field"]
+                self._cat_columns[key] = CatColumn(
+                    values_getter=self._dataset.index,
+                    field=field,
+                    key="index",
+                    feature=index,
                 )
         else:
             # below is for backward compat of ln.Curator.from_df()

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -1458,13 +1458,14 @@ class DataFrameCatManager(CatManager):
                     source=self._sources.get(key),
                     feature=feature,
                 )
+            key = "index"
             if index is not None and index.dtype.startswith("cat"):
                 result = parse_dtype(index.dtype)[0]
                 field = result["field"]
                 self._cat_columns[key] = CatColumn(
                     values_getter=self._dataset.index,
                     field=field,
-                    key="index",
+                    key=key,
                     feature=index,
                 )
         else:

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -207,15 +207,11 @@ class Schema(Record, CanCurate, TracksRun):
 
     Examples:
 
-        Create schemas::
+        The typical way to create a schema::
 
             import lamindb as ln
             import bionty as bt
             import pandas as pd
-
-            # From a dataframe
-            df = pd.DataFrame({"feat1": [1, 2], "feat2": [3.1, 4.2], "feat3": ["cond1", "cond2"]})
-            schema = ln.Schema.from_df(df)
 
             # From explicitly defined features
             schema = ln.Schema(
@@ -235,6 +231,26 @@ class Schema(Record, CanCurate, TracksRun):
                 flexible=True,
             ).save()
 
+        Passing options to the `Schema` constructor::
+
+            # also validate the index
+            schema = ln.Schema(
+                features=[
+                    ln.Feature(name="required_feature", dtype=str).save(),
+                ],
+                index=ln.Feature(name="sample", dtype=ln.ULabel.save())
+            ).save()
+
+            # mark a single feature as optional and ignore other features of the same identifier type
+            schema = ln.Schema(
+                features=[
+                    ln.Feature(name="required_feature", dtype=str).save(),
+                    ln.Feature(name="feature2", dtype=int).save().with_config(optional=True),
+                ],
+            ).save()
+
+        Alternative constructors::
+
             # By parsing & validating identifier values
             schema = ln.Schema.from_values(
                 adata.var["ensemble_id"],
@@ -242,13 +258,9 @@ class Schema(Record, CanCurate, TracksRun):
                 organism="mouse",
             ).save()
 
-            # Mark a single feature as optional and ignore other features of the same identifier type
-            schema = ln.Schema(
-                features=[
-                    ln.Feature(name="required_feature", dtype=str).save(),
-                    ln.Feature(name="feature2", dtype=int).save().with_config(optional=True),
-                ],
-            ).save()
+            # From a dataframe
+            df = pd.DataFrame({"feat1": [1, 2], "feat2": [3.1, 4.2], "feat3": ["cond1", "cond2"]})
+            schema = ln.Schema.from_df(df)
     """
 
     class Meta(Record.Meta, TracksRun.Meta, TracksUpdates.Meta):

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -213,21 +213,24 @@ class Schema(Record, CanCurate, TracksRun):
             import bionty as bt
             import pandas as pd
 
-            # From explicitly defined features
+            # explicitly define features
             schema = ln.Schema(
                 features=[
                     ln.Feature(name="required_feature", dtype=str).save(),
                 ],
             ).save()
 
-            # By merely constraining an identifier type
+            # merely constrain a feature identifier type like an Ensembl gene id
             schema = ln.Schema(itype=bt.Gene.ensembl_gene_id)
+            # or feature name
+            schema = ln.Schema(itype=ln.Feature)  # is equivalent to ln.Feature.name
 
-            # A combination of the above
+            # a combination of the above
             schema = ln.Schema(
                 features=[
                     ln.Feature(name="required_feature", dtype=str).save(),
                 ],
+                itype=ln.Schema(itype=ln.Feature),
                 flexible=True,
             ).save()
 
@@ -238,7 +241,7 @@ class Schema(Record, CanCurate, TracksRun):
                 features=[
                     ln.Feature(name="required_feature", dtype=str).save(),
                 ],
-                index=ln.Feature(name="sample", dtype=ln.ULabel.save())
+                index=ln.Feature(name="sample", dtype=ln.ULabel).save(),
             ).save()
 
             # mark a single feature as optional and ignore other features of the same identifier type

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -17,9 +17,8 @@ from lamindb.base.fields import (
     JSONField,
 )
 from lamindb.base.types import FieldAttr, ListLike
-from lamindb.errors import InvalidArgument
+from lamindb.errors import FieldValidationError, InvalidArgument
 
-from ..base import deprecated
 from ..errors import ValidationError
 from ._relations import (
     dict_related_model_to_related_name,
@@ -36,6 +35,7 @@ from .record import (
     LinkORM,
     Record,
     Registry,
+    _get_record_kwargs,
     init_self_from_db,
     update_attributes,
 )
@@ -83,14 +83,14 @@ def validate_features(features: list[Record]) -> Record:
 def get_features_config(
     features: list[Record] | tuple[Record, dict],
 ) -> tuple[list[Record], list[tuple[Record, dict]]]:
-    """Get features and their config from the return of feature.with_config."""
+    """Get features and their config from the return of feature.with_config()."""
     features_list = []
     configs = []
     try:
         for feature in features:
             if isinstance(feature, tuple):
                 features_list.append(feature[0])
-                configs.append(feature)
+                configs.append(feature)  # store the tuple in configs
             else:
                 features_list.append(feature)
         return features_list, configs  # type: ignore
@@ -164,6 +164,7 @@ class Schema(Record, CanCurate, TracksRun):
             a set upon instantiation. If you'd like to pass values, use
             :meth:`~lamindb.Schema.from_values` or
             :meth:`~lamindb.Schema.from_df`.
+        index: `Feature | None = None` A :class:`~lamindb.Feature` record to validate an index of a `DataFrame`.
         components: `dict[str, Schema] | None = None` A dictionary mapping slot names to
             components. A component is itself a :class:`~lamindb.Schema` object.
         name: `str | None = None` A name.
@@ -258,6 +259,7 @@ class Schema(Record, CanCurate, TracksRun):
         "0": ("coerce_dtype", bool),
         "1": ("optionals", list[str]),
         "2": ("flexible", bool),
+        "3": ("index_feature_uid", str),
     }
 
     id: int = models.AutoField(primary_key=True)
@@ -368,6 +370,7 @@ class Schema(Record, CanCurate, TracksRun):
     def __init__(
         self,
         features: Iterable[Record] | None = None,
+        index: Feature | None = None,
         components: dict[str, Schema] | None = None,
         name: str | None = None,
         description: str | None = None,
@@ -401,9 +404,7 @@ class Schema(Record, CanCurate, TracksRun):
         features: Iterable[Record] | None = (
             args[0] if args else kwargs.pop("features", [])
         )
-        # typing here anticipates transitioning to a ManyToMany
-        # between composites and components similar to feature_sets
-        # in lamindb v2
+        index: Feature | None = kwargs.pop("index", None)
         components: dict[str, Schema] = kwargs.pop("components", {})
         name: str | None = kwargs.pop("name", None)
         description: str | None = kwargs.pop("description", None)
@@ -420,15 +421,17 @@ class Schema(Record, CanCurate, TracksRun):
         optional_features = []
 
         if kwargs:
-            raise ValueError(
-                f"Unexpected keyword arguments: {', '.join(kwargs.keys())}\n"
-                "Valid arguments are: features, description, dtype, itype, type, "
-                "is_type, otype, minimal_set, ordered_set, maximal_set, "
-                "coerce_dtype"
+            valid_keywords = ", ".join([val[0] for val in _get_record_kwargs(Schema)])
+            raise FieldValidationError(
+                f"Only {valid_keywords} are valid keyword arguments"
             )
         optional_features = []
         if itype is not None:
             itype = serialize_dtype(itype, is_itype=True)
+        if index is not None:
+            if not isinstance(index, Feature):
+                raise TypeError("index must be a Feature")
+            features.insert(0, index)
         if features:
             features, configs = get_features_config(features)
             features_registry = validate_features(features)
@@ -516,6 +519,8 @@ class Schema(Record, CanCurate, TracksRun):
         super().__init__(**validated_kwargs)
         self.optionals.set(optional_features)
         self.flexible = flexible
+        if index is not None:
+            self._index_feature_uid = index.uid
 
     @classmethod
     def from_values(  # type: ignore
@@ -748,36 +753,26 @@ class Schema(Record, CanCurate, TracksRun):
             self._aux = self._aux or {}
             self._aux.setdefault("af", {})["2"] = value
 
-    # @property
-    # def index_feature(self) -> None | Feature:
-    #     # index_feature: `Record | None = None` A :class:`~lamindb.Feature` to validate the index of a `DataFrame`.
-    #     """The uid of the index feature, if `index_feature` was set."""
-    #     if self._index_feature_uid is None:
-    #         return None
-    #     else:
-    #         return self.features.get(uid=self._index_feature_uid)
-
-    # @property
-    # def _index_feature_uid(self) -> None | str:
-    #     """The uid of the index feature, if `index_feature` was set."""
-    #     if self._aux is not None and "af" in self._aux and "1" in self._aux["af"]:
-    #         return self._aux["af"]["1"]
-    #     else:
-    #         return None
-
-    # @_index_feature_uid.setter
-    # def _index_feature_uid(self, value: str) -> None:
-    #     self._aux = self._aux or {}
-    #     self._aux.setdefault("af", {})["0"] = value
+    @property
+    def index(self) -> None | Feature:
+        """The feature configured to act as index."""
+        if self._index_feature_uid is None:
+            return None
+        else:
+            return self.features.get(uid=self._index_feature_uid)
 
     @property
-    @deprecated("itype")
-    def registry(self) -> str:
-        return self.itype
+    def _index_feature_uid(self) -> None | str:
+        """The uid of the index feature."""
+        if self._aux is not None and "af" in self._aux and "3" in self._aux["af"]:
+            return self._aux["af"]["3"]
+        else:
+            return None
 
-    @registry.setter
-    def registry(self, value) -> None:
-        self.itype = value
+    @_index_feature_uid.setter
+    def _index_feature_uid(self, value: str) -> None:
+        self._aux = self._aux or {}
+        self._aux.setdefault("af", {})["3"] = value
 
     @property
     def slots(self) -> dict[str, Schema]:

--- a/tests/core/test_schema.py
+++ b/tests/core/test_schema.py
@@ -3,7 +3,7 @@ import lamindb as ln
 import pandas as pd
 import pytest
 from django.db.utils import IntegrityError
-from lamindb.errors import ValidationError
+from lamindb.errors import FieldValidationError, ValidationError
 from lamindb.models.schema import get_related_name, validate_features
 
 
@@ -137,7 +137,7 @@ def test_validate_features():
 
 
 def test_kwargs():
-    with pytest.raises(ValueError):
+    with pytest.raises(FieldValidationError):
         ln.Schema(x="1", features=[])
 
 

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -17,6 +17,7 @@ def small_dataset1_schema():
     perturbation = ln.ULabel(name="Perturbation", is_type=True).save()
     ln.ULabel(name="DMSO", type=perturbation).save()
     ln.ULabel(name="IFNG", type=perturbation).save()
+    ln.ULabel.from_values(["sample1", "sample2", "sample3"], create=True).save()
     bt.CellType.from_source(name="B cell").save()
     bt.CellType.from_source(name="T cell").save()
 
@@ -35,6 +36,7 @@ def small_dataset1_schema():
             ln.Feature(name="cell_type_by_expert", dtype=bt.CellType).save(),
             ln.Feature(name="cell_type_by_model", dtype=bt.CellType).save(),
         ],
+        index=ln.Feature(name="sample", dtype=ln.ULabel).save(),
     ).save()
 
     yield schema
@@ -209,6 +211,15 @@ def test_dataframe_curator(small_dataset1_schema: ln.Schema):
     curator = ln.curators.DataFrameCurator(df, small_dataset1_schema)
     artifact = curator.save_artifact(key="example_datasets/dataset1.parquet")
 
+    print(artifact.describe())
+    print(small_dataset1_schema.features.df())
+    print(artifact.feature_sets.first().features.df())
+
+    assert set(artifact.features.get_values()["sample"]) == {
+        "sample1",
+        "sample2",
+        "sample3",
+    }
     assert set(artifact.features.get_values()["cell_type_by_expert"]) == {
         "CD8-positive, alpha-beta T cell",
         "B cell",

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -212,8 +212,6 @@ def test_dataframe_curator(small_dataset1_schema: ln.Schema):
     artifact = curator.save_artifact(key="example_datasets/dataset1.parquet")
 
     print(artifact.describe())
-    print(small_dataset1_schema.features.df())
-    print(artifact.feature_sets.first().features.df())
 
     assert set(artifact.features.get_values()["sample"]) == {
         "sample1",
@@ -230,6 +228,7 @@ def test_dataframe_curator(small_dataset1_schema: ln.Schema):
     }
 
     # a second dataset with missing values
+    ln.ULabel.from_values(["sample4", "sample5", "sample6"], create=True).save()
     df = ln.core.datasets.small_dataset2(otype="DataFrame", gene_symbols_in_index=True)
     curator = ln.curators.DataFrameCurator(df, small_dataset1_schema)
     try:

--- a/tests/curators/test_curators_quickstart_example.py
+++ b/tests/curators/test_curators_quickstart_example.py
@@ -324,8 +324,8 @@ def test_anndata_curator(small_dataset1_schema: ln.Schema):
         ).save()
         assert small_dataset1_schema.id is not None, small_dataset1_schema
         assert anndata_schema.slots["var"] == var_schema
-        if add_comp == "obs":
-            assert anndata_schema.slots["obs"] == obs_schema
+        # if add_comp == "obs":
+        # assert anndata_schema.slots["obs"] == obs_schema, bring back once index is accounted for
         if add_comp == "uns":
             assert anndata_schema.slots["uns"] == uns_schema
 
@@ -350,10 +350,10 @@ def test_anndata_curator(small_dataset1_schema: ln.Schema):
         assert artifact.schema == anndata_schema
         assert artifact.features.slots["var"].n == 3  # 3 genes get linked
         if add_comp == "obs":
-            assert artifact.features.slots["obs"] == obs_schema
+            # assert artifact.features.slots["obs"] == obs_schema
             # deprecated
-            assert artifact.features._schema_by_slot["obs"] == obs_schema
-            assert artifact.features._feature_set_by_slot["obs"] == obs_schema
+            # assert artifact.features._schema_by_slot["obs"] == obs_schema
+            # assert artifact.features._feature_set_by_slot["obs"] == obs_schema
 
             assert set(artifact.features.get_values()["cell_type_by_expert"]) == {
                 "CD8-positive, alpha-beta T cell",


### PR DESCRIPTION
You can now pass `index` to the `Schema` constructor to validate an index in a `DataFrame` in complete analogy to validating columns.

<img width="470" alt="image" src="https://github.com/user-attachments/assets/cf4859cc-5591-4068-9cf0-b3b410b0d9c2" />

In particular, if you use a categorical `dtype`, the dataset will be annotated by the labels found in the index. If you use `int` or `str`, it will merely be validated.

Note that the "index feature" will appear among `schema.features` despite the constructor passing it to the new argument `index`. This is for UX and consistency with other dataframe frameworks like polars or even parquet files themselves (who don't have an index) and the `pandera` constructor (who lists the `index` argument).

## Next PR

As seen in the below example, the `index` feature isn't yet marked as such in `describe()` and isn't yet part of the feature set that belongs to the `DataFrame`. Rather than patching the current `_add_set...` family of annotations to make it appear as part of the feature set, I rather want to refactor the feature set annotation to be based on `CatColumns` in another PR.

<img width="591" alt="image" src="https://github.com/user-attachments/assets/511000ba-077b-467e-a7c7-d877e7fd6e3d" />

## Docs

Before | After
--- | ---
<img width="777" alt="image" src="https://github.com/user-attachments/assets/a09dded7-e091-4843-b00b-5ba9917e55c4" /> | <img width="620" alt="image" src="https://github.com/user-attachments/assets/69ff41db-ed3d-46ea-9129-37a0eebd3973" />
