### PR TITLE
🚸 Clearer error in `parse_cat_dtype` if cat dtype contains a module name and the module is not found

### DIFF
--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -119,8 +119,17 @@ def parse_cat_dtype(
         if "." in registry_str:
             registry_str_split = registry_str.split(".")
             assert len(registry_str_split) == 2, registry_str  # noqa: S101
-            module_name, class_name = registry_str_split
-            module_name = get_schema_module_name(module_name)
+            module_name_attempt, class_name = registry_str_split
+            module_name = get_schema_module_name(
+                module_name_attempt, raise_import_error=False
+            )
+            if module_name is None:
+                raise ImportError(
+                    f"Can not parse dtype {dtype_str} because {module_name_attempt} "
+                    f"was not found.\nInstall the module with `pip install {module_name_attempt}`\n"
+                    "and also add the module to this instance via instance settings page "
+                    "under 'schema modules'."
+                )
         else:
             module_name, class_name = "lamindb", registry_str
         module = importlib.import_module(module_name)


### PR DESCRIPTION
If dtype is `cat[bionty.CellType]`, for example, and `bionty` is not installed, a very obscure import error appears.

See also https://laminlabs.slack.com/archives/C07H7FQT9DH/p1747150860447589?thread_ts=1747148431.902579&cid=C07H7FQT9DH