### PR TITLE
✨ Support more CxG Organisms & ✨ Allow AnnDataAccessor for curators

### DIFF
--- a/lamindb/examples/cellxgene/_cellxgene.py
+++ b/lamindb/examples/cellxgene/_cellxgene.py
@@ -8,6 +8,16 @@ from lamindb.models import Feature, Schema, SQLRecord, ULabel
 from lamindb.models._from_values import _format_values
 
 CELLxGENESchemaVersions = Literal["4.0.0", "5.0.0", "5.1.0", "5.2.0", "5.3.0"]
+CELLxGENESupportedOrganisms = Literal[
+    "human",
+    "mouse",
+    "SARS-COV-2",
+    "synthetic construct",
+    "zebra danio",
+    "rhesus macaquedomestic pig",
+    "chimpanzee",
+    "white-tufted-ear marmoset",
+]
 FieldType = Literal["ontology_id", "name"]
 
 
@@ -124,7 +134,7 @@ def get_cxg_schema(
     schema_version: CELLxGENESchemaVersions,
     *,
     field_types: FieldType | Collection[FieldType] = "ontology_id",
-    organism: Literal["human", "mouse"] = "human",
+    organism: CELLxGENESupportedOrganisms = "human",
 ) -> Schema:
     """Generates a :class:`~lamindb.Schema` for a specific CELLxGENE schema version.
 

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -551,12 +551,19 @@ def data_is_scversedatastructure(
         file_suffix = ".h5mu"
     # SpatialData does not have a unique suffix but `.zarr`
 
+    # AnnData allows both AnnDataAccessor and AnnData
     if structure_type is None:
         return any(
-            hasattr(data, "__class__") and data.__class__.__name__ == cl_name
+            hasattr(data, "__class__")
+            and data.__class__.__name__
+            in (["AnnData", "AnnDataAccessor"] if cl_name == "AnnData" else [cl_name])
             for cl_name in ["AnnData", "MuData", "SpatialData"]
         )
-    elif hasattr(data, "__class__") and data.__class__.__name__ == structure_type:
+    elif hasattr(data, "__class__") and data.__class__.__name__ in (
+        ["AnnData", "AnnDataAccessor"]
+        if structure_type == "AnnData"
+        else [structure_type]
+    ):
         return True
 
     data_type = structure_type.lower()
@@ -585,6 +592,7 @@ def data_is_scversedatastructure(
                     f"we do not check whether cloud zarr is {structure_type}"
                 )
                 return False
+
     return False
 
 

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -147,6 +147,17 @@ def test_data_is_anndata_paths():
     assert not data_is_scversedatastructure("s3://somewhere/something.zarr", "AnnData")
 
 
+def test_data_is_anndata_anndatacessor():
+    artifact = ln.Artifact(
+        ln.core.datasets.anndata_file_pbmc68k_test(), key="test_adata.h5ad"
+    ).save()
+
+    with artifact.open(mode="r") as access:
+        assert data_is_scversedatastructure(access, "AnnData")
+
+    artifact.delete()
+
+
 def test_data_is_mudata_paths():
     assert data_is_scversedatastructure("something.h5mu", "MuData")
     assert data_is_scversedatastructure("something.mudata.zarr", "MuData")

--- a/tests/storage/test_streaming.py
+++ b/tests/storage/test_streaming.py
@@ -212,8 +212,7 @@ def test_backed_zarr_not_adata():
 
 def test_anndata_open_mode():
     fp = ln.core.datasets.anndata_file_pbmc68k_test()
-    artifact = ln.Artifact(fp, key="test_adata.h5ad")
-    artifact.save()
+    artifact = ln.Artifact(fp, key="test_adata.h5ad").save()
 
     with artifact.open(mode="r") as access:
         assert isinstance(access, AnnDataAccessor)


### PR DESCRIPTION
Fixes https://github.com/laminlabs/lamindb/issues/2979

- Adds all supported organisms by CELLxGENE to the typehint
- `is_scverse_datastructure` now recognizes AnnDataAccessor objects as AnnData