### PR TITLE
✨ Support validating `attrs` of Pandas DataFrames

### DIFF
--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -437,6 +437,7 @@ class DataFrameCurator(SlotsCurator):
         slot: str | None = None,
     ) -> None:
         super().__init__(dataset=dataset, schema=schema)
+        self._slot = slot
 
         # Handle composite schemas including attrs slots
         if slot is None and hasattr(schema, 'slots') and schema.slots:

--- a/lamindb/models/_is_versioned.py
+++ b/lamindb/models/_is_versioned.py
@@ -108,12 +108,12 @@ def bump_version(
 ) -> str:
     """Bumps the version number by major or minor depending on the bump_type flag.
 
-    Parameters:
-    version (str): The current version in "MAJOR" or "MAJOR.MINOR" format.
-    bump_type (str): The type of version bump, either 'major' or 'minor'.
+    Args:
+        version: The current version in "MAJOR" or "MAJOR.MINOR" format.
+        bump_type: The type of version bump, either 'major' or 'minor'.
 
     Returns:
-    str: The new version string.
+        The new version string.
     """
     try:
         # Split the version into major and minor parts if possible

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -93,6 +93,10 @@ def parse_cat_dtype(
     """Parses a categorical dtype string into its components (registry, field, subtypes)."""
     from .artifact import Artifact
 
+    if dtype_str == "Composite":
+        # Composite schemas don't have a real registry, return default
+        return {"field": Feature.name, "registry_str": "Feature", "subtype_str": ""}
+
     assert isinstance(dtype_str, str)  # noqa: S101
     if related_registries is None:
         related_registries = dict_module_name_to_model_name(Artifact)

--- a/tests/curators/test_curators_examples.py
+++ b/tests/curators/test_curators_examples.py
@@ -142,22 +142,6 @@ def mudata_papalexi21_subset_schema():
 def uns_study_metadata():
     return {"temperature": 21.6, "experiment_id": "EXP001"}
 
-@pytest.fixture(scope="module")
-def study_metadata_schema():
-    study_metadata_schema = ln.Schema(
-        features=[
-            ln.Feature(name="temperature", dtype=float).save(),
-            ln.Feature(name="experiment_id", dtype=str).save(),
-        ],
-    ).save()
-
-    yield study_metadata_schema
-
-    study_metadata_schema.delete(permanent=True)
-    ln.Schema.filter().delete()
-    ln.Feature.filter().delete()
-
-
 def test_dataframe_curator(small_dataset1_schema: ln.Schema):
     """Test DataFrame curator implementation."""
 
@@ -323,12 +307,22 @@ def test_dataframe_curator_validate_all_annotate_cat2(small_dataset1_schema):
     artifact.delete(permanent=True)
     schema.delete(permanent=True)
 
-def test_dataframe_attrs_validation(uns_study_metadata, study_metadata_schema):
+def test_dataframe_attrs_validation(uns_study_metadata):
     df = datasets.mini_immuno.get_dataset1(otype="DataFrame")
     df.attrs = uns_study_metadata
 
+    df_feature = ln.Feature.get(name="perturbation")
     df_schema = ln.Schema(
-        features=[ln.Feature.get(name="perturbation")],
+        features=[df_feature],
+    ).save()
+
+    temperature_feature = ln.Feature(name="temperature", dtype=float).save()
+    experiment_id_feature = ln.Feature(name="experiment_id", dtype=str).save()
+    study_metadata_schema = ln.Schema(
+        features=[
+            temperature_feature,
+            experiment_id_feature,
+        ],
     ).save()
 
     schema = ln.Schema(
@@ -350,14 +344,22 @@ def test_dataframe_attrs_validation(uns_study_metadata, study_metadata_schema):
     artifact = curator.save_artifact(key="examples/df_with_attrs.parquet")
 
     assert artifact.schema == schema
-    assert "df" in artifact.features.slots
+    assert "df" in artifact.features.slots  
     assert "attrs" in artifact.features.slots
     assert artifact.features.slots[
         "attrs"
     ].features.first() == ln.Feature.get(name="temperature")
     assert artifact.features.slots[
         "attrs"
-    ].features.first() == ln.Feature.get(name="pos")
+    ].features.last() == ln.Feature.get(name="experiment_id")
+
+    from lamindb.models import SchemaComponent
+    SchemaComponent.filter().delete()
+    artifact.delete(permanent=True)
+    df_schema.delete(permanent=True)
+    study_metadata_schema.delete(permanent=True)
+    schema.delete(permanent=True)
+    experiment_id_feature.delete(permanent=True)
 
 
 def test_schema_new_genes(ccaplog):
@@ -619,10 +621,17 @@ def test_anndata_curator_varT_curation_legacy(ccaplog):
             varT_schema.delete(permanent=True)
 
 
-def test_anndata_curator_nested_uns(uns_study_metadata, study_metadata_schema):
+def test_anndata_curator_nested_uns(uns_study_metadata):
     """Test AnnDataCurator with nested uns slot validation."""
     adata = datasets.small_dataset1(otype="AnnData")
     adata.uns["study_metadata"] = uns_study_metadata
+
+    study_metadata_schema = ln.Schema(
+        features=[
+            ln.Feature(name="temperature", dtype=float).save(),
+            ln.Feature(name="experiment_id", dtype=str).save(),
+        ],
+    ).save()
 
     anndata_schema = ln.Schema(
         otype="AnnData",
@@ -666,6 +675,7 @@ def test_anndata_curator_nested_uns(uns_study_metadata, study_metadata_schema):
     # Clean up
     artifact.delete(permanent=True)
     bad_schema.delete(permanent=True)
+    study_metadata_schema.delete(permanent=True)
     anndata_schema.delete(permanent=True)
 
 


### PR DESCRIPTION
In reference to https://github.com/laminlabs/lamindb/pull/3029#issuecomment-3206598980.

- Enables support for the validation of the `attrs` slot of DataFrames using the DataFrameCurator

```python
import lamindb as ln
df = ln.core.datasets.mini_immuno.get_dataset1(otype="DataFrame")
df.attrs = {"temperature": 21.6, "experiment_id": "EXP001"}

study_metadata_schema = ln.Schema(
    features=[
        ln.Feature(name="temperature", dtype=float).save(),
        ln.Feature(name="experiment_id", dtype=str).save(),
    ],
).save()

main_schema = ln.Schema(
    features=[ln.Feature(name="perturbation", dtype="str").save()],
).save()

schema = ln.Schema(
    slots={
        "df": main_schema,
        "attrs": study_metadata_schema
    },
    otype="DataFrame",
).save()

curator = ln.curators.DataFrameCurator(
    df, schema=schema
)
curator.validate()
artifact = curator.save_artifact(key="examples/df_with_attrs.parquet")

artifact.describe()
```

<pre style="white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace"><span style="font-weight: bold">Artifact</span><span style="color: #7f7f7f; text-decoration-color: #7f7f7f; font-weight: bold"> .parquet · DataFrame · dataset</span>
<span style="color: #7f7f7f; text-decoration-color: #7f7f7f">├── </span><span style="color: #00ffff; text-decoration-color: #00ffff; font-weight: bold">General</span>
<span style="color: #7f7f7f; text-decoration-color: #7f7f7f">│   ├── </span><span style="color: #7f7f7f; text-decoration-color: #7f7f7f">key: </span><span style="color: #00d7af; text-decoration-color: #00d7af">examples/df_with_attrs.parquet</span>
<span style="color: #7f7f7f; text-decoration-color: #7f7f7f">│   ├── </span><span style="color: #7f7f7f; text-decoration-color: #7f7f7f">uid: </span>40WdBYZLNbPXW8re0000          <span style="color: #7f7f7f; text-decoration-color: #7f7f7f">hash: </span>lxqqxmMIUsUAVLR9yJdaLA
<span style="color: #7f7f7f; text-decoration-color: #7f7f7f">│   ├── </span><span style="color: #7f7f7f; text-decoration-color: #7f7f7f">size: </span>9.3 KB                       <span style="color: #7f7f7f; text-decoration-color: #7f7f7f">transform: </span><span style="color: #00d7af; text-decoration-color: #00d7af">None</span>
<span style="color: #7f7f7f; text-decoration-color: #7f7f7f">│   ├── </span><span style="color: #7f7f7f; text-decoration-color: #7f7f7f">space: </span>all                         <span style="color: #7f7f7f; text-decoration-color: #7f7f7f">branch: </span>all
<span style="color: #7f7f7f; text-decoration-color: #7f7f7f">│   ├── </span><span style="color: #7f7f7f; text-decoration-color: #7f7f7f">created_by: </span>zethson                <span style="color: #7f7f7f; text-decoration-color: #7f7f7f">created_at: </span>2025-08-25 18:43:47
<span style="color: #7f7f7f; text-decoration-color: #7f7f7f">│   ├── </span><span style="color: #7f7f7f; text-decoration-color: #7f7f7f">n_observations: </span>3
<span style="color: #7f7f7f; text-decoration-color: #7f7f7f">│   └── </span><span style="color: #7f7f7f; text-decoration-color: #7f7f7f">storage path: </span><span style="color: #00d7af; text-decoration-color: #00d7af">/home/lukas/code/lamindb/run-tests</span>/examples/df_with_attrs.parquet
<span style="color: #7f7f7f; text-decoration-color: #7f7f7f">└── </span><span style="color: #ff00ff; text-decoration-color: #ff00ff; font-weight: bold">Dataset features</span>
<span style="color: #7f7f7f; text-decoration-color: #7f7f7f">    ├── </span><span style="color: #d787ff; text-decoration-color: #d787ff; font-weight: bold">df</span><span style="color: #7f7f7f; text-decoration-color: #7f7f7f; font-weight: bold"> • </span><span style="color: #ffafd7; text-decoration-color: #ffafd7; font-weight: bold">1</span><span style="font-weight: bold">                          </span><span style="color: #ffafd7; text-decoration-color: #ffafd7; font-weight: bold">[Feature]</span><span style="font-weight: bold">                                                                  </span>
<span style="color: #7f7f7f; text-decoration-color: #7f7f7f">    │   </span>perturbation                   <span style="color: #7f7f7f; text-decoration-color: #7f7f7f"> str                               </span>                                         
<span style="color: #7f7f7f; text-decoration-color: #7f7f7f">    └── </span><span style="color: #d787ff; text-decoration-color: #d787ff; font-weight: bold">attrs</span><span style="color: #7f7f7f; text-decoration-color: #7f7f7f; font-weight: bold"> • </span><span style="color: #ffafd7; text-decoration-color: #ffafd7; font-weight: bold">2</span><span style="font-weight: bold">                       </span><span style="color: #ffafd7; text-decoration-color: #ffafd7; font-weight: bold">[Feature]</span><span style="font-weight: bold">                                                                  </span>
<span style="color: #7f7f7f; text-decoration-color: #7f7f7f">        </span>temperature                    <span style="color: #7f7f7f; text-decoration-color: #7f7f7f"> float                             </span>                                         
<span style="color: #7f7f7f; text-decoration-color: #7f7f7f">        </span>experiment_id                  <span style="color: #7f7f7f; text-decoration-color: #7f7f7f"> str                               </span>                                         
</pre>

## Technical details

- Makes the `DataFrameCurator` a slot curator but we still allow the old behavior of not specifying slots.
- We have to indicate which Schema is the Schema for the main DataFrame. Currently, we are using `df` as a fixed slot. Alternatively, we find a way to automatically use all passed Features of the main Schemas as the main Schema. Now, it's just very explicit.