### PR TITLE
♻️ Rename `DBRecord` to `SQLRecord`

### DIFF
--- a/docs/faq/delete.ipynb
+++ b/docs/faq/delete.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# How to delete records?\n",
     "\n",
-    "DBRecords can be deleted with `record.delete()`, which will **permanently remove** them from your database.\n",
+    "SQLRecords can be deleted with `record.delete()`, which will **permanently remove** them from your database.\n",
     "\n",
     "When it comes to **records of `Artifact` and `Collection`**, they are **\"moved into trash\"** when you first call `record.delete()`.\n",
     "\n",

--- a/docs/faq/idempotency.ipynb
+++ b/docs/faq/idempotency.ipynb
@@ -17,9 +17,9 @@
    "source": [
     "LaminDB's operations are idempotent in the sense defined here, which allows you to re-run code without duplicating data.\n",
     "\n",
-    ":::{admonition} DBRecords with `name` field\n",
+    ":::{admonition} SQLRecords with `name` field\n",
     "\n",
-    "When you instantiate {class}`~lamindb.models.DBRecord` with a name, in case a name has an _exact match_ in a registry, the constructor returns it instead of creating a new record. In case records with _similar names_ exist, you'll see them in a table: you can then decide whether you want to save the new record or pick an existing record.\n",
+    "When you instantiate {class}`~lamindb.models.SQLRecord` with a name, in case a name has an _exact match_ in a registry, the constructor returns it instead of creating a new record. In case records with _similar names_ exist, you'll see them in a table: you can then decide whether you want to save the new record or pick an existing record.\n",
     "\n",
     "If you set {attr}`~lamindb.core.subsettings.CreationSettings.search_names` to `False`, you bypass these checks.\n",
     "\n",
@@ -69,7 +69,7 @@
    "id": "4",
    "metadata": {},
    "source": [
-    "## DBRecords with name field"
+    "## SQLRecords with name field"
    ]
   },
   {

--- a/docs/faq/search.ipynb
+++ b/docs/faq/search.ipynb
@@ -30,7 +30,7 @@
    "id": "2",
    "metadata": {},
    "source": [
-    "Here we show how to perform text search on `DBRecord` and evaluate some search queries for the {class}`bionty.CellType` ontology."
+    "Here we show how to perform text search on `SQLRecord` and evaluate some search queries for the {class}`bionty.CellType` ontology."
    ]
   },
   {

--- a/docs/registries.ipynb
+++ b/docs/registries.ipynb
@@ -271,7 +271,7 @@
    "id": "23",
    "metadata": {},
    "source": [
-    "{class}`~lamindb.models.DBRecord.get` errors if more than one matching records are found."
+    "{class}`~lamindb.models.SQLRecord.get` errors if more than one matching records are found."
    ]
   },
   {
@@ -347,7 +347,7 @@
    "source": [
     "```{note}\n",
     "\n",
-    "{meth}`~lamindb.models.DBRecord.filter` returns a {class}`~lamindb.models.QuerySet`.\n",
+    "{meth}`~lamindb.models.SQLRecord.filter` returns a {class}`~lamindb.models.QuerySet`.\n",
     "\n",
     "The registries in LaminDB are Django Models and any [Django query](https://docs.djangoproject.com/en/stable/topics/db/queries/) works.\n",
     "\n",
@@ -450,7 +450,7 @@
    "id": "39",
    "metadata": {},
    "source": [
-    "You can search every registry via {meth}`~lamindb.models.DBRecord.search`. For example, the `Artifact` registry."
+    "You can search every registry via {meth}`~lamindb.models.SQLRecord.search`. For example, the `Artifact` registry."
    ]
   },
   {

--- a/lamindb/_view.py
+++ b/lamindb/_view.py
@@ -9,7 +9,7 @@ from lamin_utils import colors, logger
 from lamindb_setup import settings
 from lamindb_setup._init_instance import get_schema_module_name
 
-from lamindb.models import DBRecord, Feature, FeatureValue, ParamValue
+from lamindb.models import Feature, FeatureValue, ParamValue, SQLRecord
 
 from .models.feature import serialize_pandas_dtype
 
@@ -106,7 +106,7 @@ def view(
         limit: Display the latest `n` records
         modules: schema module to view. Default's to
             `None` and displays all registry modules.
-        registries: List of DBRecord names. Defaults to
+        registries: List of SQLRecord names. Defaults to
             `None` and lists all registries.
 
     Examples:
@@ -142,8 +142,8 @@ def view(
             registry
             for registry in schema_module.__dict__.values()
             if inspect.isclass(registry)
-            and issubclass(registry, DBRecord)
-            and registry is not DBRecord
+            and issubclass(registry, SQLRecord)
+            and registry is not SQLRecord
         }
         if module_name == "core":
             all_registries.update({FeatureValue, ParamValue})

--- a/lamindb/core/_settings.py
+++ b/lamindb/core/_settings.py
@@ -45,7 +45,7 @@ class Settings:
 
     @property
     def creation(self) -> CreationSettings:
-        """DBRecord creation settings.
+        """SQLRecord creation settings.
 
         For example, `ln.settings.creation.search_names = False` will disable
         searching for records with similar names during creation.

--- a/lamindb/core/writelog/_db_metadata_wrapper.py
+++ b/lamindb/core/writelog/_db_metadata_wrapper.py
@@ -40,7 +40,7 @@ class DatabaseMetadataWrapper(ABC):
         tables: set[str] = set()
 
         for model in all_models:
-            # DBRecord the model's underlying table, as well as
+            # SQLRecord the model's underlying table, as well as
             # the underlying table for all of its many-to-many
             # relationships
             tables.add(model._meta.db_table)

--- a/lamindb/curators/_cellxgene_schemas/__init__.py
+++ b/lamindb/curators/_cellxgene_schemas/__init__.py
@@ -3,7 +3,7 @@ from lamin_utils import logger
 from lamindb_setup.core.upath import UPath
 
 from lamindb.base.types import FieldAttr
-from lamindb.models import DBRecord, ULabel
+from lamindb.models import SQLRecord, ULabel
 from lamindb.models._from_values import _format_values
 
 RESERVED_NAMES = {
@@ -92,11 +92,11 @@ def _add_defaults_to_obs(obs: pd.DataFrame, defaults: dict[str, str]) -> None:
 
 def _create_sources(
     categoricals: dict[str, FieldAttr], schema_version: str, organism: str
-) -> dict[str, DBRecord]:
+) -> dict[str, SQLRecord]:
     """Creates a sources dictionary that can be passed to AnnDataCatManager."""
     import bionty as bt
 
-    def _fetch_bionty_source(entity: str, organism: str) -> DBRecord | None:  # type: ignore
+    def _fetch_bionty_source(entity: str, organism: str) -> SQLRecord | None:  # type: ignore
         """Fetch the Bionty source of the pinned ontology."""
         entity_sources = sources_df.loc[(sources_df.entity == entity)].copy()
         if not entity_sources.empty:

--- a/lamindb/curators/_legacy.py
+++ b/lamindb/curators/_legacy.py
@@ -24,12 +24,12 @@ if TYPE_CHECKING:
     from mudata import MuData
     from spatialdata import SpatialData
 
-    from lamindb.models import DBRecord
+    from lamindb.models import SQLRecord
 from lamindb.base.types import FieldAttr  # noqa
 from lamindb.models import (
     Artifact,
     Feature,
-    DBRecord,
+    SQLRecord,
     Run,
     Schema,
 )
@@ -192,7 +192,7 @@ class DataFrameCatManager(CatManager):
         columns_field: FieldAttr = Feature.name,
         columns_names: Iterable[str] | None = None,
         categoricals: dict[str, FieldAttr] | None = None,
-        sources: dict[str, DBRecord] | None = None,
+        sources: dict[str, SQLRecord] | None = None,
         index: Feature | None = None,
     ) -> None:
         self._non_validated = None
@@ -331,7 +331,7 @@ class AnnDataCatManager(CatManager):
         var_index: FieldAttr | None = None,
         categoricals: dict[str, FieldAttr] | None = None,
         obs_columns: FieldAttr = Feature.name,
-        sources: dict[str, DBRecord] | None = None,
+        sources: dict[str, SQLRecord] | None = None,
     ) -> None:
         if isinstance(var_index, str):
             raise TypeError(
@@ -473,7 +473,7 @@ class MuDataCatManager(CatManager):
         mdata: MuData | Artifact,
         var_index: dict[str, FieldAttr] | None = None,
         categoricals: dict[str, FieldAttr] | None = None,
-        sources: dict[str, DBRecord] | None = None,
+        sources: dict[str, SQLRecord] | None = None,
     ) -> None:
         super().__init__(
             dataset=mdata,
@@ -665,7 +665,7 @@ class SpatialDataCatManager(CatManager):
         sdata: Any,
         var_index: dict[str, FieldAttr],
         categoricals: dict[str, dict[str, FieldAttr]] | None = None,
-        sources: dict[str, dict[str, DBRecord]] | None = None,
+        sources: dict[str, dict[str, SQLRecord]] | None = None,
         *,
         sample_metadata_key: str | None = "sample",
     ) -> None:
@@ -937,7 +937,7 @@ class TiledbsomaCatManager(CatManager):
         var_index: dict[str, tuple[str, FieldAttr]],
         categoricals: dict[str, FieldAttr] | None = None,
         obs_columns: FieldAttr = Feature.name,
-        sources: dict[str, DBRecord] | None = None,
+        sources: dict[str, SQLRecord] | None = None,
     ):
         self._obs_fields = categoricals or {}
         self._var_fields = var_index
@@ -1342,7 +1342,7 @@ class CellxGeneAnnDataCatManager(AnnDataCatManager):
         *,
         schema_version: Literal["4.0.0", "5.0.0", "5.1.0", "5.2.0"] = "5.2.0",
         defaults: dict[str, str] = None,
