### PR TITLE
✨ Implement backed access to `tables` of `SpatialData` 

### DIFF
--- a/docs/arrays.ipynb
+++ b/docs/arrays.ipynb
@@ -311,6 +311,52 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "It is also possible to access `AnnData` objects inside `SpatialData` `tables`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact = ln.Artifact.using(\"laminlabs/lamindata\").get(\n",
+    "    key=\"visium_aligned_guide_min.zarr\"\n",
+    ")\n",
+    "\n",
+    "access = artifact.open()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "access"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "access.tables[\"table\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Generic HDF5"
    ]
   },

--- a/lamindb/core/storage/__init__.py
+++ b/lamindb/core/storage/__init__.py
@@ -13,12 +13,13 @@ Array accessors.
    :toctree: .
 
    AnnDataAccessor
+   SpatialDataAccessor
    BackedAccessor
 """
 
 from lamindb_setup.core.upath import LocalPathClasses, UPath, infer_filesystem
 
-from ._backed_access import AnnDataAccessor, BackedAccessor
+from ._backed_access import AnnDataAccessor, BackedAccessor, SpatialDataAccessor
 from ._tiledbsoma import save_tiledbsoma_experiment
 from ._valid_suffixes import VALID_SUFFIXES
 from .objects import infer_suffix, write_to_disk

--- a/lamindb/core/storage/_anndata_accessor.py
+++ b/lamindb/core/storage/_anndata_accessor.py
@@ -353,7 +353,16 @@ if ZARR_INSTALLED:
         attrs_keys: dict[str, list] = {}
         obs_var_arrays = []
 
-        for path in paths:
+        prefix = storage.path
+        if prefix == "":
+            paths_iter = (path for path in paths)
+        else:
+            prefix += "/"
+            paths_iter = (
+                path.removeprefix(prefix) for path in paths if path.startswith(prefix)
+            )
+
+        for path in paths_iter:
             if path in (".zattrs", ".zgroup"):
                 continue
             parts = path.split("/")

--- a/lamindb/core/storage/_backed_access.py
+++ b/lamindb/core/storage/_backed_access.py
@@ -9,6 +9,7 @@ from anndata._io.specs.registry import get_spec
 from ._anndata_accessor import AnnDataAccessor, StorageType, registry
 from ._polars_lazy_df import POLARS_SUFFIXES, _open_polars_lazy_df
 from ._pyarrow_dataset import PYARROW_SUFFIXES, _open_pyarrow_dataset
+from ._spatialdata_accessor import SpatialDataAccessor
 from ._tiledbsoma import _open_tiledbsoma
 from .paths import filepath_from_artifact
 
@@ -80,6 +81,7 @@ def backed_access(
     **kwargs,
 ) -> (
     AnnDataAccessor
+    | SpatialDataAccessor
     | BackedAccessor
     | SOMACollection
     | SOMAExperiment
@@ -110,6 +112,8 @@ def backed_access(
         conn, storage = registry.open("h5py", objectpath, mode=mode, **kwargs)
     elif suffix == ".zarr":
         conn, storage = registry.open("zarr", objectpath, mode=mode, **kwargs)
+        if "spatialdata_attrs" in storage.attrs:
+            return SpatialDataAccessor(storage, name)
     elif len(df_suffixes := _flat_suffixes(objectpath)) == 1 and (
         df_suffix := df_suffixes.pop()
     ) in set(PYARROW_SUFFIXES).union(POLARS_SUFFIXES):

--- a/lamindb/core/storage/_spatialdata_accessor.py
+++ b/lamindb/core/storage/_spatialdata_accessor.py
@@ -28,9 +28,15 @@ class _TablesAccessor:
 
 
 class SpatialDataAccessor:
-    def __init__(self, storage: Group):
+    def __init__(self, storage: Group, name: str):
         self.storage = storage
+        self._name = name
 
     @cached_property
     def tables(self) -> _TablesAccessor:
         return _TablesAccessor(self.storage["tables"])
+
+    def __repr__(self):
+        """Description of the SpatialDataAccessor object."""
+        descr = f"SpatialDataAccessor object\n  constructed for the SpatialData object {self._name}"
+        return descr

--- a/lamindb/core/storage/_spatialdata_accessor.py
+++ b/lamindb/core/storage/_spatialdata_accessor.py
@@ -38,5 +38,9 @@ class SpatialDataAccessor:
 
     def __repr__(self):
         """Description of the SpatialDataAccessor object."""
-        descr = f"SpatialDataAccessor object\n  constructed for the SpatialData object {self._name}"
+        descr = (
+            "SpatialDataAccessor object"
+            f"\n  constructed for the SpatialData object {self._name}"
+            f"\n    with tables: {self.tables.keys()}"
+        )
         return descr

--- a/lamindb/core/storage/_spatialdata_accessor.py
+++ b/lamindb/core/storage/_spatialdata_accessor.py
@@ -21,8 +21,9 @@ class _TablesAccessor:
 
     def __repr__(self) -> str:
         """Description of the _TablesAccessor object."""
-        descr = "Accessor for the SpatialData attribute tables"
-        descr += f"\n  with keys: {self.keys()}"
+        descr = (
+            f"Accessor for the SpatialData attribute tables\n  with keys: {self.keys()}"
+        )
         return descr
 
 

--- a/lamindb/core/storage/_spatialdata_accessor.py
+++ b/lamindb/core/storage/_spatialdata_accessor.py
@@ -28,12 +28,18 @@ class _TablesAccessor:
 
 
 class SpatialDataAccessor:
+    """Cloud-backed SpatialData.
+
+    For now only allows to access `tables`.
+    """
+
     def __init__(self, storage: Group, name: str):
         self.storage = storage
         self._name = name
 
     @cached_property
     def tables(self) -> _TablesAccessor:
+        """tables of the underlying SpatialData object."""
         return _TablesAccessor(self.storage["tables"])
 
     def __repr__(self):

--- a/lamindb/core/storage/_spatialdata_accessor.py
+++ b/lamindb/core/storage/_spatialdata_accessor.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+from ._anndata_accessor import AnnDataAccessor
+
+if TYPE_CHECKING:
+    from zarr import Group
+
+
+class _TablesAccessor:
+    def __init__(self, tables: Group):
+        self._tables = tables
+
+    def __getitem__(self, key: str) -> AnnDataAccessor:
+        return AnnDataAccessor(connection=None, storage=self._tables[key], filename=key)
+
+    def keys(self) -> list[str]:
+        return list(self._tables.keys())
+
+    def __repr__(self) -> str:
+        """Description of the _TablesAccessor object."""
+        descr = "Accessor for the SpatialData attribute tables"
+        descr += f"\n  with keys: {self.keys()}"
+        return descr
+
+
+class SpatialDataAccessor:
+    def __init__(self, storage: Group):
+        self.storage = storage
+
+    @cached_property
+    def tables(self) -> _TablesAccessor:
+        return _TablesAccessor(self.storage["tables"])

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -117,7 +117,11 @@ if TYPE_CHECKING:
     from tiledbsoma import Measurement as SOMAMeasurement
 
     from lamindb.base.types import StrField
-    from lamindb.core.storage._backed_access import AnnDataAccessor, BackedAccessor
+    from lamindb.core.storage._backed_access import (
+        AnnDataAccessor,
+        BackedAccessor,
+        SpatialDataAccessor,
+    )
     from lamindb.core.types import ScverseDataStructures
 
     from ..base.types import (
@@ -2246,6 +2250,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         **kwargs,
     ) -> (
         AnnDataAccessor
+        | SpatialDataAccessor
         | BackedAccessor
         | SOMACollection
         | SOMAExperiment


### PR DESCRIPTION
This PR allows calling `artifact.open()` for `SpatialData` objects for lazy loading of `tables`.

Example:
```python
artifact = ln.Artifact.using("laminlabs/lamindata").get(key="visium_aligned_guide_min.zarr")
access = artifact.open() # SpatialDataAccessor
access.tables["table"] # get AnnDataAccessor for table
```