### PR TITLE
✨ Implement lazy artifact saving for streaming data

### DIFF
--- a/lamindb/models/__init__.py
+++ b/lamindb/models/__init__.py
@@ -9,6 +9,7 @@
    BasicQuerySet
    QuerySet
    ArtifactSet
+   LazyArtifact
    QueryManager
    SQLRecordList
    FeatureManager
@@ -49,7 +50,7 @@ from .schema import Schema
 from .ulabel import ULabel
 
 # should come last as it needs everything else
-from .artifact import Artifact
+from .artifact import Artifact, LazyArtifact
 from ._feature_manager import FeatureManager
 from ._label_manager import LabelManager
 from .collection import Collection, CollectionArtifact

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1057,13 +1057,24 @@ class LazyArtifact:
         self.kwargs = kwargs
         self.kwargs["overwrite_versions"] = overwrite_versions
 
+        if (key := kwargs.get("key")) is not None and extract_suffix_from_path(
+            PurePosixPath(key)
+        ) != suffix:
+            raise ValueError(
+                "The suffix argument and the suffix of key should be the same."
+            )
+
         uid, _ = create_uid(n_full_id=20)
         storage_key = auto_storage_key_from_artifact_uid(
             uid, suffix, overwrite_versions=overwrite_versions
         )
         storepath = setup_settings.storage.root / storage_key
 
-        self.path = storepath
+        self._path = storepath
+
+    @property
+    def path(self) -> UPath:
+        return self._path
 
     def save(self, upload: bool | None = None, **kwargs) -> Artifact:
         artifact = Artifact(self.path, _is_internal_call=True, **self.kwargs)

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1053,6 +1053,27 @@ def delete_permanently(artifact: Artifact, storage: bool, using_key: str):
 
 
 class LazyArtifact:
+    """Lazy artifact for streaming to auto-generated internal paths.
+
+    This is needed when it is desirable to stream to a `lamindb` auto-generated internal path
+    and register the path as an artifact (see :class:`~lamindb.Artifact`).
+
+    This object creates a real artifact on `.save()` with the provided arguments.
+
+    Args:
+        suffix: The suffix for the auto-generated internal path
+        overwrite_versions: Whether to overwrite versions.
+        **kwargs: Keyword arguments for the artifact to be created.
+
+    Examples:
+
+        Create a lazy artifact, write to the path and save to get a real artifact::
+
+            lazy = ln.Artifact.from_lazy(suffix=".zarr", overwrite_versions=True, key="mydata.zarr")
+            zarr.open(lazy.path, mode="w")["test"] = np.array(["test"]) # stream to the path
+            artifact = lazy.save()
+    """
+
     def __init__(self, suffix: str, overwrite_versions: bool, **kwargs):
         self.kwargs = kwargs
         self.kwargs["overwrite_versions"] = overwrite_versions
@@ -1682,7 +1703,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         super().__init__(**kwargs)
 
     @staticmethod
