### PR TITLE
🐛 Fix deletion of cloud transfer local instance

### DIFF
--- a/docs/storage/transfer-local-to-cloud.ipynb
+++ b/docs/storage/transfer-local-to-cloud.ipynb
@@ -90,7 +90,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "hide-output"
+     "hide-cell"
     ]
    },
    "outputs": [],


### PR DESCRIPTION
See https://c222b12c.lamindb.pages.dev/storage/transfer-local-to-cloud

Done via Github editor.