### PR TITLE
♻️ Support combined UID format for `lamindb_featurevalue` in `WriteLog`

### DIFF
--- a/lamindb/core/writelog/_db_metadata_wrapper.py
+++ b/lamindb/core/writelog/_db_metadata_wrapper.py
@@ -102,17 +102,39 @@ class DatabaseMetadataWrapper(ABC):
     def get_uid_columns(self, table: str, cursor: CursorWrapper) -> UIDColumns:
         """Get the UID columns for a given table."""
         if table == "lamindb_featurevalue":
-            # TODO: update this to feature uid + hash instead of value + created_at
-            # feature_id is a foreign key on the featurevalue table, so this should be easy
-            return [
-                TableUID(
-                    source_table_name=table,
-                    uid_columns=self._get_columns_by_name(
-                        table, ["value", "created_at"], cursor
-                    ),
-                    key_constraint=None,
-                )
-            ]
+            _, foreign_key_constraints = self.get_table_key_constraints(
+                table=table, cursor=cursor
+            )
+
+            for constraint in foreign_key_constraints:
+                if constraint.target_table == "lamindb_feature":
+                    feature_table_uid_columns = self.get_uid_columns(
+                        table=constraint.target_table, cursor=cursor
+                    )
+
+                    if len(feature_table_uid_columns) > 1:
+                        raise ValueError(
+                            "Expected 'lamindb_feature' to have a simple UID, but got a complex one"
+                        )
+
+                    feature_table_uid = deepcopy(feature_table_uid_columns[0])
+                    feature_table_uid.key_constraint = constraint
+
+                    return [
+                        feature_table_uid,
+                        TableUID(
+                            source_table_name=table,
+                            uid_columns=self._get_columns_by_name(
+                                table, ["hash"], cursor
+                            ),
+                            key_constraint=None,
+                        ),
+                    ]
+
+            raise ValueError(
+                "Expected lamindb_featurevalue to foreign-key to lamindb_feature, "
+                "but found no such foreign key constraint"
+            )
         else:
             column_names = self.get_column_names(table, cursor)
 
@@ -140,20 +162,20 @@ class DatabaseMetadataWrapper(ABC):
                 )
 
                 for constraint in foreign_key_constraints:
-                    constraint_uid_columns = self.get_uid_columns(
-                        table=constraint.target_table, cursor=cursor
-                    )
-
-                    if len(constraint_uid_columns) > 1:
+                    if constraint.target_table in self.get_many_to_many_db_tables():
                         raise ValueError(
                             "Many-to-many tables that reference other many-to-many tables aren't supported. "
                             f"'{table}' references '{constraint.target_table}', and both are many-to-many"
                         )
 
-                    table_uid_for_constraint = deepcopy(constraint_uid_columns[0])
-                    table_uid_for_constraint.key_constraint = constraint
+                    constraint_uid_columns = self.get_uid_columns(
+                        table=constraint.target_table, cursor=cursor
+                    )
 
-                    uid_columns.append(table_uid_for_constraint)
+                    for uid_column in constraint_uid_columns:
+                        table_uid_for_constraint = deepcopy(uid_column)
+                        table_uid_for_constraint.key_constraint = constraint
+                        uid_columns.append(table_uid_for_constraint)
 
                 return uid_columns
 

--- a/lamindb/core/writelog/_replayer.py
+++ b/lamindb/core/writelog/_replayer.py
@@ -17,7 +17,7 @@ from ._db_metadata_wrapper import DatabaseMetadataWrapper
 class WriteLogForeignKey:
     table_name: str
     foreign_key_columns: list[str]
-    foreign_uid: dict[str, str]
+    foreign_uid: dict[str, str | None]
 
 
 class WriteLogReplayer:
@@ -30,7 +30,7 @@ class WriteLogReplayer:
         self.cursor = cursor
 
     def replay(self, write_log_record: WriteLog):
-        table_name = write_log_record.table.table_name
+        table_name: str = write_log_record.table.table_name
 
         # If we're deleting the record, its (resolved) UID is the only thing we need
         if write_log_record.event_type == WriteLogEventTypes.DELETE.value:
@@ -59,30 +59,33 @@ class WriteLogReplayer:
                         record_column_names.append(column_name)
                         record_values.append(str(value))
                 else:
