### PR TITLE
🐛 Transfer feature based on uid instead of name

### DIFF
--- a/lamindb/models/_label_manager.py
+++ b/lamindb/models/_label_manager.py
@@ -268,7 +268,7 @@ class LabelManager:
                     for link in links:
                         if link.feature is not None:
                             features.add(link.feature)
-                            key = link.feature.name
+                            key = link.feature.uid
                         else:
                             key = None
                         keys.append(key)
@@ -299,9 +299,9 @@ class LabelManager:
                     )
                 save(new_features)  # type: ignore
             if hasattr(self._host, related_name):
-                for feature_name, feature_labels in labels_by_features.items():
-                    if feature_name is not None:
-                        feature_id = Feature.get(name=feature_name).id
+                for feature_uid, feature_labels in labels_by_features.items():
+                    if feature_uid is not None:
+                        feature_id = Feature.get(feature_uid).id
                     else:
                         feature_id = None
                     getattr(self._host, related_name).add(


### PR DESCRIPTION
Previously, searching features during transfer is based on name, which causes errors when multiple features are registered with the same name (e.g. different dtype).

This PR fixes the issue by searching for uid instead.