### PR TITLE
🚸 Restore validation error messages, add their fine-grained testing, and prepare `var` refactor in curators

### DIFF
--- a/lamindb/core/datasets/_small.py
+++ b/lamindb/core/datasets/_small.py
@@ -13,14 +13,19 @@ def small_dataset1(
     with_typo: bool = False,
     with_cell_type_synonym: bool = False,
     with_cell_type_typo: bool = False,
+    with_gene_typo: bool = False,
 ) -> pd.DataFrame | ad.AnnData:
     # define the data in the dataset
     # it's a mix of numerical measurements and observation-level metadata
     ifng = "IFNJ" if with_typo else "IFNG"
     if gene_symbols_in_index:
-        var_ids = ["CD8A", "CD4", "CD14"]
+        var_ids = ["CD8A", "CD4", "CD14" if not with_gene_typo else "GeneTypo"]
     else:
-        var_ids = ["ENSG00000153563", "ENSG00000010610", "ENSG00000170458"]
+        var_ids = [
+            "ENSG00000153563",
+            "ENSG00000010610",
+            "ENSG00000170458" if not with_gene_typo else "GeneTypo",
+        ]
     abt_cell = (
         "CD8-pos alpha-beta T cell"
         if with_cell_type_typo

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -564,7 +564,10 @@ class AnnDataCurator(SlotsCurator):
                 (
                     getattr(self._dataset, slot).T
                     if slot == "var.T"
-                    or (slot == "var" and schema["var"].itype not in {None, "Feature"})
+                    or (
+                        slot == "var"
+                        and schema.slots["var"].itype not in {None, "Feature"}
+                    )
                     else getattr(self._dataset, slot)
                 ),
                 slot_schema,
@@ -572,7 +575,7 @@ class AnnDataCurator(SlotsCurator):
             for slot, slot_schema in schema.slots.items()
             if slot in {"obs", "var", "uns"}
         }
-        if "var" in self._slots and schema["var"].itype not in {None, "Feature"}:
+        if "var" in self._slots and schema.slots["var"].itype not in {None, "Feature"}:
             logger.warning(
                 "auto-transposed `var` for backward compat, please indicate transposition in the schema definition by calling out `.T`: components={'var.T': itype=bt.Gene.ensembl_gene_id}"
             )
@@ -652,7 +655,10 @@ class MuDataCurator(SlotsCurator):
                     if modality_slot == "var.T"
                     or (
                         modality_slot == "var"
-                        and schema["var"].itype not in {None, "Feature"}
+                        and schema.slots[
+                            f"{modality}:var" if ":" in slot else "var"
+                        ].itype
+                        not in {None, "Feature"}
                     )
                     else getattr(schema_dataset, modality_slot)
                 ),
