### PR TITLE
✨ Write mode for `zarr` backed `AnnDataAccessor`

### DIFF
--- a/lamindb/core/storage/_anndata_accessor.py
+++ b/lamindb/core/storage/_anndata_accessor.py
@@ -830,6 +830,7 @@ class AnnDataAccessor(_AnnDataAttrsMixin):
 
         self._updated = True
         # reset the cached property
+        # todo: maybe just append the column if the df was already loaded
         self.__dict__.pop(where, None)
         # update the cached columns
         self._attrs_keys[where].append(col_name)

--- a/lamindb/core/storage/_anndata_accessor.py
+++ b/lamindb/core/storage/_anndata_accessor.py
@@ -729,6 +729,8 @@ class AnnDataAccessor(_AnnDataAttrsMixin):
 
         self._artifact = artifact
 
+        self._updated = False  # track updates in r+ mode for zarr
+
         self._closed = False
 
     def close(self):
@@ -789,6 +791,8 @@ class AnnDataAccessor(_AnnDataAttrsMixin):
         df_store = self.storage[where]  # type: ignore
         write_elem(df_store, col_name, col)
         df_store.attrs["column-order"] = df_store.attrs["column-order"] + ["new_column"]
+
+        self._updated = True
 
 
 # get the number of observations in an anndata object or file fast and safely

--- a/lamindb/core/storage/_anndata_accessor.py
+++ b/lamindb/core/storage/_anndata_accessor.py
@@ -783,17 +783,12 @@ class AnnDataAccessor(_AnnDataAttrsMixin):
         self,
         where: Literal["obs", "var"],
         col_name: str,
-        col: np.ndarray | pd.Series | pd.Categorical,
+        col: np.ndarray | pd.Categorical,
     ):
         """Add a new column to .obs or .var of the underlying AnnData object."""
-        storage_where = self.storage[where]  # type: ignore
-        if isinstance(col, pd.Series):
-            col = col.values
-
-        write_elem(storage_where, col_name, col)
-        storage_where.attrs["column-order"] = storage_where.attrs["column-order"] + [
-            "new_column"
-        ]
+        df_store = self.storage[where]  # type: ignore
+        write_elem(df_store, col_name, col)
+        df_store.attrs["column-order"] = df_store.attrs["column-order"] + ["new_column"]
 
 
 # get the number of observations in an anndata object or file fast and safely

--- a/lamindb/core/storage/_anndata_accessor.py
+++ b/lamindb/core/storage/_anndata_accessor.py
@@ -803,7 +803,7 @@ class AnnDataAccessor(_AnnDataAttrsMixin):
         df_store = self.storage[where]  # type: ignore
         if getattr(df_store, "read_only", True):
             raise ValueError(
-                "You can use .add_column only with zarr in a writable mode."
+                "You can use .add_column(...) only with zarr in a writable mode."
             )
         write_elem(df_store, col_name, col)
         df_store.attrs["column-order"] = df_store.attrs["column-order"] + ["new_column"]

--- a/lamindb/core/storage/_anndata_accessor.py
+++ b/lamindb/core/storage/_anndata_accessor.py
@@ -27,13 +27,13 @@ from lamindb_setup.core.upath import infer_filesystem
 from packaging import version
 from upath import UPath
 
-from lamindb import Artifact
-
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from fsspec.core import OpenFile
     from lamindb_setup.types import UPathStr
+
+    from lamindb import Artifact
 
 
 anndata_version_parse = version.parse(anndata_version)
@@ -742,7 +742,7 @@ class AnnDataAccessor(_AnnDataAttrsMixin):
         self._closed = True
 
         if self._updated and (artifact := self._artifact) is not None:
-            from lamindb.models.sqlrecord import init_self_from_db
+            from lamindb.models.artifact import Artifact, init_self_from_db
 
             new_version = Artifact(
                 artifact.path, revises=artifact, _is_internal_call=True

--- a/lamindb/core/storage/_anndata_accessor.py
+++ b/lamindb/core/storage/_anndata_accessor.py
@@ -798,6 +798,10 @@ class AnnDataAccessor(_AnnDataAttrsMixin):
     ):
         """Add a new column to .obs or .var of the underlying AnnData object."""
         df_store = self.storage[where]  # type: ignore
+        if getattr(df_store, "read_only", True):
+            raise ValueError(
+                "You can use .add_column only with zarr in a writable mode."
+            )
         write_elem(df_store, col_name, col)
         df_store.attrs["column-order"] = df_store.attrs["column-order"] + ["new_column"]
 

