### PR TITLE
⬆️ Unpin scipy - DO NOT MERGE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,7 @@ dependencies = [
     "typing_extensions!=4.6.0",
     "python-dateutil",
     "pandas>=2.0.0", # for .infer_objects(copy=False) in lamin-utils
-    # backed sparse is incompatible with 1.15.0 for anndata 1.11.1
-    # vitessce requires anndata<=1.11.0 now
-    "scipy<1.15.0",
-    "anndata>=0.8.0,<=0.12.0",  # will upgrade to new anndata releases
+    "anndata>=0.11.2,<=0.12.0",  # will upgrade to new anndata releases
     "fsspec",
     "graphviz",
     "psycopg2-binary",


### PR DESCRIPTION
Fixes #1546 

A rather aggressive anndata lower bound but it allows to unpin scipy.

This is probably too early to have `0.11.2` as lower bound. Therefore, we should not merge it yet.