### PR TITLE
♻️ Refactor `FeatureManager`

### DIFF
--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -53,7 +53,6 @@ from ._relations import (
     dict_related_model_to_related_name,
 )
 from .feature import Feature, FeatureValue, parse_dtype
-from .run import FeatureManager, Run
 from .sqlrecord import SQLRecord
 from .ulabel import ULabel
 
@@ -68,11 +67,16 @@ if TYPE_CHECKING:
     )
     from lamindb.models.query_set import QuerySet
 
+    from .run import Run
 
-class FeatureManagerArtifact(FeatureManager):
+
+class FeatureManager:
     """Feature manager."""
 
-    pass
+    def __init__(self, host: Artifact | Run):
+        self._host = host
+        self._slots = None
+        self._accessor_by_registry_ = None
 
 
 def get_accessor_by_registry_(host: Artifact | Collection) -> dict:
@@ -570,12 +574,6 @@ def infer_feature_type_convert_json(
     if not mute:
         logger.warning(f"cannot infer feature type of: {value}, returning '?")
     return "?", value, message
-
-
-def __init__(self, host: Artifact | Collection | Run):
-    self._host = host
-    self._slots = None
-    self._accessor_by_registry_ = None
 
 
 def __repr__(self) -> str:
@@ -1419,7 +1417,6 @@ def _add_set_from_spatialdata(
 
 
 # mypy: ignore-errors
-FeatureManager.__init__ = __init__
 FeatureManager.__repr__ = __repr__
 FeatureManager.describe = describe
 FeatureManager.__getitem__ = __getitem__

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1642,7 +1642,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                     keys_normalized, field="name", mute=True
                 )
             ):
