### PR TITLE
🐛 Respect `anon=True` in `_tiledb_config_s3`

### DIFF
--- a/lamindb/core/storage/_tiledbsoma.py
+++ b/lamindb/core/storage/_tiledbsoma.py
@@ -54,12 +54,18 @@ def _tiledb_config_s3(storepath: UPath) -> dict:
     else:
         tiledb_config["vfs.s3.region"] = get_storage_region(storepath)
 
-    if "key" in storage_options:
-        tiledb_config["vfs.s3.aws_access_key_id"] = storage_options["key"]
-    if "secret" in storage_options:
-        tiledb_config["vfs.s3.aws_secret_access_key"] = storage_options["secret"]
-    if "token" in storage_options:
-        tiledb_config["vfs.s3.aws_session_token"] = storage_options["token"]
+    if storage_options.get("anon", False):
+        tiledb_config["vfs.s3.no_sign_request"] = "true"
+        tiledb_config["vfs.s3.aws_access_key_id"] = ""
+        tiledb_config["vfs.s3.aws_secret_access_key"] = ""
+        tiledb_config["vfs.s3.aws_session_token"] = ""
+    else:
+        if "key" in storage_options:
+            tiledb_config["vfs.s3.aws_access_key_id"] = storage_options["key"]
+        if "secret" in storage_options:
+            tiledb_config["vfs.s3.aws_secret_access_key"] = storage_options["secret"]
+        if "token" in storage_options:
+            tiledb_config["vfs.s3.aws_session_token"] = storage_options["token"]
 
     return tiledb_config
 


### PR DESCRIPTION
Address https://github.com/laminlabs/pfizer-lamin-usage/issues/262#issuecomment-3012493703

`tiledbsoma` doesn't use s3fs connection options, so this adds some normalization between `s3fs` and `tiledb` context used for s3 connections.