### PR TITLE
🐛 Fix comparisons to `__isnull` for feature-based queries

### DIFF
--- a/docs/registries.ipynb
+++ b/docs/registries.ipynb
@@ -70,18 +70,8 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import lamindb as ln"
-   ]
-  },
-  {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "6",
    "metadata": {},
    "source": [
     "## Get an overview"
@@ -89,7 +79,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "7",
    "metadata": {},
    "source": [
     "The easiest way to get an overview over all artifacts is by typing {meth}`~lamindb.Artifact.df`, which returns the 100 latest artifacts in the {class}`~lamindb.Artifact` registry."
@@ -98,7 +88,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "8",
    "metadata": {
     "tags": [
      "hide-output"
@@ -106,14 +96,12 @@
    },
    "outputs": [],
    "source": [
-    "import lamindb as ln\n",
-    "\n",
     "ln.Artifact.df()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "9",
    "metadata": {},
    "source": [
     "You can include fields from other registries."
@@ -122,7 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "10",
    "metadata": {
     "tags": [
      "hide-output"
@@ -143,7 +131,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "11",
    "metadata": {},
    "source": [
     "You can include information about which artifact measures which `feature`."
@@ -152,7 +140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "12",
    "metadata": {
     "tags": [
      "hide-output"
@@ -166,7 +154,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "13",
    "metadata": {},
    "source": [
     "The flattened table that includes information from all relevant registries is easier to understand than the normalized data."
@@ -175,7 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "14",
    "metadata": {
     "tags": [
      "hide-output"
@@ -189,7 +177,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "16",
+   "id": "15",
    "metadata": {},
    "source": [
     "## Auto-complete records"
@@ -198,7 +186,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "17",
+   "id": "16",
    "metadata": {},
    "source": [
     "For registries with less than 100k records, auto-completing a `Lookup` object is the most convenient way of finding a record."
@@ -207,7 +195,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "17",
    "metadata": {
     "tags": [
      "hide-output"
@@ -224,7 +212,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "18",
    "metadata": {},
    "source": [
     ":::{dropdown} Show me a screenshot\n",
@@ -237,7 +225,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "20",
+   "id": "19",
    "metadata": {},
    "source": [
     "With auto-complete, we find a ulabel:"
@@ -246,7 +234,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "20",
    "metadata": {
     "tags": [
      "hide-output"
@@ -260,7 +248,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "21",
    "metadata": {},
    "source": [
     "## Get one record"
@@ -268,7 +256,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "22",
    "metadata": {},
    "source": [
     "{class}`~lamindb.models.SQLRecord.get` errors if more than one matching records are found."
@@ -277,7 +265,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "23",
    "metadata": {
     "tags": [
      "hide-output"
@@ -297,7 +285,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "25",
+   "id": "24",
    "metadata": {},
    "source": [
     "## Query records by fields"
@@ -306,7 +294,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "26",
+   "id": "25",
    "metadata": {},
    "source": [
     "Filter for all artifacts annotated by a ulabel:"
@@ -315,7 +303,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "26",
    "metadata": {
     "tags": [
      "hide-output"
@@ -329,7 +317,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "28",
+   "id": "27",
    "metadata": {},
    "source": [
     "To access the results encoded in a filter statement, execute its return value with one of:\n",
@@ -342,7 +330,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29",
+   "id": "28",
    "metadata": {},
    "source": [
     "```{note}\n",
@@ -368,7 +356,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "29",
    "metadata": {},
    "source": [
     "## Query datasets by features"
@@ -376,7 +364,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "30",
    "metadata": {},
    "source": [
     "The `Artifact` registry is the only registry that additionally allows to query by features."
@@ -385,7 +373,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -394,7 +382,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "32",
    "metadata": {},
    "source": [
     "You can also query for nested dictionary-like features."
@@ -403,7 +391,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -413,7 +401,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -422,7 +410,35 @@
   },
   {
    "cell_type": "markdown",
+   "id": "35",
+   "metadata": {},
+   "source": [
+    "You can query for whether a dataset is annotated or not annotated by a feature."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln.Artifact.filter(perturbation__isnull=True).df()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ln.Artifact.filter(perturbation__isnull=False).df()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38",
    "metadata": {},
    "source": [
     "## Query runs by parameters"
@@ -430,7 +446,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "39",
    "metadata": {},
    "source": [
     "Here is an example for querying by parameters: {ref}`query-by-run-parameters`."
@@ -439,7 +455,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "38",
+   "id": "40",
    "metadata": {},
    "source": [
     "## Search for records"
@@ -447,7 +463,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "41",
    "metadata": {},
    "source": [
     "You can search every registry via {meth}`~lamindb.models.SQLRecord.search`. For example, the `Artifact` registry."
@@ -456,7 +472,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "42",
    "metadata": {
     "tags": [
      "hide-output"
@@ -469,7 +485,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "43",
    "metadata": {},
    "source": [
     "Here is more background on search and examples for searching the entire cell type ontology: {doc}`/faq/search` "
@@ -478,7 +494,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "42",
+   "id": "44",
    "metadata": {},
    "source": [
     "## Query related registries"
@@ -487,7 +503,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "43",
+   "id": "45",
    "metadata": {},
    "source": [
     "Django has a double-under-score syntax to filter based on related tables.\n",
@@ -498,7 +514,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "46",
    "metadata": {
     "tags": [
      "hide-output"
@@ -512,7 +528,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "45",
+   "id": "47",
    "metadata": {},
    "source": [
     "The filter selects all artifacts based on the users who ran the generating notebook. Under the hood, in the SQL database, it's joining the artifact table with the user table.\n",
@@ -523,7 +539,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "48",
    "metadata": {
     "tags": [
      "hide-output"
@@ -540,7 +556,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "49",
    "metadata": {},
    "source": [
     "Instead of splitting this across three queries, the double-underscore syntax allows you to define a path for one query."
@@ -549,7 +565,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "50",
    "metadata": {
     "tags": [
      "hide-output"
@@ -562,7 +578,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "49",
+   "id": "51",
    "metadata": {},
    "source": [
     "## Filter operators"
@@ -571,7 +587,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "50",
+   "id": "52",
    "metadata": {},
    "source": [
     "You can qualify the type of comparison in a query by using a comparator.\n",
@@ -582,7 +598,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "51",
+   "id": "53",
    "metadata": {},
    "source": [
     "### and"
@@ -591,7 +607,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "54",
    "metadata": {
     "tags": [
      "hide-output"
@@ -605,7 +621,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "53",
+   "id": "55",
    "metadata": {},
    "source": [
     "### less than/ greater than"
@@ -614,33 +630,10 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "54",
-   "metadata": {},
-   "source": [
-    "Or subset to artifacts greater than 10kB. Here, we can't use keyword arguments, but need an explicit where statement."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "55",
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "ln.Artifact.filter(ulabels=study1, size__gt=1e4).df()"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
    "id": "56",
    "metadata": {},
    "source": [
-    "### in"
+    "Or subset to artifacts greater than 10kB. Here, we can't use keyword arguments, but need an explicit where statement."
    ]
   },
   {
@@ -654,7 +647,7 @@
    },
    "outputs": [],
    "source": [
-    "ln.Artifact.filter(suffix__in=[\".jpg\", \".fastq.gz\"]).df()"
+    "ln.Artifact.filter(ulabels=study1, size__gt=1e4).df()"
    ]
   },
   {
@@ -663,7 +656,7 @@
    "id": "58",
    "metadata": {},
    "source": [
-    "### order by"
+    "### in"
    ]
   },
   {
@@ -677,13 +670,36 @@
    },
    "outputs": [],
    "source": [
+    "ln.Artifact.filter(suffix__in=[\".jpg\", \".fastq.gz\"]).df()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "60",
+   "metadata": {},
+   "source": [
+    "### order by"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "61",
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
     "ln.Artifact.filter().order_by(\"created_at\").df()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "62",
    "metadata": {
     "tags": [
      "hide-output"
@@ -698,7 +714,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "63",
    "metadata": {
     "tags": [
      "hide-output"
@@ -712,7 +728,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -723,32 +739,10 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "63",
-   "metadata": {},
-   "source": [
-    "### contains"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "64",
-   "metadata": {
-    "tags": [
-     "hide-output"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "ln.Transform.filter(description__contains=\"search\").df().head(5)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "65",
    "metadata": {},
    "source": [
-    "And case-insensitive:"
+    "### contains"
    ]
   },
   {
@@ -762,16 +756,15 @@
    },
    "outputs": [],
    "source": [
-    "ln.Transform.filter(description__icontains=\"Search\").df().head(5)"
+    "ln.Transform.filter(description__contains=\"search\").df().head(5)"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "67",
    "metadata": {},
    "source": [
-    "### startswith"
+    "And case-insensitive:"
    ]
   },
   {
@@ -785,15 +778,16 @@
    },
    "outputs": [],
    "source": [
-    "ln.Transform.filter(description__startswith=\"Query\").df()"
+    "ln.Transform.filter(description__icontains=\"Search\").df().head(5)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "69",
    "metadata": {},
    "source": [
-    "### or"
+    "### startswith"
    ]
   },
   {
@@ -807,12 +801,34 @@
    },
    "outputs": [],
    "source": [
-    "ln.Artifact.filter(ln.Q(suffix=\".jpg\") | ln.Q(suffix=\".fastq.gz\")).df()"
+    "ln.Transform.filter(description__startswith=\"Query\").df()"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "71",
+   "metadata": {},
+   "source": [
+    "### or"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72",
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "ln.Artifact.filter(ln.Q(suffix=\".jpg\") | ln.Q(suffix=\".fastq.gz\")).df()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73",
    "metadata": {},
    "source": [
     "### negate/ unequal"
@@ -821,7 +837,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "74",
    "metadata": {
     "tags": [
      "hide-output"

--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -626,7 +626,7 @@ def filter_base(cls, _skip_validation: bool = True, **expression) -> QuerySet:
         feature = features.get(name=normalized_key)
         if not feature.dtype.startswith("cat"):
             if comparator == "__isnull":
-                if cls == FeatureManager:
+                if cls == FeatureManagerArtifact:
                     from .artifact import ArtifactFeatureValue
 
                     if value:  # True
@@ -655,7 +655,7 @@ def filter_base(cls, _skip_validation: bool = True, **expression) -> QuerySet:
             new_expression[f"_{feature_param}_values__id__in"] = feature_values
         elif isinstance(value, (str, SQLRecord, bool)):
             if comparator == "__isnull":
-                if cls == FeatureManager:
+                if cls == FeatureManagerArtifact:
                     result = parse_dtype(feature.dtype)[0]
                     kwargs = {
                         f"links_{result['registry'].__name__.lower()}__feature": feature

--- a/tests/core/test_feature_label_manager.py
+++ b/tests/core/test_feature_label_manager.py
@@ -36,6 +36,8 @@ Here is how to create a feature:
     ln.Feature(name="perturbation", dtype="cat").save()
     ln.ULabel.from_values(["DMSO", "IFNG"], create=True).save()
     artifact.features.add_values({"perturbation": df.perturbation.unique()})
+    assert artifact in ln.Artifact.filter(perturbation__isnull=False)
+    assert artifact not in ln.Artifact.filter(perturbation__isnull=True)
     artifact.delete(permanent=True)
     ln.ULabel.filter().all().delete()
     ln.Feature.filter().all().delete()


### PR DESCRIPTION
Bug was introduced in a refactor after 1.5.3. Got never released.

FeatureManager has to be overall-refactored, will happen in another PR.