### PR TITLE
🚸 Introduce two-column layout in `Artifact.describe()` and add information like `space`, `branch`, and `kind`

### DIFF
--- a/lamindb/models/_describe.py
+++ b/lamindb/models/_describe.py
@@ -154,11 +154,11 @@ def describe_general(self: Artifact | Collection, tree: Tree | None = None) -> T
         two_column_items.append(
             Text.assemble(("version: ", "dim"), f"'{self.version}'")
         )
-    if hasattr(self, "space") and self.space.name != "All":
+    if hasattr(self, "space"):
         two_column_items.append(
             Text.assemble(("space: ", "dim"), f"'{self.space.name}'")
         )
-    if hasattr(self, "branch") and self.branch.name != "Main":
+    if hasattr(self, "branch"):
         two_column_items.append(
             Text.assemble(("branch: ", "dim"), f"'{self.branch.name}'")
         )

--- a/lamindb/models/_describe.py
+++ b/lamindb/models/_describe.py
@@ -116,50 +116,76 @@ def describe_general(self: Artifact | Collection, tree: Tree | None = None) -> T
 
     # add general information (order is the same as in API docs)
     general = tree.add(Text("General", style="bold bright_cyan"))
-    general.add(f".uid = '{self.uid}'")
-    if hasattr(self, "key") and self.key:
-        general.add(f".key = '{self.key}'")
-    if hasattr(self, "size") and self.size:
-        general.add(f".size = {self.size}")
-    if hasattr(self, "hash") and self.hash:
-        general.add(f".hash = '{self.hash}'")
-    if hasattr(self, "n_files") and self.n_files:
-        general.add(f".n_files = {self.n_files}")
-    if hasattr(self, "n_observations") and self.n_observations:
-        general.add(Text(f".n_observations = {self.n_observations}"))
-    if hasattr(self, "version") and self.version:
-        general.add(Text(f".version = '{self.version}'"))
 
+    # Two column items (short content)
+    two_column_items = []
+
+    two_column_items.append(f"uid: '{self.uid}'")
+    if hasattr(self, "hash") and self.hash:
+        two_column_items.append(f"hash: '{self.hash}'")
+    if hasattr(self, "size") and self.size:
+        two_column_items.append(f"size: {self.size}")
+    if hasattr(self, "n_files") and self.n_files:
+        two_column_items.append(f"n_files: {self.n_files}")
+    if hasattr(self, "n_observations") and self.n_observations:
+        two_column_items.append(f"n_observations: {self.n_observations}")
+    if hasattr(self, "version") and self.version:
+        two_column_items.append(f"version: '{self.version}'")
+    if hasattr(self, "space") and self.space.name != "All":
+        two_column_items.append(f"space: '{self.space.name}'")
+    if hasattr(self, "branch") and self.branch.name != "Main":
+        two_column_items.append(f"branch: '{self.branch.name}'")
+    if hasattr(self, "created_at") and self.created_at:
+        two_column_items.append(
+            Text.assemble("created_at: ", highlight_time(str(self.created_at)))
+        )
+
+    # Add two-column items in pairs
+    for i in range(0, len(two_column_items), 2):
+        if i + 1 < len(two_column_items):
+            # Two items side by side
+            left_item = two_column_items[i]
+            right_item = two_column_items[i + 1]
+
+            # Handle both string and Text objects
+            if isinstance(left_item, str):
+                left_padded = left_item.ljust(35)
+            else:
+                left_padded = left_item
+
+            general.add(Text.assemble(left_padded, right_item))
+        else:
+            # Single item (odd number)
+            general.add(two_column_items[i])
+
+    # Single column items (long content)
+    if hasattr(self, "key") and self.key:
+        general.add(f"key: '{self.key}'")
     if hasattr(self, "storage"):
         storage_root = self.storage.root
-        # general.add(f".storage = {storage_root}")
         general.add(
             Text.assemble(
-                ".path = ",
+                "storage path: ",
                 (storage_root, "dim"),
                 f"{str(self.path).removeprefix(storage_root)}",
+            )
+        )
+    if hasattr(self, "transform") and self.transform is not None:
+        general.add(
+            Text(
+                f"transform: '{self.transform.key}'",
+                style="cyan3",
             )
         )
     if hasattr(self, "created_by") and self.created_by:
         general.add(
             Text.assemble(
-                ".created_by = ",
+                "created_by: ",
                 (
                     self.created_by.handle
                     if self.created_by.name is None
                     else f"{self.created_by.handle} ({self.created_by.name})"
                 ),
-            )
-        )
-    if hasattr(self, "created_at") and self.created_at:
-        general.add(
-            Text.assemble(".created_at = ", highlight_time(str(self.created_at)))
-        )
-    if hasattr(self, "transform") and self.transform:
-        general.add(
-            Text(
-                f".transform = '{self.transform.description}'",
-                style="cyan3",
             )
         )
 

