### PR TITLE
🎨 Polish curate guide

### DIFF
--- a/docs/curate.ipynb
+++ b/docs/curate.ipynb
@@ -57,13 +57,14 @@
    "source": [
     "## Schema design patterns\n",
     "\n",
-    "A {class}`~lamindb.Schema` in LaminDB is a specification that defines the expected structure, data types, and validation rules for a dataset. It is similar to `pydantic.Model` for dictionaries, and `pandera.Schema`, and `pyarrow.lib.Schema` for tables, but supporting more complicated data structures.\n",
+    "A {class}`~lamindb.Schema` in LaminDB is a specification that defines the expected structure, data types, and validation rules for a dataset.\n",
+    "It is similar to `pydantic.Model` for dictionaries, and `pandera.Schema`, and `pyarrow.lib.Schema` for tables, but supporting more complicated data structures.\n",
     "\n",
     "Schemas ensure data consistency by defining:\n",
     "- What {class}`~lamindb.Feature`s (dimensions) exist in your dataset\n",
     "- What data types those features should have\n",
     "- What values are valid for categorical features\n",
-    "- Which features are required vs optional\n",
+    "- Which {class}`~lamindb.Feature`s are required vs optional\n",
     "\n",
     "Key components of a schema:\n",
     "```python\n",
@@ -78,7 +79,7 @@
     ")\n",
     "```\n",
     "\n",
-    "For Complex Data Structures:\n",
+    "For complex data structures:\n",
     "```python\n",
     "# AnnData with multiple \"slots\"\n",
     "adata_schema = ln.Schema(\n",
@@ -90,7 +91,8 @@
     ")\n",
     "```\n",
     "\n",
-    "Before diving into curation, let's understand the different schema approaches and when to use each one. Think of schemas as rules that define what valid data should look like."
+    "Before diving into curation, let's understand the different schema approaches and when to use each one.\n",
+    "Think of schemas as rules that define what valid data should look like."
    ]
   },
   {
@@ -242,7 +244,7 @@
    "source": [
     "### Step 4: Initialize Curator and first validation\n",
     "\n",
-    "If you expect the validation to pass, can directly register an artifact by providing the schema:\n",
+    "If you expect the validation to pass, you can directly register an artifact by providing the schema:\n",
     "```python\n",
     "\n",
     "artifact = ln.Artifact.from_df(df, key=\"examples/my_curated_dataset.parquet\", schema=schema).save()\n",
@@ -254,7 +256,8 @@
    "id": "18",
    "metadata": {},
    "source": [
-    "The {meth}`~lamindb.curators.core.Curator.validate` method validates that your dataset adheres to the criteria defined by the `schema`. It identifies which values are already validated (exist in the registries) and which are potentially problematic (do not yet exist in our registries)."
+    "The {meth}`~lamindb.curators.core.Curator.validate` method validates that your dataset adheres to the criteria defined by the `schema`.\n",
+    "It identifies which values are already validated (exist in the registries) and which are potentially problematic (do not yet exist in our registries)."
    ]
   },
   {
@@ -476,7 +479,8 @@
    "source": [
     "## Common fixes\n",
     "\n",
-    "This section covers the most frequent curation issues and their solutions. Use this as a reference when validation fails."
+    "This section covers the most frequent curation issues and their solutions.\n",
+    "Use this as a reference when validation fails."
    ]
   },
   {
@@ -1060,7 +1064,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py311",
+   "display_name": "lamindb",
    "language": "python",
    "name": "python3"
   },
@@ -1074,7 +1078,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.8"
   },
   "nbproject": {
    "id": "WOK3vP0bNGLx",


### PR DESCRIPTION
Minor wording & style fixes.

- Markdown sentences should always be on their own line for easier diffs and reviews
- `feature` is such an overloaded term. Sometimes a sphinx ref might help. It's not always obvious when to add it and when not. I conservatively added one more which I think helps.
- Fixed casing of some words