-    def lazy_artifact(
+    def from_lazy(
         suffix: str,
         overwrite_versions: bool,
         key: str | None = None,
@@ -1690,6 +1711,27 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         run: Run | None = None,
         **kwargs,
     ) -> LazyArtifact:
+        """Create a lazy artifact for streaming to auto-generated internal paths.
+
+        This is needed when it is desirable to stream to a `lamindb` auto-generated internal path
+        and register the path as an artifact (see :class:`~lamindb.Artifact`).
+
+        The lazy artifact object (see :class:`~lamindb.models.LazyArtifact`) creates a real artifact
+        on `.save()` with the provided arguments.
+
+        Args:
+            suffix: The suffix for the auto-generated internal path
+            overwrite_versions: Whether to overwrite versions.
+            **kwargs: Keyword arguments for the artifact to be created.
+
+        Examples:
+
+            Create a lazy artifact, write to the path and save to get a real artifact::
+
+                lazy = ln.Artifact.from_lazy(suffix=".zarr", overwrite_versions=True, key="mydata.zarr")
+                zarr.open(lazy.path, mode="w")["test"] = np.array(["test"]) # stream to the path
+                artifact = lazy.save()
+        """
         args = {"key": key, "description": description, "run": run, **kwargs}
         return LazyArtifact(suffix, overwrite_versions, **args)
 

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1723,7 +1723,10 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         Args:
             suffix: The suffix for the auto-generated internal path
             overwrite_versions: Whether to overwrite versions.
-            **kwargs: Keyword arguments for the artifact to be created.
+            key: An optional key to reference the artifact.
+            description: A description.
+            run: The run that creates the artifact.
+            **kwargs: Other keyword arguments for the artifact to be created.
 
         Examples:
 

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1715,7 +1715,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         """Create a lazy artifact for streaming to auto-generated internal paths.
 
         This is needed when it is desirable to stream to a `lamindb` auto-generated internal path
-        and register the path as an artifact (see :class:`~lamindb.Artifact`).
+        and register the path as an artifact.
 
         The lazy artifact object (see :class:`~lamindb.models.LazyArtifact`) creates a real artifact
         on `.save()` with the provided arguments.

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1702,8 +1702,9 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
 
         super().__init__(**kwargs)
 
-    @staticmethod
+    @classmethod
     def from_lazy(
+        cls,
         suffix: str,
         overwrite_versions: bool,
         key: str | None = None,

--- a/tests/storage/test_streaming.py
+++ b/tests/storage/test_streaming.py
@@ -273,6 +273,23 @@ def test_anndata_open_mode():
     artifact.delete(permanent=True, storage=True)
 
 
+def test_lazy_artifact():
+    lazy = ln.Artifact.lazy_artifact(
+        suffix=".zarr", overwrite_versions=True, key="mydata.zarr"
+    )
+
+    store = zarr.open(lazy.path, mode="w")
+    store["test"] = np.array(["test"])
+
+    artifact = lazy.save()
+    assert ".lamindb" in artifact.path.as_posix()
+
+    access = artifact.open()
+    assert access.storage["test"][...] == "test"
+
+    artifact.delete(permanent=True, storage=True)
+
+
 @pytest.mark.parametrize("storage", [None, "s3://lamindb-test/storage"])
 def test_write_read_tiledbsoma(storage):
     if storage is not None:

--- a/tests/storage/test_streaming.py
+++ b/tests/storage/test_streaming.py
@@ -274,6 +274,12 @@ def test_anndata_open_mode():
 
 
 def test_lazy_artifact():
+    # a different suffix in key
+    with pytest.raises(ValueError):
+        ln.Artifact.lazy_artifact(
+            suffix=".zarr", overwrite_versions=True, key="mydata.h5ad"
+        )
+
     lazy = ln.Artifact.lazy_artifact(
         suffix=".zarr", overwrite_versions=True, key="mydata.zarr"
     )
@@ -282,7 +288,10 @@ def test_lazy_artifact():
     store["test"] = np.array(["test"])
 
     artifact = lazy.save()
-    assert ".lamindb" in artifact.path.as_posix()
+
+    path_str = artifact.path.as_posix()
+    assert ".lamindb" in path_str
+    assert artifact.uid[:16] in path_str
 
     access = artifact.open()
     assert access.storage["test"][...] == "test"

--- a/tests/storage/test_streaming.py
+++ b/tests/storage/test_streaming.py
@@ -273,14 +273,14 @@ def test_anndata_open_mode():
     artifact.delete(permanent=True, storage=True)
 
 
-def test_lazy_artifact():
+def test_from_lazy():
     # a different suffix in key
     with pytest.raises(ValueError):
-        ln.Artifact.lazy_artifact(
+        ln.Artifact.from_lazy(
             suffix=".zarr", overwrite_versions=True, key="mydata.h5ad"
         )
 
-    lazy = ln.Artifact.lazy_artifact(
+    lazy = ln.Artifact.from_lazy(
         suffix=".zarr", overwrite_versions=True, key="mydata.zarr"
     )
 


### PR DESCRIPTION
For https://github.com/laminlabs/pfizer-lamin-usage/issues/335

so this should work like this:
```python
lazy_artifact = ln.Artifact.from_lazy(suffix=".zarr", overwrite_versions=True, key="myzarr.zarr")
lazy_artifact.path # has the path in root/.lamindb/
... # stream into the path
artifact= lazy_artifact.save() # get the actual artifact
```