### PR TITLE
🧑‍💻 Support import of model classes before connecting to an instance

### DIFF
--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -107,32 +107,99 @@ Backwards compatibility.
 
 """
 
-# ruff: noqa: I001
+from __future__ import annotations
+
+import importlib
+import warnings
+from typing import TYPE_CHECKING
+
+from lamindb_setup import connect
+from lamindb_setup._check_setup import _check_instance_setup
+from lamindb_setup.core.upath import UPath
+
 # denote a release candidate for 0.1.0 with 0.1rc1, 0.1a1, 0.1b1, etc.
 __version__ = "1.6.1"
 
-import warnings
+_loaded_submodules_pre_connect = [
+    "base",
+    "errors",
+    "setup",
+]
+_loaded_submodules_post_connect = [
+    "core",
+    "integrations",
+    "curators",
+    "examples",
+]
+
+__all__ = [
+    # available without instance connection
+    "connect",
+    "UPath",
+    # models
+    "Artifact",
+    "Collection",
+    "Feature",
+    "Person",
+    "Project",
+    "Reference",
+    "Run",
+    "Schema",
+    "Storage",
+    "Transform",
+    "ULabel",
+    "User",
+    "Space",
+    "Branch",
+    "Record",
+    "Sheet",
+    # models django.db
+    "Q",
+    # functions
+    "tracked",
+    "view",
+    "save",
+    "track",
+    "finish",
+    # objects
+    "context",
+    "settings",
+    # backwards compat
+    "FeatureSet",
+    "Param",
+    "Curator",
+    # extras
+    *_loaded_submodules_pre_connect,
+    *_loaded_submodules_post_connect,
+]
+
+
+def __dir__():
+    return __all__
+
 
 # through SpatialData
 warnings.filterwarnings(
     "ignore", message="The legacy Dask DataFrame implementation is deprecated"
 )
 
-from lamindb_setup._check_setup import InstanceNotSetupError as _InstanceNotSetupError
-from lamindb_setup._check_setup import _check_instance_setup
-from lamindb_setup._connect_instance import connect
-from lamindb_setup.core.upath import UPath
-
-from . import base, errors, setup
-
 
 def __getattr__(name):
-    raise _InstanceNotSetupError()
+    if name in _loaded_submodules_pre_connect:
+        globals()[name] = mod = importlib.import_module(f"lamindb.{name}")
+        return mod
+
+    elif name not in __all__:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    else:
+        from lamindb_setup._check_setup import InstanceNotSetupError
+
+        raise InstanceNotSetupError()
 
 
-if _check_instance_setup(from_module="lamindb"):
-    del __getattr__  # so that imports work out
-    from . import base
+if _check_instance_setup(from_module="lamindb") or TYPE_CHECKING:
+    from . import base, core, curators, examples, integrations
     from ._tracked import tracked
     from ._view import view
     from .core._context import context
@@ -140,28 +207,24 @@ if _check_instance_setup(from_module="lamindb"):
     from .curators._legacy import CatManager as Curator
     from .models import (
         Artifact,
+        Branch,
         Collection,
         Feature,
         FeatureSet,  # backward compat
         Person,
         Project,
+        Record,
         Reference,
         Run,
         Schema,
+        Sheet,
+        Space,
         Storage,
         Transform,
         ULabel,
         User,
-        Space,
-        Branch,
-        Record,
-        Sheet,
     )
     from .models.save import save
-    from . import core
-    from . import integrations
-    from . import curators
-    from . import examples
 
     track = context._track
     finish = context._finish
@@ -170,3 +233,45 @@ if _check_instance_setup(from_module="lamindb"):
     from django.db.models import Q
 
     Param = Feature  # backward compat
+
+else:
+    import lamindb._lazy_import as _lazy_import
+
+    # classes
+    for cls_name in [
+        "Artifact",
+        "Collection",
+        "Feature",
+        "Person",
+        "Project",
+        "Reference",
+        "Run",
+        "Schema",
+        "Storage",
+        "Transform",
+        "ULabel",
+        "User",
+        "Space",
+        "Branch",
+        "Record",
+        "Sheet",
+        "Q",
+        "FeatureSet",
+        "Param",
+        "Curator",
+    ]:
+        # classes have to be assigned dynamically to prevent mypy erroring on type assignment
+        globals()[cls_name] = _lazy_import.new_metaclass_proxy(cls_name)
+
+    # functions
+    tracked = _lazy_import.new_callable_proxy("tracked")
+    view = _lazy_import.new_callable_proxy("view")
+    save = _lazy_import.new_callable_proxy("save")
+    track = _lazy_import.new_callable_proxy("track")
+    finish = _lazy_import.new_callable_proxy("finish")
+
+    # objects
+    context = _lazy_import.new_instance_proxy("context")
+    settings = _lazy_import.new_instance_proxy("settings")
+
+    del _lazy_import

--- a/lamindb/_lazy_import.py
+++ b/lamindb/_lazy_import.py
@@ -1,0 +1,97 @@
+"""helpers for providing lazy import of lamindb classes and funtions in lamindb.__init__."""
+
+import sys
+from types import new_class
+from typing import Any, NoReturn
+
+__all__ = [
+    "new_metaclass_proxy",
+    "new_instance_proxy",
+    "new_callable_proxy",
+]
+
+
+def _raise_not_connected(objname: str) -> NoReturn:
+    from lamindb_setup._check_setup import InstanceNotSetupError
+
+    msg = f"To use lamindb.{objname}, you need to connect to an instance."
+    raise InstanceNotSetupError(msg)
+
+
+class _ProxyMeta(type):
+    """MetaClass to enable lazy import of lamindb model classes."""
+
+    def __call__(cls, *args, **kwargs):
+        ln_cls = getattr(sys.modules["lamindb"], cls.__name__)
+        if ln_cls is cls:
+            _raise_not_connected(cls.__name__)
+        return ln_cls(*args, **kwargs)
+
+    def __subclasshook__(cls, __subclass):
+        ln_cls = getattr(sys.modules["lamindb"], cls.__name__)
+        if ln_cls is cls:
+            _raise_not_connected(cls.__name__)
+        return issubclass(__subclass, ln_cls)
+
+    def __repr__(cls) -> str:
+        ln_cls = getattr(sys.modules["lamindb"], cls.__name__)
+        if ln_cls is cls:
+            return f"<lamindb lazy_import proxy for {cls.__name__} (not connected)>"
+        return repr(ln_cls)
+
+    def __getattr__(cls, item):
+        ln_cls = getattr(sys.modules["lamindb"], cls.__name__)
+        if ln_cls is cls:
+            _raise_not_connected(cls.__name__)
+        return getattr(ln_cls, item)
+
+
+class _Proxy:
+    """Class proxy for lazily imported public instances in lamindb."""
+
+    def __init__(self, name: str) -> None:
+        self.__name = name
+
+    def __repr__(self) -> str:
+        obj = getattr(sys.modules["lamindb"], self.__name)
+        if obj is None:
+            return f"<lamindb lazy_import proxy for {self.__name} (not connected)>"
+        return repr(obj)
+
+    def __getattr__(self, item):
+        obj = getattr(sys.modules["lamindb"], self.__name)
+        if obj is None:
+            _raise_not_connected(self.__name)
+        return getattr(obj, item)
+
+    def __setattr__(self, key, value):
+        if key == "_Proxy__name":
+            super().__setattr__(key, value)
+        else:
+            obj = getattr(sys.modules["lamindb"], self.__name)
+            if obj is None:
+                _raise_not_connected(self.__name)
+            setattr(obj, key, value)
+
+
+def new_metaclass_proxy(name: str) -> Any:
+    """Create a metaclass proxy for top-level lamindb classes."""
+    return new_class(name, (), {"metaclass": _ProxyMeta})
+
+
+def new_instance_proxy(name: str) -> Any:
+    """Create an instance proxy for top-level lamindb instances."""
+    return _Proxy(name)
+
+
+def new_callable_proxy(func_name: str) -> Any:
+    """Create a callable proxy for top-level lamindb functions."""
+
+    def func(*args, **kwargs):
+        ln_func = getattr(sys.modules["lamindb"], func_name)
+        if ln_func is func:
+            _raise_not_connected(func_name)
+        return ln_func(*args, **kwargs)
+
+    func.__name__ = func_name
+    return func


### PR DESCRIPTION
Hi :wave:

This adds support for importing lamindb model classes before running `ln.connect(...)` via lazy import proxies for all objects that are only available after connect. This plays much nicer with modern Python code style, where all imports are on the top of the file. After the user connects to an instance, instantiating the proxy classes returns instances of the corresponding models and calling classmethods on the proxy delegates to the model class.

### Notes

This needs tests, since I would bet that there are some edge cases where it breaks down. My guess is that auto-completion in jupyter might behave differently, but it needs to be checked.

I also noticed that `lamindb` imports a lot of submodules eagerly once connect happens, and I am not sure why you'd want that. I wonder if this enabled a better experience for users in jupyter notebooks and that's why you did it that way. It would be great to understand the reasoning behind it.

In addition I changed the submodule import behavior in this PR slightly, and made the import of submodules "base", "errors", and "setup" also lazy (the three submodules that are eagerly imported before connect). I also made the module level `__getattr__` actually error with the correct Exception in case a user wants to access something that doesn't exists. For example `import lamindb as ln; ln.blah` will now correctly raise an `AttributeError`.

I'll continue with this a bit next week.