### PR TITLE
♻️ Do no longer duplicate tracking of predecessors through the corresponding link table on `Transform`

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -2831,10 +2831,6 @@ def _track_run_input(
                 for data_id in input_data_ids
             ]
         IsLink.objects.bulk_create(links, ignore_conflicts=True)
-        # generalize below for more than one data batch
-        if len(input_data) == 1:
-            if input_data[0].transform is not None:
-                run.transform.predecessors.add(input_data[0].transform)
 
 
 # privates currently dealt with separately

--- a/lamindb/models/transform.py
+++ b/lamindb/models/transform.py
@@ -318,7 +318,12 @@ class Transform(SQLRecord, IsVersioned):
         super().delete()
 
     def view_lineage(self, with_successors: bool = False, distance: int = 5):
-        """View lineage of transforms."""
+        """View lineage of transforms.
+
+        Note that this only accounts for manually defined predecessors and successors.
+
+        Auto-generate lineage through inputs and outputs of runs is not included.
+        """
         from .has_parents import view_parents
 
         return view_parents(


### PR DESCRIPTION
So far, we've added entries to `transform.predecessors` upon tracking them as run inputs. The rationale was to provide a more convenient query.

This was rarely used and led to confusion. It also prevents building a dedicated experience around "manually tracked transforms".