-        extra_sources: dict[str, DBRecord] = None,
+        extra_sources: dict[str, SQLRecord] = None,
     ) -> None:
         """CELLxGENE schema curator.
 
@@ -1972,7 +1972,7 @@ def from_anndata(
     categoricals: dict[str, FieldAttr] | None = None,
     obs_columns: FieldAttr = Feature.name,
     organism: str | None = None,
-    sources: dict[str, DBRecord] | None = None,
+    sources: dict[str, SQLRecord] | None = None,
 ) -> AnnDataCatManager:
     if organism is not None:
         logger.warning("organism is ignored, define it on the dtype level")
@@ -2012,7 +2012,7 @@ def from_tiledbsoma(
     categoricals: dict[str, FieldAttr] | None = None,
     obs_columns: FieldAttr = Feature.name,
     organism: str | None = None,
-    sources: dict[str, DBRecord] | None = None,
+    sources: dict[str, SQLRecord] | None = None,
 ) -> TiledbsomaCatManager:
     if organism is not None:
         logger.warning("organism is ignored, define it on the dtype level")
@@ -2032,7 +2032,7 @@ def from_spatialdata(
     var_index: dict[str, FieldAttr],
     categoricals: dict[str, dict[str, FieldAttr]] | None = None,
     organism: str | None = None,
-    sources: dict[str, dict[str, DBRecord]] | None = None,
+    sources: dict[str, dict[str, SQLRecord]] | None = None,
     *,
     sample_metadata_key: str = "sample",
 ):

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -27,10 +27,10 @@ from lamindb_setup.core._docs import doc_args
 from lamindb.base.types import FieldAttr  # noqa
 from lamindb.models import (
     Artifact,
-    DBRecord,
     Feature,
     Run,
     Schema,
+    SQLRecord,
 )
 from lamindb.models._from_values import _format_values
 from lamindb.models.artifact import (
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
     from mudata import MuData
     from spatialdata import SpatialData
 
-    from lamindb.models.query_set import DBRecordList
+    from lamindb.models.query_set import SQLRecordList
 
 
 def strip_ansi_codes(text):
@@ -79,7 +79,7 @@ class CatLookup:
         categoricals: list[Feature] | dict[str, FieldAttr],
         slots: dict[str, FieldAttr] = None,
         public: bool = False,
-        sources: dict[str, DBRecord] | None = None,
+        sources: dict[str, SQLRecord] | None = None,
     ) -> None:
         slots = slots or {}
         if isinstance(categoricals, list):
@@ -861,7 +861,7 @@ class CatVector:
         field: FieldAttr,  # The field to validate against.
         key: str,  # The name of the vector to validate. Only used for logging.
         values_setter: Callable | None = None,  # A callable that sets the values.
-        source: DBRecord | None = None,  # The ontology source to validate against.
+        source: SQLRecord | None = None,  # The ontology source to validate against.
         feature: Feature | None = None,
         cat_manager: DataFrameCatManager | None = None,
         subtype_str: str = "",
@@ -1042,7 +1042,7 @@ class CatVector:
 
         registry = self._field.field.model
         field_name = self._field.field.name
-        non_validated_records: DBRecordList[Any] = []  # type: ignore
+        non_validated_records: SQLRecordList[Any] = []  # type: ignore
         if df is not None and registry == Feature:
             nonval_columns = Feature.inspect(df.columns, mute=True).non_validated
             non_validated_records = Feature.from_df(df.loc[:, nonval_columns])
@@ -1206,7 +1206,7 @@ class DataFrameCatManager:
         columns_field: FieldAttr = Feature.name,
         columns_names: Iterable[str] | None = None,
         categoricals: list[Feature] | None = None,
-        sources: dict[str, DBRecord] | None = None,
+        sources: dict[str, SQLRecord] | None = None,
         index: Feature | None = None,
         slot: str | None = None,
         maximal_set: bool = False,
@@ -1374,20 +1374,20 @@ class DataFrameCatManager:
             self._cat_vectors[key].add_new(**kwargs)
 
 
-def get_current_filter_kwargs(registry: type[DBRecord], kwargs: dict) -> dict:
+def get_current_filter_kwargs(registry: type[SQLRecord], kwargs: dict) -> dict:
     """Make sure the source and organism are saved in the same database as the registry."""
     db = registry.filter().db
     source = kwargs.get("source")
     organism = kwargs.get("organism")
     filter_kwargs = kwargs.copy()
 
-    if isinstance(organism, DBRecord) and organism._state.db != "default":
+    if isinstance(organism, SQLRecord) and organism._state.db != "default":
         if db is None or db == "default":
             organism_default = copy.copy(organism)
             # save the organism record in the default database
             organism_default.save()
             filter_kwargs["organism"] = organism_default
-    if isinstance(source, DBRecord) and source._state.db != "default":
+    if isinstance(source, SQLRecord) and source._state.db != "default":
         if db is None or db == "default":
             source_default = copy.copy(source)
             # save the source record in the default database

--- a/lamindb/errors.py
+++ b/lamindb/errors.py
@@ -10,7 +10,7 @@
    MissingContextUID
    UpdateContext
    IntegrityError
-   DBRecordNameChangeIntegrityError
+   SQLRecordNameChangeIntegrityError
 
 """
 
@@ -57,7 +57,7 @@ class InconsistentKey(Exception):
     pass
 
 
-class DBRecordNameChangeIntegrityError(Exception):
+class SQLRecordNameChangeIntegrityError(Exception):
     """Custom exception for name change errors."""
 
     pass

