### PR TITLE
🚸 Simplify default transfer mode: no longer transfer annotations

### DIFF
--- a/docs/storage/transfer-local-to-cloud.ipynb
+++ b/docs/storage/transfer-local-to-cloud.ipynb
@@ -61,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "artifact.save()"
+    "artifact.save(transfer=\"annotations\")"
    ]
   },
   {
@@ -71,6 +71,18 @@
    "outputs": [],
    "source": [
     "artifact.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert artifact._state.db == \"default\"\n",
+    "assert artifact.organisms.get().name == \"human\"\n",
+    "assert artifact.experiments.get().name == \"experiment-test-transfer-to-cloud\"\n",
+    "assert artifact.features[\"var\"].count() == 2"
    ]
   },
   {

--- a/docs/storage/transfer-local-to-cloud.ipynb
+++ b/docs/storage/transfer-local-to-cloud.ipynb
@@ -79,18 +79,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert artifact._state.db == \"default\"\n",
-    "assert artifact.organisms.get().name == \"human\"\n",
-    "assert artifact.experiments.get().name == \"experiment-test-transfer-to-cloud\"\n",
-    "assert artifact.features[\"var\"].count() == 2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "!lamin delete --force test-transfer-to-cloud\n",
     "!rm -r ./test-transfer-to-cloud"
    ]

--- a/docs/transfer.ipynb
+++ b/docs/transfer.ipynb
@@ -193,7 +193,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "artifact.view_lineage()"
@@ -209,7 +213,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "artifact.transform.description"
@@ -225,7 +233,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "artifact.transform.key"
@@ -241,7 +253,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "artifact.run.initiated_by_run.transform"
@@ -257,11 +273,56 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "artifact = artifacts.filter(description__contains=\"Tabula Sapiens\").first()\n",
     "artifact.save()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you also want to transfer annotations of the artifact, you can pass `transfer=\"annotations\"` to `save()`. Just note that this might populate your target database with metadata that doesn't match the conventions you want to enforce."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "artifact = artifacts.filter(description__contains=\"Tabula Sapiens\").first()\n",
+    "artifact.save(transfer=\"annotations\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The artifact is now annotated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "artifact.describe()"
    ]
   },
   {

--- a/docs/transfer.ipynb
+++ b/docs/transfer.ipynb
@@ -40,7 +40,7 @@
    "source": [
     "import lamindb as ln\n",
     "\n",
-    "ln.track(\"ITeOtm7bhtdq0000\")"
+    "ln.track(\"ITeOtm7bhtdq\")"
    ]
   },
   {
@@ -127,7 +127,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The artifact record and all other feature & label records have been transferred to the current database."
+    "The artifact record has been transferred to the current database without feature & label annotations, but with updated data lineage."
    ]
   },
   {
@@ -147,7 +147,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You see that the data itself remained in the original storage location, which has been added to the current instance's storage location as a read-only location."
+    "You see that the data itself remained in the original storage location, which has been added to the current instance's storage location as a read-only location (indicated by the fact that the `instance_uid` doesn't match the current instance)."
    ]
   },
   {
@@ -219,7 +219,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The transform key has shape `f\"__lamindb_transfer__/{source_instance.uid}\"`:"
+    "The transform key has the form `f\"__lamindb_transfer__/{source_instance.uid}\"`:"
    ]
   },
   {
@@ -245,6 +245,23 @@
    "outputs": [],
    "source": [
     "artifact.run.initiated_by_run.transform"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Upon re-transferring a record, it will identify that the record already exists in the target database and simply map the record."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact = artifacts.filter(description__contains=\"Tabula Sapiens\").first()\n",
+    "artifact.save()"
    ]
   },
   {

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -778,7 +778,6 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
         if "using" in kwargs:
             using_key = kwargs["using"]
         db = self._state.db
-        pk_on_db = self.pk
         artifacts: list = []
         if self.__class__.__name__ == "Collection" and self.id is not None:
             # when creating a new collection without being able to access artifacts
@@ -874,18 +873,9 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                     for artifact in artifacts:
                         artifact.save()
                     self.artifacts.add(*artifacts)
-            if hasattr(self, "labels"):
-                from copy import copy
-
-                # here we go back to original record on the source database
-                self_on_db = copy(self)
-                self_on_db._state.db = db
-                self_on_db.pk = pk_on_db  # manually set the primary key
-                self.features._add_from(self_on_db, transfer_logs=transfer_logs)
-                self.labels.add_from(self_on_db, transfer_logs=transfer_logs)
             for k, v in transfer_logs.items():
                 if k != "run" and len(v) > 0:
-                    logger.important(f"{k} records: {', '.join(v)}")
+                    logger.important(f"{k}: {', '.join(v)}")
 
         if self.__class__.__name__ in {
             "Artifact",

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -777,7 +777,9 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
         using_key = None
         if "using" in kwargs:
             using_key = kwargs["using"]
+        transfer_config = kwargs.pop("transfer", None)
         db = self._state.db
+        pk_on_db = self.pk
         artifacts: list = []
         if self.__class__.__name__ == "Collection" and self.id is not None:
             # when creating a new collection without being able to access artifacts
@@ -873,6 +875,15 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                     for artifact in artifacts:
                         artifact.save()
                     self.artifacts.add(*artifacts)
+            if hasattr(self, "labels") and transfer_config == "annotations":
+                from copy import copy
+
+                # here we go back to original record on the source database
+                self_on_db = copy(self)
+                self_on_db._state.db = db
+                self_on_db.pk = pk_on_db  # manually set the primary key
+                self.features._add_from(self_on_db, transfer_logs=transfer_logs)
+                self.labels.add_from(self_on_db, transfer_logs=transfer_logs)
             for k, v in transfer_logs.items():
                 if k != "run" and len(v) > 0:
                     logger.important(f"{k}: {', '.join(v)}")


### PR DESCRIPTION
While the original idea was that it'd be highly convenient to transfer all features & labels together with a dataset, practical experience shows that the source instance of a dataset often uses slightly different conventions.

A more robust strategy is to transfer the dataset without features & labels and then either run a curator in the target instance or transfer desired features & labels in isolation.

If the user wants to _also_ tranfer annotations they can now pass:
```python
artifact.save(transfer="annotations")
```