--- a/tests/core/test_describe_and_df_calls.py
+++ b/tests/core/test_describe_and_df_calls.py
@@ -120,19 +120,61 @@ def test_curate_df():
     )  # general, internal features, external features, labels
     general_node = description_tree.children[0]
     assert general_node.label.plain == "General"
-    assert general_node.children[0].label == f".uid = '{artifact.uid}'"
-    assert general_node.children[1].label == ".key = 'examples/dataset1.h5ad'"
-    assert ".size = " in general_node.children[2].label
-    assert ".hash = " in general_node.children[3].label
-    assert general_node.children[4].label.plain == ".n_observations = 3"
-    assert ".path = " in general_node.children[5].label.plain
-    assert ".created_by = " in general_node.children[6].label.plain
-    assert ".created_at = " in general_node.children[7].label.plain
+
+    # The structure is now different due to two-column layout
+    # First few children are two-column pairs, then single-column items
+
+    # Check that uid appears in the first two-column row
+    first_row = general_node.children[0].label.plain
+    assert f"uid: '{artifact.uid}'" in first_row
+
+    # Check that hash appears somewhere in the two-column section
+    found_hash = False
+    found_size = False
+    found_n_observations = False
+
+    # Look through the two-column rows for hash, size, and n_observations
+    for child in general_node.children:
+        child_text = child.label.plain
+        if "hash: " in child_text:
+            found_hash = True
+        if "size: " in child_text:
+            found_size = True
+        if "n_observations: 3" in child_text:
+            found_n_observations = True
+
+    assert found_hash, "Hash should be present in the general section"
+    assert found_size, "Size should be present in the general section"
+    assert found_n_observations, (
+        "n_observations should be present in the general section"
+    )
+
+    # Check single-column items (these appear after the two-column items)
+    found_key = False
+    found_path = False
+    found_created_by = False
+    found_created_at = False
+
+    for child in general_node.children:
+        child_text = child.label.plain
+        if "key: 'examples/dataset1.h5ad'" in child_text:
+            found_key = True
+        if "storage location / path: " in child_text:
+            found_path = True
+        if "created_by: " in child_text:
+            found_created_by = True
+        if "created_at: " in child_text:
+            found_created_at = True
+
+    assert found_key, "Key should be present in the general section"
+    assert found_path, "Storage path should be present in the general section"
+    assert found_created_by, "Created by should be present in the general section"
+    assert found_created_at, "Created at should be present in the general section"
 
     # dataset section
     assert (
         artifact.features.describe(return_str=True)
-        == """Artifact .h5ad/AnnData
+        == """Artifact .h5ad · AnnData · dataset
 ├── Dataset features
 │   ├── obs • 4             [Feature]
 │   │   cell_type_by_expe…  cat[bionty.CellType]    B cell, CD8-positive, alpha…

--- a/tests/core/test_feature_label_manager.py
+++ b/tests/core/test_feature_label_manager.py
@@ -207,7 +207,6 @@ Here is how to create ulabels for them:
     # hard to test because of italic formatting
     tree = describe_features(artifact)
     format_rich_tree(tree)
-    assert tree.label.plain == "Artifact .h5ad/AnnData"
     assert tree.children[0].label.plain == "Linked features"
     assert len(tree.children[0].children[0].label.columns) == 3
     assert len(tree.children[0].children[0].label.rows) == 10


### PR DESCRIPTION
Before | After
--- | ---
<img width="644" alt="image" src="https://github.com/user-attachments/assets/899028ed-9c44-42f4-9d32-2fdca8ee0e28" /> | <img width="618" alt="image" src="https://github.com/user-attachments/assets/bff9575c-3457-450c-aca2-32d170e27249" />


Partially supersedes:

- https://github.com/laminlabs/lamindb/pull/2764

Fixes

- https://github.com/laminlabs/lamindb/issues/2662
- https://github.com/laminlabs/pfizer-lamin-usage/issues/202