### PR TITLE
🔊 Fix project hint in ln.track()

### DIFF
--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -452,7 +452,11 @@ class Context:
             r_or_python = "."
             if self._path is not None:
                 r_or_python = "." if self._path.suffix in {".py", ".ipynb"} else "$"
-            project_str = f', project="{project}"' if project is not None else ""
+            project_str = (
+                f', project="{project if isinstance(project, str) else project.name}"'
+                if project is not None
+                else ""
+            )
             space_str = f', space="{space}"' if space is not None else ""
             params_str = (
                 ", params={...}" if params is not None else ""


### PR DESCRIPTION
Fix https://github.com/laminlabs/lamindb/issues/2788

Now this shows project name if the argument is an instance of `ln.Project`.