### PR TITLE
🚸 Fully functional `ULabel` subtype validation, better syntax for it

### DIFF
--- a/lamindb/core/datasets/mini_immuno.py
+++ b/lamindb/core/datasets/mini_immuno.py
@@ -70,11 +70,13 @@ def get_dataset1(
     with_cell_type_synonym: bool = False,
     with_cell_type_typo: bool = False,
     with_gene_typo: bool = False,
+    with_wrong_subtype: bool = False,
 ) -> pd.DataFrame | ad.AnnData:
     """A small tabular dataset measuring expression & metadata."""
     # define the data in the dataset
     # it's a mix of numerical measurements and observation-level metadata
     ifng = "IFNJ" if with_typo else "IFNG"
+    thing = "ulabel_but_not_perturbation" if with_wrong_subtype else "DMSO"
     if gene_symbols_in_index:
         var_ids = ["CD8A", "CD4", "CD14" if not with_gene_typo else "GeneTypo"]
     else:
@@ -92,7 +94,7 @@ def get_dataset1(
         var_ids[0]: [1, 2, 3],
         var_ids[1]: [3, 4, 5],
         var_ids[2]: [5, 6, 7],
-        "perturbation": pd.Categorical(["DMSO", ifng, "DMSO"]),
+        "perturbation": pd.Categorical(["DMSO", ifng, thing]),
         "sample_note": ["was ok", "looks naah", "pretty! 🤩"],
         "cell_type_by_expert": pd.Categorical(
             ["B-cell" if with_cell_type_synonym else "B cell", abt_cell, abt_cell]

--- a/tests/curators/test_curators_examples.py
+++ b/tests/curators/test_curators_examples.py
@@ -32,7 +32,7 @@ def small_dataset1_schema():
     schema = ln.Schema(
         name="small_dataset1_obs_level_metadata",
         features=[
-            ln.Feature(name="perturbation", dtype="cat[ULabel[Perturbation]]").save(),
+            ln.Feature(name="perturbation", dtype=perturbation).save(),
             ln.Feature(name="sample_note", dtype=str).save(),
             ln.Feature(name="cell_type_by_expert", dtype=bt.CellType).save(),
             ln.Feature(name="cell_type_by_model", dtype=bt.CellType).save(),

--- a/tests/curators/test_curators_examples.py
+++ b/tests/curators/test_curators_examples.py
@@ -17,6 +17,7 @@ def small_dataset1_schema():
     perturbation = ln.ULabel(name="Perturbation", is_type=True).save()
     ln.ULabel(name="DMSO", type=perturbation).save()
     ln.ULabel(name="IFNG", type=perturbation).save()
+    ln.ULabel(name="ulabel_but_not_perturbation").save()
     ln.ULabel.from_values(["sample1", "sample2", "sample3"], create=True).save()
     bt.CellType.from_source(name="B cell").save()
     bt.CellType.from_source(name="T cell").save()
@@ -136,6 +137,7 @@ def mudata_papalexi21_subset_schema():
 def test_dataframe_curator(small_dataset1_schema: ln.Schema):
     """Test DataFrame curator implementation."""
 
+    # invalid simple dtype (float)
     feature_to_fail = ln.Feature(name="treatment_time_h", dtype=float).save()
     schema = ln.Schema(
         name="small_dataset1_obs_level_metadata_v2",
@@ -147,7 +149,6 @@ def test_dataframe_curator(small_dataset1_schema: ln.Schema):
             feature_to_fail,
         ],
     ).save()
-
     df = datasets.small_dataset1(otype="DataFrame")
     curator = ln.curators.DataFrameCurator(df, schema)
     with pytest.raises(ln.errors.ValidationError) as error:
@@ -158,6 +159,32 @@ def test_dataframe_curator(small_dataset1_schema: ln.Schema):
     )
     schema.delete()
     feature_to_fail.delete()
+
+    # Wrong subtype
+    df = datasets.small_dataset1(otype="DataFrame", with_wrong_subtype=True)
+    curator = ln.curators.DataFrameCurator(df, small_dataset1_schema)
+    with pytest.raises(ln.errors.ValidationError) as error:
+        curator.validate()
+    assert (
+        error.exconly()
+        == """lamindb.errors.ValidationError: 1 term not validated in feature 'perturbation': 'ulabel_but_not_perturbation'
+    → fix typos, remove non-existent values, or save terms via: curator.cat.add_new_from('perturbation')
+    → a valid label for subtype 'Perturbation' has to be one of ['DMSO', 'IFNG']"""
+    )
+
+    # Typo
+    df = datasets.small_dataset1(otype="DataFrame", with_typo=True)
+    curator = ln.curators.DataFrameCurator(df, small_dataset1_schema)
+    with pytest.raises(ln.errors.ValidationError) as error:
+        curator.validate()
+    assert (
+        error.exconly()
+        == """lamindb.errors.ValidationError: 1 term not validated in feature 'perturbation': 'IFNJ'
+    → fix typos, remove non-existent values, or save terms via: curator.cat.add_new_from('perturbation')
+    → a valid label for subtype 'Perturbation' has to be one of ['DMSO', 'IFNG']"""
+    )
+
+    df = datasets.small_dataset1(otype="DataFrame")
     curator = ln.curators.DataFrameCurator(df, small_dataset1_schema)
     artifact = curator.save_artifact(key="example_datasets/dataset1.parquet")
 


### PR DESCRIPTION
One can now do:
```python
perturbation = ln.ULabel(name="Perturbation", is_type=True).save()
ln.ULabel(name="DMSO", type=perturbation).save()
ln.ULabel(name="IFNG", type=perturbation).save()
ln.ULabel(name="ulabel_but_not_perturbation").save()
ln.Feature(name="perturbation", dtype=perturbation).save()
```

A dataframe containing `"ulabel_but_not_perturbation"` in column `"perturbation"` now fails validation:
```python
df = datasets.small_dataset1(otype="DataFrame", with_wrong_subtype=True)
curator = ln.curators.DataFrameCurator(df, small_dataset1_schema)
with pytest.raises(ln.errors.ValidationError) as error:
    curator.validate()
assert (
    error.exconly()
    == """lamindb.errors.ValidationError: 1 term not validated in feature 'perturbation': 'ulabel_but_not_perturbation'
→ fix typos, remove non-existent values, or save terms via: curator.cat.add_new_from('perturbation')
→ a valid label for subtype 'Perturbation' has to be one of ['DMSO', 'IFNG']"""
)
```

The new shorter syntax used above is equivalent too it's serialized form:
```python
ln.Feature(name="perturbation", dtype="cat[ULabel[Perturbation]]).save()
```