### PR TITLE
🩹 Avoid `init_storage` call in `check_path_in_existing_storage`

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -354,7 +354,7 @@ def check_path_in_existing_storage(
     if check_hub_register_storage and getattr(path, "protocol", None) in {"s3", "gs"}:
         result = select_storage_or_parent(path.as_posix())
         if result is not None:
-            return Storage(**result).save()
+            return Storage(**result, _skip_preparation=True).save()
     return None
 
 

--- a/lamindb/models/storage.py
+++ b/lamindb/models/storage.py
@@ -184,12 +184,11 @@ class Storage(SQLRecord, TracksRun, TracksUpdates):
 
             init_self_from_db(self, storage_record)
             return None
-        if "_skip_preparation" in kwargs:
-            skip_preparation = kwargs.pop("_skip_preparation")
-            if skip_preparation is True:
-                super().__init__(*args, **kwargs)
-                return None
-            kwargs.pop("_skip_preparation")
+
+        skip_preparation = kwargs.pop("_skip_preparation", False)
+        if skip_preparation:
+            super().__init__(*args, **kwargs)
+            return None
 
         # instance_id won't take effect if
         # - there is no write access


### PR DESCRIPTION
`select_storage_or_parent` already checks for the hub record, no need to do the same request again.