### PR TITLE
👷 Refactor storage management during CI runs

### DIFF
--- a/docs/arrays.ipynb
+++ b/docs/arrays.ipynb
@@ -178,7 +178,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact = ln.Artifact.get(key=\"lndb-storage/pbmc68k.h5ad\")"
+    "artifact = ln.Artifact.get(key=\"pbmc68k.h5ad\")"
    ]
   },
   {

--- a/docs/arrays.ipynb
+++ b/docs/arrays.ipynb
@@ -56,7 +56,14 @@
    "outputs": [],
    "source": [
     "!lamin login testuser1\n",
-    "!lamin init --storage s3://lamindb-ci/test-array-notebook --name test-array-notebook"
+    "!lamin init --storage s3://lamindb-ci/test-arrays"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import lamindb and track this notebook."
    ]
   },
   {
@@ -91,8 +98,8 @@
    },
    "outputs": [],
    "source": [
-    "ln.Artifact(\"s3://lamindb-ci/lndb-storage/pbmc68k.h5ad\").save()\n",
-    "ln.Artifact(\"s3://lamindb-ci/lndb-storage/testfile.hdf5\").save()"
+    "ln.Artifact(\"s3://lamindb-ci/test-arrays/pbmc68k.h5ad\").save()\n",
+    "ln.Artifact(\"s3://lamindb-ci/test-arrays/testfile.hdf5\").save()"
    ]
   },
   {
@@ -550,13 +557,13 @@
    "outputs": [],
    "source": [
     "# clean up test instance\n",
-    "!lamin delete --force test-array-notebook"
+    "!lamin delete --force test-arrays"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "py312",
    "language": "python",
    "name": "python3"
   },
@@ -570,7 +577,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.12.8"
   },
   "nbproject": {
    "id": "YVUCtH4GfQOy",

--- a/docs/arrays.ipynb
+++ b/docs/arrays.ipynb
@@ -327,7 +327,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact = ln.Artifact.get(key=\"lndb-storage/testfile.hdf5\")"
+    "artifact = ln.Artifact.get(key=\"testfile.hdf5\")"
    ]
   },
   {

--- a/docs/storage/anndata-accessor.ipynb
+++ b/docs/storage/anndata-accessor.ipynb
@@ -34,7 +34,7 @@
    },
    "outputs": [],
    "source": [
-    "ln.Artifact(\"s3://lamindb-ci/lndb-storage/pbmc68k.h5ad\").save()"
+    "ln.Artifact(\"s3://lamindb-ci/test-anndata/pbmc68k.h5ad\").save()"
    ]
   },
   {
@@ -50,7 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact = ln.Artifact.filter(key=\"lndb-storage/pbmc68k.h5ad\").one()"
+    "artifact = ln.Artifact.filter(key=\"pbmc68k.h5ad\").one()"
    ]
   },
   {

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -28,6 +28,10 @@ def pytest_sessionstart():
     ln.setup.register()  # temporarily
     ln.setup.settings.auto_connect = True
     ln.settings.creation.artifact_silence_missing_run_warning = True
+    ln.settings.storage = (
+        "s3://lamindb-ci/test-data"  # register as valid storage location
+    )
+    ln.settings.storage = "./default_storage_unit_core"
 
     total_time_elapsed = perf_counter() - t_execute_start
     print(f"Time to setup the instance: {total_time_elapsed:.3f}s")


### PR DESCRIPTION
More rigid storage constraints in LaminCentral led to tests failing. This PR fixes them by separating test datasets in a way that the different auto-created test lamindb instances don't clash anymore.

I also ran these two sets of commands in Python and on the CLI:

```python
ln.UPath("s3://lamindb-ci/lndb-storage/pbmc68k.h5ad").rename("s3://lamindb-ci/test-arrays/pbmc68k.h5ad")
ln.UPath("s3://lamindb-ci/lndb-storage/testfile.hdf5").rename("s3://lamindb-ci/test-arrays/testfile.hdf5")
```

```bash
% aws s3 cp s3://lamindb-ci/test-arrays/pbmc68k.h5ad s3://lamindb-ci/test-anndata/pbmc68k.h5ad
% aws s3 cp s3://lamindb-ci/test-arrays/testfile.hdf5 s3://lamindb-ci/test-lamin-cli/testfile.hdf5
```

Needs:

- https://github.com/laminlabs/lamin-cli/pull/133