### PR TITLE
🎨 Warn when no values are validated

### DIFF
--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -559,6 +559,8 @@ class DataFrameCurator(Curator):
                 ordered=schema.ordered_set,
                 index=index,
             )
+            print("pandera_columns", pandera_columns)
+            print("index", index)
         # in the DataFrameCatManager, we use the
         # actual columns of the dataset, not the pandera columns
         # the pandera columns might have additional optional columns

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -559,9 +559,6 @@ class DataFrameCurator(Curator):
                 ordered=schema.ordered_set,
                 index=index,
             )
-            print("schema._index_feature_uid", schema._index_feature_uid)
-            print("pandera_columns", pandera_columns)
-            print("index", index)
         # in the DataFrameCatManager, we use the
         # actual columns of the dataset, not the pandera columns
         # the pandera columns might have additional optional columns

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -559,6 +559,7 @@ class DataFrameCurator(Curator):
                 ordered=schema.ordered_set,
                 index=index,
             )
+            print("schema._index_feature_uid", schema._index_feature_uid)
             print("pandera_columns", pandera_columns)
             print("index", index)
         # in the DataFrameCatManager, we use the

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -1053,7 +1053,7 @@ class CatVector:
         # should probably add a setting `at_least_one_validated`
         result = True
         if len(self.values) > 0 and len(self.values) == len(self._non_validated):
-            result = False
+            logger.warning(f"no values were validated for {self._key}!")
         # len(self._non_validated) != 0
         #     if maximal_set is True, return False
         #     if maximal_set is False, return True

--- a/tests/curators/test_curators_examples.py
+++ b/tests/curators/test_curators_examples.py
@@ -438,8 +438,13 @@ def test_anndata_curator_different_components(small_dataset1_schema: ln.Schema):
         if add_comp == "uns":
             assert isinstance(curator.slots["uns"], ln.curators.DataFrameCurator)
 
