### PR TITLE
🚸 Improve data type issue errors

### DIFF
--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -179,6 +179,9 @@ class Curator:
     """
 
     def __init__(self, dataset: Any, schema: Schema | None = None):
+        if not isinstance(schema, Schema):
+            raise InvalidArgument("schema argument must be a Schema record.")
+
         if schema.pk is None:
             raise ValueError(
                 "Schema must be saved before curation. Please save it using '.save()'."

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -175,9 +175,15 @@ class Curator:
         - :class:`~lamindb.curators.AnnDataCurator`
         - :class:`~lamindb.curators.MuDataCurator`
         - :class:`~lamindb.curators.SpatialDataCurator`
+        - :class:`~lamindb.curators.TiledbsomaExperimentCurator`
     """
 
     def __init__(self, dataset: Any, schema: Schema | None = None):
+        if schema.pk is None:
+            raise ValueError(
+                "Schema must be saved before curation. Please save it using '.save()'."
+            )
+
         self._artifact: Artifact = None  # pass the dataset as an artifact
         self._dataset: Any = dataset  # pass the dataset as a UPathStr or data object
         if isinstance(self._dataset, Artifact):
@@ -463,12 +469,15 @@ class DataFrameCurator(Curator):
         slot: str | None = None,
     ) -> None:
         super().__init__(dataset=dataset, schema=schema)
+
         categoricals = []
         features = []
         feature_ids: set[int] = set()
+
         if schema.flexible:
             features += Feature.filter(name__in=self._dataset.keys()).list()
             feature_ids = {feature.id for feature in features}
