### PR TITLE
✨ Enable converting records to dataframes

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -124,6 +124,7 @@ if TYPE_CHECKING:
     from ._label_manager import LabelManager
     from .collection import Collection
     from .project import Project, Reference
+    from .record import Record
     from .transform import Transform
 
 
@@ -1312,6 +1313,8 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
     """Linked projects."""
     references: Reference
     """Linked references."""
+    records: Record
+    """Linked records."""
 
     @overload
     def __init__(

--- a/lamindb/models/query_set.py
+++ b/lamindb/models/query_set.py
@@ -19,7 +19,7 @@ from ..errors import DoesNotExist
 from ._is_versioned import IsVersioned
 from .can_curate import CanCurate, _inspect, _standardize, _validate
 from .query_manager import _lookup, _search
-from .sqlrecord import SQLRecord
+from .sqlrecord import Registry, SQLRecord
 
 if TYPE_CHECKING:
     from lamindb.base.types import ListLike, StrField
@@ -303,12 +303,19 @@ def get_basic_field_names(
 
 
 def get_feature_annotate_kwargs(
+    registry: Registry,
     features: bool | list[str] | None,
 ) -> tuple[dict[str, Any], list[str], QuerySet]:
     from lamindb.models import (
         Artifact,
         Feature,
+        Record,
     )
+
+    if registry not in {Artifact, Record}:
+        raise ValueError(
+            f"features=True is only applicable for Artifact and Record, not {registry.__name__}"
+        )
 
     feature_qs = Feature.filter()
     if isinstance(features, list):
@@ -316,11 +323,13 @@ def get_feature_annotate_kwargs(
         feature_names = features
     else:  # features is True -- only consider categorical features from ULabel and non-categorical features
         feature_qs = feature_qs.filter(
-            Q(~Q(dtype__startswith="cat[")) | Q(dtype__startswith="cat[ULabel")
+            Q(~Q(dtype__startswith="cat["))
+            | Q(dtype__startswith="cat[ULabel")
+            | Q(dtype__startswith="cat[Record")
         )
         feature_names = feature_qs.list("name")
         logger.important(
-            f"queried for all categorical features with dtype 'cat[ULabel...'] and non-categorical features: ({len(feature_names)}) {feature_names}"
+            f"queried for all categorical features with dtype ULabel or Record and non-categorical features: ({len(feature_names)}) {feature_names}"
         )
     # Get the categorical features
     cat_feature_types = {
@@ -331,18 +340,28 @@ def get_feature_annotate_kwargs(
     # Get relationships of labels and features
     link_models_on_models = {
         getattr(
-            Artifact, obj.related_name
+            registry, obj.related_name
         ).through.__get_name_with_module__(): obj.related_model.__get_name_with_module__()
-        for obj in Artifact._meta.related_objects
+        for obj in registry._meta.related_objects
         if obj.related_model.__get_name_with_module__() in cat_feature_types
     }
-    link_models_on_models["ArtifactULabel"] = "ULabel"
+    if registry is Artifact:
+        link_models_on_models["ArtifactULabel"] = "ULabel"
+    else:
+        link_models_on_models["RecordRecord"] = "Record"
     link_attributes_on_models = {
         obj.related_name: link_models_on_models[
             obj.related_model.__get_name_with_module__()
         ]
-        for obj in Artifact._meta.related_objects
-        if obj.related_model.__get_name_with_module__() in link_models_on_models
+        for obj in registry._meta.related_objects
+        if (
+            obj.related_model.__get_name_with_module__() in link_models_on_models
+            and (
+                not obj.related_name.startswith("links_record")
+                if registry is Record
+                else True
+            )
+        )
     }
     # Prepare Django's annotate for features
     annotate_kwargs = {}
@@ -350,17 +369,22 @@ def get_feature_annotate_kwargs(
         annotate_kwargs[f"{link_attr}__feature__name"] = F(
             f"{link_attr}__feature__name"
         )
-        field_name = (
-            feature_type.split(".")[1] if "." in feature_type else feature_type
-        ).lower()
+        if registry is Artifact or feature_type.startswith("bionty."):
+            field_name = (
+                feature_type.split(".")[1] if "." in feature_type else feature_type
+            ).lower()
+        else:
+            field_name = "value"
         annotate_kwargs[f"{link_attr}__{field_name}__name"] = F(
             f"{link_attr}__{field_name}__name"
         )
-
-    annotate_kwargs["_feature_values__feature__name"] = F(
-        "_feature_values__feature__name"
+    json_values_attribute = "_feature_values" if registry is Artifact else "values_json"
+    annotate_kwargs[f"{json_values_attribute}__feature__name"] = F(
+        f"{json_values_attribute}__feature__name"
     )
-    annotate_kwargs["_feature_values__value"] = F("_feature_values__value")
+    annotate_kwargs[f"{json_values_attribute}__value"] = F(
+        f"{json_values_attribute}__value"
+    )
     return annotate_kwargs, feature_names, feature_qs
 
 
@@ -426,6 +450,7 @@ def reorder_subset_columns_in_df(df: pd.DataFrame, column_order: list[str], posi
 # https://lamin.ai/laminlabs/lamindata/transform/BblTiuKxsb2g0003
 # https://claude.ai/chat/6ea2498c-944d-4e7a-af08-29e5ddf637d2
 def reshape_annotate_result(
+    registry: Registry,
     df: pd.DataFrame,
     field_names: list[str],
     cols_from_include: dict[str, str] | None,
@@ -441,29 +466,38 @@ def reshape_annotate_result(
             e.g., {'ulabels__name': 'many', 'created_by__name': 'one'}
         feature_names: Feature names.
     """
+    from lamindb.models import Artifact
+
     cols_from_include = cols_from_include or {}
+
+    json_values_attribute = "_feature_values" if registry is Artifact else "values_json"
 
     # initialize result with basic fields, need a copy as we're modifying it
     # will give us warnings otherwise
     result = df[field_names].copy()
     # process features if requested
     if feature_names:
-        # handle feature_values
-        feature_cols = ["_feature_values__feature__name", "_feature_values__value"]
+        # handle json values
+        feature_cols = [
+            f"{json_values_attribute}__feature__name",
+            f"{json_values_attribute}__value",
+        ]
         if all(col in df.columns for col in feature_cols):
             # Create two separate dataframes - one for dict values and one for non-dict values
-            is_dict = df["_feature_values__value"].apply(lambda x: isinstance(x, dict))
+            is_dict = df[f"{json_values_attribute}__value"].apply(
+                lambda x: isinstance(x, dict)
+            )
             dict_df, non_dict_df = df[is_dict], df[~is_dict]
 
             # Process non-dict values using set aggregation
             non_dict_features = non_dict_df.groupby(
-                ["id", "_feature_values__feature__name"]
-            )["_feature_values__value"].agg(set)
+                ["id", f"{json_values_attribute}__feature__name"]
+            )[f"{json_values_attribute}__value"].agg(set)
 
             # Process dict values using first aggregation
-            dict_features = dict_df.groupby(["id", "_feature_values__feature__name"])[
-                "_feature_values__value"
-            ].agg("first")
+            dict_features = dict_df.groupby(
+                ["id", f"{json_values_attribute}__feature__name"]
+            )[f"{json_values_attribute}__value"].agg("first")
 
             # Combine the results
             combined_features = pd.concat([non_dict_features, dict_features])
@@ -477,10 +511,11 @@ def reshape_annotate_result(
                 )
 
         # handle categorical features
+        links_prefix = "links_" if registry is Artifact else ("links_", "values_")
         links_features = [
             col
             for col in df.columns
-            if "feature__name" in col and col.startswith("links_")
+            if "feature__name" in col and col.startswith(links_prefix)
         ]
 
         if links_features:
@@ -523,12 +558,14 @@ def process_links_features(
     """Process links_XXX feature columns."""
     # this loops over different entities that might be linked under a feature
     for feature_col in feature_cols:
-        prefix = re.match(r"links_(.+?)__feature__name", feature_col).group(1)
+        links_attribute = "links_" if feature_col.startswith("links_") else "values_"
+        regex = f"{links_attribute}(.+?)__feature__name"
+        prefix = re.match(regex, feature_col).group(1)
 
         value_cols = [
             col
             for col in df.columns
-            if col.startswith(f"links_{prefix}__")
+            if col.startswith(f"{links_attribute}{prefix}__")
             and col.endswith("__name")
             and "feature__name" not in col
         ]
@@ -620,7 +657,7 @@ class BasicQuerySet(models.QuerySet):
         feature_qs = None
         if features:
             feature_annotate_kwargs, feature_names, feature_qs = (
-                get_feature_annotate_kwargs(features)
+                get_feature_annotate_kwargs(self.model, features)
             )
             time = logger.debug("finished feature_annotate_kwargs", time=time)
             annotate_kwargs.update(feature_annotate_kwargs)
@@ -655,7 +692,7 @@ class BasicQuerySet(models.QuerySet):
         cols_from_include = analyze_lookup_cardinality(self.model, include_input)  # type: ignore
         time = logger.debug("finished analyze_lookup_cardinality", time=time)
         df_reshaped = reshape_annotate_result(
-            df, field_names, cols_from_include, feature_names, feature_qs
+            self.model, df, field_names, cols_from_include, feature_names, feature_qs
         )
         time = logger.debug("finished reshape_annotate_result", time=time)
         pk_name = self.model._meta.pk.name

--- a/tests/curators/test_records.py
+++ b/tests/curators/test_records.py
@@ -28,16 +28,16 @@ def test_record_example_compound_treatment():
     # a sheet for treatments
     my_treatments = ln.Record(
         name="My treatments 2025-05", type=treatment_type
-    ).save()  # sheet without schema
+    ).save()  # sheet without validating schema
 
     # populate treatment1
-    treatment1 = ln.Record(name="drug1", type=my_treatments).save()
+    treatment1 = ln.Record(name="treatment1", type=my_treatments).save()
     ln.models.RecordRecord(record=treatment1, feature=compound, value=drug1).save()
     assert drug1 in treatment1.components.all()
     assert treatment1 in drug1.composites.all()
     ln.models.RecordJson(record=treatment1, feature=concentration, value="2nM").save()
     # populate treatment2
-    treatment2 = ln.Record(name="drug2", type=my_treatments).save()
+    treatment2 = ln.Record(name="treatment2", type=my_treatments).save()
     ln.models.RecordRecord(record=treatment2, feature=compound, value=drug2).save()
     ln.models.RecordJson(record=treatment2, feature=concentration, value="4nM").save()
 
@@ -93,6 +93,22 @@ def test_record_example_compound_treatment():
     bt.models.RecordCellLine(
         record=sample4, feature=cell_line, cellline=hek293t
     ).save()  # parallel to ArtifactCellLine
+
+    dictionary = (
+        ln.Record.filter(type=my_treatments).df()[["is_type", "name"]].to_dict()
+    )
+    assert dictionary == {
+        "is_type": {
+            2: False,
+            3: False,
+        },
+        "name": {
+            2: "treatment1",
+            3: "treatment2",
+        },
+    }
+
+    print(ln.Record.filter(type=my_treatments).df(features=True))
 
 
 def test_record_nextflow_samples():

--- a/tests/curators/test_records.py
+++ b/tests/curators/test_records.py
@@ -46,6 +46,8 @@ def test_record_example_compound_treatment():
     sample_type = ln.Record(name="BioSample", is_type=True).save()
     treatment = ln.Feature(name="treatment", dtype=compound_type).save()
     cell_line = ln.Feature(name="cell_line", dtype=bt.CellLine).save()
+    cell_line.dtype = "cat[bionty.CellLine]"  # might have previously been set to "cat"
+    cell_line.save()
     schema = ln.Schema(
         name="My samples schema 2025-05", features=[treatment, cell_line]
     ).save()

--- a/tests/curators/test_records.py
+++ b/tests/curators/test_records.py
@@ -44,14 +44,11 @@ def test_record_example_compound_treatment():
     # Samples ---------------------------
 
     sample_type = ln.Record(name="BioSample", is_type=True).save()
-
-    # features for samples
     treatment = ln.Feature(name="treatment", dtype=compound_type).save()
     cell_line = ln.Feature(name="cell_line", dtype=bt.CellLine).save()
     schema = ln.Schema(
         name="My samples schema 2025-05", features=[treatment, cell_line]
     ).save()
-    # a sheet for samples
     sheet1 = ln.Record(
         name="My samples 2025-05", schema=schema, type=sample_type
     ).save()
@@ -61,15 +58,11 @@ def test_record_example_compound_treatment():
     # populate sample1
     sample1 = ln.Record(name="sample1", type=sheet1).save()
     ln.models.RecordRecord(record=sample1, feature=treatment, value=treatment1).save()
-    bt.models.RecordCellLine(
-        record=sample1, feature=cell_line, cellline=hek293t
-    ).save()  # parallel to ArtifactCellLine
+    bt.models.RecordCellLine(record=sample1, feature=cell_line, cellline=hek293t).save()
     # populate sample2
     sample2 = ln.Record(name="sample2", type=sheet1).save()
     ln.models.RecordRecord(record=sample2, feature=treatment, value=treatment2).save()
-    bt.models.RecordCellLine(
-        record=sample2, feature=cell_line, cellline=hek293t
-    ).save()  # parallel to ArtifactCellLine
+    bt.models.RecordCellLine(record=sample2, feature=cell_line, cellline=hek293t).save()
 
     # another sheet for samples
     sample_note = ln.Feature(name="sample_note", dtype="str").save()
@@ -95,20 +88,60 @@ def test_record_example_compound_treatment():
     ).save()  # parallel to ArtifactCellLine
 
     dictionary = (
-        ln.Record.filter(type=my_treatments).df()[["is_type", "name"]].to_dict()
+        ln.Record.filter(type=my_treatments)
+        .df()[["is_type", "name"]]
+        .to_dict(orient="list")
     )
     assert dictionary == {
-        "is_type": {
-            2: False,
-            3: False,
-        },
-        "name": {
-            2: "treatment1",
-            3: "treatment2",
-        },
+        "is_type": [
+            False,
+            False,
+        ],
+        "name": [
+            "treatment1",
+            "treatment2",
+        ],
     }
 
-    print(ln.Record.filter(type=my_treatments).df(features=True))
+    dictionary = (
+        ln.Record.filter(type=my_treatments)
+        .df(features=True)[["compound", "concentration", "name"]]
+        .to_dict(orient="list")
+    )
+    assert dictionary == {
+        "compound": [
+            "drug1",
+            "drug2",
+        ],
+        "concentration": [
+            "2nM",
+            "4nM",
+        ],
+        "name": [
+            "treatment1",
+            "treatment2",
+        ],
+    }
+
+    dictionary = (
+        ln.Record.filter(type=sheet1)
+        .df(features=["cell_line", "treatment"])[["cell_line", "name", "treatment"]]
+        .to_dict(orient="list")
+    )
+    assert dictionary == {
+        "cell_line": [
+            "HEK293T cell",
+            "HEK293T cell",
+        ],
+        "name": [
+            "sample1",
+            "sample2",
+        ],
+        "treatment": [
+            "treatment1",
+            "treatment2",
+        ],
+    }
 
 
 def test_record_nextflow_samples():


### PR DESCRIPTION
What has already worked for artifacts now also works for records:
```python
ln.Record.df(features=True)
```

In particular, given a record type `my_sheet`, one can export the sheet as a dataframe:
```python
ln.Record.filter(type=my_sheet).df(features=True)
```

For example, from the unit tests:
```python
dictionary = (
    ln.Record.filter(type=sheet1)
    .df(features=["cell_line", "treatment"])[["name", "cell_line", "treatment"]]
    .to_dict(orient="list")
)
assert dictionary == {
    "name": [
        "sample1",
        "sample2",
    ],
    "cell_line": [
        "HEK293T cell",
        "HEK293T cell",
    ],
    "treatment": [
        "treatment1",
        "treatment2",
    ],
}
```