### PR TITLE
🥅 Do not raise exceptions on problems with `copy_or_move_to_cache` within `Artifact.save`

### DIFF
--- a/lamindb/models/save.py
+++ b/lamindb/models/save.py
@@ -157,7 +157,10 @@ def check_and_attempt_upload(
             return exception
         # copies (if on-disk) or moves the temporary file (if in-memory) to the cache
         if os.getenv("LAMINDB_MULTI_INSTANCE") is None:
-            copy_or_move_to_cache(artifact, storage_path, cache_path)
+            try:
+                copy_or_move_to_cache(artifact, storage_path, cache_path)
+            except Exception as e:
+                logger.warning(f"A problem with cache on saving: {e}")
         # after successful upload, we should remove the attribute so that another call
         # call to save won't upload again, the user should call replace() then
         del artifact._local_filepath

--- a/lamindb/models/save.py
+++ b/lamindb/models/save.py
@@ -157,6 +157,9 @@ def check_and_attempt_upload(
             return exception
         # copies (if on-disk) or moves the temporary file (if in-memory) to the cache
         if os.getenv("LAMINDB_MULTI_INSTANCE") is None:
+            # this happens only after the actual upload was performed
+            # we avoid failing here in case any problems happen in copy_or_move_to_cache
+            # because the cache copying or cleanup is not absolutely necessary
             try:
                 copy_or_move_to_cache(artifact, storage_path, cache_path)
             except Exception as e:


### PR DESCRIPTION
I have a ton of problems with moving cached files when running `lamin-cli` tests locally on Windows. 

It looks like something holds cached run logs open and this causes problems with moving them within `copy_or_move_to_cache` on Windows.

As `copy_or_move_to_cache` happens after successful saving, there is no need to fail at the end of the process, copying the cache is not absolutely necessary, it will work without it anyways. This prevents failing of `Artifact.save`  if errors inside `copy_or_move_to_cache` happen.

Also runs `lamin-cli` tests for https://github.com/laminlabs/lamin-cli/pull/129, as running locally on Windows is problematic.