--- a/lamindb/core/storage/_anndata_accessor.py
+++ b/lamindb/core/storage/_anndata_accessor.py
@@ -816,6 +816,8 @@ class AnnDataAccessor(_AnnDataAttrsMixin):
             )
 
         self._updated = True
+        # reset the cached property
+        self.__dict__.pop(where, None)
 
 
 # get the number of observations in an anndata object or file fast and safely

--- a/lamindb/core/storage/_anndata_accessor.py
+++ b/lamindb/core/storage/_anndata_accessor.py
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
     from fsspec.core import OpenFile
     from lamindb_setup.types import UPathStr
 
+    from lamindb import Artifact
+
 
 anndata_version_parse = version.parse(anndata_version)
 
@@ -708,6 +710,7 @@ class AnnDataAccessor(_AnnDataAttrsMixin):
         connection: OpenFile | None,
         storage: StorageType,
         filename: str,
+        artifact: Artifact | None = None,
     ):
         self._conn = connection
         self.storage = storage
@@ -718,6 +721,8 @@ class AnnDataAccessor(_AnnDataAttrsMixin):
 
         self._obs_names = _safer_read_index(self.storage["obs"])  # type: ignore
         self._var_names = _safer_read_index(self.storage["var"])  # type: ignore
+
+        self._artifact = artifact
 
         self._closed = False
 

--- a/lamindb/core/storage/_spatialdata_accessor.py
+++ b/lamindb/core/storage/_spatialdata_accessor.py
@@ -8,13 +8,22 @@ from ._anndata_accessor import AnnDataAccessor
 if TYPE_CHECKING:
     from zarr import Group
 
+    from lamindb import Artifact
+
 
 class _TablesAccessor:
-    def __init__(self, tables: Group):
+    def __init__(self, tables: Group, artifact: Artifact | None = None):
         self._tables = tables
 
+        self._artifact = artifact
+
     def __getitem__(self, key: str) -> AnnDataAccessor:
-        return AnnDataAccessor(connection=None, storage=self._tables[key], filename=key)
+        return AnnDataAccessor(
+            connection=None,
+            storage=self._tables[key],
+            filename=key,
+            artifact=self._artifact,
+        )
 
     def keys(self) -> list[str]:
         return list(self._tables.keys())
@@ -33,14 +42,16 @@ class SpatialDataAccessor:
     For now only allows to access `tables`.
     """
 
-    def __init__(self, storage: Group, name: str):
+    def __init__(self, storage: Group, name: str, artifact: Artifact | None = None):
         self.storage = storage
         self._name = name
+
+        self._artifact = artifact
 
     @cached_property
     def tables(self) -> _TablesAccessor:
         """tables of the underlying SpatialData object."""
-        return _TablesAccessor(self.storage["tables"])
+        return _TablesAccessor(self.storage["tables"], self._artifact)
 
     def __repr__(self):
         """Description of the SpatialDataAccessor object."""

--- a/lamindb/core/storage/_zarr.py
+++ b/lamindb/core/storage/_zarr.py
@@ -37,6 +37,9 @@ def get_zarr_store(
     if isinstance(storepath, LocalPathClasses):
         store = storepath_str
     elif IS_ZARR_V3:
+        # todo: also check how to treat non-asynchronous filesystems
+        # zarr has something for this, using fsspec async wrapper
+        # check FsspecStore code
         store = zarr.storage.FsspecStore.from_upath(UPath(storepath, asynchronous=True))
     else:
         store = create_mapper(storepath.fs, storepath_str, check=check, create=create)

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -2360,11 +2360,12 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         is_tiledbsoma_w = (
             filepath.name == "soma" or self.suffix == ".tiledbsoma"
         ) and mode == "w"
+        is_zarr_w = self.suffix == ".zarr" and mode == "r+"
         # consider the case where an object is already locally cached
         localpath = setup_settings.paths.cloud_to_local_no_update(
             filepath, cache_key=cache_key
         )
-        if is_tiledbsoma_w:
+        if is_tiledbsoma_w or is_zarr_w:
             open_cache = False
         else:
             open_cache = not isinstance(

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -2412,6 +2412,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                         new_version = Artifact(
                             filepath, revises=self, _is_internal_call=True
                         ).save()
+                        # note: sets _state.db = "default"
                         init_self_from_db(self, new_version)
 
                         if localpath != filepath and localpath.exists():

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -2395,9 +2395,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                 else:
                     localpath.unlink(missing_ok=True)
         else:
-            access = backed_access(
-                filepath, mode, engine, using_key=using_key, **kwargs
-            )
+            access = backed_access(self, mode, engine, using_key=using_key, **kwargs)
             if is_tiledbsoma_w:
 
                 def finalize():

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -2289,17 +2289,19 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
     ):
         """Open a dataset for streaming.
 