-                return filter_base(FeatureManagerArtifact, **expressions)
+                return filter_base(Artifact, **expressions)
             else:
                 features = ", ".join(
                     sorted(np.array(keys_normalized)[~features_validated])

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -70,7 +70,6 @@ from ..models._is_versioned import (
 from ._django import get_artifact_with_related
 from ._feature_manager import (
     FeatureManager,
-    FeatureManagerArtifact,
     add_label_feature_links,
     filter_base,
     get_label_links,
@@ -1098,44 +1097,48 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
     _len_full_uid: int = 20
     _len_stem_uid: int = 16
 
-    features: FeatureManager = FeatureManagerArtifact  # type: ignore
-    """Feature manager.
+    @property
+    def features(self) -> FeatureManager:
+        """Feature manager.
 
-    Typically, you annotate a dataset with features by defining a `Schema` and passing it to the `Artifact` constructor.
+        Typically, you annotate a dataset with features by defining a `Schema` and passing it to the `Artifact` constructor.
 
-    Here is how to do annotate an artifact ad hoc::
-
-       artifact.features.add_values({
-            "species": organism,  # here, organism is an Organism record
-            "scientist": ['Barbara McClintock', 'Edgar Anderson'],
-            "temperature": 27.6,
-            "experiment": "Experiment 1"
-       })
-
-    Query artifacts by features::
-
-        ln.Artifact.filter(scientist="Barbara McClintock")
-
-    Features may or may not be part of the dataset, i.e., the artifact content in storage. For
-    instance, the :class:`~lamindb.curators.DataFrameCurator` flow validates the columns of a
-    `DataFrame`-like artifact and annotates it with features corresponding to
-    these columns. `artifact.features.add_values`, by contrast, does not
-    validate the content of the artifact.
-
-    .. dropdown:: An example for a model-like artifact
-
-        ::
+        Here is how to do annotate an artifact ad hoc::
 
             artifact.features.add_values({
-                "hidden_size": 32,
-                "bottleneck_size": 16,
-                "batch_size": 32,
-                "preprocess_params": {
-                    "normalization_type": "cool",
-                    "subset_highlyvariable": True,
-                },
+                "species": organism,  # here, organism is an Organism record
+                "scientist": ['Barbara McClintock', 'Edgar Anderson'],
+                "temperature": 27.6,
+                "experiment": "Experiment 1"
             })
-    """
+
+        Query artifacts by features::
+
+            ln.Artifact.filter(scientist="Barbara McClintock")
+
+        Features may or may not be part of the dataset, i.e., the artifact content in storage. For
+        instance, the :class:`~lamindb.curators.DataFrameCurator` flow validates the columns of a
+        `DataFrame`-like artifact and annotates it with features corresponding to
+        these columns. `artifact.features.add_values`, by contrast, does not
+        validate the content of the artifact.
+
+        .. dropdown:: An example for a model-like artifact
+
+            ::
+
+                artifact.features.add_values({
+                    "hidden_size": 32,
+                    "bottleneck_size": 16,
+                    "batch_size": 32,
+                    "preprocess_params": {
+                        "normalization_type": "cool",
+                        "subset_highlyvariable": True,
+                    },
+                })
+        """
+        from ._feature_manager import FeatureManager
+
+        return FeatureManager(self)
 
     @property
     def labels(self) -> LabelManager:
@@ -1224,9 +1227,6 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
     """Number of files for folder-like artifacts, `None` for file-like artifacts.
 
     Note that some arrays are also stored as folders, e.g., `.zarr` or `.tiledbsoma`.
-
-    .. versionchanged:: 1.0
-        Renamed from `n_objects` to `n_files`.
     """
     n_observations: int | None = BigIntegerField(
         null=True, db_index=True, default=None, editable=False
@@ -1330,19 +1330,11 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         *args,
         **kwargs,
     ):
-        self.features = FeatureManager(self)  # type: ignore
-        # Below checks for the Django-internal call in from_db()
-        # it'd be better if we could avoid this, but not being able to create a Artifact
-        # from data with the default constructor renders the central class of the API
-        # essentially useless
-        # The danger below is not that a user might pass as many args (12 of it), but rather
-        # that at some point the Django API might change; on the other hand, this
-        # condition of for calling the constructor based on kwargs should always
-        # stay robust
+        # check whether we are called with db args
         if len(args) == len(self._meta.concrete_fields):
             super().__init__(*args, **kwargs)
             return None
-        # now we proceed with the user-facing constructor
+        # now proceed with the user-facing constructor
         if len(args) > 1:
             raise ValueError("Only one non-keyword arg allowed: data")
         data: str | Path = kwargs.pop("data") if len(args) == 0 else args[0]

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -70,7 +70,6 @@ from ..models._is_versioned import (
 from ._django import get_artifact_with_related
 from ._feature_manager import (
     FeatureManager,
-    add_label_feature_links,
     filter_base,
     get_label_links,
 )
@@ -960,8 +959,7 @@ def add_labels(
             features_labels = {
                 registry_name: [(feature, label_record) for label_record in records]
             }
-            add_label_feature_links(
-                self.features,
+            self.features._add_label_feature_links(
                 features_labels,
                 feature_ref_is_name=feature_ref_is_name,
                 label_ref_is_name=label_ref_is_name,

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
 FEATURE_DTYPES = set(get_args(Dtype))
 
 
-def parse_dtype(dtype_str: str, is_param: bool = False) -> list[dict[str, str]]:
+def parse_dtype(dtype_str: str, is_param: bool = False) -> list[dict[str, Any]]:
     """Parses feature data type string into a structured list of components."""
     from .artifact import Artifact
 

--- a/lamindb/models/run.py
+++ b/lamindb/models/run.py
@@ -441,7 +441,7 @@ class Run(SQLRecord):
                     keys_normalized, field="name", mute=True
                 )
             ):
-                return filter_base(FeatureManagerRun, **expressions)
+                return filter_base(Run, **expressions)
             else:
                 params = ", ".join(sorted(np.array(keys_normalized)[~params_validated]))
                 message = f"feature names: {params}"

--- a/lamindb/models/run.py
+++ b/lamindb/models/run.py
@@ -27,6 +27,7 @@ from .sqlrecord import BaseSQLRecord, IsLink, SQLRecord
 if TYPE_CHECKING:
     from datetime import datetime
 
+    from ._feature_manager import FeatureManager
     from .artifact import Artifact
     from .collection import Collection
     from .feature import FeatureValue
@@ -37,18 +38,6 @@ if TYPE_CHECKING:
 
 
 _TRACKING_READY: bool | None = None
-
-
-class FeatureManager:
-    """Feature manager."""
-
-    pass
-
-
-class FeatureManagerRun(FeatureManager):
-    """Feature manager."""
-
-    pass
 
 
 def current_run() -> Run | None:
@@ -234,26 +223,6 @@ class Run(SQLRecord):
 
     _name_field: str = "started_at"
 
-    features: FeatureManager = FeatureManagerRun  # type: ignore
-    """Features manager.
-
-    Run parameters are tracked via the `Feature` registry, just like all other variables.
-
-    Guide: :ref:`track-run-parameters`
-
-    Example::
-
-        run.features.add_values({
-            "learning_rate": 0.01,
-            "input_dir": "s3://my-bucket/mydataset",
-            "downsample": True,
-            "preprocess_params": {
-                "normalization_type": "cool",
-                "subset_highlyvariable": True,
-            },
-        })
-    """
-
     id: int = models.BigAutoField(primary_key=True)
     """Internal id, valid only in one DB instance."""
     # default uid was changed from base62_20 to base62_16 in 1.6.0
@@ -367,7 +336,6 @@ class Run(SQLRecord):
         *args,
         **kwargs,
     ):
-        self.features = FeatureManager(self)  # type: ignore
         if len(args) == len(self._meta.concrete_fields):
             super().__init__(*args, **kwargs)
             return None
@@ -401,6 +369,30 @@ class Run(SQLRecord):
     @deprecated("features")
     def params(self) -> FeatureManager:
         return self.features
+
+    @property
+    def features(self) -> FeatureManager:
+        """Features manager.
+
+        Run parameters are tracked via the `Feature` registry, just like all other variables.
+
+        Guide: :ref:`track-run-parameters`
+
+        Example::
+
+            run.features.add_values({
+                "learning_rate": 0.01,
+                "input_dir": "s3://my-bucket/mydataset",
+                "downsample": True,
+                "preprocess_params": {
+                    "normalization_type": "cool",
+                    "subset_highlyvariable": True,
+                },
+            })
+        """
+        from ._feature_manager import FeatureManager
+
+        return FeatureManager(self)
 
     @classmethod
     def filter(

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
 
     from .artifact import Artifact
     from .project import Project
-    from .query_set import QuerySet
+    from .query_set import QuerySet, SQLRecordList
 
 
 NUMBER_TYPE = "num"
@@ -464,7 +464,10 @@ class Schema(SQLRecord, CanCurate, TracksRun):
     @overload
     def __init__(
         self,
-        features: list[SQLRecord] | list[tuple[Feature, dict]] | None = None,
+        features: list[SQLRecord]
+        | SQLRecordList
+        | list[tuple[Feature, dict]]
+        | None = None,
         index: Feature | None = None,
         slots: dict[str, Schema] | None = None,
         name: str | None = None,

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -858,13 +858,10 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
             if hasattr(self, "labels"):
                 from copy import copy
 
-                from lamindb.models._feature_manager import FeatureManager
-
                 # here we go back to original record on the source database
                 self_on_db = copy(self)
                 self_on_db._state.db = db
                 self_on_db.pk = pk_on_db  # manually set the primary key
-                self_on_db.features = FeatureManager(self_on_db)  # type: ignore
                 self.features._add_from(self_on_db, transfer_logs=transfer_logs)
                 self.labels.add_from(self_on_db, transfer_logs=transfer_logs)
             for k, v in transfer_logs.items():

--- a/tests/core/test_feature_label_manager.py
+++ b/tests/core/test_feature_label_manager.py
@@ -264,9 +264,9 @@ Here is how to create ulabels for them:
         "lamindb.errors.InvalidArgument: You can query either by available fields:"
     )
 
-    ln.Artifact.features.get(temperature=100.0)
-    ln.Artifact.features.get(project="project_1")
-    ln.Artifact.features.get(is_validated=True)
+    ln.Artifact.filter(temperature=100.0)
+    ln.Artifact.filter(project="project_1")
+    ln.Artifact.filter(is_validated=True)
     ln.Artifact.filter(temperature=100.0, project="project_1", donor="U0123").one()
     # for bionty
     assert (
@@ -279,7 +279,7 @@ Here is how to create ulabels for them:
 
     # test not finding the ULabel
     with pytest.raises(DoesNotExist) as error:
-        ln.Artifact.features.get(project="project__1")
+        ln.Artifact.filter(project="project__1")
     assert error.exconly().startswith(
         "lamindb.errors.DoesNotExist: Did not find a ULabel matching"
     )


### PR DESCRIPTION
This eliminates all monkey-patching and unconventional code organization that dates back to using the deprecated `Artifact.features.filter()` access pattern.

Meanwhile, there was a transition to filtering by features as we filter by fields, through `Artifact.filter()` and there is no longer a need for the complexity.

This refactor prepares a refactor for the transfer flow.