--- a/lamindb/migrations/0071_lamindbv1_migrate_schema.py
+++ b/lamindb/migrations/0071_lamindbv1_migrate_schema.py
@@ -326,7 +326,7 @@ class Migration(migrations.Migration):
                 WHERE dtype = 'number'
             """
         ),
-        # an aux field on DBRecord
+        # an aux field on SQLRecord
         migrations.AddField(
             model_name="artifact",
             name="aux",
@@ -670,7 +670,7 @@ class Migration(migrations.Migration):
             old_name="n_objects",
             new_name="n_files",
         ),
-        # let feature value and paramvalue inherit from DBRecord
+        # let feature value and paramvalue inherit from SQLRecord
         migrations.AddField(
             model_name="featurevalue",
             name="_branch_code",

--- a/lamindb/migrations/0073_merge_ourprojects.py
+++ b/lamindb/migrations/0073_merge_ourprojects.py
@@ -173,7 +173,7 @@ def migrate_data(apps, schema_editor):
             )
         else:
             cursor.execute("ROLLBACK")
-            raise Exception("Migration failed: DBRecord count mismatch")
+            raise Exception("Migration failed: SQLRecord count mismatch")
 
     except Exception as e:
         cursor.execute("ROLLBACK")

--- a/lamindb/migrations/0090_runproject_project_runs.py
+++ b/lamindb/migrations/0090_runproject_project_runs.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 
 import lamindb.base.fields
 import lamindb.base.users
-import lamindb.models.dbrecord
+import lamindb.models.sqlrecord
 
 
 class Migration(migrations.Migration):
@@ -61,7 +61,7 @@ class Migration(migrations.Migration):
             options={
                 "unique_together": {("run", "project")},
             },
-            bases=(models.Model, lamindb.models.dbrecord.IsLink),
+            bases=(models.Model, lamindb.models.sqlrecord.IsLink),
         ),
         migrations.AddField(
             model_name="project",

--- a/lamindb/migrations/0095_remove_rundata_flextable.py
+++ b/lamindb/migrations/0095_remove_rundata_flextable.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 
 import lamindb.base.fields
 import lamindb.base.users
-import lamindb.models.dbrecord
+import lamindb.models.sqlrecord
 
 
 class Migration(migrations.Migration):
@@ -60,7 +60,7 @@ class Migration(migrations.Migration):
             options={
                 "unique_together": {("run", "featurevalue")},
             },
-            bases=(models.Model, lamindb.models.dbrecord.IsLink),
+            bases=(models.Model, lamindb.models.sqlrecord.IsLink),
         ),
         migrations.AddField(
             model_name="run",

--- a/lamindb/migrations/0097_squashed.py
+++ b/lamindb/migrations/0097_squashed.py
@@ -9,9 +9,9 @@ import lamindb.base.fields
 import lamindb.base.uids
 import lamindb.base.users
 import lamindb.models.can_curate
-import lamindb.models.dbrecord
 import lamindb.models.has_parents
 import lamindb.models.run
+import lamindb.models.sqlrecord
 
 
 class Migration(migrations.Migration):
@@ -222,7 +222,7 @@ class Migration(migrations.Migration):
             bases=(
                 lamindb.models.can_curate.CanCurate,
                 models.Model,
-                lamindb.models.dbrecord.ValidateFields,
+                lamindb.models.sqlrecord.ValidateFields,
             ),
         ),
         migrations.CreateModel(
@@ -688,7 +688,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            bases=(lamindb.models.dbrecord.IsLink, models.Model),
+            bases=(lamindb.models.sqlrecord.IsLink, models.Model),
         ),
         migrations.AddField(
             model_name="collection",
@@ -722,7 +722,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            bases=(lamindb.models.dbrecord.IsLink, models.Model),
+            bases=(lamindb.models.sqlrecord.IsLink, models.Model),
         ),
         migrations.CreateModel(
             name="CollectionReference",
@@ -747,7 +747,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            bases=(lamindb.models.dbrecord.IsLink, models.Model),
+            bases=(lamindb.models.sqlrecord.IsLink, models.Model),
         ),
         migrations.CreateModel(
             name="Feature",
@@ -925,7 +925,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            bases=(lamindb.models.dbrecord.IsLink, models.Model),
+            bases=(lamindb.models.sqlrecord.IsLink, models.Model),
         ),
         migrations.CreateModel(
             name="ArtifactProject",
@@ -973,7 +973,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            bases=(lamindb.models.dbrecord.IsLink, models.Model),
+            bases=(lamindb.models.sqlrecord.IsLink, models.Model),
         ),
         migrations.CreateModel(
             name="FeatureProject",
@@ -998,7 +998,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            bases=(lamindb.models.dbrecord.IsLink, models.Model),
+            bases=(lamindb.models.sqlrecord.IsLink, models.Model),
         ),
         migrations.CreateModel(
             name="FeatureValue",
@@ -1091,7 +1091,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            bases=(lamindb.models.dbrecord.IsLink, models.Model),
+            bases=(lamindb.models.sqlrecord.IsLink, models.Model),
         ),
         migrations.AddField(
             model_name="artifact",
@@ -1131,7 +1131,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            bases=(lamindb.models.dbrecord.IsLink, models.Model),
+            bases=(lamindb.models.sqlrecord.IsLink, models.Model),
         ),
         migrations.CreateModel(
             name="Project",
@@ -1274,7 +1274,7 @@ class Migration(migrations.Migration):
             bases=(
                 lamindb.models.can_curate.CanCurate,
                 models.Model,
-                lamindb.models.dbrecord.ValidateFields,
+                lamindb.models.sqlrecord.ValidateFields,
             ),
         ),
         migrations.AddField(
@@ -1462,7 +1462,7 @@ class Migration(migrations.Migration):
             bases=(
                 lamindb.models.can_curate.CanCurate,
                 models.Model,
-                lamindb.models.dbrecord.ValidateFields,
+                lamindb.models.sqlrecord.ValidateFields,
             ),
         ),
         migrations.AddField(
@@ -1881,7 +1881,7 @@ class Migration(migrations.Migration):
             options={
                 "unique_together": {("run", "featurevalue")},
             },
-            bases=(models.Model, lamindb.models.dbrecord.IsLink),
+            bases=(models.Model, lamindb.models.sqlrecord.IsLink),
         ),
         migrations.AddField(
             model_name="run",
@@ -1938,7 +1938,7 @@ class Migration(migrations.Migration):
             options={
                 "unique_together": {("run", "project")},
             },
-            bases=(models.Model, lamindb.models.dbrecord.IsLink),
+            bases=(models.Model, lamindb.models.sqlrecord.IsLink),
         ),
         migrations.AddField(
             model_name="project",
@@ -2199,7 +2199,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            bases=(lamindb.models.dbrecord.IsLink, models.Model),
+            bases=(lamindb.models.sqlrecord.IsLink, models.Model),
         ),
         migrations.AddField(
             model_name="artifact",
@@ -2288,7 +2288,7 @@ class Migration(migrations.Migration):
                     ("composite", "slot", "component"),
                 },
             },
-            bases=(lamindb.models.dbrecord.IsLink, models.Model),
+            bases=(lamindb.models.sqlrecord.IsLink, models.Model),
         ),
         migrations.AddField(
             model_name="schema",
@@ -2325,7 +2325,7 @@ class Migration(migrations.Migration):
             options={
                 "unique_together": {("schema", "feature")},
             },
-            bases=(models.Model, lamindb.models.dbrecord.IsLink),
+            bases=(models.Model, lamindb.models.sqlrecord.IsLink),
         ),
         migrations.AddField(
             model_name="feature",
@@ -2393,7 +2393,7 @@ class Migration(migrations.Migration):
             options={
                 "unique_together": {("schema", "project")},
             },
-            bases=(lamindb.models.dbrecord.IsLink, models.Model),
+            bases=(lamindb.models.sqlrecord.IsLink, models.Model),
         ),
         migrations.AddField(
             model_name="project",
@@ -2859,7 +2859,7 @@ class Migration(migrations.Migration):
             options={
                 "unique_together": {("transform", "project")},
             },
-            bases=(lamindb.models.dbrecord.IsLink, models.Model),
+            bases=(lamindb.models.sqlrecord.IsLink, models.Model),
         ),
         migrations.AddField(
             model_name="project",
@@ -2927,7 +2927,7 @@ class Migration(migrations.Migration):
             options={
                 "unique_together": {("transform", "reference")},
             },
-            bases=(lamindb.models.dbrecord.IsLink, models.Model),
+            bases=(lamindb.models.sqlrecord.IsLink, models.Model),
         ),
         migrations.AddField(
             model_name="reference",
@@ -3138,7 +3138,7 @@ class Migration(migrations.Migration):
             options={
                 "unique_together": {("transform", "ulabel")},
             },
-            bases=(lamindb.models.dbrecord.IsLink, models.Model),
+            bases=(lamindb.models.sqlrecord.IsLink, models.Model),
         ),
         migrations.AddField(
             model_name="transform",
@@ -3194,7 +3194,7 @@ class Migration(migrations.Migration):
             options={
                 "unique_together": {("run", "ulabel")},
             },
-            bases=(models.Model, lamindb.models.dbrecord.IsLink),
+            bases=(models.Model, lamindb.models.sqlrecord.IsLink),
         ),
         migrations.AddField(
             model_name="run",
@@ -3280,7 +3280,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            bases=(lamindb.models.dbrecord.IsLink, models.Model),
+            bases=(lamindb.models.sqlrecord.IsLink, models.Model),
         ),
         migrations.AddField(
             model_name="collection",
@@ -3368,7 +3368,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
             ],
-            bases=(lamindb.models.dbrecord.IsLink, models.Model),
+            bases=(lamindb.models.sqlrecord.IsLink, models.Model),
         ),
         migrations.AddField(
             model_name="artifact",
@@ -3436,7 +3436,7 @@ class Migration(migrations.Migration):
             options={
                 "unique_together": {("ulabel", "project")},
             },
-            bases=(lamindb.models.dbrecord.IsLink, models.Model),
+            bases=(lamindb.models.sqlrecord.IsLink, models.Model),
         ),
         migrations.AddField(
             model_name="project",

--- a/lamindb/migrations/0098_alter_feature_type_alter_project_type_and_more.py
+++ b/lamindb/migrations/0098_alter_feature_type_alter_project_type_and_more.py
@@ -8,8 +8,8 @@ import lamindb.base.fields
 import lamindb.base.uids
 import lamindb.base.users
 import lamindb.models.can_curate
-import lamindb.models.dbrecord
 import lamindb.models.run
+import lamindb.models.sqlrecord
 
 
 class Migration(migrations.Migration):
@@ -221,7 +221,7 @@ class Migration(migrations.Migration):
             options={
                 "unique_together": {("record", "feature", "value")},
             },
-            bases=(models.Model, lamindb.models.dbrecord.IsLink),
+            bases=(models.Model, lamindb.models.sqlrecord.IsLink),
         ),
         migrations.AddField(
             model_name="record",
@@ -267,7 +267,7 @@ class Migration(migrations.Migration):
             options={
                 "unique_together": {("record", "feature")},
             },
-            bases=(models.Model, lamindb.models.dbrecord.IsLink),
+            bases=(models.Model, lamindb.models.sqlrecord.IsLink),
         ),
         migrations.AddField(
             model_name="project",
@@ -333,7 +333,7 @@ class Migration(migrations.Migration):
             options={
                 "unique_together": {("record", "feature")},
             },
-            bases=(models.Model, lamindb.models.dbrecord.IsLink),
+            bases=(models.Model, lamindb.models.sqlrecord.IsLink),
         ),
         migrations.AddField(
             model_name="record",
@@ -379,7 +379,7 @@ class Migration(migrations.Migration):
             options={
                 "unique_together": {("record", "feature")},
             },
-            bases=(models.Model, lamindb.models.dbrecord.IsLink),
+            bases=(models.Model, lamindb.models.sqlrecord.IsLink),
         ),
         migrations.AddField(
             model_name="record",
@@ -423,7 +423,7 @@ class Migration(migrations.Migration):
             options={
                 "unique_together": {("record", "feature")},
             },
-            bases=(models.Model, lamindb.models.dbrecord.IsLink),
+            bases=(models.Model, lamindb.models.sqlrecord.IsLink),
         ),
         migrations.AddField(
             model_name="record",
@@ -608,7 +608,7 @@ class Migration(migrations.Migration):
             options={
                 "unique_together": {("sheet", "project")},
             },
-            bases=(lamindb.models.dbrecord.IsLink, models.Model),
+            bases=(lamindb.models.sqlrecord.IsLink, models.Model),
         ),
         migrations.AddField(
             model_name="project",
@@ -651,6 +651,6 @@ class Migration(migrations.Migration):
             options={
                 "unique_together": {("record", "feature")},
             },
-            bases=(models.Model, lamindb.models.dbrecord.IsLink),
+            bases=(models.Model, lamindb.models.sqlrecord.IsLink),
         ),
     ]

--- a/lamindb/models/__init__.py
+++ b/lamindb/models/__init__.py
@@ -3,14 +3,14 @@
 .. autosummary::
    :toctree: .
 
-   BaseDBRecord
-   DBRecord
+   BaseSQLRecord
+   SQLRecord
    Registry
    BasicQuerySet
    QuerySet
    ArtifactSet
    QueryManager
-   DBRecordList
+   SQLRecordList
    FeatureManager
    LabelManager
    IsVersioned
@@ -29,9 +29,9 @@
 from lamin_utils._inspect import InspectResult
 from ._is_versioned import IsVersioned
 from .can_curate import CanCurate
-from .dbrecord import (
-    BaseDBRecord,
-    DBRecord,
+from .sqlrecord import (
+    BaseSQLRecord,
+    SQLRecord,
     Registry,
     Space,
     ValidateFields,
@@ -53,7 +53,7 @@ from ._label_manager import LabelManager
 from .collection import Collection, CollectionArtifact
 from .project import Person, Project, Reference
 from .query_manager import QueryManager
-from .query_set import BasicQuerySet, QuerySet, DBRecordList
+from .query_set import BasicQuerySet, QuerySet, SQLRecordList
 from .artifact_set import ArtifactSet
 from .has_parents import HasParents
 from datetime import datetime as _datetime
@@ -73,7 +73,7 @@ from .project import (
     CollectionReference,
     SheetProject,
 )
-from .dbrecord import Migration
+from .sqlrecord import Migration
 from .run import RunFeatureValue
 from .schema import (
     SchemaFeature,
@@ -100,4 +100,4 @@ ParamValue = FeatureValue  # backward compat
 ArtifactParamValue = ArtifactFeatureValue  # backward compat
 RunParamValue = RunFeatureValue  # backward compat
 Param = Feature  # backward compat
-BasicRecord = BaseDBRecord  # backward compat
+BasicRecord = BaseSQLRecord  # backward compat

--- a/lamindb/models/_django.py
+++ b/lamindb/models/_django.py
@@ -15,7 +15,7 @@ from .schema import Schema
 
 if TYPE_CHECKING:
     from .artifact import Artifact
-    from .dbrecord import DBRecord
+    from .sqlrecord import SQLRecord
 
 
 def patch_many_to_many_descriptor() -> None:
@@ -59,7 +59,7 @@ def get_related_model(model, field_name):
 
 
 def get_artifact_with_related(
-    artifact: DBRecord,
+    artifact: SQLRecord,
     include_fk: bool = False,
     include_m2m: bool = False,
     include_feature_link: bool = False,

--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -23,18 +23,18 @@ from rich.text import Text
 from lamindb.core.storage import LocalPathClasses
 from lamindb.errors import DoesNotExist, ValidationError
 from lamindb.models._from_values import _format_values
-from lamindb.models.dbrecord import (
-    REGISTRY_UNIQUE_FIELD,
-    get_name_field,
-    transfer_fk_to_default_db_bulk,
-    transfer_to_default_db,
-)
 from lamindb.models.feature import (
     serialize_pandas_dtype,
     suggest_categorical_for_str_iterable,
 )
 from lamindb.models.save import save
 from lamindb.models.schema import DICT_KEYS_TYPE, Schema
+from lamindb.models.sqlrecord import (
+    REGISTRY_UNIQUE_FIELD,
+    get_name_field,
+    transfer_fk_to_default_db_bulk,
+    transfer_to_default_db,
+)
 
 from ..base import deprecated
 from ._describe import (
@@ -49,9 +49,9 @@ from ._label_manager import _get_labels, describe_labels
 from ._relations import (
     dict_related_model_to_related_name,
 )
-from .dbrecord import DBRecord
 from .feature import Feature, FeatureValue, parse_dtype
 from .run import FeatureManager, FeatureManagerRun, Run
+from .sqlrecord import SQLRecord
 from .ulabel import ULabel
 
 if TYPE_CHECKING:
@@ -556,13 +556,13 @@ def infer_feature_type_convert_json(
                     return "list[float]", value, message
                 elif first_element_type is str:
                     return ("list[cat ? str]", value, message)
-                elif first_element_type == DBRecord:
+                elif first_element_type == SQLRecord:
                     return (
                         f"list[cat[{first_element_type.__get_name_with_module__()}]]",
                         value,
                         message,
                     )
-    elif isinstance(value, DBRecord):
+    elif isinstance(value, SQLRecord):
         return (f"cat[{value.__class__.__get_name_with_module__()}]", value, message)
     if not mute:
         logger.warning(f"cannot infer feature type of: {value}, returning '?")
@@ -653,7 +653,7 @@ def filter_base(cls, _skip_validation: bool = True, **expression) -> QuerySet:
             expression = {feature_param: feature, f"value{comparator}": value}
             feature_values = value_model.filter(**expression)
             new_expression[f"_{feature_param}_values__id__in"] = feature_values
-        elif isinstance(value, (str, DBRecord, bool)):
+        elif isinstance(value, (str, SQLRecord, bool)):
             if comparator == "__isnull":
                 if cls == FeatureManager:
                     result = parse_dtype(feature.dtype)[0]
@@ -681,7 +681,7 @@ def filter_base(cls, _skip_validation: bool = True, **expression) -> QuerySet:
                         )
                     elif len(labels) == 1:
                         label = labels[0]
-                elif isinstance(value, DBRecord):
+                elif isinstance(value, SQLRecord):
                     label = value
                 label_registry = (
                     label.__class__ if label is not None else labels[0].__class__
@@ -720,7 +720,7 @@ def filter(cls, **expression) -> QuerySet:
 
 @classmethod  # type: ignore
 @deprecated("the filter() registry classmethod")
-def get(cls, **expression) -> DBRecord:
+def get(cls, **expression) -> SQLRecord:
     """Query a single artifact by feature."""
     return filter_base(cls, _skip_validation=False, **expression).one()
 
@@ -860,7 +860,9 @@ def _add_values(
                 )
         elif feature.dtype.startswith("cat"):
             if inferred_type != "?":
-                if not (inferred_type.startswith("cat") or isinstance(value, DBRecord)):
+                if not (
+                    inferred_type.startswith("cat") or isinstance(value, SQLRecord)
+                ):
                     raise TypeError(
                         f"Value for feature '{feature.name}' with type '{feature.dtype}' must be a string or record."
                     )
@@ -875,10 +877,10 @@ def _add_values(
             feature_value, _ = value_model.get_or_create(**filter_kwargs)
             _feature_values.append(feature_value)
         else:
-            if isinstance(value, DBRecord) or (
-                isinstance(value, Iterable) and isinstance(next(iter(value)), DBRecord)
+            if isinstance(value, SQLRecord) or (
+                isinstance(value, Iterable) and isinstance(next(iter(value)), SQLRecord)
             ):
-                if isinstance(value, DBRecord):
+                if isinstance(value, SQLRecord):
                     label_records = [value]
                 else:
                     label_records = value  # type: ignore
@@ -1011,7 +1013,7 @@ def remove_values(
     if feature.dtype.startswith("cat["):  # type: ignore
         feature_registry = feature.dtype.replace("cat[", "").replace("]", "")  # type: ignore
         if value is not None:
-            assert isinstance(value, DBRecord)  # noqa: S101
+            assert isinstance(value, SQLRecord)  # noqa: S101
             # the below uses our convention for field names in link models
             link_name = (
                 feature_registry.split(".")[1]
@@ -1211,7 +1213,7 @@ def parse_staged_feature_sets_from_anndata(
     obs_field: FieldAttr = Feature.name,
     uns_field: FieldAttr | None = None,
     mute: bool = False,
-    organism: str | DBRecord | None = None,
+    organism: str | SQLRecord | None = None,
 ) -> dict:
     data_parse = adata
     if not isinstance(adata, AnnData):  # is a path
@@ -1285,7 +1287,7 @@ def _add_set_from_anndata(
     obs_field: FieldAttr | None = Feature.name,
     uns_field: FieldAttr | None = None,
     mute: bool = False,
-    organism: str | DBRecord | None = None,
+    organism: str | SQLRecord | None = None,
 ):
     """Add features from AnnData."""
     assert self._host.otype == "AnnData"  # noqa: S101
@@ -1311,7 +1313,7 @@ def _add_set_from_mudata(
     var_fields: dict[str, FieldAttr] | None = None,
     obs_fields: dict[str, FieldAttr] | None = None,
     mute: bool = False,
-    organism: str | DBRecord | None = None,
+    organism: str | SQLRecord | None = None,
 ):
     """Add features from MuData."""
     if obs_fields is None:
@@ -1348,7 +1350,7 @@ def _add_set_from_spatialdata(
     var_fields: dict[str, FieldAttr] | None = None,
     obs_fields: dict[str, FieldAttr] | None = None,
     mute: bool = False,
-    organism: str | DBRecord | None = None,
+    organism: str | SQLRecord | None = None,
 ):
     """Add features from SpatialData."""
     obs_fields, var_fields = obs_fields or {}, var_fields or {}

--- a/lamindb/models/_from_values.py
+++ b/lamindb/models/_from_values.py
@@ -8,8 +8,8 @@ from lamin_utils import colors, logger
 if TYPE_CHECKING:
     from lamindb.base.types import FieldAttr, ListLike
 
-    from .dbrecord import DBRecord
-    from .query_set import DBRecordList
+    from .query_set import SQLRecordList
+    from .sqlrecord import SQLRecord
 
 
 # The base function for `from_values`
@@ -18,12 +18,12 @@ def _from_values(
     field: FieldAttr,
     *,
     create: bool = False,
-    organism: DBRecord | str | None = None,
-    source: DBRecord | None = None,
+    organism: SQLRecord | str | None = None,
+    source: SQLRecord | None = None,
     mute: bool = False,
-) -> DBRecordList:
+) -> SQLRecordList:
     """Get or create records from iterables."""
-    from .query_set import DBRecordList
+    from .query_set import SQLRecordList
 
     registry = field.field.model  # type: ignore
     organism_record = get_organism_record_from_field(field, organism, values=iterable)
@@ -32,7 +32,7 @@ def _from_values(
         create_kwargs = {}
         if organism_record:
             create_kwargs["organism"] = organism_record
-        return DBRecordList(
+        return SQLRecordList(
             [
                 registry(**{field.field.name: value}, **create_kwargs)
                 for value in iterable
@@ -89,13 +89,13 @@ def _from_values(
                     f"{colors.red('did not create')} {registry.__name__} record{s} for "
                     f"{n_nonval} {colors.italic(f'{field.field.name}{s}')}: {print_values}"  # type: ignore
                 )
-    return DBRecordList(records)
+    return SQLRecordList(records)
 
 
 def get_existing_records(
     iterable_idx: pd.Index,
     field: FieldAttr,
-    organism: DBRecord | None = None,
+    organism: SQLRecord | None = None,
     mute: bool = False,
 ) -> tuple[list, pd.Index, str]:
     """Get existing records from the database."""
@@ -177,8 +177,8 @@ def get_existing_records(
 def create_records_from_source(
     iterable_idx: pd.Index,
     field: FieldAttr,
-    organism: DBRecord | None = None,
-    source: DBRecord | None = None,
+    organism: SQLRecord | None = None,
+    source: SQLRecord | None = None,
     msg: str = "",
     mute: bool = False,
 ) -> tuple[list, pd.Index]:
@@ -341,10 +341,10 @@ def _bulk_create_dicts_from_df(
 
 def get_organism_record_from_field(  # type: ignore
     field: FieldAttr,
-    organism: str | DBRecord | None = None,
+    organism: str | SQLRecord | None = None,
     values: ListLike = None,
     using_key: str | None = None,
-) -> DBRecord | None:
+) -> SQLRecord | None:
     """Get organism record.
 
     Args:

--- a/lamindb/models/_label_manager.py
+++ b/lamindb/models/_label_manager.py
@@ -11,13 +11,13 @@ from rich.tree import Tree
 
 from lamindb.models import CanCurate, Feature
 from lamindb.models._from_values import _format_values
-from lamindb.models.dbrecord import (
+from lamindb.models.save import save
+from lamindb.models.sqlrecord import (
     REGISTRY_UNIQUE_FIELD,
     get_name_field,
     transfer_fk_to_default_db_bulk,
     transfer_to_default_db,
 )
-from lamindb.models.save import save
 
 from ._describe import (
     NAME_WIDTH,
@@ -30,7 +30,7 @@ from ._django import get_artifact_with_related, get_related_model
 from ._relations import dict_related_model_to_related_name
 
 if TYPE_CHECKING:
-    from lamindb.models import Artifact, Collection, DBRecord
+    from lamindb.models import Artifact, Collection, SQLRecord
     from lamindb.models.query_set import QuerySet
 
 # we do not want to show records because this is a breaking change until all instances are migrated
@@ -195,7 +195,7 @@ class LabelManager:
 
     def add(
         self,
-        records: DBRecord | list[DBRecord] | QuerySet,
+        records: SQLRecord | list[SQLRecord] | QuerySet,
         feature: Feature | None = None,
     ) -> None:
         """Add one or several labels and associate them with a feature.
@@ -310,7 +310,7 @@ class LabelManager:
                         *feature_labels, through_defaults={"feature_id": feature_id}
                     )
 
-    def make_external(self, label: DBRecord) -> None:
+    def make_external(self, label: SQLRecord) -> None:
         """Make a label external, aka dissociate label from internal features.
 
         Args:

--- a/lamindb/models/_relations.py
+++ b/lamindb/models/_relations.py
@@ -10,10 +10,10 @@ from lamindb_setup._connect_instance import (
 )
 from lamindb_setup.core._settings_store import instance_settings_file
 
-from lamindb.models.dbrecord import IsLink
+from lamindb.models.sqlrecord import IsLink
 
 if TYPE_CHECKING:
-    from lamindb.models.dbrecord import DBRecord, Registry
+    from lamindb.models.sqlrecord import Registry, SQLRecord
 
 
 def get_schema_modules(instance: str | None) -> set[str]:
@@ -64,9 +64,9 @@ def dict_module_name_to_model_name(
 
 
 def dict_related_model_to_related_name(
-    registry: type[DBRecord], links: bool = False, instance: str | None = None
+    registry: type[SQLRecord], links: bool = False, instance: str | None = None
 ) -> dict[str, str]:
-    def include(model: DBRecord):
+    def include(model: SQLRecord):
         return not links != issubclass(model, IsLink)
 
     schema_modules = get_schema_modules(instance)
@@ -88,7 +88,7 @@ def dict_related_model_to_related_name(
     return d
 
 
-def get_related_name(features_type: type[DBRecord]) -> str:
+def get_related_name(features_type: type[SQLRecord]) -> str:
     from lamindb.models.schema import Schema
 
     candidates = [
@@ -100,7 +100,7 @@ def get_related_name(features_type: type[DBRecord]) -> str:
         raise ValueError(
             f"Can't create feature sets from {features_type.__name__} because it's not"
             " related to it!\nYou need to create a link model between Schema and"
-            " your DBRecord in your custom module.\nTo do so, add a"
+            " your SQLRecord in your custom module.\nTo do so, add a"
             " line:\n_feature_sets = models.ManyToMany(Schema,"
             " related_name='mythings')\n"
         )

--- a/lamindb/models/can_curate.py
+++ b/lamindb/models/can_curate.py
@@ -14,19 +14,19 @@ from ._from_values import (
     _from_values,
     get_organism_record_from_field,
 )
-from .dbrecord import DBRecord, get_name_field
+from .sqlrecord import SQLRecord, get_name_field
 
 if TYPE_CHECKING:
     from lamin_utils._inspect import InspectResult
 
     from lamindb.base.types import ListLike, StrField
 
-    from .query_set import DBRecordList
+    from .query_set import SQLRecordList
 
 
-def _check_if_record_in_db(record: str | DBRecord | None, using_key: str | None):
+def _check_if_record_in_db(record: str | SQLRecord | None, using_key: str | None):
     """Check if the record is from the using_key DB."""
-    if isinstance(record, DBRecord):
+    if isinstance(record, SQLRecord):
         if using_key is not None and using_key != "default":
             if record._state.db != using_key:
                 raise ValueError(
@@ -55,8 +55,8 @@ def _inspect(
     field: StrField | None = None,
     *,
     mute: bool = False,
-    organism: str | DBRecord | None = None,
-    source: DBRecord | None = None,
+    organism: str | SQLRecord | None = None,
+    source: SQLRecord | None = None,
     from_source: bool = True,
     strict_source: bool = False,
 ) -> pd.DataFrame | dict[str, list[str]]:
@@ -69,7 +69,7 @@ def _inspect(
     queryset = cls.all() if isinstance(cls, (QuerySet, Manager)) else cls.objects.all()
     registry = queryset.model
     model_name = registry._meta.model.__name__
-    if isinstance(source, DBRecord):
+    if isinstance(source, SQLRecord):
         _check_if_record_in_db(source, queryset.db)
         # if strict_source mode, restrict the query to the passed ontology source
         # otherwise, inspect across records present in the DB from all ontology sources and no-source
@@ -158,8 +158,8 @@ def _validate(
     field: StrField | None = None,
     *,
     mute: bool = False,
-    organism: str | DBRecord | None = None,
-    source: DBRecord | None = None,
+    organism: str | SQLRecord | None = None,
+    source: SQLRecord | None = None,
     strict_source: bool = False,
 ) -> np.ndarray:
     """{}"""  # noqa: D415
@@ -172,7 +172,7 @@ def _validate(
 
     queryset = cls.all() if isinstance(cls, (QuerySet, Manager)) else cls.objects.all()
     registry = queryset.model
-    if isinstance(source, DBRecord):
+    if isinstance(source, SQLRecord):
         _check_if_record_in_db(source, queryset.db)
         if strict_source:
             queryset = queryset.filter(source=source)
@@ -224,8 +224,8 @@ def _standardize(
     source_aware: bool = True,
     keep: Literal["first", "last", False] = "first",
     synonyms_field: str = "synonyms",
-    organism: str | DBRecord | None = None,
-    source: DBRecord | None = None,
+    organism: str | SQLRecord | None = None,
+    source: SQLRecord | None = None,
     strict_source: bool = False,
 ) -> list[str] | dict[str, str]:
     """{}"""  # noqa: D415
@@ -240,7 +240,7 @@ def _standardize(
     )
     queryset = cls.all() if isinstance(cls, (QuerySet, Manager)) else cls.objects.all()
     registry = queryset.model
-    if isinstance(source, DBRecord):
+    if isinstance(source, SQLRecord):
         _check_if_record_in_db(source, queryset.db)
         if strict_source:
             queryset = queryset.filter(source=source)
@@ -431,7 +431,7 @@ def _check_synonyms_field_exist(record: CanCurate):
 
 def _filter_queryset_with_organism(
     queryset: QuerySet,
-    organism: DBRecord | None = None,
+    organism: SQLRecord | None = None,
     values_list_field: str | None = None,
     values_list_fields: list[str] | None = None,
 ):
@@ -453,7 +453,7 @@ def _filter_queryset_with_organism(
 
 
 class CanCurate:
-    """Base class providing :class:`~lamindb.models.DBRecord`-based validation."""
+    """Base class providing :class:`~lamindb.models.SQLRecord`-based validation."""
 
     @classmethod
     def inspect(
@@ -462,8 +462,8 @@ class CanCurate:
         field: StrField | None = None,
         *,
         mute: bool = False,
-        organism: Union[str, DBRecord, None] = None,
-        source: DBRecord | None = None,
+        organism: Union[str, SQLRecord, None] = None,
+        source: SQLRecord | None = None,
         from_source: bool = True,
         strict_source: bool = False,
     ) -> InspectResult:
@@ -518,8 +518,8 @@ class CanCurate:
         field: StrField | None = None,
         *,
         mute: bool = False,
-        organism: Union[str, DBRecord, None] = None,
-        source: DBRecord | None = None,
+        organism: Union[str, SQLRecord, None] = None,
+        source: SQLRecord | None = None,
         strict_source: bool = False,
     ) -> np.ndarray:
         """Validate values against existing values of a string field.
@@ -571,16 +571,16 @@ class CanCurate:
         values: ListLike,
         field: StrField | None = None,
         create: bool = False,
-        organism: Union[DBRecord, str, None] = None,
-        source: DBRecord | None = None,
+        organism: Union[SQLRecord, str, None] = None,
+        source: SQLRecord | None = None,
         mute: bool = False,
-    ) -> DBRecordList:
+    ) -> SQLRecordList:
         """Bulk create validated records by parsing values for an identifier such as a name or an id).
 
         Args:
             values: A list of values for an identifier, e.g.
                 `["name1", "name2"]`.
-            field: A `DBRecord` field to look up, e.g., `bt.CellMarker.name`.
+            field: A `SQLRecord` field to look up, e.g., `bt.CellMarker.name`.
             create: Whether to create records if they don't exist.
             organism: A `bionty.Organism` name or record.
             source: A `bionty.Source` record to validate against to create records for.
@@ -629,8 +629,8 @@ class CanCurate:
         source_aware: bool = True,
         keep: Literal["first", "last", False] = "first",
         synonyms_field: str = "synonyms",
-        organism: Union[str, DBRecord, None] = None,
-        source: DBRecord | None = None,
+        organism: Union[str, SQLRecord, None] = None,
+        source: SQLRecord | None = None,
         strict_source: bool = False,
     ) -> list[str] | dict[str, str]:
         """Maps input synonyms to standardized names.

--- a/lamindb/models/collection.py
+++ b/lamindb/models/collection.py
@@ -36,16 +36,16 @@ from .artifact import (
     get_run,
     save_schema_links,
 )
-from .dbrecord import (
-    BaseDBRecord,
-    DBRecord,
+from .has_parents import view_lineage
+from .run import Run, TracksRun, TracksUpdates
+from .sqlrecord import (
+    BaseSQLRecord,
     IsLink,
+    SQLRecord,
     _get_record_kwargs,
     init_self_from_db,
     update_attributes,
 )
-from .has_parents import view_lineage
-from .run import Run, TracksRun, TracksUpdates
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -128,7 +128,7 @@ def _load_concat_artifacts(
     return concat_object
 
 
-class Collection(DBRecord, IsVersioned, TracksRun, TracksUpdates):
+class Collection(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
     """Collections of artifacts.
 
     Collections provide a simple way of versioning collections of artifacts.
@@ -158,7 +158,7 @@ class Collection(DBRecord, IsVersioned, TracksRun, TracksUpdates):
 
     """
 
-    class Meta(DBRecord.Meta, IsVersioned.Meta, TracksRun.Meta, TracksUpdates.Meta):
+    class Meta(SQLRecord.Meta, IsVersioned.Meta, TracksRun.Meta, TracksUpdates.Meta):
         abstract = False
 
     _len_full_uid: int = 20
@@ -368,7 +368,7 @@ class Collection(DBRecord, IsVersioned, TracksRun, TracksUpdates):
             :exc:`docs:lamindb.errors.DoesNotExist`: In case no matching record is found.
 
         See Also:
-            - Method in `DBRecord` base class: :meth:`~lamindb.models.DBRecord.get`
+            - Method in `SQLRecord` base class: :meth:`~lamindb.models.SQLRecord.get`
 
         Examples:
 
@@ -723,7 +723,7 @@ def from_artifacts(artifacts: Iterable[Artifact]) -> tuple[str, dict[str, str]]:
     return hash
 
 
-class CollectionArtifact(BaseDBRecord, IsLink, TracksRun):
+class CollectionArtifact(BaseSQLRecord, IsLink, TracksRun):
     id: int = models.BigAutoField(primary_key=True)
     collection: Collection = ForeignKey(
         Collection, CASCADE, related_name="links_artifact"

--- a/lamindb/models/core.py
+++ b/lamindb/models/core.py
@@ -12,8 +12,8 @@ from lamindb.base.fields import (
 )
 
 from ..base.ids import base62_12
-from .dbrecord import DBRecord
 from .run import TracksRun, TracksUpdates
+from .sqlrecord import SQLRecord
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from .artifact import Artifact
 
 
-class Storage(DBRecord, TracksRun, TracksUpdates):
+class Storage(SQLRecord, TracksRun, TracksUpdates):
     """Storage locations of artifacts such as S3 buckets or local directories.
 
     A storage location is either a directory/folder (local or in the cloud) or
@@ -68,7 +68,7 @@ class Storage(DBRecord, TracksRun, TracksUpdates):
         >>> ln.settings.storage = "./storage_2" # or a cloud bucket
     """
 
-    class Meta(DBRecord.Meta, TracksRun.Meta, TracksUpdates.Meta):
+    class Meta(SQLRecord.Meta, TracksRun.Meta, TracksUpdates.Meta):
         abstract = False
 
     _name_field: str = "root"

--- a/lamindb/models/has_parents.py
+++ b/lamindb/models/has_parents.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, Literal
 import lamindb_setup as ln_setup
 from lamin_utils import logger
 
-from .dbrecord import format_field_value, get_name_field
 from .run import Run
+from .sqlrecord import format_field_value, get_name_field
 
 if TYPE_CHECKING:
     from graphviz import Digraph
@@ -17,8 +17,8 @@ if TYPE_CHECKING:
 
     from .artifact import Artifact
     from .collection import Collection
-    from .dbrecord import DBRecord
     from .query_set import QuerySet
+    from .sqlrecord import SQLRecord
     from .transform import Transform
 
 LAMIN_GREEN_LIGHTER = "#10b981"
@@ -38,7 +38,7 @@ is_run_from_ipython = getattr(builtins, "__IPYTHON__", False)
 # this is optimized to have fewer recursive calls
 # also len of QuerySet can be costly at times
 def _query_relatives(
-    records: QuerySet | list[DBRecord],
+    records: QuerySet | list[SQLRecord],
     kind: Literal["parents", "children"],
     cls: type[HasParents],
 ) -> QuerySet:
@@ -242,7 +242,7 @@ def view_lineage(
 
 
 def view_parents(
-    record: DBRecord,
+    record: SQLRecord,
     field: str,
     with_parents: bool = True,
     with_children: bool = False,
@@ -332,7 +332,7 @@ def view_parents(
 
 
 def _get_parents(
-    record: DBRecord,
+    record: SQLRecord,
     field: str,
     distance: int,
     children: bool = False,
@@ -368,7 +368,7 @@ def _get_parents(
 
 
 def _df_edges_from_parents(
-    record: DBRecord,
+    record: SQLRecord,
     field: str,
     distance: int,
     children: bool = False,
@@ -418,7 +418,7 @@ def _df_edges_from_parents(
     return df_edges
 
 
-def _record_label(record: DBRecord, field: str | None = None):
+def _record_label(record: SQLRecord, field: str | None = None):
     from .artifact import Artifact
     from .collection import Collection
     from .transform import Transform
@@ -471,7 +471,7 @@ def _record_label(record: DBRecord, field: str | None = None):
         )
 
 
-def _add_emoji(record: DBRecord, label: str):
+def _add_emoji(record: SQLRecord, label: str):
     if record.__class__.__name__ == "Transform":
         emoji = TRANSFORM_EMOJIS.get(record.type, "💫")
     elif record.__class__.__name__ == "Run":

--- a/lamindb/models/project.py
+++ b/lamindb/models/project.py
@@ -23,11 +23,11 @@ from ..base.ids import base62_8, base62_12
 from .artifact import Artifact
 from .can_curate import CanCurate
 from .collection import Collection
-from .dbrecord import BaseDBRecord, DBRecord, IsLink, ValidateFields
 from .feature import Feature
 from .record import Record, Sheet
 from .run import Run, TracksRun, TracksUpdates, User
 from .schema import Schema
+from .sqlrecord import BaseSQLRecord, IsLink, SQLRecord, ValidateFields
 from .transform import Transform
 from .ulabel import ULabel
 
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from datetime import datetime
 
 
-class Person(DBRecord, CanCurate, TracksRun, TracksUpdates, ValidateFields):
+class Person(SQLRecord, CanCurate, TracksRun, TracksUpdates, ValidateFields):
     """People such as authors of a study or collaborators in a project.
 
     This registry is distinct from `User` and exists for project management.
@@ -51,7 +51,7 @@ class Person(DBRecord, CanCurate, TracksRun, TracksUpdates, ValidateFields):
         ... ).save()
     """
 
-    class Meta(DBRecord.Meta, TracksRun.Meta, TracksUpdates.Meta):
+    class Meta(SQLRecord.Meta, TracksRun.Meta, TracksUpdates.Meta):
         abstract = False
 
     id: int = models.AutoField(primary_key=True)
@@ -85,7 +85,7 @@ class Person(DBRecord, CanCurate, TracksRun, TracksUpdates, ValidateFields):
         super().__init__(*args, **kwargs)
 
 
-class Reference(DBRecord, CanCurate, TracksRun, TracksUpdates, ValidateFields):
+class Reference(SQLRecord, CanCurate, TracksRun, TracksUpdates, ValidateFields):
     """References such as internal studies, papers, documents, or URLs.
 
     Example:
@@ -101,7 +101,7 @@ class Reference(DBRecord, CanCurate, TracksRun, TracksUpdates, ValidateFields):
         ... ).save()
     """
 
-    class Meta(DBRecord.Meta, TracksRun.Meta, TracksUpdates.Meta):
+    class Meta(SQLRecord.Meta, TracksRun.Meta, TracksUpdates.Meta):
         abstract = False
 
     id: int = models.AutoField(primary_key=True)
@@ -190,7 +190,7 @@ class Reference(DBRecord, CanCurate, TracksRun, TracksUpdates, ValidateFields):
         super().__init__(*args, **kwargs)
 
 
-class Project(DBRecord, CanCurate, TracksRun, TracksUpdates, ValidateFields):
+class Project(SQLRecord, CanCurate, TracksRun, TracksUpdates, ValidateFields):
     """Projects.
 
     Example:
@@ -201,7 +201,7 @@ class Project(DBRecord, CanCurate, TracksRun, TracksUpdates, ValidateFields):
         ... ).save()
     """
 
-    class Meta(DBRecord.Meta, TracksRun.Meta, TracksUpdates.Meta):
+    class Meta(SQLRecord.Meta, TracksRun.Meta, TracksUpdates.Meta):
         abstract = False
 
     id: int = models.AutoField(primary_key=True)
@@ -313,7 +313,7 @@ class Project(DBRecord, CanCurate, TracksRun, TracksUpdates, ValidateFields):
         super().__init__(*args, **kwargs)
 
 
-class ArtifactProject(BaseDBRecord, IsLink, TracksRun):
+class ArtifactProject(BaseSQLRecord, IsLink, TracksRun):
     id: int = models.BigAutoField(primary_key=True)
     artifact: Artifact = ForeignKey(Artifact, CASCADE, related_name="links_project")
     project: Project = ForeignKey(Project, PROTECT, related_name="links_artifact")
@@ -332,7 +332,7 @@ class ArtifactProject(BaseDBRecord, IsLink, TracksRun):
         unique_together = ("artifact", "project", "feature")
 
 
-class RunProject(BaseDBRecord, IsLink):
+class RunProject(BaseSQLRecord, IsLink):
     id: int = models.BigAutoField(primary_key=True)
     run: Run = ForeignKey(Run, CASCADE, related_name="links_project")
     project: Project = ForeignKey(Project, PROTECT, related_name="links_run")
@@ -353,7 +353,7 @@ class RunProject(BaseDBRecord, IsLink):
         unique_together = ("run", "project")
 
 
-class TransformProject(BaseDBRecord, IsLink, TracksRun):
+class TransformProject(BaseSQLRecord, IsLink, TracksRun):
     id: int = models.BigAutoField(primary_key=True)
     transform: Transform = ForeignKey(Transform, CASCADE, related_name="links_project")
     project: Project = ForeignKey(Project, PROTECT, related_name="links_transform")
@@ -362,7 +362,7 @@ class TransformProject(BaseDBRecord, IsLink, TracksRun):
         unique_together = ("transform", "project")
 
 
-class CollectionProject(BaseDBRecord, IsLink, TracksRun):
+class CollectionProject(BaseSQLRecord, IsLink, TracksRun):
     id: int = models.BigAutoField(primary_key=True)
     collection: Collection = ForeignKey(
         Collection, CASCADE, related_name="links_project"
@@ -373,7 +373,7 @@ class CollectionProject(BaseDBRecord, IsLink, TracksRun):
         unique_together = ("collection", "project")
 
 
-class ULabelProject(BaseDBRecord, IsLink, TracksRun):
+class ULabelProject(BaseSQLRecord, IsLink, TracksRun):
     id: int = models.BigAutoField(primary_key=True)
     ulabel: ULabel = ForeignKey(ULabel, CASCADE, related_name="links_project")
     project: Project = ForeignKey(Project, PROTECT, related_name="links_ulabel")
@@ -382,7 +382,7 @@ class ULabelProject(BaseDBRecord, IsLink, TracksRun):
         unique_together = ("ulabel", "project")
 
 
-class PersonProject(BaseDBRecord, IsLink, TracksRun):
+class PersonProject(BaseSQLRecord, IsLink, TracksRun):
     id: int = models.BigAutoField(primary_key=True)
     person: Person = ForeignKey(Person, CASCADE, related_name="links_project")
     project: Project = ForeignKey(Project, PROTECT, related_name="links_person")
@@ -392,7 +392,7 @@ class PersonProject(BaseDBRecord, IsLink, TracksRun):
         unique_together = ("person", "project")
 
 
-class FeatureProject(BaseDBRecord, IsLink, TracksRun):
+class FeatureProject(BaseSQLRecord, IsLink, TracksRun):
     id: int = models.BigAutoField(primary_key=True)
     feature: Feature = ForeignKey(Feature, CASCADE, related_name="links_project")
     project: Project = ForeignKey(Project, PROTECT, related_name="links_feature")
@@ -401,7 +401,7 @@ class FeatureProject(BaseDBRecord, IsLink, TracksRun):
         unique_together = ("feature", "project")
 
 
-class SchemaProject(BaseDBRecord, IsLink, TracksRun):
+class SchemaProject(BaseSQLRecord, IsLink, TracksRun):
     id: int = models.BigAutoField(primary_key=True)
     schema: Schema = ForeignKey(Schema, CASCADE, related_name="links_project")
     project: Project = ForeignKey(Project, PROTECT, related_name="links_schema")
@@ -410,7 +410,7 @@ class SchemaProject(BaseDBRecord, IsLink, TracksRun):
         unique_together = ("schema", "project")
 
 
-class RecordProject(BaseDBRecord, IsLink):
+class RecordProject(BaseSQLRecord, IsLink):
     id: int = models.BigAutoField(primary_key=True)
     record: Record = ForeignKey(Record, CASCADE, related_name="values_project")
     feature: Feature = ForeignKey(Feature, CASCADE, related_name="links_recordproject")
@@ -420,7 +420,7 @@ class RecordProject(BaseDBRecord, IsLink):
         unique_together = ("record", "feature")
 
 
-class SheetProject(BaseDBRecord, IsLink, TracksRun):
+class SheetProject(BaseSQLRecord, IsLink, TracksRun):
     id: int = models.BigAutoField(primary_key=True)
     sheet: Sheet = ForeignKey(Sheet, CASCADE, related_name="links_project")
     project: Project = ForeignKey(Project, PROTECT, related_name="links_sheet")
@@ -429,7 +429,7 @@ class SheetProject(BaseDBRecord, IsLink, TracksRun):
         unique_together = ("sheet", "project")
 
 
-class ArtifactReference(BaseDBRecord, IsLink, TracksRun):
+class ArtifactReference(BaseSQLRecord, IsLink, TracksRun):
     id: int = models.BigAutoField(primary_key=True)
     artifact: Artifact = ForeignKey(Artifact, CASCADE, related_name="links_reference")
     reference: Reference = ForeignKey(Reference, PROTECT, related_name="links_artifact")
@@ -448,7 +448,7 @@ class ArtifactReference(BaseDBRecord, IsLink, TracksRun):
         unique_together = ("artifact", "reference", "feature")
 
 
-class TransformReference(BaseDBRecord, IsLink, TracksRun):
+class TransformReference(BaseSQLRecord, IsLink, TracksRun):
     id: int = models.BigAutoField(primary_key=True)
     transform: Transform = ForeignKey(
         Transform, CASCADE, related_name="links_reference"
@@ -461,7 +461,7 @@ class TransformReference(BaseDBRecord, IsLink, TracksRun):
         unique_together = ("transform", "reference")
 
 
-class CollectionReference(BaseDBRecord, IsLink, TracksRun):
+class CollectionReference(BaseSQLRecord, IsLink, TracksRun):
     id: int = models.BigAutoField(primary_key=True)
     collection: Collection = ForeignKey(
         Collection, CASCADE, related_name="links_reference"

--- a/lamindb/models/query_manager.py
+++ b/lamindb/models/query_manager.py
@@ -53,8 +53,8 @@ def _search(
         If `return_queryset` is `True`.  `QuerySet`.
 
     See Also:
-        :meth:`~lamindb.models.DBRecord.filter`
-        :meth:`~lamindb.models.DBRecord.lookup`
+        :meth:`~lamindb.models.SQLRecord.filter`
+        :meth:`~lamindb.models.SQLRecord.lookup`
 
     Examples:
         >>> ulabels = ln.ULabel.from_values(["ULabel1", "ULabel2", "ULabel3"], field="name")
@@ -87,7 +87,7 @@ def _search(
                     fields.append(field.field.name)
                 except AttributeError as error:
                     raise TypeError(
-                        "Please pass a DBRecord string field, e.g., `CellType.name`!"
+                        "Please pass a SQLRecord string field, e.g., `CellType.name`!"
                     ) from error
             else:
                 fields.append(field)
@@ -185,7 +185,7 @@ def _lookup(
         dictionary converter.
 
     See Also:
-        :meth:`~lamindb.models.DBRecord.search`
+        :meth:`~lamindb.models.SQLRecord.search`
 
     Examples:
         >>> import bionty as bt
@@ -199,7 +199,7 @@ def _lookup(
         >>> genes.ensg00000002745
         >>> lookup_return_symbols = bt.Gene.lookup(field="ensembl_gene_id", return_field="symbol")
     """
-    from .dbrecord import get_name_field
+    from .sqlrecord import get_name_field
 
     queryset = cls.all() if isinstance(cls, (QuerySet, Manager)) else cls.objects.all()
     field = get_name_field(registry=queryset.model, field=field)

--- a/lamindb/models/query_set.py
+++ b/lamindb/models/query_set.py
@@ -18,8 +18,8 @@ from lamindb_setup.core._docs import doc_args
 from ..errors import DoesNotExist
 from ._is_versioned import IsVersioned
 from .can_curate import CanCurate, _inspect, _standardize, _validate
-from .dbrecord import DBRecord
 from .query_manager import _lookup, _search
+from .sqlrecord import SQLRecord
 
 if TYPE_CHECKING:
     from lamindb.base.types import ListLike, StrField
@@ -40,7 +40,7 @@ pd.set_option("display.max_columns", 200)
 #     return (series + timedelta).dt.strftime("%Y-%m-%d %H:%M:%S %Z")
 
 
-def get_keys_from_df(data: list, registry: DBRecord) -> list[str]:
+def get_keys_from_df(data: list, registry: SQLRecord) -> list[str]:
     if len(data) > 0:
         if isinstance(data[0], dict):
             keys = list(data[0].keys())
@@ -108,7 +108,7 @@ def get_backward_compat_filter_kwargs(queryset, expressions):
 
 def process_expressions(queryset: QuerySet, expressions: dict) -> dict:
     def _map_databases(value: Any, key: str, target_db: str) -> tuple[str, Any]:
-        if isinstance(value, DBRecord):
+        if isinstance(value, SQLRecord):
             if value._state.db != target_db:
                 logger.warning(
                     f"passing record from database {value._state.db} to query {target_db}, matching on uid '{value.uid}'"
@@ -121,12 +121,14 @@ def process_expressions(queryset: QuerySet, expressions: dict) -> dict:
             and isinstance(value, IterableType)
             and not isinstance(value, str)
         ):
-            if any(isinstance(v, DBRecord) and v._state.db != target_db for v in value):
+            if any(
+                isinstance(v, SQLRecord) and v._state.db != target_db for v in value
+            ):
                 logger.warning(
                     f"passing records from another database to query {target_db}, matching on uids"
                 )
                 return key.replace("__in", "__uid__in"), [
-                    v.uid if isinstance(v, DBRecord) else v for v in value
+                    v.uid if isinstance(v, SQLRecord) else v for v in value
                 ]
             return key, value
 
@@ -137,7 +139,7 @@ def process_expressions(queryset: QuerySet, expressions: dict) -> dict:
         expressions,
     )
 
-    if issubclass(queryset.model, DBRecord):
+    if issubclass(queryset.model, SQLRecord):
         # _branch_code is set to 0 unless expressions contains id or uid
         if not (
             "id" in expressions
@@ -166,10 +168,10 @@ def process_expressions(queryset: QuerySet, expressions: dict) -> dict:
 
 
 def get(
-    registry_or_queryset: Union[type[DBRecord], QuerySet],
+    registry_or_queryset: Union[type[SQLRecord], QuerySet],
     idlike: int | str | None = None,
     **expressions,
-) -> DBRecord:
+) -> SQLRecord:
     if isinstance(registry_or_queryset, QuerySet):
         qs = registry_or_queryset
         registry = qs.model
@@ -219,7 +221,7 @@ def get(
             raise registry.DoesNotExist from registry.DoesNotExist
 
 
-class DBRecordList(UserList, Generic[T]):
+class SQLRecordList(UserList, Generic[T]):
     """Is ordered, can't be queried, but has `.df()`."""
 
     def __init__(self, records: Iterable[T]):
@@ -242,7 +244,7 @@ class DBRecordList(UserList, Generic[T]):
         """Exactly one result. Throws error if there are more or none."""
         return one_helper(self)
 
-    def save(self) -> DBRecordList[T]:
+    def save(self) -> SQLRecordList[T]:
         """Save all records to the database."""
         from lamindb.models.save import save
 
@@ -359,7 +361,7 @@ def get_feature_annotate_kwargs(
 
 # https://claude.ai/share/16280046-6ae5-4f6a-99ac-dec01813dc3c
 def analyze_lookup_cardinality(
-    model_class: DBRecord, lookup_paths: list[str] | None
+    model_class: SQLRecord, lookup_paths: list[str] | None
 ) -> dict[str, str]:
     """Analyze lookup cardinality.
 
@@ -590,7 +592,7 @@ class BasicQuerySet(models.QuerySet):
             new_cls = cls
         return object.__new__(new_cls)
 
-    @doc_args(DBRecord.df.__doc__)
+    @doc_args(SQLRecord.df.__doc__)
     def df(
         self,
         include: str | list[str] | None = None,
@@ -670,7 +672,7 @@ class BasicQuerySet(models.QuerySet):
         else:
             super().delete(*args, **kwargs)
 
-    def list(self, field: str | None = None) -> list[DBRecord] | list[str]:
+    def list(self, field: str | None = None) -> list[SQLRecord] | list[str]:
         """Populate an (unordered) list with the results.
 
         Note that the order in this list is only meaningful if you ordered the underlying query set with `.order_by()`.
@@ -685,7 +687,7 @@ class BasicQuerySet(models.QuerySet):
             # list casting is necessary because values_list does not return a list
             return list(self.values_list(field, flat=True))
 
-    def first(self) -> DBRecord | None:
+    def first(self) -> SQLRecord | None:
         """If non-empty, the first result in the query set, otherwise ``None``.
 
         Examples:
@@ -695,11 +697,11 @@ class BasicQuerySet(models.QuerySet):
             return None
         return self[0]
 
-    def one(self) -> DBRecord:
+    def one(self) -> SQLRecord:
         """Exactly one result. Raises error if there are more or none."""
         return one_helper(self)
 
-    def one_or_none(self) -> DBRecord | None:
+    def one_or_none(self) -> SQLRecord | None:
         """At most one result. Returns it if there is one, otherwise returns ``None``.
 
         Examples:
@@ -718,7 +720,7 @@ class BasicQuerySet(models.QuerySet):
         if issubclass(self.model, IsVersioned):
             return self.filter(is_latest=True)
         else:
-            raise ValueError("DBRecord isn't subclass of `lamindb.core.IsVersioned`")
+            raise ValueError("SQLRecord isn't subclass of `lamindb.core.IsVersioned`")
 
     @doc_args(_search.__doc__)
     def search(self, string: str, **kwargs):
@@ -781,7 +783,7 @@ class QuerySet(BasicQuerySet):
             ) from None
         raise error  # pragma: no cover
 
-    def get(self, idlike: int | str | None = None, **expressions) -> DBRecord:
+    def get(self, idlike: int | str | None = None, **expressions) -> SQLRecord:
         """Query a single record. Raises error if there are more or none."""
         is_run_input = expressions.pop("is_run_input", False)
 

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -16,9 +16,9 @@ from lamindb.errors import FieldValidationError
 from ..base.ids import base62_12, base62_16
 from .artifact import Artifact
 from .can_curate import CanCurate
-from .dbrecord import BaseDBRecord, DBRecord, IsLink, _get_record_kwargs
 from .feature import Feature
 from .run import Run, TracksRun, TracksUpdates
+from .sqlrecord import BaseSQLRecord, IsLink, SQLRecord, _get_record_kwargs
 from .ulabel import ULabel
 
 if TYPE_CHECKING:
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from .schema import Schema
 
 
-class Record(DBRecord, CanCurate, TracksRun, TracksUpdates):
+class Record(SQLRecord, CanCurate, TracksRun, TracksUpdates):
     """Flexible records to register, e.g., samples, donors, cells, compounds, sequences.
 
     This is currently more convenient to use through the UI.
@@ -44,7 +44,7 @@ class Record(DBRecord, CanCurate, TracksRun, TracksUpdates):
             Feature manager for an artifact.
     """
 
-    class Meta(DBRecord.Meta, TracksRun.Meta, TracksUpdates.Meta):
+    class Meta(SQLRecord.Meta, TracksRun.Meta, TracksUpdates.Meta):
         abstract = False
 
     _name_field: str = "name"
@@ -149,10 +149,10 @@ class Record(DBRecord, CanCurate, TracksRun, TracksUpdates):
         )
 
 
-class Sheet(DBRecord, TracksRun, TracksUpdates):
+class Sheet(SQLRecord, TracksRun, TracksUpdates):
     """Sheets to group records."""
 
-    class Meta(DBRecord.Meta, TracksRun.Meta, TracksUpdates.Meta):
+    class Meta(SQLRecord.Meta, TracksRun.Meta, TracksUpdates.Meta):
         abstract = False
 
     id: int = models.AutoField(primary_key=True)
@@ -172,7 +172,7 @@ class Sheet(DBRecord, TracksRun, TracksUpdates):
     """Linked projects."""
 
 
-class RecordJson(BaseDBRecord, IsLink):
+class RecordJson(BaseSQLRecord, IsLink):
     id: int = models.BigAutoField(primary_key=True)
     record: Record = ForeignKey(Record, CASCADE, related_name="values_json")
     feature: Feature = ForeignKey(Feature, CASCADE, related_name="links_recordjson")
@@ -182,7 +182,7 @@ class RecordJson(BaseDBRecord, IsLink):
         unique_together = ("record", "feature")
 
 
-class RecordRecord(DBRecord, IsLink):
+class RecordRecord(SQLRecord, IsLink):
     id: int = models.BigAutoField(primary_key=True)
     record: Record = ForeignKey(
         Record, CASCADE, related_name="values_record"
@@ -196,7 +196,7 @@ class RecordRecord(DBRecord, IsLink):
         unique_together = ("record", "feature")
 
 
-class RecordULabel(BaseDBRecord, IsLink):
+class RecordULabel(BaseSQLRecord, IsLink):
     id: int = models.BigAutoField(primary_key=True)
     record: Record = ForeignKey(Record, CASCADE, related_name="values_ulabel")
     feature: Feature = ForeignKey(Feature, CASCADE, related_name="links_recordulabel")
@@ -207,7 +207,7 @@ class RecordULabel(BaseDBRecord, IsLink):
         unique_together = ("record", "feature")
 
 
-class RecordRun(BaseDBRecord, IsLink):
+class RecordRun(BaseSQLRecord, IsLink):
     id: int = models.BigAutoField(primary_key=True)
     record: Record = ForeignKey(Record, CASCADE, related_name="values_run")
     feature: Feature = ForeignKey(Feature, CASCADE, related_name="links_recordrun")
@@ -218,7 +218,7 @@ class RecordRun(BaseDBRecord, IsLink):
         unique_together = ("record", "feature")
 
 
-class RecordArtifact(BaseDBRecord, IsLink):
+class RecordArtifact(BaseSQLRecord, IsLink):
     id: int = models.BigAutoField(primary_key=True)
     record: Record = ForeignKey(Record, CASCADE, related_name="values_artifact")
     feature: Feature = ForeignKey(Feature, CASCADE, related_name="links_recordartifact")

--- a/lamindb/models/run.py
+++ b/lamindb/models/run.py
@@ -22,7 +22,7 @@ from lamindb.errors import InvalidArgument
 
 from ..base.ids import base62_20
 from .can_curate import CanCurate
-from .dbrecord import BaseDBRecord, DBRecord, IsLink
+from .sqlrecord import BaseSQLRecord, IsLink, SQLRecord
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -136,7 +136,7 @@ class TracksUpdates(models.Model):
         super().__init__(*args, **kwargs)
 
 
-class User(BaseDBRecord, CanCurate):
+class User(BaseSQLRecord, CanCurate):
     """Users.
 
     All data in this registry is synced from `lamin.ai` to ensure a universal
@@ -197,7 +197,7 @@ class User(BaseDBRecord, CanCurate):
         super().__init__(*args, **kwargs)
 
 
-class Run(DBRecord):
+class Run(SQLRecord):
     """Runs of transforms such as the execution of a script.
 
     A registry to store runs of transforms, such as an executation of a script.
@@ -472,7 +472,7 @@ def delete_run_artifacts(run: Run) -> None:
             report.delete(permanent=True)
 
 
-class RunFeatureValue(BaseDBRecord, IsLink):
+class RunFeatureValue(BaseSQLRecord, IsLink):
     id: int = models.BigAutoField(primary_key=True)
     run: Run = ForeignKey(Run, CASCADE, related_name="links_featurevalue")
     # we follow the lower() case convention rather than snake case for link models

--- a/lamindb/models/save.py
+++ b/lamindb/models/save.py
@@ -21,7 +21,7 @@ from ..core.storage.paths import (
     delete_storage_using_key,
     store_file_or_folder,
 )
-from .dbrecord import DBRecord
+from .sqlrecord import SQLRecord
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from .artifact import Artifact
 
 
-def save(records: Iterable[DBRecord], ignore_conflicts: bool | None = False) -> None:
+def save(records: Iterable[SQLRecord], ignore_conflicts: bool | None = False) -> None:
     """Bulk save records.
 
     Note:
@@ -42,7 +42,7 @@ def save(records: Iterable[DBRecord], ignore_conflicts: bool | None = False) -> 
         existing records! Use ``record.save()`` for these use cases.
 
     Args:
-        records: Multiple :class:`~lamindb.models.DBRecord` objects.
+        records: Multiple :class:`~lamindb.models.SQLRecord` objects.
         ignore_conflicts: If ``True``, do not error if some records violate a
            unique or another constraint. However, it won't inplace update the id
            fields of records. If you need records with ids, you need to query
@@ -69,7 +69,7 @@ def save(records: Iterable[DBRecord], ignore_conflicts: bool | None = False) -> 
     """
     from .artifact import Artifact
 
-    if isinstance(records, DBRecord):
+    if isinstance(records, SQLRecord):
         raise ValueError("Please use record.save() if saving a single record.")
 
     # previously, this was all set based,
@@ -107,7 +107,7 @@ def save(records: Iterable[DBRecord], ignore_conflicts: bool | None = False) -> 
     return None
 
 
-def bulk_create(records: Iterable[DBRecord], ignore_conflicts: bool | None = False):
+def bulk_create(records: Iterable[SQLRecord], ignore_conflicts: bool | None = False):
     records_by_orm = defaultdict(list)
     for record in records:
         records_by_orm[record.__class__].append(record)
@@ -116,7 +116,7 @@ def bulk_create(records: Iterable[DBRecord], ignore_conflicts: bool | None = Fal
         # records[:] = created  # In-place list update; does not seem to be necessary
 
 
-def bulk_update(records: Iterable[DBRecord], ignore_conflicts: bool | None = False):
+def bulk_update(records: Iterable[SQLRecord], ignore_conflicts: bool | None = False):
     records_by_orm = defaultdict(list)
     for record in records:
         records_by_orm[record.__class__].append(record)

--- a/lamindb/models/transform.py
+++ b/lamindb/models/transform.py
@@ -18,8 +18,8 @@ from lamindb.base.users import current_user_id
 
 from ..models._is_versioned import process_revises
 from ._is_versioned import IsVersioned
-from .dbrecord import DBRecord, init_self_from_db, update_attributes
 from .run import Run, User, delete_run_artifacts
+from .sqlrecord import SQLRecord, init_self_from_db, update_attributes
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 
 # does not inherit from TracksRun because the Transform
 # is needed to define a run
-class Transform(DBRecord, IsVersioned):
+class Transform(SQLRecord, IsVersioned):
     """Data transformations such as scripts, notebooks, functions, or pipelines.
 
     A "transform" can refer to a Python function, a script, a notebook, or a
@@ -93,7 +93,7 @@ class Transform(DBRecord, IsVersioned):
         >>> transform.view_lineage()
     """
 
-    class Meta(DBRecord.Meta, IsVersioned.Meta):
+    class Meta(SQLRecord.Meta, IsVersioned.Meta):
         abstract = False
 
     _len_stem_uid: int = 12

--- a/lamindb/models/ulabel.py
+++ b/lamindb/models/ulabel.py
@@ -16,10 +16,10 @@ from lamindb.errors import FieldValidationError
 
 from ..base.ids import base62_8
 from .can_curate import CanCurate
-from .dbrecord import BaseDBRecord, DBRecord, IsLink, _get_record_kwargs
 from .feature import Feature
 from .has_parents import HasParents
 from .run import Run, TracksRun, TracksUpdates, User, current_user_id
+from .sqlrecord import BaseSQLRecord, IsLink, SQLRecord, _get_record_kwargs
 from .transform import Transform
 
 if TYPE_CHECKING:
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from .project import Project
 
 
-class ULabel(DBRecord, HasParents, CanCurate, TracksRun, TracksUpdates):
+class ULabel(SQLRecord, HasParents, CanCurate, TracksRun, TracksUpdates):
     """Universal labels.
 
     Args:
@@ -87,7 +87,7 @@ class ULabel(DBRecord, HasParents, CanCurate, TracksRun, TracksUpdates):
         >>> ln.Artifact.filter(ulabels=train_split).df()
     """
 
-    class Meta(DBRecord.Meta, TracksRun.Meta, TracksUpdates.Meta):
+    class Meta(SQLRecord.Meta, TracksRun.Meta, TracksUpdates.Meta):
         abstract = False
 
     _name_field: str = "name"
@@ -203,7 +203,7 @@ class ULabel(DBRecord, HasParents, CanCurate, TracksRun, TracksUpdates):
         return self.instances
 
 
-class ArtifactULabel(BaseDBRecord, IsLink, TracksRun):
+class ArtifactULabel(BaseSQLRecord, IsLink, TracksRun):
     id: int = models.BigAutoField(primary_key=True)
     artifact: Artifact = ForeignKey("Artifact", CASCADE, related_name="links_ulabel")
     ulabel: ULabel = ForeignKey(ULabel, PROTECT, related_name="links_artifact")
@@ -219,7 +219,7 @@ class ArtifactULabel(BaseDBRecord, IsLink, TracksRun):
         unique_together = ("artifact", "ulabel", "feature")
 
 
-class TransformULabel(BaseDBRecord, IsLink, TracksRun):
+class TransformULabel(BaseSQLRecord, IsLink, TracksRun):
     id: int = models.BigAutoField(primary_key=True)
     transform: Transform = ForeignKey(Transform, CASCADE, related_name="links_ulabel")
     ulabel: ULabel = ForeignKey(ULabel, PROTECT, related_name="links_transform")
@@ -228,7 +228,7 @@ class TransformULabel(BaseDBRecord, IsLink, TracksRun):
         unique_together = ("transform", "ulabel")
 
 
-class RunULabel(BaseDBRecord, IsLink):
+class RunULabel(BaseSQLRecord, IsLink):
     id: int = models.BigAutoField(primary_key=True)
     run: Run = ForeignKey(Run, CASCADE, related_name="links_ulabel")
     ulabel: ULabel = ForeignKey(ULabel, PROTECT, related_name="links_run")
@@ -245,7 +245,7 @@ class RunULabel(BaseDBRecord, IsLink):
         unique_together = ("run", "ulabel")
 
 
-class CollectionULabel(BaseDBRecord, IsLink, TracksRun):
+class CollectionULabel(BaseSQLRecord, IsLink, TracksRun):
     id: int = models.BigAutoField(primary_key=True)
     collection: Collection = ForeignKey(
         "Collection", CASCADE, related_name="links_ulabel"

--- a/tests/core/test_data.py
+++ b/tests/core/test_data.py
@@ -4,7 +4,7 @@ import pytest
 
 def test_rename():
     import pandas as pd
-    from lamindb.errors import DBRecordNameChangeIntegrityError
+    from lamindb.errors import SQLRecordNameChangeIntegrityError
 
     df = pd.DataFrame(
         {
@@ -38,7 +38,7 @@ def test_rename():
 
     # rename label
     ulabel = ln.ULabel.get(name="label-to-rename")
-    with pytest.raises(DBRecordNameChangeIntegrityError):
+    with pytest.raises(SQLRecordNameChangeIntegrityError):
         ulabel.name = "label-renamed"
         ulabel.save()
 
@@ -51,7 +51,7 @@ def test_rename():
 
     # rename feature
     feature = ln.Feature.get(name="feature_to_rename")
-    with pytest.raises(DBRecordNameChangeIntegrityError):
+    with pytest.raises(SQLRecordNameChangeIntegrityError):
         feature.name = "feature_renamed"
         feature.save()
 

--- a/tests/core/test_feature.py
+++ b/tests/core/test_feature.py
@@ -32,7 +32,7 @@ def test_feature_init():
     # wrong type
     with pytest.raises(ValueError):
         ln.Feature(name="feat", dtype="x")
-    # type has to be a list of DBRecord types
+    # type has to be a list of SQLRecord types
     with pytest.raises(ValidationError):
         ln.Feature(name="feat", dtype="cat[1]")
     # ensure feat1 does not exist

--- a/tests/core/test_feature_label_manager.py
+++ b/tests/core/test_feature_label_manager.py
@@ -359,7 +359,7 @@ def test_labels_add(adata):
         artifact.labels.add("experiment_1", experiment)
     assert (
         error.exconly()
-        == "ValueError: Please pass a record (a `DBRecord` object), not a string, e.g.,"
+        == "ValueError: Please pass a record (a `SQLRecord` object), not a string, e.g.,"
         " via: label = ln.ULabel(name='experiment_1')"
     )
     with pytest.raises(ValidationError) as error:

--- a/tests/core/test_record.py
+++ b/tests/core/test_record.py
@@ -6,7 +6,7 @@ import bionty as bt
 import lamindb as ln
 import pytest
 from lamindb.errors import FieldValidationError
-from lamindb.models.dbrecord import (
+from lamindb.models.sqlrecord import (
     _get_record_kwargs,
     _search,
     get_name_field,
@@ -228,13 +228,13 @@ def test_get_record_kwargs():
 
 
 def test_get_record_kwargs_empty():
-    class EmptyDBRecord:
+    class EmptySQLRecord:
         pass
 
-    assert _get_record_kwargs(EmptyDBRecord) == []
+    assert _get_record_kwargs(EmptySQLRecord) == []
 
-    class NoInitDBRecord:
+    class NoInitSQLRecord:
         def method(self):
             pass
 
-    assert _get_record_kwargs(NoInitDBRecord) == []
+    assert _get_record_kwargs(NoInitSQLRecord) == []

--- a/tests/writelog/test_postgres_trigger_installer.py
+++ b/tests/writelog/test_postgres_trigger_installer.py
@@ -17,8 +17,8 @@ from lamindb.core.writelog._trigger_installer import (
 )
 from lamindb.core.writelog._types import TableUID, UIDColumns
 from lamindb.models.artifact import Artifact
-from lamindb.models.dbrecord import Space
 from lamindb.models.run import Run
+from lamindb.models.sqlrecord import Space
 from lamindb.models.transform import Transform
 from lamindb.models.writelog import (
     WriteLog,


### PR DESCRIPTION
An iteration to the change made here:

- https://github.com/laminlabs/lamindb/pull/2760

I think `SQLRecord` is more specific than `DBRecord` given how broadly we and users use the term "DB". A flexible `Record` is also a "database record", if you will.

The term `SQLRecord` conveys more clearly that we're referring to a single record on the SQL level (1:1 correspondence). A flexible `Record`, by contrast, is composed of many records on the SQL level.

Another nice aspect about the `SQLRecord` is that it's parallel to tiangolo's `SQLModel`. And that parallelism is correct because both are "classical" ORMs.