-        Works for `AnnData` (`.h5ad` and `.zarr`), generic `hdf5` and `zarr`,
-        `tiledbsoma` objects (`.tiledbsoma`), `pyarrow` or `polars` compatible formats
+        Works for `AnnData` (`.h5ad` and `.zarr`), `SpatialData` (`.zarr`),
+        generic `hdf5` and `zarr`, `tiledbsoma` objects (`.tiledbsoma`),
+        `pyarrow` or `polars` compatible formats
         (`.parquet`, `.csv`, `.ipc` etc. files or directories with such files).
 
         Args:
-            mode: can only be `"w"` (write mode) for `tiledbsoma` stores,
+            mode: can be `"r"` or `"w"` (write mode) for `tiledbsoma` stores,
+                `"r"` or `"r+"` for `AnnData` or `SpatialData` `zarr` stores,
                 otherwise should be always `"r"` (read-only mode).
             engine: Which module to use for lazy loading of a dataframe
                 from `pyarrow` or `polars` compatible formats.
                 This has no effect if the artifact is not a dataframe, i.e.
-                if it is an `AnnData,` `hdf5`, `zarr` or `tiledbsoma` object.
+                if it is an `AnnData,` `hdf5`, `zarr`, `tiledbsoma` object etc.
             is_run_input: Whether to track this artifact as run input.
             **kwargs: Keyword arguments for the accessor, i.e. `h5py` or `zarr` connection,
                 `pyarrow.dataset.dataset`, `polars.scan_*` function.

--- a/tests/storage/test_streaming.py
+++ b/tests/storage/test_streaming.py
@@ -168,6 +168,37 @@ def test_backed_access(adata_format):
         shutil.rmtree(fp)
 
 
+def test_add_column():
+    previous_storage = ln.setup.settings.storage.root_as_str
+    ln.settings.storage = "s3://lamindb-test/storage"
+
+    adata = load_h5ad(ln.core.datasets.anndata_file_pbmc68k_test())
+    zarr_path = "adata_write_mode.zarr"
+    adata.write_zarr(zarr_path)
+
+    artifact = ln.Artifact(zarr_path, description="test add_column").save()
+
+    access = artifact.open(mode="r+")
+    n_obs, n_var = access.shape
+    access.add_column("obs", "ones_obs", np.ones(n_obs))
+    access.add_column("var", "ones_var", np.ones(n_var))
+    assert np.all(access.obs["ones_obs"] == 1)
+    assert np.all(access.var["ones_var"] == 1)
+    access.close()
+    assert artifact.uid.endswith("0001")
+
+    cat_col = pd.Categorical(["one"] + ["two"] * (n_obs - 1))
+    with artifact.open(mode="r+") as access:
+        access.add_column("obs", "cat_col", cat_col)
+        assert access.obs["cat_col"].cat.categories.to_list() == ["one", "two"]
+    assert artifact.uid.endswith("0002")
+
+    artifact.delete(permanent=True)
+    shutil.rmtree(zarr_path)
+
+    ln.settings.storage = previous_storage
+
+
 def test_to_index():
     elem_int = np.arange(3, dtype=int)
     elem_float = elem_int.astype(float)

--- a/tests/storage/test_streaming.py
+++ b/tests/storage/test_streaming.py
@@ -192,6 +192,9 @@ def test_add_column():
         access.add_column("obs", "cat_col", cat_col)
         assert access.obs["cat_col"].cat.categories.to_list() == ["one", "two"]
     assert artifact.uid.endswith("0002")
+    # can't add in read mode
+    with pytest.raises(ValueError):
+        artifact.open().add_column("obs", "new_col", cat_col)
 
     artifact.delete(permanent=True)
     shutil.rmtree(zarr_path)


### PR DESCRIPTION
Allows to add columns to `.obs` and `.var` of cloud `zarr` `AnnData` objects.
Example:

```python
with artifact.open(mode="r+"):
  n_obs, n_var = access.shape
  access.add_column("obs", "ones_obs", np.ones(n_obs))
  access.add_column("var", "ones_var", np.ones(n_var))
```
`artifact` version is updated after the modification.