### PR TITLE
👷 Exclude sub directory from source distribution on pypi

### DIFF
--- a/lamindb/migrations/0096_remove_artifact__param_values_and_more.py
+++ b/lamindb/migrations/0096_remove_artifact__param_values_and_more.py
@@ -201,11 +201,7 @@ def get_params_count(apps, schema_editor):
     RunParamValue = apps.get_model("lamindb", "RunParamValue")
     ArtifactParamValue = apps.get_model("lamindb", "ArtifactParamValue")
 
-    print("Moving the following params into features and deleting the params table")
-    response = input("Do you want to continue? [y/n]")
-    if response != "y":
-        print("Aborting migration.")
-        quit()
+    print("Moving params into features and deleting the params table")
     print(f"Param count: {Param.objects.count()}")
     print(f"ParamValue count: {ParamValue.objects.count()}")
     print(f"RunParamValue count: {RunParamValue.objects.count()}")

--- a/lamindb/migrations/0103_remove_writelog_migration_state_and_more.py
+++ b/lamindb/migrations/0103_remove_writelog_migration_state_and_more.py
@@ -10,7 +10,7 @@ def fix_artifact_kind(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("lamindb", "0103_remove_writelog_migration_state_and_more"),
+        ("lamindb", "0102_remove_writelog_branch_code_and_more"),
     ]
 
     operations = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,7 +232,5 @@ omit = ["**/core/datasets/*", "**/migrations/*", "**/core/_compat.py", "**/core/
 
 [tool.flit.sdist]
 exclude = [
-    "sub/",
-    "tests/",
-    "docs/",
+    "sub/"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,3 +229,10 @@ exclude_lines = [
 
 [tool.coverage.run]
 omit = ["**/core/datasets/*", "**/migrations/*", "**/core/_compat.py", "**/core/types.py"]
+
+[tool.flit.sdist]
+exclude = [
+    "sub/",
+    "tests/",
+    "docs/",
+]


### PR DESCRIPTION
We don't want the `sub/` directory within `sdist` on pypi because it contains pypi packages itself.