### PR TITLE
✨ Allow to use `polars` in `Artifact.open()` and `Collection.open()`

### DIFF
--- a/docs/arrays.ipynb
+++ b/docs/arrays.ipynb
@@ -497,7 +497,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By default `Artifact.open()` and `Collection.open()` use `pyarrow` to lazily open dataframes. `polars` can be also used by passing `df_engine=\"polars\"`. Note also that `.open(df_engine=\"polars\")` returns a context manager with [LazyFrame](https://docs.pola.rs/api/python/stable/reference/lazyframe/index.html)."
+    "By default `Artifact.open()` and `Collection.open()` use `pyarrow` to lazily open dataframes. `polars` can be also used by passing `engine=\"polars\"`. Note also that `.open(engine=\"polars\")` returns a context manager with [LazyFrame](https://docs.pola.rs/api/python/stable/reference/lazyframe/index.html)."
    ]
   },
   {
@@ -510,7 +510,7 @@
    },
    "outputs": [],
    "source": [
-    "with collection.open(df_engine=\"polars\") as lazy_df:\n",
+    "with collection.open(engine=\"polars\") as lazy_df:\n",
     "    display(lazy_df.collect().to_pandas())"
    ]
   },

--- a/docs/arrays.ipynb
+++ b/docs/arrays.ipynb
@@ -494,6 +494,27 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default `Artifact.open()` and `Collection.open()` use `pyarrow` to lazily open dataframes. `polars` can be also used by passing `df_engine=\"polars\"`. Note also that `.open(df_engine=\"polars\")` returns a context manager with [LazyFrame](https://docs.pola.rs/api/python/stable/reference/lazyframe/index.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "with collection.open(df_engine=\"polars\") as lazy_df:\n",
+    "    display(lazy_df.collect().to_pandas())"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -510,7 +531,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py312",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -524,7 +545,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.10.16"
   },
   "nbproject": {
    "id": "YVUCtH4GfQOy",

--- a/lamindb/core/storage/_backed_access.py
+++ b/lamindb/core/storage/_backed_access.py
@@ -149,7 +149,8 @@ def _df_storage_suffix(paths: UPath | list[UPath]) -> str | None:
     # but this is a requirement for pyarrow.dataset.dataset
     if isinstance(paths, list):
         path_list = paths
-    elif paths.is_dir():
+    # assume http is always a file
+    elif paths.protocol not in {"http", "https"} and paths.is_dir():
         path_list = [path for path in paths.rglob("*") if path.suffix != ""]
     else:
         path_list = [paths]

--- a/lamindb/core/storage/_backed_access.py
+++ b/lamindb/core/storage/_backed_access.py
@@ -114,6 +114,7 @@ def backed_access(
         return BackedAccessor(conn, storage)
 
 
+# returns a single suffix if all the paths have the same suffix or None otherwise
 def _df_dataset_suffix(paths: UPath | list[UPath]) -> str | None:
     # it is assumed here that the paths exist
     # we don't check here that the filesystem is the same

--- a/lamindb/core/storage/_backed_access.py
+++ b/lamindb/core/storage/_backed_access.py
@@ -97,7 +97,7 @@ def backed_access(
         conn, storage = registry.open("h5py", objectpath, mode=mode, **kwargs)
     elif suffix == ".zarr":
         conn, storage = registry.open("zarr", objectpath, mode=mode, **kwargs)
-    elif _df_dataset_suffix(objectpath) in PYARROW_SUFFIXES:
+    elif _df_storage_suffix(objectpath) in PYARROW_SUFFIXES:
         return _open_pyarrow_dataset(objectpath, **kwargs)
     else:
         raise ValueError(
@@ -115,7 +115,7 @@ def backed_access(
 
 
 # returns a single suffix if all the paths have the same suffix or None otherwise
-def _df_dataset_suffix(paths: UPath | list[UPath]) -> str | None:
+def _df_storage_suffix(paths: UPath | list[UPath]) -> str | None:
     # it is assumed here that the paths exist
     # we don't check here that the filesystem is the same
     # but this is a requirement for pyarrow.dataset.dataset

--- a/lamindb/core/storage/_backed_access.py
+++ b/lamindb/core/storage/_backed_access.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from fsspec.core import OpenFile
+    from polars import LazyFrame as PolarsLazyFrame
     from pyarrow.dataset import Dataset as PyArrowDataset
     from tiledbsoma import Collection as SOMACollection
     from tiledbsoma import Experiment as SOMAExperiment
@@ -84,7 +85,7 @@ def backed_access(
     | SOMAExperiment
     | SOMAMeasurement
     | PyArrowDataset
-    | Iterator
+    | Iterator[PolarsLazyFrame]
 ):
     from lamindb.models import Artifact
 

--- a/lamindb/core/storage/_backed_access.py
+++ b/lamindb/core/storage/_backed_access.py
@@ -12,7 +12,8 @@ from ._tiledbsoma import _open_tiledbsoma
 from .paths import filepath_from_artifact
 
 if TYPE_CHECKING:
-    from collection.abc import Iterator
+    from collections.abc import Iterator
+
     from fsspec.core import OpenFile
     from pyarrow.dataset import Dataset as PyArrowDataset
     from tiledbsoma import Collection as SOMACollection

--- a/lamindb/core/storage/_backed_access.py
+++ b/lamindb/core/storage/_backed_access.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Literal
 
 from anndata._io.specs.registry import get_spec
-from upath import UPath
 
 from ._anndata_accessor import AnnDataAccessor, StorageType, registry
 from ._polars_lazy_df import POLARS_SUFFIXES, _open_polars_lazy_df
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from tiledbsoma import Collection as SOMACollection
     from tiledbsoma import Experiment as SOMAExperiment
     from tiledbsoma import Measurement as SOMAMeasurement
+    from upath import UPath
 
     from lamindb.models.artifact import Artifact
 
@@ -149,7 +150,7 @@ def _df_storage_suffix(paths: UPath | list[UPath]) -> str | None:
     # we don't check here that the filesystem is the same
     # but this is a requirement for pyarrow.dataset.dataset
     path_list = []
-    if isinstance(paths, UPath):
+    if isinstance(paths, Path):
         paths = [paths]
     for path in paths:
         # assume http is always a file

--- a/lamindb/core/storage/_backed_access.py
+++ b/lamindb/core/storage/_backed_access.py
@@ -75,7 +75,7 @@ class BackedAccessor:
 def backed_access(
     artifact_or_filepath: Artifact | UPath,
     mode: str = "r",
-    df_engine: Literal["pyarrow", "polars"] = "pyarrow",
+    engine: Literal["pyarrow", "polars"] = "pyarrow",
     using_key: str | None = None,
     **kwargs,
 ) -> (
@@ -113,21 +113,21 @@ def backed_access(
     elif (df_suffix := _df_storage_suffix(objectpath)) in set(PYARROW_SUFFIXES).union(
         POLARS_SUFFIXES
     ):
-        if df_engine == "pyarrow":
+        if engine == "pyarrow":
             if df_suffix not in PYARROW_SUFFIXES:
                 raise ValueError(
-                    f"{df_suffix} files are not supported by pyarrow, try with df_engine='polars'."
+                    f"{df_suffix} files are not supported by pyarrow, try with engine='polars'."
                 )
             return _open_pyarrow_dataset(objectpath, **kwargs)
-        elif df_engine == "polars":
+        elif engine == "polars":
             if df_suffix not in POLARS_SUFFIXES:
                 raise ValueError(
-                    f"{df_suffix} files are not supported by polars, try with df_engine='pyarrow'."
+                    f"{df_suffix} files are not supported by polars, try with engine='pyarrow'."
                 )
             return _open_polars_lazy_df(objectpath, **kwargs)
         else:
             raise ValueError(
-                f"Unknown df_engine: {df_engine}. It should be 'pyarrow' or 'polars'."
+                f"Unknown engine: {engine}. It should be 'pyarrow' or 'polars'."
             )
     else:
         raise ValueError(

--- a/lamindb/core/storage/_polars_lazy_df.py
+++ b/lamindb/core/storage/_polars_lazy_df.py
@@ -18,7 +18,7 @@ def _open_polars_lazy_df(paths: UPath | list[UPath], **kwargs):
     scans = {
         ".parquet": pl.scan_parquet,
         ".csv": pl.scan_csv,
-        ".nbjson": pl.scan_nbjson,
+        ".ndjson": pl.scan_ndjson,
         ".ipc": pl.scan_ipc,
     }
 

--- a/lamindb/core/storage/_polars_lazy_df.py
+++ b/lamindb/core/storage/_polars_lazy_df.py
@@ -24,7 +24,7 @@ def _open_polars_lazy_df(paths: UPath | list[UPath], **kwargs):
         paths = [paths]
     for path in paths:
         # assume http is always a file
-        if path.protocol not in {"http", "https"} and path.is_dir():
+        if getattr(path, "protocol", None) not in {"http", "https"} and path.is_dir():
             path_list += [p for p in path.rglob("*") if p.suffix != ""]
         else:
             path_list.append(path)

--- a/lamindb/core/storage/_polars_lazy_df.py
+++ b/lamindb/core/storage/_polars_lazy_df.py
@@ -1,0 +1,1 @@
+POLARS_SUFFIXES = (".parquet", ".csv", ".ndjson", ".ipc")

--- a/lamindb/core/storage/_polars_lazy_df.py
+++ b/lamindb/core/storage/_polars_lazy_df.py
@@ -1,1 +1,24 @@
+from contextlib import contextmanager
+
+from upath import UPath
+
 POLARS_SUFFIXES = (".parquet", ".csv", ".ndjson", ".ipc")
+
+
+@contextmanager
+def _open_polars_lazy_df(paths: UPath | list[UPath], **kwargs):
+    try:
+        import polars as pl
+    except ImportError as ie:
+        raise ImportError("Please install polars: pip install polars") from ie
+
+    if isinstance(paths, UPath):
+        paths = [paths]
+
+    open_files = [path.open(mode="rb") for path in paths]
+
+    try:
+        yield pl.scan_parquet(open_files, **kwargs)
+    finally:
+        for open_file in open_files:
+            open_file.close()

--- a/lamindb/core/storage/_polars_lazy_df.py
+++ b/lamindb/core/storage/_polars_lazy_df.py
@@ -5,13 +5,18 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from polars import LazyFrame as PolarsLazyFrame
     from upath import UPath
 
 POLARS_SUFFIXES = (".parquet", ".csv", ".ndjson", ".ipc")
 
 
 @contextmanager
-def _open_polars_lazy_df(paths: UPath | list[UPath], **kwargs):
+def _open_polars_lazy_df(
+    paths: UPath | list[UPath], **kwargs
+) -> Iterator[PolarsLazyFrame]:
     try:
         import polars as pl
     except ImportError as ie:

--- a/lamindb/core/storage/_polars_lazy_df.py
+++ b/lamindb/core/storage/_polars_lazy_df.py
@@ -12,19 +12,22 @@ def _open_polars_lazy_df(paths: UPath | list[UPath], **kwargs):
     except ImportError as ie:
         raise ImportError("Please install polars: pip install polars") from ie
 
-    if isinstance(paths, list):
-        path_list = paths
-    elif paths.is_dir():
-        path_list = [path for path in paths.rglob("*") if path.suffix != ""]
-    else:
-        path_list = [paths]
-
     scans = {
         ".parquet": pl.scan_parquet,
         ".csv": pl.scan_csv,
         ".ndjson": pl.scan_ndjson,
         ".ipc": pl.scan_ipc,
     }
+
+    path_list = []
+    if isinstance(paths, UPath):
+        paths = [paths]
+    for path in paths:
+        # assume http is always a file
+        if path.protocol not in {"http", "https"} and path.is_dir():
+            path_list += [p for p in path.rglob("*") if p.suffix != ""]
+        else:
+            path_list.append(path)
 
     open_files = []
 

--- a/lamindb/core/storage/_polars_lazy_df.py
+++ b/lamindb/core/storage/_polars_lazy_df.py
@@ -15,10 +15,20 @@ def _open_polars_lazy_df(paths: UPath | list[UPath], **kwargs):
     if isinstance(paths, UPath):
         paths = [paths]
 
-    open_files = [path.open(mode="rb") for path in paths]
+    scans = {
+        ".parquet": pl.scan_parquet,
+        ".csv": pl.scan_csv,
+        ".nbjson": pl.scan_nbjson,
+        ".ipc": pl.scan_ipc,
+    }
+
+    open_files = []
 
     try:
-        yield pl.scan_parquet(open_files, **kwargs)
+        for path in paths:
+            open_files.append(path.open(mode="rb"))
+
+        yield scans[paths[0].suffix](open_files, **kwargs)
     finally:
         for open_file in open_files:
             open_file.close()

--- a/lamindb/core/storage/_polars_lazy_df.py
+++ b/lamindb/core/storage/_polars_lazy_df.py
@@ -12,8 +12,12 @@ def _open_polars_lazy_df(paths: UPath | list[UPath], **kwargs):
     except ImportError as ie:
         raise ImportError("Please install polars: pip install polars") from ie
 
-    if isinstance(paths, UPath):
-        paths = [paths]
+    if isinstance(paths, list):
+        path_list = paths
+    elif paths.is_dir():
+        path_list = [path for path in paths.rglob("*") if path.suffix != ""]
+    else:
+        path_list = [paths]
 
     scans = {
         ".parquet": pl.scan_parquet,
@@ -25,10 +29,10 @@ def _open_polars_lazy_df(paths: UPath | list[UPath], **kwargs):
     open_files = []
 
     try:
-        for path in paths:
+        for path in path_list:
             open_files.append(path.open(mode="rb"))
 
-        yield scans[paths[0].suffix](open_files, **kwargs)
+        yield scans[path_list[0].suffix](open_files, **kwargs)
     finally:
         for open_file in open_files:
             open_file.close()

--- a/lamindb/core/storage/_polars_lazy_df.py
+++ b/lamindb/core/storage/_polars_lazy_df.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from pathlib import Path
 
 from upath import UPath
 
@@ -20,7 +21,7 @@ def _open_polars_lazy_df(paths: UPath | list[UPath], **kwargs):
     }
 
     path_list = []
-    if isinstance(paths, UPath):
+    if isinstance(paths, Path):
         paths = [paths]
     for path in paths:
         # assume http is always a file

--- a/lamindb/core/storage/_polars_lazy_df.py
+++ b/lamindb/core/storage/_polars_lazy_df.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 from contextlib import contextmanager
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from upath import UPath
+if TYPE_CHECKING:
+    from upath import UPath
 
 POLARS_SUFFIXES = (".parquet", ".csv", ".ndjson", ".ipc")
 

--- a/lamindb/core/storage/_pyarrow_dataset.py
+++ b/lamindb/core/storage/_pyarrow_dataset.py
@@ -13,34 +13,6 @@ if TYPE_CHECKING:
 PYARROW_SUFFIXES = (".parquet", ".csv", ".json", ".orc", ".arrow", ".feather", ".ipc")
 
 
-def _is_pyarrow_dataset(paths: UPath | list[UPath]) -> bool:
-    # it is assumed here that the paths exist
-    # we don't check here that the filesystem is the same
-    # but this is a requirement for pyarrow.dataset.dataset
-    if isinstance(paths, list):
-        path_list = paths
-    elif paths.is_dir():
-        path_list = [path for path in paths.rglob("*") if path.suffix != ""]
-    else:
-        path_list = [paths]
-    suffix = None
-    for path in path_list:
-        path_suffixes = path.suffixes
-        # this doesn't work for externally gzipped files, REMOVE LATER
-        path_suffix = (
-            path_suffixes[-2]
-            if len(path_suffixes) > 1 and ".gz" in path_suffixes
-            else path.suffix
-        )
-        if path_suffix not in PYARROW_SUFFIXES:
-            return False
-        elif suffix is None:
-            suffix = path_suffix
-        elif path_suffix != suffix:
-            return False
-    return True
-
-
 def _open_pyarrow_dataset(paths: UPath | list[UPath], **kwargs) -> PyArrowDataset:
     if isinstance(paths, list):
         path0 = paths[0]

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -48,6 +48,10 @@ from ..core.storage import (
     write_to_disk,
 )
 from ..core.storage._anndata_accessor import _anndata_n_observations
+from ..core.storage._backed_access import (
+    _track_writes_factory,
+    backed_access,
+)
 from ..core.storage._pyarrow_dataset import PYARROW_SUFFIXES
 from ..core.storage._tiledbsoma import _soma_n_observations
 from ..core.storage.paths import (
@@ -2212,10 +2216,6 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
             )
 
         from lamindb import settings
-        from lamindb.core.storage._backed_access import (
-            _track_writes_factory,
-            backed_access,
-        )
 
         using_key = settings._using_key
         filepath, cache_key = filepath_cache_key_from_artifact(

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -2162,7 +2162,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
         | PyArrowDataset
         | Iterator[PolarsLazyFrame]
     ):
-        """Return a cloud-backed data object.
+        """Open a dataset for streaming.
 
         Works for `AnnData` (`.h5ad` and `.zarr`), generic `hdf5` and `zarr`,
         `tiledbsoma` objects (`.tiledbsoma`), `pyarrow` or `polars` compatible formats.
@@ -2171,13 +2171,15 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
             mode: can only be `"w"` (write mode) for `tiledbsoma` stores,
                 otherwise should be always `"r"` (read-only mode).
             df_engine: Which module to use for lazy loading of a dataframe
-                from `pyarrow` or `polars` compatible formats (`.parquet` etc).
+                from `pyarrow` or `polars` compatible formats (`.parquet`, `.csv`, `.ipc` etc).
+                This has no effect if the artifact is not a dataframe, i.e.
+                if it is an `AnnData,` `hdf5`, `zarr` or `tiledbsoma` object.
             is_run_input: Whether to track this artifact as run input.
             **kwargs: Keyword arguments for the accessor, i.e. `h5py` or `zarr` connection,
-                `pyarrow.dataset.dataset`.
+                `pyarrow.dataset.dataset`, `polars.scan_*` function.
 
         Notes:
-            For more info, see tutorial: :doc:`/arrays`.
+            For more info, see guide: :doc:`/arrays`.
 
         Example::
 
@@ -2190,6 +2192,10 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
             #> AnnDataAccessor object with n_obs × n_vars = 70 × 765
             #>     constructed for the AnnData object pbmc68k.h5ad
             #>     ...
+            artifact = ln.Artifact.get(key=lndb-storage/df.parquet)
+            artifact.open()
+            #> pyarrow._dataset.FileSystemDataset
+
         """
         if self._overwrite_versions and not self.is_latest:
             raise ValueError(INCONSISTENT_STATE_MSG)

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -113,6 +113,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
 
     from mudata import MuData  # noqa: TC004
+    from polars import LazyFrame as PolarsLazyFrame
     from pyarrow.dataset import Dataset as PyArrowDataset
     from spatialdata import SpatialData  # noqa: TC004
     from tiledbsoma import Collection as SOMACollection
@@ -2159,7 +2160,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
         | SOMAExperiment
         | SOMAMeasurement
         | PyArrowDataset
-        | Iterator
+        | Iterator[PolarsLazyFrame]
     ):
         """Return a cloud-backed data object.
 

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -2150,7 +2150,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
     def open(
         self,
         mode: str = "r",
-        df_engine: Literal["pyarrow", "polars"] = "pyarrow",
+        engine: Literal["pyarrow", "polars"] = "pyarrow",
         is_run_input: bool | None = None,
         **kwargs,
     ) -> (
@@ -2165,13 +2165,14 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
         """Open a dataset for streaming.
 
         Works for `AnnData` (`.h5ad` and `.zarr`), generic `hdf5` and `zarr`,
-        `tiledbsoma` objects (`.tiledbsoma`), `pyarrow` or `polars` compatible formats.
+        `tiledbsoma` objects (`.tiledbsoma`), `pyarrow` or `polars` compatible formats
+        (`.parquet`, `.csv`, `.ipc` etc. files or directories with such files).
 
         Args:
             mode: can only be `"w"` (write mode) for `tiledbsoma` stores,
                 otherwise should be always `"r"` (read-only mode).
-            df_engine: Which module to use for lazy loading of a dataframe
-                from `pyarrow` or `polars` compatible formats (`.parquet`, `.csv`, `.ipc` etc).
+            engine: Which module to use for lazy loading of a dataframe
+                from `pyarrow` or `polars` compatible formats.
                 This has no effect if the artifact is not a dataframe, i.e.
                 if it is an `AnnData,` `hdf5`, `zarr` or `tiledbsoma` object.
             is_run_input: Whether to track this artifact as run input.
@@ -2253,7 +2254,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
         if open_cache:
             try:
                 access = backed_access(
-                    localpath, mode, df_engine, using_key=using_key, **kwargs
+                    localpath, mode, engine, using_key=using_key, **kwargs
                 )
             except Exception as e:
                 if isinstance(filepath, LocalPathClasses) or isinstance(e, ImportError):
@@ -2262,7 +2263,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
                     f"The cache might be corrupted: {e}. Trying to open directly."
                 )
                 access = backed_access(
-                    filepath, mode, df_engine, using_key=using_key, **kwargs
+                    filepath, mode, engine, using_key=using_key, **kwargs
                 )
                 # happens only if backed_access has been successful
                 # delete the corrupted cache
@@ -2272,7 +2273,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
                     localpath.unlink(missing_ok=True)
         else:
             access = backed_access(
-                filepath, mode, df_engine, using_key=using_key, **kwargs
+                filepath, mode, engine, using_key=using_key, **kwargs
             )
             if is_tiledbsoma_w:
 

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -2193,7 +2193,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
             #> AnnDataAccessor object with n_obs × n_vars = 70 × 765
             #>     constructed for the AnnData object pbmc68k.h5ad
             #>     ...
-            artifact = ln.Artifact.get(key=lndb-storage/df.parquet)
+            artifact = ln.Artifact.get(key="lndb-storage/df.parquet")
             artifact.open()
             #> pyarrow._dataset.FileSystemDataset
 

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -110,9 +110,8 @@ except ImportError:
 
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Iterator
 
-    from collection.abc import Iterator
     from mudata import MuData  # noqa: TC004
     from pyarrow.dataset import Dataset as PyArrowDataset
     from spatialdata import SpatialData  # noqa: TC004

--- a/lamindb/models/collection.py
+++ b/lamindb/models/collection.py
@@ -376,10 +376,7 @@ class Collection(Record, IsVersioned, TracksRun, TracksUpdates):
         if df_suffix is None:
             suffixes = set()
             for path in paths:
-                if (
-                    getattr(path, "protocol", None) not in {"http", "https"}
-                    and path.is_dir()
-                ):
+                if path.protocol not in {"http", "https"} and path.is_dir():
                     suffixes.update(p.suffix for p in path.rglob("*") if p.suffix != "")
                 else:
                     suffixes.add(path.suffix)

--- a/lamindb/models/collection.py
+++ b/lamindb/models/collection.py
@@ -347,17 +347,18 @@ class Collection(Record, IsVersioned, TracksRun, TracksUpdates):
 
     def open(
         self,
-        df_engine: Literal["pyarrow", "polars"] = "pyarrow",
+        engine: Literal["pyarrow", "polars"] = "pyarrow",
         is_run_input: bool | None = None,
         **kwargs,
     ) -> PyArrowDataset | Iterator[PolarsLazyFrame]:
         """Open a dataset for streaming.
 
-        Works for `pyarrow` and `polars` compatible formats.
+        Works for `pyarrow` and `polars` compatible formats
+        (`.parquet`, `.csv`, `.ipc` etc. files or directories with such files).
 
         Args:
-            df_engine: Which module to use for lazy loading of a dataframe
-                from `pyarrow` or `polars` compatible formats (`.parquet`, `.csv`, `.ipc` etc).
+            engine: Which module to use for lazy loading of a dataframe
+                from `pyarrow` or `polars` compatible formats.
             is_run_input: Whether to track this artifact as run input.
             **kwargs: Keyword arguments for `pyarrow.dataset.dataset` or `polars.scan_*` functions.
 
@@ -384,7 +385,7 @@ class Collection(Record, IsVersioned, TracksRun, TracksUpdates):
                 f"The artifacts in the collection have different file formats: {', '.join(suffixes)}."
             )
 
-        if df_engine == "pyarrow":
+        if engine == "pyarrow":
             if df_suffix not in PYARROW_SUFFIXES:
                 raise ValueError(
                     f"{df_suffix} files are not supported by pyarrow, "
@@ -401,7 +402,7 @@ class Collection(Record, IsVersioned, TracksRun, TracksUpdates):
                         "this is not supported."
                     )
             dataset = _open_pyarrow_dataset(paths, **kwargs)
-        elif df_engine == "polars":
+        elif engine == "polars":
             if df_suffix not in POLARS_SUFFIXES:
                 raise ValueError(
                     f"{df_suffix} files are not supported by polars, "
@@ -410,7 +411,7 @@ class Collection(Record, IsVersioned, TracksRun, TracksUpdates):
             dataset = _open_polars_lazy_df(paths, **kwargs)
         else:
             raise ValueError(
-                f"Unknown df_engine: {df_engine}. It should be 'pyarrow' or 'polars'."
+                f"Unknown engine: {engine}. It should be 'pyarrow' or 'polars'."
             )
 
         # track only if successful

--- a/lamindb/models/collection.py
+++ b/lamindb/models/collection.py
@@ -24,7 +24,7 @@ from lamindb.base.fields import (
 
 from ..base.ids import base62_20
 from ..core._mapped_collection import MappedCollection
-from ..core.storage._backed_access import _df_dataset_suffix
+from ..core.storage._backed_access import _df_storage_suffix
 from ..core.storage._pyarrow_dataset import PYARROW_SUFFIXES, _open_pyarrow_dataset
 from ..errors import FieldValidationError
 from ..models._is_versioned import process_revises
@@ -366,7 +366,7 @@ class Collection(Record, IsVersioned, TracksRun, TracksUpdates):
                 raise ValueError(
                     "The collection has artifacts with different filesystems, this is not supported."
                 )
-        if _df_dataset_suffix(paths) not in PYARROW_SUFFIXES:
+        if _df_storage_suffix(paths) not in PYARROW_SUFFIXES:
             suffixes = {path.suffix for path in paths}
             suffixes_str = ", ".join(suffixes)
             err_msg = (

--- a/lamindb/models/collection.py
+++ b/lamindb/models/collection.py
@@ -382,7 +382,7 @@ class Collection(Record, IsVersioned, TracksRun, TracksUpdates):
             if df_suffix not in PYARROW_SUFFIXES:
                 raise ValueError(
                     f"{df_suffix} files are not supported by pyarrow, "
-                    f"they should have one of these formats: {' '.join(PYARROW_SUFFIXES)}."
+                    f"they should have one of these formats: {', '.join(PYARROW_SUFFIXES)}."
                 )
             # this checks that the filesystem is the same for all paths
             # this is a requirement of pyarrow.dataset.dataset
@@ -399,7 +399,7 @@ class Collection(Record, IsVersioned, TracksRun, TracksUpdates):
             if df_suffix not in POLARS_SUFFIXES:
                 raise ValueError(
                     f"{df_suffix} files are not supported by polars, "
-                    f"they should have one of these formats: {' '.join(POLARS_SUFFIXES)}."
+                    f"they should have one of these formats: {', '.join(POLARS_SUFFIXES)}."
                 )
             dataset = _open_polars_lazy_df(paths, **kwargs)
         else:

--- a/lamindb/models/collection.py
+++ b/lamindb/models/collection.py
@@ -373,9 +373,14 @@ class Collection(Record, IsVersioned, TracksRun, TracksUpdates):
         df_suffix = _df_storage_suffix(paths)
 
         if df_suffix is None:
-            suffixes_str = ", ".join({path.suffix for path in paths})
+            suffixes = set()
+            for path in paths:
+                if path.protocol not in {"http", "https"} and path.is_dir():
+                    suffixes.update(p.suffix for p in path.rglob("*") if p.suffix != "")
+                else:
+                    suffixes.add(path.suffix)
             raise ValueError(
-                f"The artifacts in the collection have different file formats: {suffixes_str}."
+                f"The artifacts in the collection have different file formats: {', '.join(suffixes)}."
             )
 
         if df_engine == "pyarrow":

--- a/lamindb/models/collection.py
+++ b/lamindb/models/collection.py
@@ -25,6 +25,7 @@ from lamindb.base.fields import (
 from ..base.ids import base62_20
 from ..core._mapped_collection import MappedCollection
 from ..core.storage._backed_access import _df_storage_suffix
+from ..core.storage._polars_lazy_df import POLARS_SUFFIXES, _open_polars_lazy_df
 from ..core.storage._pyarrow_dataset import PYARROW_SUFFIXES, _open_pyarrow_dataset
 from ..errors import FieldValidationError
 from ..models._is_versioned import process_revises
@@ -49,7 +50,7 @@ from .record import (
 from .run import Run, TracksRun, TracksUpdates
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Iterator
 
     from pyarrow.dataset import Dataset as PyArrowDataset
 
@@ -343,10 +344,21 @@ class Collection(Record, IsVersioned, TracksRun, TracksUpdates):
             run=run,
         )
 
-    def open(self, is_run_input: bool | None = None) -> PyArrowDataset:
+    def open(
+        self,
+        df_engine: Literal["pyarrow", "polars"] = "pyarrow",
+        is_run_input: bool | None = None,
+        **kwargs,
+    ) -> PyArrowDataset | Iterator:
         """Return a cloud-backed pyarrow Dataset.
 
-        Works for `pyarrow` compatible formats.
+        Works for `pyarrow` and `polars` compatible formats.
+
+        Args:
+            df_engine: Which module to use for lazy loading of a dataframe
+                from `pyarrow` or `polars` compatible formats (`.parquet` etc).
+            is_run_input: Whether to track this artifact as run input.
+            **kwargs: Keyword arguments for `pyarrow.dataset.dataset` or `polars.scan_*` functions.
 
         Notes:
             For more info, see tutorial: :doc:`/arrays`.
@@ -357,28 +369,44 @@ class Collection(Record, IsVersioned, TracksRun, TracksUpdates):
         else:
             artifacts = self.ordered_artifacts.all()
         paths = [artifact.path for artifact in artifacts]
-        # this checks that the filesystem is the same for all paths
-        # this is a requirement of pyarrow.dataset.dataset
-        fs = paths[0].fs
-        for path in paths[1:]:
-            # this assumes that the filesystems are cached by fsspec
-            if path.fs is not fs:
+
+        df_suffix = _df_storage_suffix(paths)
+
+        if df_suffix is None:
+            suffixes_str = ", ".join({path.suffix for path in paths})
+            raise ValueError(
+                f"The artifacts in the collection have different file formats: {suffixes_str}."
+            )
+
+        if df_engine == "pyarrow":
+            if df_suffix not in PYARROW_SUFFIXES:
                 raise ValueError(
-                    "The collection has artifacts with different filesystems, this is not supported."
+                    f"{df_suffix} files are not supported by pyarrow, "
+                    f"they should have one of these formats: {' '.join(PYARROW_SUFFIXES)}."
                 )
-        if _df_storage_suffix(paths) not in PYARROW_SUFFIXES:
-            suffixes = {path.suffix for path in paths}
-            suffixes_str = ", ".join(suffixes)
-            err_msg = (
-                "This collection is not compatible with pyarrow.dataset.dataset(), "
+            # this checks that the filesystem is the same for all paths
+            # this is a requirement of pyarrow.dataset.dataset
+            fs = paths[0].fs
+            for path in paths[1:]:
+                # this assumes that the filesystems are cached by fsspec
+                if path.fs is not fs:
+                    raise ValueError(
+                        "The collection has artifacts with different filesystems, "
+                        "this is not supported."
+                    )
+            dataset = _open_pyarrow_dataset(paths, **kwargs)
+        elif df_engine == "polars":
+            if df_suffix not in POLARS_SUFFIXES:
+                raise ValueError(
+                    f"{df_suffix} files are not supported by polars, "
+                    f"they should have one of these formats: {' '.join(POLARS_SUFFIXES)}."
+                )
+            dataset = _open_polars_lazy_df(paths, **kwargs)
+        else:
+            raise ValueError(
+                f"Unknown df_engine: {df_engine}. It should be 'pyarrow' or 'polars'."
             )
-            err_msg += (
-                f"the artifacts have incompatible file types: {suffixes_str}"
-                if len(suffixes) > 1
-                else f"the file type {suffixes_str} is not supported by pyarrow."
-            )
-            raise ValueError(err_msg)
-        dataset = _open_pyarrow_dataset(paths)
+
         # track only if successful
         _track_run_input(self, is_run_input)
         return dataset

--- a/lamindb/models/collection.py
+++ b/lamindb/models/collection.py
@@ -375,7 +375,10 @@ class Collection(Record, IsVersioned, TracksRun, TracksUpdates):
         if df_suffix is None:
             suffixes = set()
             for path in paths:
-                if path.protocol not in {"http", "https"} and path.is_dir():
+                if (
+                    getattr(path, "protocol", None) not in {"http", "https"}
+                    and path.is_dir()
+                ):
                     suffixes.update(p.suffix for p in path.rglob("*") if p.suffix != "")
                 else:
                     suffixes.add(path.suffix)

--- a/lamindb/models/collection.py
+++ b/lamindb/models/collection.py
@@ -351,18 +351,18 @@ class Collection(Record, IsVersioned, TracksRun, TracksUpdates):
         is_run_input: bool | None = None,
         **kwargs,
     ) -> PyArrowDataset | Iterator[PolarsLazyFrame]:
-        """Return a cloud-backed pyarrow Dataset.
+        """Open a dataset for streaming.
 
         Works for `pyarrow` and `polars` compatible formats.
 
         Args:
             df_engine: Which module to use for lazy loading of a dataframe
-                from `pyarrow` or `polars` compatible formats (`.parquet` etc).
+                from `pyarrow` or `polars` compatible formats (`.parquet`, `.csv`, `.ipc` etc).
             is_run_input: Whether to track this artifact as run input.
             **kwargs: Keyword arguments for `pyarrow.dataset.dataset` or `polars.scan_*` functions.
 
         Notes:
-            For more info, see tutorial: :doc:`/arrays`.
+            For more info, see guide: :doc:`/arrays`.
         """
         if self._state.adding:
             artifacts = self._artifacts

--- a/lamindb/models/collection.py
+++ b/lamindb/models/collection.py
@@ -24,7 +24,8 @@ from lamindb.base.fields import (
 
 from ..base.ids import base62_20
 from ..core._mapped_collection import MappedCollection
-from ..core.storage._pyarrow_dataset import _is_pyarrow_dataset, _open_pyarrow_dataset
+from ..core.storage._backed_access import _df_dataset_suffix
+from ..core.storage._pyarrow_dataset import PYARROW_SUFFIXES, _open_pyarrow_dataset
 from ..errors import FieldValidationError
 from ..models._is_versioned import process_revises
 from ._is_versioned import IsVersioned
@@ -365,7 +366,7 @@ class Collection(Record, IsVersioned, TracksRun, TracksUpdates):
                 raise ValueError(
                     "The collection has artifacts with different filesystems, this is not supported."
                 )
-        if not _is_pyarrow_dataset(paths):
+        if _df_dataset_suffix(paths) not in PYARROW_SUFFIXES:
             suffixes = {path.suffix for path in paths}
             suffixes_str = ", ".join(suffixes)
             err_msg = (

--- a/lamindb/models/collection.py
+++ b/lamindb/models/collection.py
@@ -52,6 +52,7 @@ from .run import Run, TracksRun, TracksUpdates
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
 
+    from polars import LazyFrame as PolarsLazyFrame
     from pyarrow.dataset import Dataset as PyArrowDataset
 
     from ..core.storage import UPath
@@ -349,7 +350,7 @@ class Collection(Record, IsVersioned, TracksRun, TracksUpdates):
         df_engine: Literal["pyarrow", "polars"] = "pyarrow",
         is_run_input: bool | None = None,
         **kwargs,
-    ) -> PyArrowDataset | Iterator:
+    ) -> PyArrowDataset | Iterator[PolarsLazyFrame]:
         """Return a cloud-backed pyarrow Dataset.
 
         Works for `pyarrow` and `polars` compatible formats.

--- a/noxfile.py
+++ b/noxfile.py
@@ -102,6 +102,7 @@ def install_ci(session, group):
         run(
             session, "uv pip install --system tiledbsoma<1.16.2"
         )  # not compatible yet with 1.16.2
+        run(session, "uv pip install --system polars")
     elif group == "tutorial":
         extras += "jupyter,bionty"
         run(session, "uv pip install --system huggingface_hub")

--- a/noxfile.py
+++ b/noxfile.py
@@ -106,6 +106,7 @@ def install_ci(session, group):
     elif group == "tutorial":
         extras += "jupyter,bionty"
         run(session, "uv pip install --system huggingface_hub")
+        run(session, "uv pip install --system polars")
     elif group == "guide":
         extras += "bionty,zarr,jupyter"
         run(session, "uv pip install --system scanpy mudata spatialdata")

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -477,7 +477,7 @@ def test_backed_pyarrow_collection():
     artifact2 = ln.Artifact(shard2, key="df2.parquet").save()
     artifact3 = ln.Artifact("mini.csv", key="mini.csv").save()
     artifact4 = ln.Artifact(
-        "https://raw.githubusercontent.com/laminlabs/lamindb/refs/heads/main/README.md"
+        "https://lamindb-test.s3.amazonaws.com/schmidt22-crispra-gws-IFNG.csv"
     ).save()
 
     collection1 = ln.Collection([artifact1, artifact2], key="parquet_col")
@@ -494,7 +494,7 @@ def test_backed_pyarrow_collection():
         "ValueError: The artifacts in the collection have different file formats"
     )
 
-    collection3 = ln.Collection([artifact1, artifact4], key="s3_http_col").save()
+    collection3 = ln.Collection([artifact3, artifact4], key="s3_http_col").save()
     with pytest.raises(ValueError) as err:
         collection3.open()
     assert err.exconly().startswith(

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -491,7 +491,7 @@ def test_backed_pyarrow_collection():
     with pytest.raises(ValueError) as err:
         collection2.open()
     assert err.exconly().startswith(
-        "ValueError: This collection is not compatible with pyarrow.dataset.dataset()"
+        "ValueError: The artifacts in the collection have different file formats"
     )
 
     collection3 = ln.Collection([artifact1, artifact4], key="s3_http_col").save()

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -16,12 +16,10 @@ from lamindb.core.storage._anndata_accessor import _anndata_n_observations
 from lamindb.core.storage._backed_access import (
     AnnDataAccessor,
     BackedAccessor,
+    _df_storage_suffix,
     backed_access,
 )
-from lamindb.core.storage._pyarrow_dataset import (
-    _is_pyarrow_dataset,
-    _open_pyarrow_dataset,
-)
+from lamindb.core.storage._pyarrow_dataset import _open_pyarrow_dataset
 from lamindb.core.storage._tiledbsoma import (
     _open_tiledbsoma,
     _soma_store_n_observations,
@@ -470,7 +468,7 @@ def test_backed_pyarrow_collection():
     df[:2].to_parquet(shard1, engine="pyarrow")
     df[2:].to_parquet(shard2, engine="pyarrow")
     # test checking and opening local paths
-    assert not _is_pyarrow_dataset([shard1, ln.UPath("some.csv")])
+    assert _df_storage_suffix([shard1, ln.UPath("some.csv")]) is None
     assert _open_pyarrow_dataset([shard1, shard2]).to_table().to_pandas().equals(df)
 
     ln.core.datasets.file_mini_csv()

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -422,7 +422,7 @@ def test_tiledb_config():
     assert tiledb_config["vfs.s3.region"] == ""
 
 
-def test_backed_pyarrow_artifact():
+def test_open_dataframe_artifact():
     previous_storage = ln.setup.settings.storage.root_as_str
     ln.settings.storage = "s3://lamindb-test/storage"
 
@@ -438,8 +438,16 @@ def test_backed_pyarrow_artifact():
     assert ds.to_table().to_pandas().equals(df)
     # remove cache
     artifact_file.cache().unlink()
-    ds = artifact_file.open()
+    # pyarrow
+    ds = artifact_file.open(df_engine="pyarrow")
     assert ds.to_table().to_pandas().equals(df)
+    # polars
+    with artifact_file.open(df_engine="polars") as ldf:
+        assert ldf.collect().to_pandas().equals(df)
+    # wrong df_engine
+    with pytest.raises(ValueError) as err:
+        artifact_file.open(df_engine="some-other-engine")
+    assert err.exconly().startswith("ValueError: Unknown df_engine")
     # check as partitioned folder
     df.to_parquet("save_df", engine="pyarrow", partition_cols=["feat1"])
     assert Path("save_df").is_dir()
@@ -450,8 +458,12 @@ def test_backed_pyarrow_artifact():
     assert ds.to_table().to_pandas().equals(df[["feat2"]])
     # remove cache
     shutil.rmtree(artifact_folder.cache())
+    # pyarrow
     ds = artifact_folder.open()
     assert ds.to_table().to_pandas().equals(df[["feat2"]])
+    # polars
+    with artifact_folder.open(df_engine="polars") as ldf:
+        assert ldf.collect().to_pandas().equals(df[["feat2"]])
 
     artifact_file.delete(permanent=True)
     artifact_folder.delete(permanent=True)
@@ -459,7 +471,7 @@ def test_backed_pyarrow_artifact():
     ln.settings.storage = previous_storage
 
 
-def test_backed_pyarrow_collection():
+def test_open_dataframe_collection():
     ln.settings.storage = "s3://lamindb-test/storage"
 
     df = pd.DataFrame({"feat1": [0, 0, 1, 1], "feat2": [6, 7, 8, 9]})
@@ -482,18 +494,27 @@ def test_backed_pyarrow_collection():
 
     collection1 = ln.Collection([artifact1, artifact2], key="parquet_col")
     # before saving
+    # df_engine="pyarrow" by default
     assert collection1.open().to_table().to_pandas().equals(df)
     # after saving
     collection1.save()
-    assert collection1.open().to_table().to_pandas().equals(df)
-
+    # pyarrow
+    assert collection1.open(df_engine="pyarrow").to_table().to_pandas().equals(df)
+    # polars
+    with collection1.open(df_engine="polars") as ldf:
+        assert ldf.collect().to_pandas().equals(df)
+    # wrong engine
+    with pytest.raises(ValueError) as err:
+        collection1.open(df_engine="some-other-engine")
+    assert err.exconly().startswith("ValueError: Unknown df_engine")
+    # different file formats
     collection2 = ln.Collection([artifact1, artifact3], key="parquet_csv_col").save()
     with pytest.raises(ValueError) as err:
         collection2.open()
     assert err.exconly().startswith(
         "ValueError: The artifacts in the collection have different file formats"
     )
-
+    # different filesystems with pyarrow
     collection3 = ln.Collection([artifact3, artifact4], key="s3_http_col").save()
     with pytest.raises(ValueError) as err:
         collection3.open()

--- a/tests/storage/test_storage.py
+++ b/tests/storage/test_storage.py
@@ -439,15 +439,15 @@ def test_open_dataframe_artifact():
     # remove cache
     artifact_file.cache().unlink()
     # pyarrow
-    ds = artifact_file.open(df_engine="pyarrow")
+    ds = artifact_file.open(engine="pyarrow")
     assert ds.to_table().to_pandas().equals(df)
     # polars
-    with artifact_file.open(df_engine="polars") as ldf:
+    with artifact_file.open(engine="polars") as ldf:
         assert ldf.collect().to_pandas().equals(df)
-    # wrong df_engine
+    # wrong engine
     with pytest.raises(ValueError) as err:
-        artifact_file.open(df_engine="some-other-engine")
-    assert err.exconly().startswith("ValueError: Unknown df_engine")
+        artifact_file.open(engine="some-other-engine")
+    assert err.exconly().startswith("ValueError: Unknown engine")
     # check as partitioned folder
     df.to_parquet("save_df", engine="pyarrow", partition_cols=["feat1"])
     assert Path("save_df").is_dir()
@@ -462,7 +462,7 @@ def test_open_dataframe_artifact():
     ds = artifact_folder.open()
     assert ds.to_table().to_pandas().equals(df[["feat2"]])
     # polars
-    with artifact_folder.open(df_engine="polars") as ldf:
+    with artifact_folder.open(engine="polars") as ldf:
         assert ldf.collect().to_pandas().equals(df[["feat2"]])
 
     artifact_file.delete(permanent=True)
@@ -494,19 +494,19 @@ def test_open_dataframe_collection():
 
     collection1 = ln.Collection([artifact1, artifact2], key="parquet_col")
     # before saving
-    # df_engine="pyarrow" by default
+    # engine="pyarrow" by default
     assert collection1.open().to_table().to_pandas().equals(df)
     # after saving
     collection1.save()
     # pyarrow
-    assert collection1.open(df_engine="pyarrow").to_table().to_pandas().equals(df)
+    assert collection1.open(engine="pyarrow").to_table().to_pandas().equals(df)
     # polars
-    with collection1.open(df_engine="polars") as ldf:
+    with collection1.open(engine="polars") as ldf:
         assert ldf.collect().to_pandas().equals(df)
     # wrong engine
     with pytest.raises(ValueError) as err:
-        collection1.open(df_engine="some-other-engine")
-    assert err.exconly().startswith("ValueError: Unknown df_engine")
+        collection1.open(engine="some-other-engine")
+    assert err.exconly().startswith("ValueError: Unknown engine")
     # different file formats
     collection2 = ln.Collection([artifact1, artifact3], key="parquet_csv_col").save()
     with pytest.raises(ValueError) as err:


### PR DESCRIPTION
Closes https://github.com/laminlabs/lamindb/issues/2725

This PR adds `polars` support to `Artifact.open()` and `Collection.open()`.

Examples:
```python
...
# an artifact with .parquet file, for example
with artifact.open(df_engine="polars") as lazy_df: # lazy_df is polars.LazyFrame
    df = lazy_df.collect().to_pandas() # here just loads into memory, but can be anything
# a collection with .parquet files, for example
with collection.open(df_engine="polars") as lazy_df: # lazy_df is polars.LazyFrame
    df = lazy_df.collect().to_pandas()
```