### PR TITLE
🚸 Mark failed upload of artifacts via `artifact._is_saved_to_storage_location`

### DIFF
--- a/docs/faq/acid.ipynb
+++ b/docs/faq/acid.ipynb
@@ -247,7 +247,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.17"
+   "version": "3.10.16"
   },
   "nbproject": {
    "id": "zz23msudiiQR",

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -79,6 +79,7 @@ from ._relations import (
 from .feature import Feature, FeatureValue
 from .has_parents import view_lineage
 from .run import Run, TracksRun, TracksUpdates, User
+from .save import check_and_attempt_clearing, check_and_attempt_upload
 from .schema import Schema
 from .sqlrecord import (
     BaseSQLRecord,
@@ -2675,8 +2676,6 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             self._save_complete = False  # will be updated to True at the end
 
         self._save_skip_storage(**kwargs)
-
-        from .save import check_and_attempt_clearing, check_and_attempt_upload
 
         using_key = None
         if "using" in kwargs:

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -2632,6 +2632,8 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
     def _is_saved_to_storage_location(self) -> bool | None:
         """Indicates whether this artifact was correctly written to its storage.
 
+        This is meaningful only after calling `.save()`.
+
         `None` means no writing was necessary, `True` - that it was written correctly.
         `False` shows that there was a problem with writing.
         """

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -2630,6 +2630,11 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
 
     @property
     def _is_saved_to_storage_location(self) -> bool | None:
+        """Indicates whether this artifact was correctly written to its storage.
+
+        `None` means no writing was necessary, `True` - that it was written correctly.
+        `False` shows that there was a problem with writing.
+        """
         if self._aux is not None:
             return self._aux.get("af", {}).get("0", None)
         else:

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -2631,7 +2631,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
     @property
     def _save_complete(self) -> bool | None:
         if self._aux is not None:
-            return self._aux.get("auf", {}).get("0", None)
+            return self._aux.get("af", {}).get("0", None)
         else:
             return None
 

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -2711,6 +2711,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         if exception_clear is not None:
             raise RuntimeError(exception_clear)
         # the saving / upload process has been successfull, just mark it as such
+        # maybe some error handling here?
         if flag_complete:
             self._is_saved_to_storage_location = True
             super().save()  # do we need to pass kwargs here?

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -2709,7 +2709,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         # the saving / upload process has been successfull, just mark it as such
         if flag_complete:
             self._save_complete = True
-            super().save(**kwargs)  # do we need to pass kwargs here?
+            super().save()  # do we need to pass kwargs here?
 
         # this is only for keep_artifacts_local
         if local_path is not None and not state_was_adding:

--- a/lamindb/models/save.py
+++ b/lamindb/models/save.py
@@ -339,21 +339,17 @@ def store_artifacts(
         exception = check_and_attempt_upload(artifact, using_key)
         if exception is not None:
             break
+
+        stored_artifacts += [artifact]
         # update to show successful saving
         # only update if _is_saved_to_storage_location was set to False before
         # this should be a single transaction for the updates of all the artifacts
         # but then it would just abort all artifacts, even successfully saved before
-        try:
-            if artifact._is_saved_to_storage_location is False:
-                artifact._is_saved_to_storage_location = True
-                super(Artifact, artifact).save()
-        except Exception as e:
-            if getattr(artifact, "_to_store", False):
-                artifact._clear_storagekey = auto_storage_key_from_artifact(artifact)
-            exception = e
-            break
-
-        stored_artifacts += [artifact]
+        # TODO: there should also be some kind of exception handling here
+        # but this requires proper refactoring
+        if artifact._is_saved_to_storage_location is False:
+            artifact._is_saved_to_storage_location = True
+            super(Artifact, artifact).save()
         # if check_and_attempt_upload was successful
         # then this can have only ._clear_storagekey from .replace
         exception = check_and_attempt_clearing(

--- a/lamindb/models/save.py
+++ b/lamindb/models/save.py
@@ -106,7 +106,8 @@ def save(
         with transaction.atomic():
             for record in artifacts:
                 # will swtich to True after the successful upload / saving
-                record._save_complete = False
+                if hasattr(record, "_local_filepath"):
+                    record._save_complete = False
                 record._save_skip_storage()
         using_key = settings._using_key
         store_artifacts(artifacts, using_key=using_key)
@@ -338,8 +339,10 @@ def store_artifacts(
             break
         stored_artifacts += [artifact]
         # update to show successful saving
-        artifact._save_complete = True
-        super(Artifact, artifact).save()
+        # only update if _save_complete was set to False before
+        if artifact._save_complete is False:
+            artifact._save_complete = True
+            super(Artifact, artifact).save()
         # if check_and_attempt_upload was successful
         # then this can have only ._clear_storagekey from .replace
         exception = check_and_attempt_clearing(

--- a/lamindb/models/save.py
+++ b/lamindb/models/save.py
@@ -322,6 +322,8 @@ def store_artifacts(
 
     If any upload fails, subsequent artifacts are cleaned up from the DB.
     """
+    from .artifact import Artifact
+
     exception: Exception | None = None
     # because uploads might fail, we need to maintain a new list
     # of the succeeded uploads

--- a/lamindb/models/save.py
+++ b/lamindb/models/save.py
@@ -349,7 +349,9 @@ def store_artifacts(
         # but this requires proper refactoring
         if artifact._is_saved_to_storage_location is False:
             artifact._is_saved_to_storage_location = True
-            super(Artifact, artifact).save()
+            super(
+                Artifact, artifact
+            ).save()  # each .save is a separate transaction here
         # if check_and_attempt_upload was successful
         # then this can have only ._clear_storagekey from .replace
         exception = check_and_attempt_clearing(

--- a/lamindb/models/save.py
+++ b/lamindb/models/save.py
@@ -379,7 +379,7 @@ def prepare_error_message(records, stored_artifacts, exception) -> str:
     else:
         error_message = (
             "The following entries have been"
-            " successfuly uploaded and committed to the database:\n"
+            " successfully uploaded and committed to the database:\n"
         )
         for record in stored_artifacts:
             error_message += (

--- a/tests/storage/conftest.py
+++ b/tests/storage/conftest.py
@@ -59,11 +59,14 @@ def delete_test_instance():
     if Path("./default_storage_unit_storage").exists():
         shutil.rmtree("./default_storage_unit_storage")
     # handle below better in the future
-    if ln.UPath("s3://lamindb-test/storage/.lamindb").exists():
-        ln.UPath("s3://lamindb-test/storage/.lamindb").rmdir()
-    another_storage = ln.UPath("s3://lamindb-ci/lamindb-unit-tests-cloud/.lamindb")
-    if another_storage.exists():
-        another_storage.rmdir()
+    for path in (
+        "s3://lamindb-test/storage/.lamindb",
+        "s3://lamindb-ci/lamindb-unit-tests-cloud/.lamindb",
+        "s3://lamindb-test/core/.lamindb",
+    ):
+        upath = ln.UPath(path)
+        if upath.exists():
+            upath.rmdir()
     ln.setup.delete("lamindb-unit-tests-storage", force=True)
 
 

--- a/tests/storage/test_artifact_zarr.py
+++ b/tests/storage/test_artifact_zarr.py
@@ -30,9 +30,12 @@ def test_zarr_upload_cache(get_small_adata):
     get_small_adata.write_zarr(zarr_path)
 
     artifact = ln.Artifact(zarr_path, key="test_adata.zarr")
+    assert artifact._save_complete is None
     assert artifact.otype == "AnnData"
     assert artifact.n_files >= 1
     artifact.save()
+
+    assert artifact._save_complete
 
     assert isinstance(artifact.path, CloudPath)
     assert artifact.path.exists()
@@ -54,12 +57,14 @@ def test_zarr_upload_cache(get_small_adata):
 
     # test zarr from memory
     artifact = ln.Artifact(get_small_adata, key="test_adata.anndata.zarr")
+    assert artifact._save_complete is None
     assert artifact._local_filepath.is_dir()
     assert artifact.otype == "AnnData"
     assert artifact.suffix == ".anndata.zarr"
     assert artifact.n_files >= 1
 
     artifact.save()
+    assert artifact._save_complete
     assert isinstance(artifact.path, CloudPath)
     assert artifact.path.exists()
     cache_path = artifact._cache_path

--- a/tests/storage/test_artifact_zarr.py
+++ b/tests/storage/test_artifact_zarr.py
@@ -63,7 +63,7 @@ def test_zarr_upload_cache(get_small_adata):
     assert artifact.suffix == ".anndata.zarr"
     assert artifact.n_files >= 1
 
-    artifact.save()
+    ln.save([artifact])  # use bulk save here for testing
     assert artifact._save_complete
     assert isinstance(artifact.path, CloudPath)
     assert artifact.path.exists()

--- a/tests/storage/test_artifact_zarr.py
+++ b/tests/storage/test_artifact_zarr.py
@@ -30,12 +30,12 @@ def test_zarr_upload_cache(get_small_adata):
     get_small_adata.write_zarr(zarr_path)
 
     artifact = ln.Artifact(zarr_path, key="test_adata.zarr")
-    assert artifact._save_complete is None
+    assert artifact._is_saved_to_storage_location is None
     assert artifact.otype == "AnnData"
     assert artifact.n_files >= 1
     artifact.save()
 
-    assert artifact._save_complete
+    assert artifact._is_saved_to_storage_location
 
     assert isinstance(artifact.path, CloudPath)
     assert artifact.path.exists()
@@ -57,14 +57,14 @@ def test_zarr_upload_cache(get_small_adata):
 
     # test zarr from memory
     artifact = ln.Artifact(get_small_adata, key="test_adata.anndata.zarr")
-    assert artifact._save_complete is None
+    assert artifact._is_saved_to_storage_location is None
     assert artifact._local_filepath.is_dir()
     assert artifact.otype == "AnnData"
     assert artifact.suffix == ".anndata.zarr"
     assert artifact.n_files >= 1
 
     ln.save([artifact])  # use bulk save here for testing
-    assert artifact._save_complete
+    assert artifact._is_saved_to_storage_location
     assert isinstance(artifact.path, CloudPath)
     assert artifact.path.exists()
     cache_path = artifact._cache_path


### PR DESCRIPTION
Now artifacts have `._is_saved_to_storage_location` property which is `True` only if upload or local saving was completed successfully. 

`artifact._is_saved_to_storage_location` is meaningful only after calling `.save()`. `None` means no writing was necessary, `True` - that it was written correctly. `False` shows that there was a problem with writing.

```python
artifact.save() # or ln.save([artifact])
assert artifact._is_saved_to_storage_location
```