### PR TITLE
✨ Allow getting artifacts by path via `Artifact.get(path="...")`

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1691,7 +1691,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         )
 
     @classmethod
-    def get_from_path(cls, path: UPathStr) -> Artifact | None:
+    def get_by_path(cls, path: UPathStr) -> Artifact | None:
         """Get the latest artifact registered for the path if exists, ``None`` otherwise.
 
         Args:
@@ -1699,7 +1699,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         """
         from .query_set import QuerySet
 
-        return QuerySet(model=cls).get_from_path(path)
+        return QuerySet(model=cls).get_by_path(path)
 
     @classmethod
     def get(

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1704,6 +1704,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             idlike: Either a uid stub, uid or an integer id.
             is_run_input: Whether to track this artifact as run input.
             expressions: Fields and values passed as Django query expressions.
+                Use `path=...` to get an artifact for a local or remote filepath if exists.
 
         Raises:
             :exc:`docs:lamindb.errors.DoesNotExist`: In case no matching record is found.
@@ -1718,6 +1719,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
 
                 artifact = ln.Artifact.get("tCUkRcaEjTjhtozp0000")
                 artifact = ln.Arfifact.get(key="examples/my_file.parquet")
+                artifact = ln.Artifact.get(path="s3://bucket/folder/adata.h5ad")
         """
         from .query_set import QuerySet
 

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1691,17 +1691,6 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         )
 
     @classmethod
-    def get_by_path(cls, path: UPathStr) -> Artifact | None:
-        """Get the latest artifact registered for the path if exists, ``None`` otherwise.
-
-        Args:
-            path: A path for which to return the latest registered artifact.
-        """
-        from .query_set import QuerySet
-
-        return QuerySet(model=cls).get_by_path(path)
-
-    @classmethod
     def get(
         cls,
         idlike: int | str | None = None,

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1691,6 +1691,17 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         )
 
     @classmethod
+    def get_from_path(cls, path: UPathStr) -> Artifact | None:
+        """Get the latest artifact registered for the path if exists, ``None`` otherwise.
+
+        Args:
+            path: A path for which to return the latest registered artifact.
+        """
+        from .query_set import QuerySet
+
+        return QuerySet(model=cls).get_from_path(path)
+
+    @classmethod
     def get(
         cls,
         idlike: int | str | None = None,

--- a/lamindb/models/artifact_set.py
+++ b/lamindb/models/artifact_set.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Iterator
 from typing import TYPE_CHECKING, Literal
 
-from django.db.models import TextField, Value
+from django.db.models import Q, TextField, Value
 from django.db.models.functions import Concat
 from lamin_utils import logger
 from lamindb_setup.core._docs import doc_args
@@ -135,10 +135,11 @@ def artifacts_from_path(artifacts: ArtifactSet, path: UPathStr) -> ArtifactSet:
 
     if stem_len == 16:
         qs = artifacts.filter(  # type: ignore
-            uid__startswith=stem, _key_is_virtual=True
+            Q(_key_is_virtual=True) | Q(key__isnull=True),
+            uid__startswith=stem,
         )
     elif stem_len == 20:
-        qs = artifacts.filter(uid=stem, _key_is_virtual=True)  # type: ignore
+        qs = artifacts.filter(Q(_key_is_virtual=True) | Q(key__isnull=True), uid=stem)  # type: ignore
     else:
         qs = None
 

--- a/lamindb/models/artifact_set.py
+++ b/lamindb/models/artifact_set.py
@@ -124,8 +124,8 @@ class ArtifactSet(Iterable):
         _track_run_input(artifacts, is_run_input)
         return ds
 
-    @doc_args(Artifact.get_from_path.__doc__)
-    def get_from_path(self, path: UPathStr) -> Artifact | None:
+    @doc_args(Artifact.get_by_path.__doc__)
+    def get_by_path(self, path: UPathStr) -> Artifact | None:
         """{}"""  # noqa: D415
         upath = UPath(path)
 

--- a/lamindb/models/artifact_set.py
+++ b/lamindb/models/artifact_set.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 from collections.abc import Iterable, Iterator
 from typing import TYPE_CHECKING, Literal
 
+from django.db.models import TextField, Value
+from django.db.models.functions import Concat
 from lamin_utils import logger
 from lamindb_setup.core._docs import doc_args
+from upath import UPath
 
 from ..core._mapped_collection import MappedCollection
 from ..core.storage._backed_access import _open_dataframe
@@ -13,10 +16,10 @@ from .collection import Collection, _load_concat_artifacts
 
 if TYPE_CHECKING:
     from anndata import AnnData
+    from lamindb_setup.types import UPathStr
     from pandas import DataFrame
     from polars import LazyFrame as PolarsLazyFrame
     from pyarrow.dataset import Dataset as PyArrowDataset
-    from upath import UPath
 
 
 UNORDERED_WARNING = (
@@ -120,3 +123,37 @@ class ArtifactSet(Iterable):
         # track only if successful
         _track_run_input(artifacts, is_run_input)
         return ds
+
+    @doc_args(Artifact.get_from_path.__doc__)
+    def get_from_path(self, path: UPathStr) -> Artifact | None:
+        """{}"""  # noqa: D415
+        upath = UPath(path)
+
+        path_str = upath.as_posix()
+
+        stem = upath.stem
+        stem_len = len(stem)
+
+        artifacts = self
+
+        if stem_len == 16:
+            artifact = artifacts.filter(  # type: ignore
+                uid__startswith=stem, _key_is_virtual=True, is_latest=True
+            ).one_or_none()
+        elif stem_len == 20:
+            artifact = artifacts.filter(uid=stem, _key_is_virtual=True).one_or_none()  # type: ignore
+        else:
+            artifact = None
+
+        if artifact is None:
+            artifact = (
+                artifacts.filter(_key_is_virtual=False)  # type: ignore
+                .annotate(
+                    db_path=Concat(
+                        "storage__root", Value("/"), "key", output_field=TextField()
+                    )
+                )
+                .filter(db_path=path_str, is_latest=True)
+                .one_or_none()
+            )
+        return artifact

--- a/lamindb/models/artifact_set.py
+++ b/lamindb/models/artifact_set.py
@@ -126,6 +126,7 @@ class ArtifactSet(Iterable):
 
 
 def artifacts_from_path(artifacts: ArtifactSet, path: UPathStr) -> ArtifactSet:
+    """Returns artifacts in the query set that are registered for the provided path."""
     upath = UPath(path)
 
     path_str = upath.as_posix()

--- a/lamindb/models/artifact_set.py
+++ b/lamindb/models/artifact_set.py
@@ -147,7 +147,7 @@ def artifacts_from_path(artifacts: ArtifactSet, path: UPathStr) -> ArtifactSet:
 
     qs = (
         artifacts.filter(_key_is_virtual=False)  # type: ignore
-        .annotate(
+        .alias(
             db_path=Concat("storage__root", Value("/"), "key", output_field=TextField())
         )
         .filter(db_path=path_str)

--- a/lamindb/models/artifact_set.py
+++ b/lamindb/models/artifact_set.py
@@ -135,7 +135,7 @@ def artifacts_from_path(artifacts: ArtifactSet, path: UPathStr) -> ArtifactSet:
 
     if stem_len == 16:
         qs = artifacts.filter(  # type: ignore
-            uid__startswith=stem, _key_is_virtual=True, is_latest=True
+            uid__startswith=stem, _key_is_virtual=True
         )
     elif stem_len == 20:
         qs = artifacts.filter(uid=stem, _key_is_virtual=True)  # type: ignore
@@ -150,6 +150,6 @@ def artifacts_from_path(artifacts: ArtifactSet, path: UPathStr) -> ArtifactSet:
         .annotate(
             db_path=Concat("storage__root", Value("/"), "key", output_field=TextField())
         )
-        .filter(db_path=path_str, is_latest=True)
+        .filter(db_path=path_str)
     )
     return qs

--- a/lamindb/models/query_set.py
+++ b/lamindb/models/query_set.py
@@ -172,28 +172,28 @@ def process_expressions(queryset: QuerySet, expressions: dict) -> dict:
 
 
 def get(
-    registry_or_queryset: Union[type[SQLRecord], QuerySet],
+    registry_or_queryset: Union[type[SQLRecord], BasicQuerySet],
     idlike: int | str | None = None,
     **expressions,
 ) -> SQLRecord:
-    if isinstance(registry_or_queryset, QuerySet):
+    if isinstance(registry_or_queryset, BasicQuerySet):
         qs = registry_or_queryset
         registry = qs.model
     else:
-        qs = QuerySet(model=registry_or_queryset)
+        qs = BasicQuerySet(model=registry_or_queryset)
         registry = registry_or_queryset
     if isinstance(idlike, int):
-        return super(QuerySet, qs).get(id=idlike)  # type: ignore
+        return BasicQuerySet.get(qs, id=idlike)
     elif isinstance(idlike, str):
         NAME_FIELD = (
             registry._name_field if hasattr(registry, "_name_field") else "name"
         )
         DOESNOTEXIST_MSG = f"No record found with uid '{idlike}'. Did you forget a keyword as in {registry.__name__}.get({NAME_FIELD}='{idlike}')?"
         if issubclass(registry, IsVersioned) and len(idlike) <= registry._len_stem_uid:
-            qs = qs.filter(uid__startswith=idlike, is_latest=True)
+            qs = BasicQuerySet.filter(qs, uid__startswith=idlike, is_latest=True)
             return one_helper(qs, DOESNOTEXIST_MSG)
         else:
-            qs = qs.filter(uid__startswith=idlike)
+            qs = BasicQuerySet.filter(qs, uid__startswith=idlike)
             return one_helper(qs, DOESNOTEXIST_MSG)
     else:
         assert idlike is None  # noqa: S101
@@ -205,20 +205,19 @@ def get(
         if issubclass(registry, IsVersioned) and is_latest_was_not_in_expressions:
             expressions["is_latest"] = True
         try:
-            return registry.objects.using(qs.db).get(**expressions)
-        except registry.DoesNotExist:
+            return BasicQuerySet.get(qs, **expressions)
+        except registry.DoesNotExist as e:
             # handle the case in which the is_latest injection led to a missed query
             if "is_latest" in expressions and is_latest_was_not_in_expressions:
                 expressions.pop("is_latest")
                 result = (
-                    registry.objects.using(qs.db)
-                    .filter(**expressions)
+                    BasicQuerySet.filter(qs, **expressions)
                     .order_by("-created_at")
                     .first()
                 )
                 if result is not None:
                     return result
-            raise registry.DoesNotExist from registry.DoesNotExist
+            raise registry.DoesNotExist from e
 
 
 class SQLRecordList(UserList, Generic[T]):
@@ -864,8 +863,18 @@ class QuerySet(BasicQuerySet):
         """Query a single record. Raises error if there are more or none."""
         is_run_input = expressions.pop("is_run_input", False)
 
+        if path := expressions.pop("path", None):
+            from .artifact_set import ArtifactSet, artifacts_from_path
+
+            if not isinstance(self, ArtifactSet):
+                raise ValueError("Querying by path is only possible for artifacts.")
+
+            qs = artifacts_from_path(self, path)
+        else:
+            qs = self
+
         try:
-            record = get(self, idlike, **expressions)
+            record = get(qs, idlike, **expressions)  # type: ignore
         except ValueError as e:
             # Pass through original error for explicit id lookups
             if "Field 'id' expected a number" in str(e):
@@ -881,8 +890,8 @@ class QuerySet(BasicQuerySet):
             raise  # pragma: no cover
 
         if is_run_input is not False:  # might be None or True or Run
-            from lamindb.models.artifact import Artifact, _track_run_input
-            from lamindb.models.collection import Collection
+            from .artifact import Artifact, _track_run_input
+            from .collection import Collection
 
             if isinstance(record, (Artifact, Collection)):
                 _track_run_input(record, is_run_input)

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -1023,4 +1023,7 @@ def test_get_by_path(df):
     with pytest.raises(ln.Artifact.DoesNotExist):
         ln.Artifact.get(path="s3://bucket/folder/file.parquet")
 
+    with pytest.raises(ValueError):
+        ln.User.get(path="some/path")
+
     artifact.delete(permanent=True)

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -625,6 +625,8 @@ def test_create_from_local_filepath(
             else:
                 assert artifact.path == lamindb_setup.settings.storage.root / key
 
+    # check get by path
+    assert ln.Artifact.get(path=artifact.path) == artifact
     # only delete from storage if a file copy took place
     delete_from_storage = str(test_filepath.resolve()) != str(artifact.path)
     artifact.delete(permanent=True, storage=delete_from_storage)

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -582,7 +582,7 @@ def test_create_from_local_filepath(
     artifact.save()
     assert artifact.path.exists()
     # check get by path
-    assert ln.Artifact.get(path=artifact.path) == artifact, (artifact, artifact.path)
+    assert ln.Artifact.get(path=artifact.path) == artifact
 
     if key is None:
         assert (

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -582,7 +582,7 @@ def test_create_from_local_filepath(
     artifact.save()
     assert artifact.path.exists()
     # check get by path
-    #    assert ln.Artifact.get(path=artifact.path) == artifact
+    assert ln.Artifact.get(path=artifact.path) == artifact, (artifact, artifact.path)
 
     if key is None:
         assert (

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -582,7 +582,7 @@ def test_create_from_local_filepath(
     artifact.save()
     assert artifact.path.exists()
     # check get by path
-    assert ln.Artifact.get(path=artifact.path) == artifact
+    #    assert ln.Artifact.get(path=artifact.path) == artifact
 
     if key is None:
         assert (

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -1011,3 +1011,15 @@ def test_artifact_get_tracking(df):
 
     artifact.delete(permanent=True)
     transform.delete()
+
+
+def test_get_by_path(df):
+    artifact = ln.Artifact.from_df(df, key="df.parquet").save()
+    artifact_path = artifact.path
+
+    assert ln.Artifact.get_by_path(artifact_path) == artifact
+    assert ln.Artifact.filter().get_by_path(artifact_path.as_posix()) == artifact
+
+    assert ln.Artifact.get_by_path("s3://bucket/folder/file.parquet") is None
+
+    artifact.delete(permanent=True)

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -1017,9 +1017,10 @@ def test_get_by_path(df):
     artifact = ln.Artifact.from_df(df, key="df.parquet").save()
     artifact_path = artifact.path
 
-    assert ln.Artifact.get_by_path(artifact_path) == artifact
-    assert ln.Artifact.filter().get_by_path(artifact_path.as_posix()) == artifact
+    assert ln.Artifact.get(path=artifact_path) == artifact
+    assert ln.Artifact.filter().get(path=artifact_path.as_posix()) == artifact
 
-    assert ln.Artifact.get_by_path("s3://bucket/folder/file.parquet") is None
+    with pytest.raises(ln.Artifact.DoesNotExist):
+        ln.Artifact.get(path="s3://bucket/folder/file.parquet")
 
     artifact.delete(permanent=True)

--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -581,6 +581,8 @@ def test_create_from_local_filepath(
     assert artifact.n_files is None
     artifact.save()
     assert artifact.path.exists()
+    # check get by path
+    assert ln.Artifact.get(path=artifact.path) == artifact
 
     if key is None:
         assert (
@@ -624,9 +626,6 @@ def test_create_from_local_filepath(
                 )
             else:
                 assert artifact.path == lamindb_setup.settings.storage.root / key
-
-    # check get by path
-    assert ln.Artifact.get(path=artifact.path) == artifact
     # only delete from storage if a file copy took place
     delete_from_storage = str(test_filepath.resolve()) != str(artifact.path)
     artifact.delete(permanent=True, storage=delete_from_storage)

--- a/tests/storage/test_artifact_storage.py
+++ b/tests/storage/test_artifact_storage.py
@@ -15,6 +15,7 @@ def test_create_from_anndata_in_existing_cloud_storage():
     )
     assert artifact.n_observations == 70
     artifact.save()
+    assert ln.Artifact.get(path=artifact.path) == artifact
     # check that the local filepath has been cleared
     assert not hasattr(artifact, "_local_filepath")
     assert artifact.path.as_posix().startswith("s3://lamindb-test/core")

--- a/tests/storage/test_artifact_zarr.py
+++ b/tests/storage/test_artifact_zarr.py
@@ -35,6 +35,8 @@ def test_zarr_upload_cache(get_small_adata):
     assert artifact.n_files >= 1
     artifact.save()
 
+    assert ln.Artifact.get(path=artifact.path) == artifact
+
     assert artifact._is_saved_to_storage_location
 
     assert isinstance(artifact.path, CloudPath)


### PR DESCRIPTION
Example:
```python
artifact = ln.Artifact.get(path="s3://bucket/folder/file.h5ad")
# or in another instance
artifact = ln.Artifact.using("laminlabs/cellxgene").get(path="s3://bucket/folder/file.h5ad")
```

Internal [Slack discussion](https://laminlabs.slack.com/archives/C04FPE8V01W/p1746009345011899).