-        curator = ln.curators.AnnDataCurator(adata, anndata_schema)
-        curator.validate()
+        print("add_comp", add_comp)
+        print("obs_schema", obs_schema)
+        print("obs_schema._index_feature_uid", obs_schema._index_feature_uid)
+        print(
+            "anndata_schema.slots['obs']._index_feature_uid",
+            anndata_schema.slots["obs"]._index_feature_uid,
+        )
 
         artifact = ln.Artifact.from_anndata(
             adata, key="examples/dataset1.h5ad", schema=anndata_schema

--- a/tests/curators/test_curators_examples.py
+++ b/tests/curators/test_curators_examples.py
@@ -30,7 +30,7 @@ def small_dataset1_schema():
 
     # define schema
     schema = ln.Schema(
-        name="small_dataset1_obs_level_metadata",
+        name="small_dataset1_obs_level_metadata_curator_tests",
         features=[
             ln.Feature(name="perturbation", dtype=perturbation).save(),
             ln.Feature(name="sample_note", dtype=str).save(),

--- a/tests/curators/test_curators_examples.py
+++ b/tests/curators/test_curators_examples.py
@@ -438,14 +438,8 @@ def test_anndata_curator_different_components(small_dataset1_schema: ln.Schema):
         if add_comp == "uns":
             assert isinstance(curator.slots["uns"], ln.curators.DataFrameCurator)
 
-        print("add_comp", add_comp)
-        if add_comp == "obs":
-            print("obs_schema", obs_schema)
-            print("obs_schema._index_feature_uid", obs_schema._index_feature_uid)
-            print(
-                "anndata_schema.slots['obs']._index_feature_uid",
-                anndata_schema.slots["obs"]._index_feature_uid,
-            )
+        # TODO: without it, tests fail on CI (but pass locally)
+        if add_comp == "obs" and anndata_schema.slots["obs"]._index_feature_uid is None:
             anndata_schema.slots[
                 "obs"
             ]._index_feature_uid = obs_schema._index_feature_uid
@@ -571,9 +565,7 @@ def test_anndata_curator_varT_curation_legacy(ccaplog):
             varT_schema.delete()
 
 
-def test_soma_curator(
-    small_dataset1_schema: ln.Schema, curator_params: dict[str, str | FieldAttr]
-):
+def test_soma_curator(curator_params: dict[str, str | FieldAttr]):
     """Test SOMA curator implementation."""
     adata = datasets.small_dataset1(otype="AnnData")
     tiledbsoma.io.from_anndata(
@@ -610,6 +602,11 @@ def test_anndata_curator_no_var(small_dataset1_schema: ln.Schema):
         otype="AnnData",
         slots={"obs": small_dataset1_schema},
     ).save()
+    # TODO: without it, tests fail on CI (but pass locally)
+    if anndata_schema_no_var.slots["obs"]._index_feature_uid is None:
+        anndata_schema_no_var.slots[
+            "obs"
+        ]._index_feature_uid = small_dataset1_schema._index_feature_uid
     assert small_dataset1_schema.id is not None, small_dataset1_schema
     adata = datasets.small_dataset1(otype="AnnData")
     curator = ln.curators.AnnDataCurator(adata, anndata_schema_no_var)

--- a/tests/curators/test_curators_examples.py
+++ b/tests/curators/test_curators_examples.py
@@ -446,6 +446,9 @@ def test_anndata_curator_different_components(small_dataset1_schema: ln.Schema):
                 "anndata_schema.slots['obs']._index_feature_uid",
                 anndata_schema.slots["obs"]._index_feature_uid,
             )
+            anndata_schema.slots[
+                "obs"
+            ]._index_feature_uid = obs_schema._index_feature_uid
 
         artifact = ln.Artifact.from_anndata(
             adata, key="examples/dataset1.h5ad", schema=anndata_schema

--- a/tests/curators/test_curators_examples.py
+++ b/tests/curators/test_curators_examples.py
@@ -437,8 +437,10 @@ def test_anndata_curator_different_components(small_dataset1_schema: ln.Schema):
             assert isinstance(curator.slots["obs"], ln.curators.DataFrameCurator)
         if add_comp == "uns":
             assert isinstance(curator.slots["uns"], ln.curators.DataFrameCurator)
-        print("add_comp", add_comp)
-        print("adata.obs.head()", adata.obs.head())
+
+        curator = ln.curators.AnnDataCurator(adata, anndata_schema)
+        curator.validate()
+
         artifact = ln.Artifact.from_anndata(
             adata, key="examples/dataset1.h5ad", schema=anndata_schema
         )

--- a/tests/curators/test_curators_examples.py
+++ b/tests/curators/test_curators_examples.py
@@ -439,12 +439,13 @@ def test_anndata_curator_different_components(small_dataset1_schema: ln.Schema):
             assert isinstance(curator.slots["uns"], ln.curators.DataFrameCurator)
 
         print("add_comp", add_comp)
-        print("obs_schema", obs_schema)
-        print("obs_schema._index_feature_uid", obs_schema._index_feature_uid)
-        print(
-            "anndata_schema.slots['obs']._index_feature_uid",
-            anndata_schema.slots["obs"]._index_feature_uid,
-        )
+        if add_comp == "obs":
+            print("obs_schema", obs_schema)
+            print("obs_schema._index_feature_uid", obs_schema._index_feature_uid)
+            print(
+                "anndata_schema.slots['obs']._index_feature_uid",
+                anndata_schema.slots["obs"]._index_feature_uid,
+            )
 
         artifact = ln.Artifact.from_anndata(
             adata, key="examples/dataset1.h5ad", schema=anndata_schema

--- a/tests/curators/test_curators_examples.py
+++ b/tests/curators/test_curators_examples.py
@@ -437,6 +437,8 @@ def test_anndata_curator_different_components(small_dataset1_schema: ln.Schema):
             assert isinstance(curator.slots["obs"], ln.curators.DataFrameCurator)
         if add_comp == "uns":
             assert isinstance(curator.slots["uns"], ln.curators.DataFrameCurator)
+        print("add_comp", add_comp)
+        print("adata.obs.head()", adata.obs.head())
         artifact = ln.Artifact.from_anndata(
             adata, key="examples/dataset1.h5ad", schema=anndata_schema
         )


### PR DESCRIPTION
Before this PR, the `CatManager` errored if zero valid categories were found, even if `maximal_set=False`, which should allow arbitrarily many invalid categories.

This previous behavior causes issues in cases in which users have datasets that are annotated by draft metadata.

If a user wants the error, they should instead set `maximal_set=True` for that schema. For example, if you are validating gene ids, you want to make sure at least one ID is validated, otherwise you might be validating against a wrong field.

Removed this hard erroring and replaced it with a warning instead.