### PR TITLE
🐛 Fix SpatialData in-memory repr

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -2363,6 +2363,11 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
 
         if hasattr(self, "_memory_rep") and self._memory_rep is not None:
             access_memory = self._memory_rep
+            # SpatialData objects zarr stores are moved when saved
+            # SpatialData's __repr__ method attempts to access information from the old path
+            # Therefore, we need to update the in-memory path to the now moved Artifact storage path
+            if access_memory.__class__.__name__ == "SpatialData":
+                access_memory.path = self.path
         else:
             filepath, cache_key = filepath_cache_key_from_artifact(
                 self, using_key=settings._using_key
@@ -2395,6 +2400,7 @@ class Artifact(Record, IsVersioned, TracksRun, TracksUpdates):
                 access_memory = load_to_memory(cache_path, **kwargs)
         # only call if load is successfull
         _track_run_input(self, is_run_input)
+
         return access_memory
 
     @doc_args(DEBUG_KWARGS_DOC)

--- a/tests/core/test_load.py
+++ b/tests/core/test_load.py
@@ -135,6 +135,17 @@ def test_load_spatialdata(get_small_sdata):
     assert artifact._local_filepath.resolve() == artifact.cache() == artifact.path
 
 
+def load_blobs__repr__():
+    example_blobs_sdata = ln.core.datasets.spatialdata_blobs()
+    blobs_af = ln.Artifact.from_spatialdata(
+        example_blobs_sdata, key="example_blobs.zarr"
+    ).save()
+    example_blobs_sdata = ln.Artifact.get(key="example_blobs.zarr")
+    example_blobs_sdata = blobs_af.load()
+    # Must exist and not throw errors
+    assert example_blobs_sdata.__repr__
+
+
 def test_load_html(html_filepath):
     artifact = ln.Artifact(html_filepath, key=str(html_filepath))
     artifact.load()


### PR DESCRIPTION
https://laminlabs.slack.com/archives/C04FPE8V01W/p1746691319386589

SpatialData objects zarr stores are moved when saved. However, SpatialData's `__repr__` method attempts to access information from the old path. Therefore, we need to update the in-memory path to the now moved Artifact storage path.