### PR TITLE
🔊 Correct treatment of carriage returns in logs

### DIFF
--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -100,6 +100,14 @@ def pretty_pypackages(dependencies: dict) -> str:
     return " ".join(deps_list)
 
 
+def last_non_empty_r_block(line: str):
+    blocks = line.split("\r")
+    for block in reversed(blocks):
+        if block:
+            return block
+    return ""
+
+
 class LogStreamHandler:
     def __init__(self, log_stream, file):
         self.log_stream = log_stream
@@ -113,7 +121,7 @@ class LogStreamHandler:
         # write only the last part of a line with carriage returns
         while "\n" in self._buffer:
             line, self._buffer = self._buffer.split("\n", 1)
-            self.file.write(line.split("\r")[-1] + "\n")
+            self.file.write(last_non_empty_r_block(line) + "\n")
             self.file.flush()
 
         return len(data)
@@ -124,7 +132,7 @@ class LogStreamHandler:
         if self.file.closed:
             return
         if self._buffer:
-            self.file.write(self._buffer.split("\r")[-1])
+            self.file.write(last_non_empty_r_block)
             self._buffer = ""
         self.file.flush()
 

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -108,7 +108,7 @@ def last_non_empty_r_block(line: str) -> str:
 
 
 class LogStreamHandler:
-    def __init__(self, log_stream: TextIO, file: TextIO, use_buffer: bool = True):
+    def __init__(self, log_stream: TextIO, file: TextIO, use_buffer: bool):
         self.log_stream = log_stream
         self.file = file
 
@@ -162,6 +162,7 @@ class LogStreamTracker:
             ln_setup.settings.cache_dir / f"run_logs_{self.run.uid}.txt"
         )
         self.log_file = open(self.log_file_path, "w")
+        # use buffering for correct handling of carriage returns
         sys.stdout = LogStreamHandler(
             self.original_stdout, self.log_file, use_buffer=True
         )

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -101,8 +101,7 @@ def pretty_pypackages(dependencies: dict) -> str:
 
 
 def last_non_empty_r_block(line: str):
-    blocks = line.split("\r")
-    for block in reversed(blocks):
+    for block in reversed(line.split("\r")):
         if block:
             return block
     return ""
@@ -132,7 +131,7 @@ class LogStreamHandler:
         if self.file.closed:
             return
         if self._buffer:
-            self.file.write(last_non_empty_r_block)
+            self.file.write(last_non_empty_r_block(self._buffer))
             self._buffer = ""
         self.file.flush()
 

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -100,7 +100,7 @@ def pretty_pypackages(dependencies: dict) -> str:
     return " ".join(deps_list)
 
 
-def last_non_empty_r_block(line: str):
+def last_non_empty_r_block(line: str) -> str:
     for block in reversed(line.split("\r")):
         if block:
             return block


### PR DESCRIPTION
Fix https://github.com/laminlabs/lamindb/issues/2606

This PR fixes logging strings with carriage returns, it only writes the last non-empty text segment so that carriage return is obeyed.