### PR TITLE
🐛 Fix `ordered_set` in curators

### DIFF
--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -402,11 +402,11 @@ class DataFrameCurator(Curator):
             if schema._index_feature_uid is not None:
                 schema_features = [
                     feature
-                    for feature in schema.features.all().list()
+                    for feature in schema.members.list()
                     if feature.uid != schema._index_feature_uid
                 ]
             else:
-                schema_features = schema.features.all().list()
+                schema_features = schema.members.list()
             if feature_ids:
                 features.extend(
                     feature

--- a/tests/curators/test_curators_general.py
+++ b/tests/curators/test_curators_general.py
@@ -211,3 +211,27 @@ def test_schema_optionals():
     # clean up
     ln.Schema.filter().delete()
     ln.Feature.filter().delete()
+
+
+def test_schema_ordered_set(df):
+    # create features with a different order so that sample_id is not the first
+    ln.Feature(name="sample_name", dtype=str).save()
+    ln.Feature(name="sample_type", dtype=str).save()
+    ln.Feature(name="sample_id", dtype=str).save()
+
+    # create an ordered schema with sample_id as the first feature
+    schema = ln.Schema(
+        name="my-schema",
+        features=[
+            ln.Feature(name="sample_id", dtype=str).save(),
+            ln.Feature(name="sample_name", dtype=str).save(),
+            ln.Feature(name="sample_type", dtype=str).save(),
+        ],
+        ordered_set=True,
+    ).save()
+
+    assert ln.curators.DataFrameCurator(df, schema=schema).validate() is None
+
+    # clean up
+    ln.Schema.filter().delete()
+    ln.Feature.filter().delete()


### PR DESCRIPTION
The order should be determined based on the list that passed to `Schema` constructor. Under the hood, the correct order should be retrieved via `schema.members`.