-                    uid_list = self.db_metadata.get_uid_columns(
-                        table=table_name, cursor=self.cursor
-                    )
-
-                    if len(uid_list) != 1:
-                        raise ValueError(
-                            f"Table {table_name} is not marked as many-to-many, but has "
-                            "more than one table reference in its UID"
+                    if table_name != "lamindb_featurevalue":
+                        uid_list = self.db_metadata.get_uid_columns(
+                            table=table_name, cursor=self.cursor
                         )
 
-                    record_uid = uid_list[0]
+                        if len(uid_list) != 1:
+                            raise ValueError(
+                                f"Table {table_name} is not marked as many-to-many, but has "
+                                "more than one table reference in its UID"
+                            )
 
-                    if len(record_uid.uid_columns) != len(write_log_record.record_uid):
-                        raise ValueError(
-                            f"Write log record {write_log_record.uid} expected to "
-                            f"have {len(record_uid.uid_columns)} components to its "
-                            "UID, but only had {len(write_log_record.record_uid)}"
-                        )
+                        record_uid = uid_list[0]
 
-                    for uid_column, value in zip(
-                        record_uid.uid_columns, write_log_record.record_uid
-                    ):
-                        record_column_names.append(uid_column.name)
-                        record_values.append(self._cast_column(uid_column, value))
+                        if len(record_uid.uid_columns) != len(
+                            write_log_record.record_uid
+                        ):
+                            raise ValueError(
+                                f"Write log record {write_log_record.uid} expected to "
+                                f"have {len(record_uid.uid_columns)} components to its "
+                                "UID, but only had {len(write_log_record.record_uid)}"
+                            )
+
+                        for uid_column, value in zip(
+                            record_uid.uid_columns, write_log_record.record_uid
+                        ):
+                            record_column_names.append(uid_column.name)
+                            record_values.append(self._cast_column(uid_column, value))
 
                 self.cursor.execute(f"""
                 INSERT INTO {table_name}
@@ -161,9 +164,29 @@ class WriteLogReplayer:
         else:
             raise ValueError(f"Unhandled type {column.type}")
 
-    def _resolve_uid(self, table_name: str, record_uid) -> dict[str, int]:
+    def _resolve_uid(self, table_name: str, record_uid) -> dict[str, int | None]:
         if table_name in self.db_metadata.get_many_to_many_db_tables():
             resolved_record_uid = self._resolve_foreign_keys_list(record_uid)
+        elif table_name == "lamindb_featurevalue":
+            self.cursor.execute(
+                """
+            SELECT V.id AS id
+            FROM lamindb_featurevalue V
+            LEFT OUTER JOIN lamindb_feature F ON (V.feature_id = F.id)
+            WHERE V.hash = %s AND F.uid = %s
+            LIMIT 1
+            """,
+                [record_uid[0], record_uid[1]],
+            )
+
+            record_id = self.cursor.fetchone()
+
+            if record_id is None:
+                raise ValueError(
+                    f"Could not find 'lamindb_featurevalue' record with uid {record_uid}"
+                )
+
+            return {"id": record_id[0]}
         else:
             table_uid_list = self.db_metadata.get_uid_columns(
                 table=table_name, cursor=self.cursor
@@ -249,7 +272,10 @@ class WriteLogReplayer:
                         )
 
                     record_data_tuples.append(
-                        (columns_by_name[foreign_key_column], str(foreign_key_value))
+                        (
+                            columns_by_name[foreign_key_column],
+                            str(foreign_key_value or "NULL"),
+                        )
                     )
             else:
                 if key not in columns_by_name:
@@ -261,7 +287,7 @@ class WriteLogReplayer:
 
         return record_data_tuples
 
-    def _resolve_foreign_keys_list(self, foreign_keys_list) -> dict[str, int]:
+    def _resolve_foreign_keys_list(self, foreign_keys_list) -> dict[str, int | None]:
         """Resolves a reference to a foreign record by UID into the foreign-keys needed by the source table.
 
         Write logs refer to records in other tables by their UID. These references are stored as a list of 3-tuples,
@@ -282,7 +308,7 @@ class WriteLogReplayer:
         ):
             raise ValueError("Expected a foreign keys list to be a list of 3-tuples")
 
-        resolved_foreign_keys: dict[str, int] = {}
+        resolved_foreign_keys: dict[str, int | None] = {}
 
         for foreign_table_uid in foreign_keys_list:
             resolved_foreign_key = self._foreign_key_from_json(
@@ -327,40 +353,75 @@ class WriteLogReplayer:
 
     def _get_foreign_key_values(
         self, foreign_key: WriteLogForeignKey
-    ) -> dict[str, int]:
-        primary_key, _ = self.db_metadata.get_table_key_constraints(
-            foreign_key.table_name, cursor=self.cursor
-        )
+    ) -> dict[str, int | None]:
+        if all(v is None for v in foreign_key.foreign_uid.values()):
+            return dict.fromkeys(foreign_key.foreign_key_columns, None)
 
-        if len(foreign_key.foreign_key_columns) != len(primary_key.source_columns):
-            raise ValueError(
-                f"Expected number of primary key columns for {primary_key.target_table} "
-                f"({len(primary_key.source_columns)}) and number of foreign key columns "
-                f"for {foreign_key.table_name} ({len(foreign_key.foreign_key_columns)}) to match"
+        if foreign_key.table_name == "lamindb_featurevalue":
+            if len(foreign_key.foreign_key_columns) != 1:
+                raise ValueError(
+                    "Unexpected number of foreign-key columns for 'lamindb_featurevalue'"
+                )
+
+            if all(v is None for v in foreign_key.foreign_uid.values()):
+                return dict.fromkeys(foreign_key.foreign_key_columns, None)
+
+            self.cursor.execute(
+                """
+            SELECT V.id AS id
+            FROM lamindb_featurevalue V
+            LEFT OUTER JOIN lamindb_feature F ON (V.feature_id = F.id)
+            WHERE V.hash = %s AND F.uid = %s
+            LIMIT 1
+            """,
+                [
+                    foreign_key.foreign_uid["hash"],
+                    foreign_key.foreign_uid["feature.uid"],
+                ],
             )
 
-        uid_constraints = " AND ".join(
-            f"{k} = '{v}'" for (k, v) in foreign_key.foreign_uid.items()
-        )
+            record_id = self.cursor.fetchone()
 
-        self.cursor.execute(
-            f"SELECT {','.join(c.name for c in primary_key.source_columns)} "  # noqa: S608
-            f"FROM {foreign_key.table_name} "
-            f"WHERE {uid_constraints}"
-        )
+            if record_id is None:
+                raise ValueError(
+                    f"Unable to find record in 'lamindb_featurevalue' with UID {foreign_key.foreign_uid}"
+                )
 
-        rows = self.cursor.fetchall()
-
-        if len(rows) == 0:
-            raise ValueError(
-                f"Record matching foreign key constraint {foreign_key} not found"
+            return {foreign_key.foreign_key_columns[0]: record_id[0]}
+        else:
+            primary_key, _ = self.db_metadata.get_table_key_constraints(
+                foreign_key.table_name, cursor=self.cursor
             )
 
-        if len(rows) > 1:
-            raise ValueError(
-                f"Found more than one record matching foreign key constraint {foreign_key}"
+            if len(foreign_key.foreign_key_columns) != len(primary_key.source_columns):
+                raise ValueError(
+                    f"Expected number of primary key columns for {primary_key.target_table} "
+                    f"({len(primary_key.source_columns)}) and number of foreign key columns "
+                    f"for {foreign_key.table_name} ({len(foreign_key.foreign_key_columns)}) to match"
+                )
+
+            uid_constraints = " AND ".join(
+                f"{k} = '{v}'" for (k, v) in foreign_key.foreign_uid.items()
             )
 
-        row = rows[0]
+            self.cursor.execute(
+                f"SELECT {','.join(c.name for c in primary_key.source_columns)} "  # noqa: S608
+                f"FROM {foreign_key.table_name} "
+                f"WHERE {uid_constraints}"
+            )
 
-        return dict(zip(foreign_key.foreign_key_columns, row))
+            rows = self.cursor.fetchall()
+
+            if len(rows) == 0:
+                raise ValueError(
+                    f"Record matching foreign key constraint {foreign_key} not found"
+                )
+
+            if len(rows) > 1:
+                raise ValueError(
+                    f"Found more than one record matching foreign key constraint {foreign_key}"
+                )
+
+            row = rows[0]
+
+            return dict(zip(foreign_key.foreign_key_columns, row))

--- a/lamindb/core/writelog/_trigger_installer.py
+++ b/lamindb/core/writelog/_trigger_installer.py
@@ -798,7 +798,6 @@ coalesce(
             record_uid := {self._build_record_uid(is_delete=True)};
             event_type := {WriteLogEventTypes.DELETE.value};
             space_id := ({self._build_space_id(is_delete=True)});
-            {self._assign_delete_only_variables()}
         ELSE
             record_data := {self._build_record_data()};
             record_uid := {self._build_record_uid(is_delete=False)};
@@ -850,6 +849,9 @@ CREATE OR REPLACE FUNCTION {self.function_name}(old_record RECORD, new_record RE
 AS $$
 {self._build_variable_declarations()}
 BEGIN
+    IF (trigger_op = 'DELETE') THEN
+        {self._assign_delete_only_variables()}
+    END IF;
 {function_body}
 END;
 $$ LANGUAGE PLPGSQL;

--- a/tests/writelog_sqlite/test_replayer.py
+++ b/tests/writelog_sqlite/test_replayer.py
@@ -15,7 +15,11 @@ from lamindb.core.writelog._utils import (
     update_migration_state,
     update_write_log_table_state,
 )
+from lamindb.models.feature import Feature, FeatureValue
+from lamindb.models.run import User
+from lamindb.models.sqlrecord import Branch
 from lamindb.models.writelog import (
+    DEFAULT_BRANCH,
     MigrationState,
     TableState,
     WriteLog,
@@ -389,3 +393,97 @@ def test_replayer_many_to_many(
         simple_uid_to_id["SimpleRecord1"],
         simple_uid_to_id["SimpleRecord2"],
     )
+
+
+@pytest.fixture(scope="function")
+def test_feature():
+    feature = Feature(name="perturbation", dtype="int").save()
+
+    yield feature
+
+    feature.delete()
+
+
+def test_replayer_lamindb_featurevalue(test_feature, write_log_lock, write_log_state):
+    update_write_log_table_state(
+        {
+            "lamindb_featurevalue",
+            "lamindb_branch",
+            "lamindb_user",
+            "lamindb_feature",
+            "lamindb_run",
+        }
+    )
+    update_migration_state()
+
+    featurevalue_table = TableState.objects.get(table_name="lamindb_featurevalue")
+
+    input_write_log = [
+        WriteLog(
+            migration_state=get_latest_migration_state(),
+            table=featurevalue_table,
+            uid="WriteLog1",
+            record_uid=["valhash", Feature.objects.get(name="perturbation").uid],
+            record_data={
+                "value": 50,
+                "hash": "valhash",
+                "created_at": "2025-05-27T16:00:04.234512+00:00",
+                "_aux": None,
+                FOREIGN_KEYS_LIST_COLUMN_NAME: [
+                    [
+                        TableState.objects.get(table_name="lamindb_branch").id,
+                        ["_branch_code"],
+                        {"uid": Branch.objects.get(id=DEFAULT_BRANCH).uid},
+                    ],
+                    [
+                        TableState.objects.get(table_name="lamindb_user").id,
+                        ["created_by_id"],
+                        {"uid": User.objects.get(id=1).uid},
+                    ],
+                    [
+                        TableState.objects.get(table_name="lamindb_feature").id,
+                        ["feature_id"],
+                        {"uid": Feature.objects.get(name="perturbation").uid},
+                    ],
+                    [
+                        TableState.objects.get(table_name="lamindb_run").id,
+                        ["run_id"],
+                        {"uid": None},
+                    ],
+                ],
+            },
+            event_type=WriteLogEventTypes.INSERT.value,
+            created_at=datetime.datetime(2025, 5, 27, 16, 2),
+        )
+    ]
+
+    replayer = WriteLogReplayer(
+        db_metadata=SQLiteDatabaseMetadataWrapper(), cursor=django_connection.cursor()
+    )
+
+    for write_log_entry in input_write_log:
+        replayer.replay(write_log_entry)
+        write_log_entry.save()
+
+    write_log = WriteLog.objects.all().order_by("id")
+
+    assert len(write_log) == 1
+    assert list(write_log) == input_write_log
+
+    feature_values = FeatureValue.objects.all()
+
+    assert len(feature_values) == 1
+
+    feature_value = list(feature_values)[0]
+
+    assert feature_value.branch_id == DEFAULT_BRANCH
+    assert feature_value.value == 50
+    assert feature_value.hash == "valhash"
+    assert feature_value._aux is None
+    assert feature_value.run is None
+    assert feature_value.created_at == datetime.datetime(
+        2025, 5, 27, 16, 0, 4, 234512, tzinfo=datetime.timezone.utc
+    )
+    assert feature_value.created_by.id == 1
+    assert feature_value.feature is not None
+    assert feature_value.feature.uid == Feature.objects.get(name="perturbation").uid


### PR DESCRIPTION
`lamindb_featurevalue` is unique among our current tables because its UID is composed of both its own fields and the fields of one of its foreign-keyed tables. This requires some special handling both in cursor installation and replay. 