### PR TITLE
🐛 Fix schema transfer

### DIFF
--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -856,7 +856,7 @@ class Schema(DBRecord, CanCurate, TracksRun):
         """Save."""
         from .save import bulk_create
 
-        if not self._state.adding:
+        if self.pk is not None:
             features = (
                 self._features[1]
                 if hasattr(self, "_features")


### PR DESCRIPTION
Credits go to @Koncopd and @falexwolf 

- fixes a case where the to-be-transferred record likely has `state record._state.adding` is False and so the Schema management thinks it’s an already-existing record and it tries to re-calculate the hash. But in fact it’s a new record.

More context: https://laminlabs.slack.com/archives/C046F63LJJ2/p1747141050444589?thread_ts=1743600829.515319&cid=C046F63LJJ2