### PR TITLE
♻️ Execute curator examples and also show them in the curation guide

### DIFF
--- a/docs/curate.ipynb
+++ b/docs/curate.ipynb
@@ -549,21 +549,13 @@
    "id": "41",
    "metadata": {},
    "source": [
-    "## Standardize an AnnData"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "42",
-   "metadata": {},
-   "source": [
     "If you need more control, you can access `DataFrameCurator` objects for the `\"var\"` and `\"obs\"` slots, respectively."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "42",
    "metadata": {
     "tags": [
      "hide-output"
@@ -577,7 +569,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "43",
    "metadata": {
     "tags": [
      "hide-output"
@@ -597,7 +589,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "44",
    "metadata": {
     "tags": [
      "hide-output"
@@ -615,7 +607,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "45",
    "metadata": {
     "tags": [
      "hide-output"
@@ -629,7 +621,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "46",
    "metadata": {
     "tags": [
      "hide-output"
@@ -642,33 +634,58 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48",
+   "id": "47",
    "metadata": {},
    "source": [
-    "## Summary"
+    "## SpatialData"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "48",
    "metadata": {},
    "source": [
-    "We've walked through the process of validating, standardizing, and annotating datasets going through these key steps:\n",
-    "\n",
-    "1. Defining validation criteria\n",
-    "2. Validating data against existing registries\n",
-    "3. Adding new validated entries to registries\n",
-    "4. Annotating artifacts with validated metadata\n",
-    "\n",
-    "By following these steps, you can ensure your data is standardized and well-curated.\n",
-    "\n",
+    "```{eval-rst}\n",
+    ".. literalinclude:: scripts/curate-spatialdata.py\n",
+    "   :language: python\n",
+    "   :caption: curate-spatialdata.py\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "49",
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "!python scripts/curate-spatialdata.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50",
+   "metadata": {},
+   "source": [
+    "## Other data structures"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51",
+   "metadata": {},
+   "source": [
     "If you have other data structures, read: {doc}`/faq/curate-any`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "52",
    "metadata": {
     "tags": [
      "hide-cell"
@@ -683,7 +700,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py311",
+   "display_name": "py312",
    "language": "python",
    "name": "python3"
   },
@@ -697,7 +714,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.8"
   },
   "nbproject": {
    "id": "WOK3vP0bNGLx",

--- a/docs/curate.ipynb
+++ b/docs/curate.ipynb
@@ -21,7 +21,7 @@
    "id": "1",
    "metadata": {},
    "source": [
-    "## Curate a DataFrame"
+    "## DataFrame"
    ]
   },
   {
@@ -342,7 +342,7 @@
    "id": "25",
    "metadata": {},
    "source": [
-    "## Curate an AnnData\n",
+    "## AnnData\n",
     "\n",
     "Here we additionally specify which `var_index` to validate against."
    ]
@@ -433,8 +433,8 @@
     "curator = ln.curators.AnnDataCurator(adata, anndata_schema)\n",
     "try:\n",
     "    curator.validate()\n",
-    "except ln.errors.ValidationError as error:\n",
-    "    print(error)"
+    "except ln.errors.ValidationError:\n",
+    "    pass"
    ]
   },
   {
@@ -637,7 +637,7 @@
    "id": "47",
    "metadata": {},
    "source": [
-    "## SpatialData"
+    "## MuData"
    ]
   },
   {
@@ -653,9 +653,29 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "49",
+   "metadata": {},
+   "source": [
+    "## SpatialData"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50",
+   "metadata": {},
+   "source": [
+    "```{eval-rst}\n",
+    ".. literalinclude:: scripts/curate-spatialdata.py\n",
+    "   :language: python\n",
+    "   :caption: curate-spatialdata.py\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "51",
    "metadata": {
     "tags": [
      "hide-output"
@@ -668,7 +688,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50",
+   "id": "52",
    "metadata": {},
    "source": [
     "## Other data structures"
@@ -676,7 +696,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "53",
    "metadata": {},
    "source": [
     "If you have other data structures, read: {doc}`/faq/curate-any`."
@@ -685,7 +705,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "54",
    "metadata": {
     "tags": [
      "hide-cell"

--- a/docs/scripts/curate-anndata.py
+++ b/docs/scripts/curate-anndata.py
@@ -1,0 +1,40 @@
+import lamindb as ln
+import bionty as bt
+
+# define valid labels
+perturbation = ln.ULabel(name="Perturbation", is_type=True).save()
+ln.ULabel(name="DMSO", type=perturbation).save()
+ln.ULabel(name="IFNG", type=perturbation).save()
+bt.CellType.from_source(name="B cell").save()
+bt.CellType.from_source(name="T cell").save()
+
+# define obs schema
+obs_schema = ln.Schema(
+    name="small_dataset1_obs_level_metadata",
+    features=[
+        ln.Feature(name="perturbation", dtype="cat[ULabel[Perturbation]]").save(),
+        ln.Feature(name="sample_note", dtype=str).save(),
+        ln.Feature(name="cell_type_by_expert", dtype=bt.CellType).save(),
+        ln.Feature(name="cell_type_by_model", dtype=bt.CellType).save(),
+    ],
+).save()
+
+# define var schema
+var_schema = ln.Schema(
+    name="scRNA_seq_var_schema",
+    itype=bt.Gene.ensembl_gene_id,
+    dtype=int,
+).save()
+
+# define composite schema
+anndata_schema = ln.Schema(
+    name="small_dataset1_anndata_schema",
+    otype="AnnData",
+    components={"obs": obs_schema, "var": var_schema},
+).save()
+
+# curate an AnnData
+adata = ln.core.datasets.small_dataset1(otype="AnnData")
+curator = ln.curators.AnnDataCurator(adata, anndata_schema)
+artifact = curator.save_artifact(key="example_datasets/dataset1.h5ad")
+assert artifact.schema == anndata_schema

--- a/docs/scripts/curate-dataframe.py
+++ b/docs/scripts/curate-dataframe.py
@@ -1,0 +1,26 @@
+import lamindb as ln
+import bionty as bt
+
+# define valid labels
+perturbation = ln.ULabel(name="Perturbation", is_type=True).save()
+ln.ULabel(name="DMSO", type=perturbation).save()
+ln.ULabel(name="IFNG", type=perturbation).save()
+bt.CellType.from_source(name="B cell").save()
+bt.CellType.from_source(name="T cell").save()
+
+# define schema
+schema = ln.Schema(
+    name="small_dataset1_obs_level_metadata",
+    features=[
+        ln.Feature(name="perturbation", dtype="cat[ULabel[Perturbation]]").save(),
+        ln.Feature(name="sample_note", dtype=str).save(),
+        ln.Feature(name="cell_type_by_expert", dtype=bt.CellType).save(),
+        ln.Feature(name="cell_type_by_model", dtype=bt.CellType).save(),
+    ],
+).save()
+
+# curate a DataFrame
+df = ln.core.datasets.small_dataset1(otype="DataFrame")
+curator = ln.curators.DataFrameCurator(df, schema)
+artifact = curator.save_artifact(key="example_datasets/dataset1.parquet")
+assert artifact.schema == schema

--- a/docs/scripts/curate-mudata.py
+++ b/docs/scripts/curate-mudata.py
@@ -1,0 +1,58 @@
+import lamindb as ln
+import bionty as bt
+
+
+# define the global obs schema
+obs_schema = ln.Schema(
+    name="mudata_papalexi21_subset_obs_schema",
+    features=[
+        ln.Feature(name="perturbation", dtype="cat[ULabel[Perturbation]]").save(),
+        ln.Feature(name="replicate", dtype="cat[ULabel[Replicate]]").save(),
+    ],
+).save()
+
+# define the ['rna'].obs schema
+obs_schema_rna = ln.Schema(
+    name="mudata_papalexi21_subset_rna_obs_schema",
+    features=[
+        ln.Feature(name="nCount_RNA", dtype=int).save(),
+        ln.Feature(name="nFeature_RNA", dtype=int).save(),
+        ln.Feature(name="percent.mito", dtype=float).save(),
+    ],
+).save()
+
+# define the ['hto'].obs schema
+obs_schema_hto = ln.Schema(
+    name="mudata_papalexi21_subset_hto_obs_schema",
+    features=[
+        ln.Feature(name="nCount_HTO", dtype=int).save(),
+        ln.Feature(name="nFeature_HTO", dtype=int).save(),
+        ln.Feature(name="technique", dtype=bt.ExperimentalFactor).save(),
+    ],
+).save()
+
+# define ['rna'].var schema
+var_schema_rna = ln.Schema(
+    name="mudata_papalexi21_subset_rna_var_schema",
+    itype=bt.Gene.symbol,
+    dtype=float,
+).save()
+
+# define composite schema
+mudata_schema = ln.Schema(
+    name="mudata_papalexi21_subset_mudata_schema",
+    otype="MuData",
+    components={
+        "obs": obs_schema,
+        "rna:obs": obs_schema_rna,
+        "hto:obs": obs_schema_hto,
+        "rna:var": var_schema_rna,
+    },
+).save()
+
+# curate a MuData
+mdata = ln.core.datasets.mudata_papalexi21_subset()
+bt.settings.organism = "human"  # set the organism to map gene symbols
+curator = ln.curators.MuDataCurator(mdata, mudata_schema)
+artifact = curator.save_artifact(key="example_datasets/mudata_papalexi21_subset.h5mu")
+assert artifact.schema == mudata_schema

--- a/docs/scripts/curate-spatialdata.py
+++ b/docs/scripts/curate-spatialdata.py
@@ -1,0 +1,52 @@
+import lamindb as ln
+import bionty as bt
+
+
+# define sample schema
+sample_schema = ln.Schema(
+    name="blobs_sample_level_metadata",
+    features=[
+        ln.Feature(name="assay", dtype=bt.ExperimentalFactor).save(),
+        ln.Feature(name="disease", dtype=bt.Disease).save(),
+    ],
+).save()
+
+# define table obs schema
+blobs_obs_schema = ln.Schema(
+    name="blobs_obs_level_metadata",
+    features=[
+        ln.Feature(name="sample_region", dtype="str").save(),
+    ],
+).save()
+
+# define table var schema
+blobs_var_schema = ln.Schema(
+    name="blobs_var_schema", itype=bt.Gene.ensembl_gene_id, dtype=int
+).save()
+
+# define composite schema
+spatialdata_schema = ln.Schema(
+    name="blobs_spatialdata_schema",
+    otype="SpatialData",
+    components={
+        "sample": sample_schema,
+        "table:obs": blobs_obs_schema,
+        "table:var": blobs_var_schema,
+    },
+).save()
+
+# curate a SpatialData
+spatialdata = ln.core.datasets.spatialdata_blobs()
+curator = ln.curators.SpatialDataCurator(spatialdata, spatialdata_schema)
+try:
+    curator.validate()
+except ln.errors.ValidationError:
+    pass
+
+spatialdata.tables["table"].var.drop(index="ENSG00000999999", inplace=True)
+
+# validate again (must pass now) and save artifact
+artifact = ln.Artifact.from_spatialdata(
+    spatialdata, key="example_datasets/spatialdata1.zarr", schema=spatialdata_schema
+)
+assert artifact.schema == spatialdata_schema

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -827,8 +827,8 @@ class SpatialDataCurator(SlotsCurator):
     Example:
 
         .. literalinclude:: scripts/curate-spatialdata.py
-        :language: python
-        :caption: curate-spatialdata.py
+            :language: python
+            :caption: curate-spatialdata.py
     """
 
     def __init__(

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -359,34 +359,11 @@ class DataFrameCurator(Curator):
         dataset: The DataFrame-like object to validate & annotate.
         schema: A :class:`~lamindb.Schema` object that defines the validation constraints.
 
-    Example::
+    Example:
 
-        import lamindb as ln
-        import bionty as bt
-
-        # define valid labels
-        perturbation = ln.ULabel(name="Perturbation", is_type=True).save()
-        ln.ULabel(name="DMSO", type=perturbation).save()
-        ln.ULabel(name="IFNG", type=perturbation).save()
-        bt.CellType.from_source(name="B cell").save()
-        bt.CellType.from_source(name="T cell").save()
-
-        # define schema
-        schema = ln.Schema(
-            name="small_dataset1_obs_level_metadata",
-            features=[
-                ln.Feature(name="perturbation", dtype="cat[ULabel[Perturbation]]").save(),
-                ln.Feature(name="sample_note", dtype=str).save(),
-                ln.Feature(name="cell_type_by_expert", dtype=bt.CellType).save(),
-                ln.Feature(name="cell_type_by_model", dtype=bt.CellType).save(),
-            ],
-        ).save()
-
-        # curate a DataFrame
-        df = datasets.small_dataset1(otype="DataFrame")
-        curator = ln.curators.DataFrameCurator(df, schema)
-        artifact = curator.save_artifact(key="example_datasets/dataset1.parquet")
-        assert artifact.schema == schema
+        .. literalinclude:: scripts/curate-dataframe.py
+            :language: python
+            :caption: curate-dataframe.py
     """
 
     def __init__(
@@ -599,48 +576,11 @@ class AnnDataCurator(SlotsCurator):
         dataset: The AnnData-like object to validate & annotate.
         schema: A :class:`~lamindb.Schema` object that defines the validation constraints.
 
-    Example::
+    Example:
 
-        import lamindb as ln
-        import bionty as bt
-
-        # define valid labels
-        perturbation = ln.ULabel(name="Perturbation", is_type=True).save()
-        ln.ULabel(name="DMSO", type=perturbation).save()
-        ln.ULabel(name="IFNG", type=perturbation).save()
-        bt.CellType.from_source(name="B cell").save()
-        bt.CellType.from_source(name="T cell").save()
-
-        # define obs schema
-        obs_schema = ln.Schema(
-            name="small_dataset1_obs_level_metadata",
-            features=[
-                ln.Feature(name="perturbation", dtype="cat[ULabel[Perturbation]]").save(),
-                ln.Feature(name="sample_note", dtype=str).save(),
-                ln.Feature(name="cell_type_by_expert", dtype=bt.CellType).save(),
-                ln.Feature(name="cell_type_by_model", dtype=bt.CellType).save(),
-            ],
-        ).save()
-
-        # define var schema
-        var_schema = ln.Schema(
-            name="scRNA_seq_var_schema",
-            itype=bt.Gene.ensembl_gene_id,
-            dtype=int,
-        ).save()
-
-        # define composite schema
-        anndata_schema = ln.Schema(
-            name="small_dataset1_anndata_schema",
-            otype="AnnData",
-            components={"obs": obs_schema, "var": var_schema},
-        ).save()
-
-        # curate an AnnData
-        adata = ln.core.datasets.small_dataset1(otype="AnnData")
-        curator = ln.curators.AnnDataCurator(adata, anndata_schema)
-        artifact = curator.save_artifact(key="example_datasets/dataset1.h5ad")
-        assert artifact.schema == anndata_schema
+        .. literalinclude:: scripts/curate-anndata.py
+            :language: python
+            :caption: curate-anndata.py
     """
 
     def __init__(
@@ -706,74 +646,17 @@ def _assign_var_fields_categoricals_multimodal(
 
 
 class MuDataCurator(SlotsCurator):
-    # the example in the docstring is tested in test_curators_quickstart_example
     """Curator for `MuData`.
 
     Args:
         dataset: The MuData-like object to validate & annotate.
         schema: A :class:`~lamindb.Schema` object that defines the validation constraints.
 
-    Example::
+    Example:
 
-        import lamindb as ln
-        import bionty as bt
-
-        # define the global obs schema
-        obs_schema = ln.Schema(
-            name="mudata_papalexi21_subset_obs_schema",
-            features=[
-                ln.Feature(name="perturbation", dtype="cat[ULabel[Perturbation]]").save(),
-                ln.Feature(name="replicate", dtype="cat[ULabel[Replicate]]").save(),
-            ],
-        ).save()
-
-        # define the ['rna'].obs schema
-        obs_schema_rna = ln.Schema(
-            name="mudata_papalexi21_subset_rna_obs_schema",
-            features=[
-                ln.Feature(name="nCount_RNA", dtype=int).save(),
-                ln.Feature(name="nFeature_RNA", dtype=int).save(),
-                ln.Feature(name="percent.mito", dtype=float).save(),
-            ],
-            coerce_dtype=True,
-        ).save()
-
-        # define the ['hto'].obs schema
-        obs_schema_hto = ln.Schema(
-            name="mudata_papalexi21_subset_hto_obs_schema",
-            features=[
-                ln.Feature(name="nCount_HTO", dtype=int).save(),
-                ln.Feature(name="nFeature_HTO", dtype=int).save(),
-                ln.Feature(name="technique", dtype=bt.ExperimentalFactor).save(),
-            ],
-            coerce_dtype=True,
-        ).save()
-
-        # define ['rna'].var schema
-        var_schema_rna = ln.Schema(
-            name="mudata_papalexi21_subset_rna_var_schema",
-            itype=bt.Gene.symbol,
-            dtype=float,
-        ).save()
-
-        # define composite schema
-        mudata_schema = ln.Schema(
-            name="mudata_papalexi21_subset_mudata_schema",
-            otype="MuData",
-            components={
-                "obs": obs_schema,
-                "rna:obs": obs_schema_rna,
-                "hto:obs": obs_schema_hto,
-                "rna:var": var_schema_rna,
-            },
-        ).save()
-
-        # curate a MuData
-        mdata = ln.core.datasets.mudata_papalexi21_subset()
-        bt.settings.organism = "human" # set the organism
-        curator = ln.curators.MuDataCurator(mdata, mudata_schema)
-        artifact = curator.save_artifact(key="example_datasets/mudata_papalexi21_subset.h5mu")
-        assert artifact.schema == mudata_schema
+        .. literalinclude:: scripts/curate-mudata.py
+            :language: python
+            :caption: curate-mudata.py
     """
 
     def __init__(
@@ -817,7 +700,6 @@ class MuDataCurator(SlotsCurator):
 
 
 class SpatialDataCurator(SlotsCurator):
-    # the example in the docstring is tested in test_curators_quickstart_example
     """Curator for `SpatialData`.
 
     Args:

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -788,7 +788,6 @@ class MuDataCurator(SlotsCurator):
             raise InvalidArgument("Schema otype must be 'MuData'.")
 
         for slot, slot_schema in schema.slots.items():
-            # Assign to _slots
             if ":" in slot:
                 modality, modality_slot = slot.split(":")
                 schema_dataset = self._dataset.__getitem__(modality)
@@ -825,59 +824,11 @@ class SpatialDataCurator(SlotsCurator):
         dataset: The SpatialData-like object to validate & annotate.
         schema: A :class:`~lamindb.Schema` object that defines the validation constraints.
 
-    Example::
+    Example:
 
-        import lamindb as ln
-        import bionty as bt
-
-        # define sample schema
-        sample_schema = ln.Schema(
-            name="blobs_sample_level_metadata",
-            features=[
-                ln.Feature(name="assay", dtype=bt.ExperimentalFactor).save(),
-                ln.Feature(name="disease", dtype=bt.Disease).save(),
-                ln.Feature(name="development_stage", dtype=bt.DevelopmentalStage).save(),
-            ],
-            coerce_dtype=True
-        ).save()
-
-        # define table obs schema
-        blobs_obs_schema = ln.Schema(
-            name="blobs_obs_level_metadata",
-            features=[
-                ln.Feature(name="sample_region", dtype="str").save(),
-            ],
-            coerce_dtype=True
-        ).save()
-
-        # define table var schema
-        blobs_var_schema = ln.Schema(
-            name="blobs_var_schema",
-            itype=bt.Gene.ensembl_gene_id,
-            dtype=int
-        ).save()
-
-        # define composite schema
-        spatialdata_schema = ln.Schema(
-            name="blobs_spatialdata_schema",
-            otype="SpatialData",
-            components={
-                "sample": sample_schema,
-                "table:obs": blobs_obs_schema,
-                "table:var": blobs_var_schema,
-        }).save()
-
-        # curate a SpatialData
-        spatialdata = ln.core.datasets.spatialdata_blobs()
-        curator = ln.curators.SpatialDataCurator(spatialdata, spatialdata_schema)
-        try:
-            curator.validate()
-        except ln.errors.ValidationError as error:
-            print(error)
-
-        # validate again (must pass now) and save artifact
-        artifact = curator.save_artifact(key="example_datasets/spatialdata1.zarr")
-        assert artifact.schema == spatialdata_schema
+        .. literalinclude:: scripts/curate-spatialdata.py
+        :language: python
+        :caption: curate-spatialdata.py
     """
 
     def __init__(

--- a/lamindb/curators/__init__.py
+++ b/lamindb/curators/__init__.py
@@ -166,10 +166,7 @@ class CatLookup:
 CAT_MANAGER_DOCSTRING = """Manage categoricals by updating registries."""
 
 
-SLOTS_DOCSTRING = """Curator objects by slot.
-
-.. versionadded:: 1.1.1
-"""
+SLOTS_DOCSTRING = """Access sub curators by slot."""
 
 
 VALIDATE_DOCSTRING = """Validate dataset against Schema.

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, overload
+from typing import TYPE_CHECKING, Any, Type, overload
 
 import numpy as np
 from django.db import models
@@ -389,7 +389,7 @@ class Schema(Record, CanCurate, TracksRun):
         components: dict[str, Schema] | None = None,
         name: str | None = None,
         description: str | None = None,
-        dtype: str | None = None,
+        dtype: str | Type[int | float | str] | None = None,  # noqa
         itype: str | Registry | FieldAttr | None = None,
         type: Schema | None = None,
         is_type: bool = False,

--- a/noxfile.py
+++ b/noxfile.py
@@ -103,7 +103,7 @@ def install_ci(session, group):
         run(session, "uv pip install --system huggingface_hub")
     elif group == "guide":
         extras += "bionty,zarr,jupyter"
-        run(session, "uv pip install --system scanpy")
+        run(session, "uv pip install --system scanpy mudata spatialdata")
     elif group == "biology":
         extras += "bionty,fcs,jupyter"
         run(session, "uv pip install --system ipywidgets")


### PR DESCRIPTION
Before this PR, the very extensive examples for curators were neither executed nor shown in the context of the curation guide.

Now they are.

## Guide

Before | After
--- | ---
<img width="991" alt="image" src="https://github.com/user-attachments/assets/c733c7a4-17b6-4805-9f78-3bb380c825ac" /> | <img width="902" alt="image" src="https://github.com/user-attachments/assets/01ffdd04-ff4c-4f42-9976-ba944e2cf5ce" />

## API reference

Exemplarily shown for `SpatialData`. Same changes for all other data structures.

Before | After
--- | ---
<img width="968" alt="image" src="https://github.com/user-attachments/assets/223021ec-4e25-4055-b09a-458ee6802478" /> | <img width="966" alt="image" src="https://github.com/user-attachments/assets/85a87305-bdef-4100-b826-275c38f966d0" />
