### PR TITLE
🚸 Expose `overwrite_versions`

### DIFF
--- a/lamindb/core/storage/_tiledbsoma.py
+++ b/lamindb/core/storage/_tiledbsoma.py
@@ -148,7 +148,7 @@ def save_tiledbsoma_experiment(
     else:
         uid, _ = create_uid(n_full_id=20)
         storage_key = auto_storage_key_from_artifact_uid(
-            uid, ".tiledbsoma", is_dir=True
+            uid, ".tiledbsoma", overwrite_versions=True
         )
         storepath = setup_settings.storage.root / storage_key
 

--- a/lamindb/core/storage/paths.py
+++ b/lamindb/core/storage/paths.py
@@ -26,15 +26,18 @@ AUTO_KEY_PREFIX = ".lamindb/"
 # add type annotations back asap when re-organizing the module
 def auto_storage_key_from_artifact(artifact: Artifact):
     if artifact.key is None or artifact._key_is_virtual:
-        is_dir = artifact.n_files is not None
-        return auto_storage_key_from_artifact_uid(artifact.uid, artifact.suffix, is_dir)
+        return auto_storage_key_from_artifact_uid(
+            artifact.uid, artifact.suffix, artifact.overwrite_versions
+        )
     else:
         return artifact.key
 
 
-def auto_storage_key_from_artifact_uid(uid: str, suffix: str, is_dir: bool) -> str:
+def auto_storage_key_from_artifact_uid(
+    uid: str, suffix: str, overwrite_versions: bool
+) -> str:
     assert isinstance(suffix, str)  # noqa: S101 Suffix cannot be None.
-    if is_dir:
+    if overwrite_versions:
         uid_storage = uid[:16]  # 16 chars, leave 4 chars for versioning
     else:
         uid_storage = uid

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -390,6 +390,7 @@ def get_artifact_kwargs_from_data(
     using_key: str | None = None,
     is_replace: bool = False,
     skip_check_exists: bool = False,
+    overwrite_versions: bool | None = None,
 ):
     from lamindb import settings
 
@@ -458,7 +459,8 @@ def get_artifact_kwargs_from_data(
     # we use an actual storage key
     if check_path_in_storage:
         key_is_virtual = False
-
+    if overwrite_versions is None:
+        overwrite_versions = n_files is not None
     kwargs = {
         "uid": provisional_uid,
         "suffix": suffix,
@@ -471,7 +473,7 @@ def get_artifact_kwargs_from_data(
         # to make them both available immediately
         # after object creation
         "n_files": n_files,
-        "_overwrite_versions": n_files is not None,  # True for folder, False for file
+        "_overwrite_versions": overwrite_versions,  # True for folder, False for file
         "n_observations": None,  # to implement
         "run_id": run.id if run is not None else None,
         "run": run,
@@ -982,6 +984,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         key: `str | None = None` A path-like key to reference artifact in default storage, e.g., `"myfolder/myfile.fcs"`. Artifacts with the same key form a version family.
         description: `str | None = None` A description.
         revises: `Artifact | None = None` Previous version of the artifact. Is an alternative way to passing `key` to trigger a new version.
+        overwrite_versions: `bool | None = None` Whether to overwrite versions. Defaults to `True` for folders and `False` for files.
         run: `Run | None = None` The run that creates the artifact.
 
     Examples:
@@ -1291,10 +1294,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
     )
     """Creator of record."""
     _overwrite_versions: bool = BooleanField(default=None)
-    """Indicates whether to store or overwrite versions.
-
-    It defaults to False for file-like artifacts and to True for folder-like artifacts.
-    """
+    # see corresponding property `overwrite_versions`
     projects: Project
     """Linked projects."""
     references: Reference
@@ -1315,6 +1315,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         key: str | None = None,
         description: str | None = None,
         revises: Artifact | None = None,
+        overwrite_versions: bool | None = None,
         run: Run | None = None,
     ): ...
 
@@ -1351,6 +1352,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         run: Run | None = kwargs.pop("run", None)
         description: str | None = kwargs.pop("description", None)
         revises: Artifact | None = kwargs.pop("revises", None)
+        overwrite_versions: bool | None = kwargs.pop("overwrite_versions", None)
         version: str | None = kwargs.pop("version", None)
         branch_id: int | None = None
         if "visibility" in kwargs:  # backward compat
@@ -1420,6 +1422,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             default_storage=default_storage,
             using_key=using_key,
             skip_check_exists=skip_check_exists,
+            overwrite_versions=overwrite_versions,
         )
 
         # an object with the same hash already exists
@@ -1515,6 +1518,14 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
     @deprecated("n_files")
     def n_objects(self) -> int:
         return self.n_files
+
+    @property
+    def overwrite_versions(self) -> bool:
+        """Indicates whether to keep or overwrite versions.
+
+        It defaults to False for file-like artifacts and to True for folder-like artifacts.
+        """
+        return self._overwrite_versions
 
     @property
     def path(self) -> Path:

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1523,7 +1523,11 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
     def overwrite_versions(self) -> bool:
         """Indicates whether to keep or overwrite versions.
 
-        It defaults to False for file-like artifacts and to True for folder-like artifacts.
+        It defaults to `False` for file-like artifacts and to `True` for folder-like artifacts.
+
+        Note that this requires significant storage space for large folders with
+        many duplicated files. Currently, `lamindb` does *not* de-duplicate files across
+        versions as in git, but keeps all files for all versions of the folder in storage.
         """
         return self._overwrite_versions
 

--- a/tests/core/test_artifact_folders.py
+++ b/tests/core/test_artifact_folders.py
@@ -56,9 +56,38 @@ def test_folder_like_artifact(get_test_filepaths, key):
     artifact3.save()
 
     # the state of artifact1 is lost, because artifact3 is stored at the same path
+    assert artifact3.overwrite_versions
+    assert artifact1.overwrite_versions
     assert artifact3.path == artifact1.path
     test_filepath_added.unlink()
 
     # delete the artifact
     artifact2.delete(permanent=True, storage=False)
+    artifact3.delete(permanent=True, storage=False)
+
+
+def test_overwrite_versions_false(get_test_filepaths):
+    # get variables from fixture
+    is_in_registered_storage = get_test_filepaths[0]
+    test_dirpath = get_test_filepaths[2]
+    hash_test_dir = get_test_filepaths[5]
+    if is_in_registered_storage:
+        return
+    artifact1 = ln.Artifact(
+        test_dirpath, key="my_folder", overwrite_versions=False
+    ).save()
+    assert artifact1.hash == hash_test_dir
+    # skip artifact2 because we already test this above
+    # create a first file
+    test_filepath_added = test_dirpath / "my_file_added.txt"
+    test_filepath_added.write_text("2")
+    artifact3 = ln.Artifact(test_dirpath, key="my_folder", overwrite_versions=False)
+    assert artifact3.hash != hash_test_dir
+    artifact3.save()
+    # the state of artifact1 is lost, because artifact3 is stored at the same path
+    assert not artifact3.overwrite_versions
+    assert not artifact1.overwrite_versions
+    assert artifact3.path != artifact1.path
+    test_filepath_added.unlink()
+    artifact1.delete(permanent=True, storage=False)
     artifact3.delete(permanent=True, storage=False)


### PR DESCRIPTION
You can now avoid overwriting versions of folder-like artifacts by passing `overwrite_versions=False`.

```python
ln.Artifact("./my_folder", key="my_folder", overwrite_versions=False)
```

We can perform de-duplication by tracking shared files across versions in case it ever becomes relevant. Some notes on this here: https://claude.ai/share/7cec66cd-edcc-4ae6-9b01-b1bf9610dd31