### PR TITLE
✨ Can save csv artifacts in `DataFrameCurator`

### DIFF
--- a/lamindb/core/storage/objects.py
+++ b/lamindb/core/storage/objects.py
@@ -21,6 +21,7 @@ def infer_suffix(dmem: SupportedDataTypes, format: str | None = None):
     """Infer LaminDB storage file suffix from a data object."""
     if isinstance(dmem, AnnData):
         if format is not None:
+            # should be `.h5ad`, `.`zarr`, or `.anndata.zarr`
             if format not in {"h5ad", "zarr", "anndata.zarr"}:
                 raise ValueError(
                     "Error when specifying AnnData storage format, it should be"
@@ -31,6 +32,8 @@ def infer_suffix(dmem: SupportedDataTypes, format: str | None = None):
         return ".h5ad"
 
     if isinstance(dmem, DataFrame):
+        if format == ".csv":
+            return ".csv"
         return ".parquet"
 
     if with_package_obj(
@@ -79,6 +82,9 @@ def write_to_disk(dmem: SupportedDataTypes, filepath: UPathStr) -> None:
             raise NotImplementedError
 
     if isinstance(dmem, DataFrame):
+        if filepath.suffix == ".csv":
+            dmem.to_csv(filepath)
+            return
         dmem.to_parquet(filepath)
         return
 

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -1354,7 +1354,7 @@ class CatManager:
 
         if self._artifact is None:
             if isinstance(self._dataset, pd.DataFrame):
-                if key.endswith(".csv"):
+                if key and key.endswith(".csv"):
                     # forms
                     csv = self._dataset.to_csv(key, index=False)
                     artifact = Artifact(

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -574,6 +574,7 @@ class DataFrameCurator(Curator):
                 description=description,
                 revises=revises,
                 run=run,
+                format=".csv" if key.endswith(".csv") else None,
             )
             self._artifact.schema = self._schema
             self._artifact.save()
@@ -1354,22 +1355,13 @@ class CatManager:
 
         if self._artifact is None:
             if isinstance(self._dataset, pd.DataFrame):
-                if key and key.endswith(".csv"):
-                    # forms
-                    csv = self._dataset.to_csv(key, index=False)
-                    artifact = Artifact(
-                        csv, key=key, description=description, revises=revises, run=run
-                    )
-                    artifact.otype = "DataFrame"
-                    artifact.n_observations = self._dataset.shape[0]
-                else:
-                    artifact = Artifact.from_df(
-                        self._dataset,
-                        key=key,
-                        description=description,
-                        revises=revises,
-                        run=run,
-                    )
+                artifact = Artifact.from_df(
+                    self._dataset,
+                    key=key,
+                    description=description,
+                    revises=revises,
+                    run=run,
+                )
             elif isinstance(self._dataset, AnnData):
                 artifact = Artifact.from_anndata(
                     self._dataset,

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -1354,13 +1354,22 @@ class CatManager:
 
         if self._artifact is None:
             if isinstance(self._dataset, pd.DataFrame):
-                artifact = Artifact.from_df(
-                    self._dataset,
-                    key=key,
-                    description=description,
-                    revises=revises,
-                    run=run,
-                )
+                if key.endswith(".csv"):
+                    # forms
+                    csv = self._dataset.to_csv(key, index=False)
+                    artifact = Artifact(
+                        csv, key=key, description=description, revises=revises, run=run
+                    )
+                    artifact.otype = "DataFrame"
+                    artifact.n_observations = self._dataset.shape[0]
+                else:
+                    artifact = Artifact.from_df(
+                        self._dataset,
+                        key=key,
+                        description=description,
+                        revises=revises,
+                        run=run,
+                    )
             elif isinstance(self._dataset, AnnData):
                 artifact = Artifact.from_anndata(
                     self._dataset,

--- a/tests/curators/test_dataframe_curators_accounting_example.py
+++ b/tests/curators/test_dataframe_curators_accounting_example.py
@@ -91,7 +91,8 @@ def test_data_curation(transactions_schema, transactions_dataframe):
     """Test if data curation works properly"""
     curator = ln.curators.DataFrameCurator(transactions_dataframe, transactions_schema)
     assert curator.validate() is None
-    artifact = curator.save_artifact(key="test_transaction_dataset.parquet")
+    artifact = curator.save_artifact(key="test_transaction_dataset.csv")
+    assert artifact.suffix == ".csv"
     artifact.delete(permanent=True)
 
 


### PR DESCRIPTION
This PR passes `format=".csv"` to `Artifact.from_df` in `DataFrameCurator` to allow saving samplesheets as csv files. Previously only `.parquet` was possible.

Example:
```python
import lamindb as ln

curator = ln.curators.DataFrameCurator(df, schema)
curator.save_artifact("forms/samplesheet.csv")
```