### PR TITLE
🚸 Improve describe output

### DIFF
--- a/lamindb/core/constants.py
+++ b/lamindb/core/constants.py
@@ -1,0 +1,18 @@
+from enum import Enum
+
+
+class Colors(str, Enum):
+    """Main colors used throughout our stack.
+
+    Colors that are prefixed with `LAMIN` are our branding colors.
+    """
+
+    LAMIN_GREEN = "#12b981"
+    LAMIN_ORANGE = "#fb923c"
+    LAMIN_BLUE = "#2F5F9E"
+    GREEN_LIGHTER = "#10b981"
+    GREEN_DARKER = "#065f46"
+    GREEN_FILL = "honeydew"
+
+    def __str__(self):
+        return self.value

--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -20,6 +20,7 @@ from lamindb_setup.core.upath import create_path
 from rich.table import Column, Table
 from rich.text import Text
 
+from lamindb.core.constants import Colors
 from lamindb.core.storage import LocalPathClasses
 from lamindb.errors import DoesNotExist, ValidationError
 from lamindb.models._from_values import _format_values
@@ -275,7 +276,7 @@ def _create_feature_table(
     """Create a Rich table for a feature group."""
     table = Table(
         Column(name, style="", no_wrap=True, width=NAME_WIDTH),
-        Column(registry_str, style="dim", no_wrap=True, width=TYPE_WIDTH),
+        Column(registry_str, style="", no_wrap=True, width=TYPE_WIDTH),
         Column("", width=VALUES_WIDTH, no_wrap=True),
         show_header=show_header,
         box=None,
@@ -390,7 +391,7 @@ def describe_features(
             # Sort into internal/external
             feature_info = (
                 feature_name,
-                Text(feature_dtype, style="dim"),
+                Text(feature_dtype, style=""),
                 printed_values,
             )
             if feature_name in internal_feature_names:
@@ -421,9 +422,7 @@ def describe_features(
                 feature_rows += [
                     (
                         feature_name,
-                        Text(
-                            str(internal_feature_names.get(feature_name)), style="dim"
-                        ),
+                        Text(str(internal_feature_names.get(feature_name)), style=""),
                         "",
                     )
                     for feature_name in feature_names
@@ -440,7 +439,7 @@ def describe_features(
                                 if feature_name in internal_feature_names
                                 else schema.dtype
                             ),
-                            style="dim",
+                            style="",
                         ),
                         "",
                     )
@@ -450,11 +449,11 @@ def describe_features(
         int_features_tree_children.append(
             _create_feature_table(
                 Text.assemble(
-                    (slot, "violet"),
+                    (slot, f"{Colors.LAMIN_BLUE}"),
                     (" • ", "dim"),
-                    (str(schema.n), "pink1"),
+                    (str(schema.n), f"{Colors.LAMIN_BLUE}"),
                 ),
-                Text.assemble((f"[{schema.itype}]", "pink1")),
+                Text.assemble((f"[{schema.itype}]", f"{Colors.LAMIN_BLUE}")),
                 feature_rows,
                 show_header=True,
             )
@@ -463,7 +462,7 @@ def describe_features(
     if int_features_tree_children:
         dataset_tree = tree.add(
             Text.assemble(
-                ("Dataset features", "bold bright_magenta"),
+                ("Dataset features", f"bold {Colors.LAMIN_ORANGE}"),
             )
         )
         for child in int_features_tree_children:
@@ -480,7 +479,7 @@ def describe_features(
             )
         )
     # ext_features_tree = None
-    ext_features_header = Text("Linked features", style="bold dark_orange")
+    ext_features_header = Text("Linked features", style=f"bold {Colors.LAMIN_ORANGE}")
     if ext_features_tree_children:
         ext_features_tree = tree.add(ext_features_header)
         for child in ext_features_tree_children:

--- a/lamindb/models/_label_manager.py
+++ b/lamindb/models/_label_manager.py
@@ -9,6 +9,7 @@ from rich.table import Column, Table
 from rich.text import Text
 from rich.tree import Tree
 
+from lamindb.core.constants import Colors
 from lamindb.models import CanCurate, Feature
 from lamindb.models._from_values import _format_values
 from lamindb.models.dbrecord import (
@@ -90,7 +91,7 @@ def describe_labels(
 
     labels_table = Table(
         Column("", style="", no_wrap=True, width=NAME_WIDTH),
-        Column("", style="dim", no_wrap=True, width=TYPE_WIDTH),
+        Column("", style="", no_wrap=True, width=TYPE_WIDTH),
         Column("", width=VALUES_WIDTH, no_wrap=True),
         show_header=False,
         box=None,
@@ -110,10 +111,10 @@ def describe_labels(
             related_model = get_related_model(self, related_name)
             type_str = related_model.__get_name_with_module__()
             labels_table.add_row(
-                f".{related_name}", Text(type_str, style="dim"), print_values
+                f".{related_name}", Text(type_str, style=""), print_values
             )
 
-    labels_header = Text("Labels", style="bold green_yellow")
+    labels_header = Text("Labels", style=f"bold {Colors.LAMIN_ORANGE}")
     if as_subtree:
         if labels_table.rows:
             labels_tree = Tree(labels_header, guide_style="dim")

--- a/lamindb/models/has_parents.py
+++ b/lamindb/models/has_parents.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Literal
 import lamindb_setup as ln_setup
 from lamin_utils import logger
 
+from lamindb.core.constants import Colors
+
 from .dbrecord import format_field_value, get_name_field
 from .run import Run
 
@@ -21,9 +23,7 @@ if TYPE_CHECKING:
     from .query_set import QuerySet
     from .transform import Transform
 
-LAMIN_GREEN_LIGHTER = "#10b981"
-LAMIN_GREEN_DARKER = "#065f46"
-GREEN_FILL = "honeydew"
+
 TRANSFORM_EMOJIS = {
     "notebook": "📔",
     "upload": "🖥️",
@@ -200,7 +200,7 @@ def view_lineage(
         if isinstance(record, Run):
             fillcolor = "gainsboro"
         else:
-            fillcolor = GREEN_FILL
+            fillcolor = Colors.GREEN_FILL
         u.node(
             node_id,
             label=node_label,
@@ -212,8 +212,8 @@ def view_lineage(
     u = graphviz.Digraph(
         f"{data._meta.model_name}_{data.uid}",
         node_attr={
-            "fillcolor": GREEN_FILL,
-            "color": LAMIN_GREEN_DARKER,
+            "fillcolor": Colors.GREEN_FILL,
+            "color": Colors.GREEN_DARKER,
             "fontname": "Helvetica",
             "fontsize": "10",
         },
@@ -231,7 +231,7 @@ def view_lineage(
         f"{data._meta.model_name}_{data.uid}",
         label=data_label,
         style="rounded,filled",
-        fillcolor=LAMIN_GREEN_LIGHTER,
+        fillcolor=Colors.GREEN_LIGHTER,
         shape="box",
     )
 
@@ -304,8 +304,8 @@ def view_parents(
     u = graphviz.Digraph(
         record.uid,
         node_attr={
-            "color": LAMIN_GREEN_DARKER,
-            "fillcolor": GREEN_FILL,
+            "color": Colors.GREEN_DARKER,
+            "fillcolor": Colors.GREEN_FILL,
             "shape": "box",
             "style": "rounded,filled",
             "fontname": "Helvetica",
@@ -320,7 +320,7 @@ def view_parents(
             if record.__class__.__name__ == "Transform"
             else _add_emoji(record, record_label)
         ),
-        fillcolor=LAMIN_GREEN_LIGHTER,
+        fillcolor=Colors.GREEN_LIGHTER,
     )
     if df_edges is not None:
         for _, row in df_edges.iterrows():


### PR DESCRIPTION
Fixes

- https://github.com/laminlabs/lamindb/issues/2662
- https://github.com/laminlabs/pfizer-lamin-usage/issues/202
- https://github.com/laminlabs/lamindb/issues/2276

This PR

- Introduces a new `constants.py` module where we defined constants that we use across the repository. We start with Colors.
- Defines our standard color scheme based on existing graphics. I took the hex code from our circle graphic but am happy to change the hexcode if our hub team has a different ones.
- The main color is green, the first highlight color is orange and the second highlight color is blue.
- Adds `.space` and `kind` to the output
- Reorders the output of General slightly.
- Removes many `"dim"` as I found them to be confusing. I don't have the strongest opinion on this. Just let me know.


| Before | After |
| ------ | ----- |
| ![Before error message](https://github.com/user-attachments/assets/35c8f8ab-7471-4337-8ee9-424516f240f1) | ![After error message](https://github.com/user-attachments/assets/d55392d5-f3e4-4635-bf37-f0416e0f86f8) |

