### PR TITLE
🏷️ BaseSQLRecord.save should return self type

### DIFF
--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -763,7 +763,7 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
             super().__init__(*args)
         track_current_key_and_name_values(self)
 
-    def save(self, *args, **kwargs) -> SQLRecord:
+    def save(self: T, *args, **kwargs) -> T:
         """Save.
 
         Always saves to the default database.


### PR DESCRIPTION
`BaseSQLRecord.save()` should return Self type.

This PR uses the TypeVar T defined above which is bound by SQLRecord (==Self).

This fixes issues with typing of for example `ULabel(...).save()`