+
         if schema.n > 0:
             if schema._index_feature_uid is not None:
                 schema_features = [
@@ -488,6 +497,7 @@ class DataFrameCurator(Curator):
                 features.extend(schema_features)
         else:
             assert schema.itype is not None  # noqa: S101
+
         pandera_columns = {}
         if features or schema._index_feature_uid is not None:
             # populate features

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -653,8 +653,11 @@ class DataFrameCurator(Curator):
                 self._cat_manager_validate()
             except (pandera.errors.SchemaError, pandera.errors.SchemaErrors) as err:
                 self._is_validated = False
-                # .exconly() doesn't exist on SchemaError
-                raise ValidationError(str(err)) from err
+                has_dtype_error = "WRONG_DATATYPE" in str(err)
+                error_msg = str(err)
+                if has_dtype_error:
+                    error_msg += "   ▶ Hint: Consider setting 'coerce_datatypes=True' in your Schema definition to automatically convert types."
+                raise ValidationError(error_msg) from err
         else:
             self._cat_manager_validate()
 

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -656,7 +656,7 @@ class DataFrameCurator(Curator):
                 has_dtype_error = "WRONG_DATATYPE" in str(err)
                 error_msg = str(err)
                 if has_dtype_error:
-                    error_msg += "   ▶ Hint: Consider setting 'coerce_datatypes=True' in your Schema definition to automatically convert types."
+                    error_msg += "   ▶ Hint: Consider setting 'coerce_datatype=True' to attempt coercing/converting values during validation to the pre-defined dtype."
                 raise ValidationError(error_msg) from err
         else:
             self._cat_manager_validate()

--- a/tests/curators/test_curators_general.py
+++ b/tests/curators/test_curators_general.py
@@ -517,3 +517,19 @@ def test_curate_columns(df):
 
     schema.delete()
     ln.Feature.filter().delete()
+
+
+def test_wrong_datatype(df):
+    schema = ln.Schema(
+        features=[ln.Feature(name="sample_id", dtype=ln.ULabel).save()]
+    ).save()
+
+    curator = ln.curators.DataFrameCurator(df, schema)
+    with pytest.raises(ln.errors.ValidationError) as e:
+        curator.validate()
+
+    assert "expected series 'sample_id' to have type category, got object" in str(e)
+    assert (
+        "Hint: Consider setting 'coerce_datatypes=True' in your Schema definition to automatically convert types."
+        in str(e)
+    )

--- a/tests/curators/test_curators_general.py
+++ b/tests/curators/test_curators_general.py
@@ -235,7 +235,7 @@ def test_schema_not_saved(df):
     feature = ln.Feature(name="cell_type", dtype="str").save()
     schema = ln.Schema(features=[feature])
 
-    with pytest.raises(ValidationError) as excinfo:
+    with pytest.raises(ValueError) as excinfo:
         ln.curators.DataFrameCurator(df, schema)
     assert excinfo.exconly() == (
         "ValueError: Schema must be saved before curation. Please save it using '.save()'."

--- a/tests/curators/test_curators_general.py
+++ b/tests/curators/test_curators_general.py
@@ -240,7 +240,6 @@ def test_schema_not_saved(df):
     assert excinfo.exconly() == (
         "ValueError: Schema must be saved before curation. Please save it using '.save()'."
     )
-    ln.curators.DataFrameCurator(df, schema)
 
 
 def test_schema_optionals():

--- a/tests/curators/test_curators_general.py
+++ b/tests/curators/test_curators_general.py
@@ -520,16 +520,20 @@ def test_curate_columns(df):
 
 
 def test_wrong_datatype(df):
-    schema = ln.Schema(
-        features=[ln.Feature(name="sample_id", dtype=ln.ULabel).save()]
-    ).save()
+    feature = ln.Feature(name="sample_id", dtype=ln.ULabel).save()
+    schema = ln.Schema(features=[feature]).save()
 
     curator = ln.curators.DataFrameCurator(df, schema)
-    with pytest.raises(ln.errors.ValidationError) as e:
+    with pytest.raises(ln.errors.ValidationError) as excinfo:
         curator.validate()
 
-    assert "expected series 'sample_id' to have type category, got object" in str(e)
+    assert "expected series 'sample_id' to have type category, got object" in str(
+        excinfo.value
+    )
     assert (
         "Hint: Consider setting 'coerce_datatypes=True' in your Schema definition to automatically convert types."
-        in str(e)
+        in str(excinfo.value)
     )
+
+    schema.delete()
+    feature.delete()

--- a/tests/curators/test_curators_general.py
+++ b/tests/curators/test_curators_general.py
@@ -531,7 +531,7 @@ def test_wrong_datatype(df):
         excinfo.value
     )
     assert (
-        "Hint: Consider setting 'coerce_datatypes=True' in your Schema definition to automatically convert types."
+        "Hint: Consider setting 'coerce_datatype=True' to attempt coercing/converting values during validation to the pre-defined dtype."
         in str(excinfo.value)
     )
 

--- a/tests/curators/test_curators_general.py
+++ b/tests/curators/test_curators_general.py
@@ -230,6 +230,19 @@ def test_pandera_dataframe_schema(
     ln.Feature.filter().delete()
 
 
+def test_schema_not_saved(df):
+    """Attempting to validate an unsaved Schema must error."""
+    feature = ln.Feature(name="cell_type", dtype="str").save()
+    schema = ln.Schema(features=[feature])
+
+    with pytest.raises(ValidationError) as excinfo:
+        ln.curators.DataFrameCurator(df, schema)
+    assert excinfo.exconly() == (
+        "ValueError: Schema must be saved before curation. Please save it using '.save()'."
+    )
+    ln.curators.DataFrameCurator(df, schema)
+
+
 def test_schema_optionals():
     schema = ln.Schema(
         name="my-schema",


### PR DESCRIPTION
Fixes https://github.com/laminlabs/lamindb/issues/2551

Not my favorite solution but I tried a few:
1. Fully circumventing the Pandera error is possible but it might be helpful. Especially when users don't want to use `coerce_dtype`, I don't think that we should swallow it.
2. Instead of modifying the traceback, we could omit a logger message. However, the traceback is so long, I don't think that people will even see the logger message
3. Instead of appending to the same line, I had used a few new lines. The issue is that the vscode renderer then moves the essential error lines up and they're hidden.

| Before | After |
| ------ | ----- |
| ![Before message](https://github.com/user-attachments/assets/170f065b-9f6b-4abf-bb89-aef666e9d362) | ![After message](https://github.com/user-attachments/assets/44f699a4-d015-4771-8fd4-f3159ac44c5a) |