@@ -715,7 +721,10 @@ class SpatialDataCurator(SlotsCurator):
                     if table_slot == "var.T"
                     or (
                         table_slot == "var"
-                        and schema["var"].itype not in {None, "Feature"}
+                        and schema.slots[
+                            f"{table_key}:var" if ":" in slot else "var"
+                        ].itype
+                        not in {None, "Feature"}
                     )
                     else (
                         getattr(schema_dataset, table_slot)

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -971,16 +971,12 @@ class CatColumn:
             values_validated += [getattr(r, field_name) for r in public_records]
 
         # logging messages
-        in_slot = (
-            f" in slot '{self._cat_manager._slot}'"
-            if self._cat_manager._slot is not None
-            else ""
-        )
-        slot_prefix = (
-            f"slots['{self._cat_manager._slot}']"
-            if self._cat_manager._slot is not None
-            else ""
-        )
+        if self._cat_manager is not None:
+            slot = self._cat_manager._slot
+        else:
+            slot = None
+        in_slot = f" in slot '{slot}'" if slot is not None else ""
+        slot_prefix = f"slots['{slot}']" if slot is not None else ""
         non_validated_hint_print = f"curator.{slot_prefix}.add_new_from('{self._key}')"
         non_validated = [i for i in non_validated if i not in values_validated]
         n_non_validated = len(non_validated)

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -976,8 +976,10 @@ class CatColumn:
         else:
             slot = None
         in_slot = f" in slot '{slot}'" if slot is not None else ""
-        slot_prefix = f"slots['{slot}']" if slot is not None else ""
-        non_validated_hint_print = f"curator.{slot_prefix}.add_new_from('{self._key}')"
+        slot_prefix = f".slots['{slot}']" if slot is not None else ""
+        non_validated_hint_print = (
+            f"curator{slot_prefix}.cat.add_new_from('{self._key}')"
+        )
         non_validated = [i for i in non_validated if i not in values_validated]
         n_non_validated = len(non_validated)
         if n_non_validated == 0:

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -292,10 +292,7 @@ class Schema(Record, CanCurate, TracksRun):
     )
     """A registry that stores feature identifiers used in this schema, e.g., `'Feature'` or `'bionty.Gene'`.
 
-    Depending on the registry, `.members` stores, e.g., `Feature` or `bionty.Gene` records.
-
-    .. versionchanged:: 1.0.0
-        Was called `registry` before.
+    Depending on `itype`, `.members` stores, e.g., `Feature` or `bionty.Gene` records.
     """
     type: Schema | None = ForeignKey("self", PROTECT, null=True, related_name="records")
     """Type of schema.

--- a/tests/core/test_collection.py
+++ b/tests/core/test_collection.py
@@ -142,14 +142,6 @@ def test_from_consistent_artifacts(adata, adata2):
     assert "artifact_uid" in adata_joined.obs.columns
     assert artifact1.uid in adata_joined.obs.artifact_uid.cat.categories
 
-    # feature_sets = collection.features._get_staged_feature_sets_union()
-    # assert set(feature_sets["var"].members.values_list("symbol", flat=True)) == {
-    #     "MYC",
-    #     "TCF7",
-    #     "GATA1",
-    # }
-    # assert set(feature_sets["obs"].members.values_list("name", flat=True)) == {"feat1"}
-
     # re-run with hash-based lookup
     collection2 = ln.Collection([artifact1, artifact2], name="My test 1", run=run)
     assert not collection2._state.adding

--- a/tests/curators/conftest.py
+++ b/tests/curators/conftest.py
@@ -11,3 +11,17 @@ def pytest_sessionstart():
 def pytest_sessionfinish(session: pytest.Session):
     shutil.rmtree("./testdb")
     ln_setup.delete("testdb", force=True)
+
+
+@pytest.fixture
+def ccaplog(caplog):
+    """Add caplog handler to our custom logger at session start."""
+    from lamin_utils._logger import logger
+
+    # Add caplog's handler to our custom logger
+    logger.addHandler(caplog.handler)
+
+    yield caplog
+
+    # Clean up at the end of the session
+    logger.removeHandler(caplog.handler)

--- a/tests/curators/test_curators_examples.py
+++ b/tests/curators/test_curators_examples.py
@@ -374,7 +374,7 @@ def test_anndata_curator(small_dataset1_schema: ln.Schema):
         var_schema.delete()
 
 
-def test_anndata_curator_var_curation_legacy_convention():
+def test_anndata_curator_var_curation_legacy_convention(ccaplog):
     var_schema = ln.Schema(
         itype=bt.Gene.ensembl_gene_id,
         dtype="num",
@@ -399,6 +399,10 @@ def test_anndata_curator_var_curation_legacy_convention():
             artifact = ln.Artifact.from_anndata(
                 adata, key="example_datasets/dataset1.h5ad", schema=anndata_schema
             ).save()
+            assert (
+                "auto-transposed `var` for backward compat, please indicate transposition in the schema definition by calling out `.T`: components={'var.T': itype=bt.Gene.ensembl_gene_id}"
+                in ccaplog.text
+            )
             assert artifact.features.slots["var"].n == 3  # 3 genes get linked
             assert set(
                 artifact.features.slots["var"].members.list("ensembl_gene_id")

--- a/tests/curators/test_curators_examples.py
+++ b/tests/curators/test_curators_examples.py
@@ -393,7 +393,7 @@ def test_anndata_curator_var_curation_legacy_convention():
                 ).save()
             assert error.exconly() == (
                 "lamindb.errors.ValidationError: 1 term not validated in feature 'var_index' in slot 'var': 'GeneTypo'\n"
-                "    → fix typos, remove non-existent values, or save terms via: curator.slots['var'].add_new_from('var_index')"
+                "    → fix typos, remove non-existent values, or save terms via: curator.slots['var'].cat.add_new_from('var_index')"
             )
         else:
             artifact = ln.Artifact.from_anndata(


### PR DESCRIPTION
## Logging validation errors and hints

In preparation to refactoring the `.var` treatment, I realized that the information about both slot and `.cat` attribute was absent in the logging messages.

Also, there are no tests for these messages and they did were not appear as _error messages_ (in addition to being logged).

These issues are addressed with the exemplary test below.
```python
def test_anndata_curator_var_curation_legacy_convention():
    var_schema = ln.Schema(
        itype=bt.Gene.ensembl_gene_id,
        dtype="num",
    ).save()
    components = {"var": var_schema}
    anndata_schema = ln.Schema(
        otype="AnnData",
        components=components,
    ).save()
    for with_gene_typo in [True, False]:
        adata = datasets.small_dataset1(otype="AnnData", with_gene_typo=with_gene_typo)
        if with_gene_typo:
            with pytest.raises(ValidationError) as error:
                artifact = ln.Artifact.from_anndata(
                    adata, key="example_datasets/dataset1.h5ad", schema=anndata_schema
                ).save()
            assert error.exconly() == (
                "lamindb.errors.ValidationError: 1 term not validated in feature 'var_index' in slot 'var': 'GeneTypo'\n"
                "    → fix typos, remove non-existent values, or save terms via: curator.slots['var'].cat.add_new_from('var_index')"
            )
        else:
            artifact = ln.Artifact.from_anndata(
                adata, key="example_datasets/dataset1.h5ad", schema=anndata_schema
            ).save()
            assert (
                "auto-transposed `var` for backward compat, please indicate transposition in the schema definition by calling out `.T`: components={'var.T': itype=bt.Gene.ensembl_gene_id}"
                in ccaplog.text
            )
            assert artifact.features.slots["var"].n == 3  # 3 genes get linked
            assert set(
                artifact.features.slots["var"].members.list("ensembl_gene_id")
            ) == {
                "ENSG00000153563",
                "ENSG00000010610",
                "ENSG00000170458",
            }
```

## Ensuring backward compat for upcoming `.var` changes

Because we no longer want to implicitly transpose `adata.var`, but also don't want to break backward compatibility, we now alert the user to the new convention through a warning that's tested in the above test with this line:

```python
assert (
    "auto-transposed `var` for backward compat, please indicate transposition in the schema definition by calling out `.T`: components={'var.T': itype=bt.Gene.ensembl_gene_id}"
    in ccaplog.text
)
```

This warning is printed in `AnnDataCurator`, `MuDataCurator`, and `SpatialDataCurator` if encountering a schema with component `'var'` and `itype is not None`.