### PR TITLE
🚸 Handle schema updates decently

### DIFF
--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -157,8 +157,12 @@ def serialize_dtype(
         dtype_str = dtype.__name__
     elif dtype is dict:
         dtype_str = "dict"
-    elif is_itype and dtype == "Feature":
-        dtype_str = "Feature"
+    elif is_itype and isinstance(dtype, str):
+        if dtype != "Feature":
+            parse_cat_dtype(
+                dtype_str=dtype, is_itype=True
+            )  # throws an error if invalid
+        dtype_str = dtype
     elif isinstance(dtype, (ExtensionDtype, np.dtype)):
         dtype_str = serialize_pandas_dtype(dtype)
     else:

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -158,7 +158,7 @@ def serialize_dtype(
     elif dtype is dict:
         dtype_str = "dict"
     elif is_itype and isinstance(dtype, str):
-        if dtype != "Feature":
+        if dtype not in "Feature":
             parse_cat_dtype(
                 dtype_str=dtype, is_itype=True
             )  # throws an error if invalid

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -143,7 +143,7 @@ def parse_cat_dtype(
 
 
 def serialize_dtype(
-    dtype: Registry | Record | FieldAttr | list[Record] | list[Registry],
+    dtype: Registry | Record | FieldAttr | list[Record] | list[Registry] | str,
     is_itype: bool = False,
 ) -> str:
     """Converts a data type object into its string representation."""
@@ -157,6 +157,8 @@ def serialize_dtype(
         dtype_str = dtype.__name__
     elif dtype is dict:
         dtype_str = "dict"
+    elif is_itype and dtype == "Feature":
+        dtype_str = "Feature"
     elif isinstance(dtype, (ExtensionDtype, np.dtype)):
         dtype_str = serialize_pandas_dtype(dtype)
     else:

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -663,7 +663,6 @@ class BasicRecord(models.Model, metaclass=Registry):
                 from ..core._settings import settings
                 from .can_curate import CanCurate
                 from .collection import Collection
-                from .schema import Schema
                 from .transform import Transform
 
                 validate_fields(self, kwargs)
@@ -707,11 +706,6 @@ class BasicRecord(models.Model, metaclass=Registry):
                                 f"returning existing {self.__class__.__name__} record with same"
                                 f" {name_field}{version_comment}: '{kwargs[name_field]}'"
                             )
-                            if isinstance(self, Schema):
-                                if existing_record.hash != kwargs["hash"]:
-                                    logger.warning(
-                                        f"You're updating schema {existing_record.uid}, which might already have been used to validate datasets. Be careful."
-                                    )
                             init_self_from_db(self, existing_record)
                             update_attributes(self, kwargs)
                             return None

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -512,7 +512,7 @@ class Schema(Record, CanCurate, TracksRun):
             raise FieldValidationError(
                 f"Only {valid_keywords} are valid keyword arguments"
             )
-        validated_kwargs, optional_features, features_registry = (
+        validated_kwargs, optional_features, features_registry, flexible = (
             self._validate_kwargs_calculate_hash(
                 features=features,
                 index=index,
@@ -576,6 +576,7 @@ class Schema(Record, CanCurate, TracksRun):
         n_features: int | None,
     ):
         optional_features = []
+        features_registry: Registry = None
         if itype is not None:
             itype = serialize_dtype(itype, is_itype=True)
         if index is not None:
@@ -647,7 +648,7 @@ class Schema(Record, CanCurate, TracksRun):
                 )
             hash = hash_set(union_set)
         validated_kwargs["hash"] = hash
-        return validated_kwargs, optional_features, features_registry
+        return validated_kwargs, optional_features, features_registry, flexible
 
     @classmethod
     def from_values(  # type: ignore

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -346,7 +346,7 @@ class Schema(Record, CanCurate, TracksRun):
     id: int = models.AutoField(primary_key=True)
     """Internal id, valid only in one DB instance."""
     uid: str = CharField(editable=False, unique=True, db_index=True, max_length=20)
-    """A universal id (hash of the set of feature values)."""
+    """A universal id."""
     name: str | None = CharField(max_length=150, null=True, db_index=True)
     """A name."""
     description: str | None = CharField(null=True, db_index=True)

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -532,7 +532,11 @@ class Schema(Record, CanCurate, TracksRun):
                 n_features=n_features,
             )
         )
-        schema = Schema.objects.using(using).filter(hash=hash).one_or_none()
+        schema = (
+            Schema.objects.using(using)
+            .filter(hash=validated_kwargs["hash"])
+            .one_or_none()
+        )
         if schema is not None:
             logger.important(f"returning existing schema with same hash: {schema}")
             init_self_from_db(self, schema)
@@ -629,7 +633,7 @@ class Schema(Record, CanCurate, TracksRun):
         if coerce_dtype:
             validated_kwargs["_aux"] = {"af": {"0": coerce_dtype}}
         if slots:
-            hash = hash_set({component.hash for component in slots.values()})
+            schema_hash = hash_set({component.hash for component in slots.values()})
         else:
             # we do not want pure informational annotations like otype, name, type, is_type, otype to be part of the hash
             hash_args = ["dtype", "itype", "minimal_set", "ordered_set", "maximal_set"]
@@ -646,8 +650,8 @@ class Schema(Record, CanCurate, TracksRun):
                 union_set = union_set.union(
                     {f"optional:{feature.uid}" for feature in optional_features}
                 )
-            hash = hash_set(union_set)
-        validated_kwargs["hash"] = hash
+            schema_hash = hash_set(union_set)
+        validated_kwargs["hash"] = schema_hash
         return validated_kwargs, optional_features, features_registry, flexible
 
     @classmethod

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -579,7 +579,8 @@ class Schema(Record, CanCurate, TracksRun):
         optional_features = []
         features_registry: Registry = None
         if itype is not None:
-            itype = serialize_dtype(itype, is_itype=True)
+            if itype != "Composite":
+                itype = serialize_dtype(itype, is_itype=True)
         if index is not None:
             if not isinstance(index, Feature):
                 raise TypeError("index must be a Feature")
@@ -788,7 +789,9 @@ class Schema(Record, CanCurate, TracksRun):
 
         if not self._state.adding:
             features = (
-                self._features[1] if hasattr(self, "_features") else self.members.list()
+                self._features[1]
+                if hasattr(self, "_features")
+                else (self.members.list() if self.members.exists() else [])
             )
             _, validated_kwargs, _, _, _ = self._validate_kwargs_calculate_hash(
                 features=features,
@@ -862,6 +865,8 @@ class Schema(Record, CanCurate, TracksRun):
             # this should return a queryset and not a list...
             # need to fix this
             return self._features[1]
+        if self.itype == "Composite":
+            return Feature.objects.none()
         related_name = self._get_related_name()
         if related_name is None:
             related_name = "features"

--- a/tests/curators/test_curators_examples.py
+++ b/tests/curators/test_curators_examples.py
@@ -216,16 +216,22 @@ def test_dataframe_curator(small_dataset1_schema: ln.Schema, ccaplog):
 
     # update schema
     assert small_dataset1_schema.n == 5
+    orig_hash = small_dataset1_schema.hash
     small_dataset1_schema.features.add(feature_to_fail)
     assert small_dataset1_schema.n == 5
+    assert small_dataset1_schema.hash == orig_hash
     small_dataset1_schema.save()
     assert small_dataset1_schema.n == 6
-
+    assert small_dataset1_schema.hash != orig_hash
     assert (
         "you updated the schema hash and might invalidate datasets that were previously validated with this schema:"
         in ccaplog.text
     )
-
+    small_dataset1_schema.features.remove(feature_to_fail)
+    small_dataset1_schema.save()
+    assert small_dataset1_schema.n == 5
+    assert small_dataset1_schema.hash == orig_hash
+    feature_to_fail.delete()
     artifact.delete(permanent=True)
 
 

--- a/tests/curators/test_curators_examples.py
+++ b/tests/curators/test_curators_examples.py
@@ -638,3 +638,7 @@ def test_spatialdata_curator(
         BRAF                num"""
     )
     artifact.delete(permanent=True)
+
+
+# def test_update_schema(small_dataset1_schema):
+#

--- a/tests/curators/test_curators_examples.py
+++ b/tests/curators/test_curators_examples.py
@@ -134,7 +134,7 @@ def mudata_papalexi21_subset_schema():
     bt.ExperimentalFactor.filter().delete()
 
 
-def test_dataframe_curator(small_dataset1_schema: ln.Schema):
+def test_dataframe_curator(small_dataset1_schema: ln.Schema, ccaplog):
     """Test DataFrame curator implementation."""
 
     # invalid simple dtype (float)
@@ -158,7 +158,6 @@ def test_dataframe_curator(small_dataset1_schema: ln.Schema):
         == "lamindb.errors.ValidationError: Column 'treatment_time_h' failed series or dataframe validator 0: <Check check_function: Column 'treatment_time_h' failed dtype check for 'float': got int64>"
     )
     schema.delete()
-    feature_to_fail.delete()
 
     # Wrong subtype
     df = datasets.small_dataset1(otype="DataFrame", with_wrong_subtype=True)
@@ -188,6 +187,7 @@ def test_dataframe_curator(small_dataset1_schema: ln.Schema):
     curator = ln.curators.DataFrameCurator(df, small_dataset1_schema)
     artifact = curator.save_artifact(key="example_datasets/dataset1.parquet")
 
+    assert artifact.schema == small_dataset1_schema
     assert artifact.features.slots["columns"].n == 5
     assert set(artifact.features.get_values()["sample_label"]) == {
         "sample1",
@@ -213,6 +213,18 @@ def test_dataframe_curator(small_dataset1_schema: ln.Schema):
         assert str(error).startswith("column 'sample_note' not in dataframe")
     curator.standardize()
     curator.validate()
+
+    # update schema
+    assert small_dataset1_schema.n == 5
+    small_dataset1_schema.features.add(feature_to_fail)
+    assert small_dataset1_schema.n == 5
+    small_dataset1_schema.save()
+    assert small_dataset1_schema.n == 6
+
+    assert (
+        "you updated the schema hash and might invalidate datasets that were previously validated with this schema:"
+        in ccaplog.text
+    )
 
     artifact.delete(permanent=True)
 
@@ -638,7 +650,3 @@ def test_spatialdata_curator(
         BRAF                num"""
     )
     artifact.delete(permanent=True)
-
-
-# def test_update_schema(small_dataset1_schema):
-#


### PR DESCRIPTION
# This PR

If a user attempts to update a schema, e.g., by adding or removing a feature from `schema.features` or by changing a setting, the API will now provide better feedback.

More specifically, upon `schema.save()` it'll print a warning that lists all datasets that were previously validated with this schema, which might now no longer be valid.

```python
class Schema:
    def save(self):
        ...
        if validated_kwargs["hash"] != self.hash:
            from .artifact import Artifact
        
            datasets = Artifact.filter(schema=self).all()
            if datasets.exists():
                logger.warning(
                    f"you updated the schema hash and might invalidate datasets that were previously validated with this schema: {datasets.list('uid')}"
                )
            self.hash = validated_kwargs["hash"]
            self.n = validated_kwargs["n"]
```

# Future work

If we monitor in detail what kind of updates a user performs, we can print a more specific warning. For instance, adding optional features is never going to be a problem, whereas adding required features is a problem.