### PR TITLE
🐛 Fix `queryset.to_dataframe(include=...)` with `using` and annotations

### DIFF
--- a/lamindb/models/query_set.py
+++ b/lamindb/models/query_set.py
@@ -709,7 +709,7 @@ class BasicQuerySet(models.QuerySet):
             id_subquery = self.values("id")
             time = logger.debug("finished get id values", time=time)
             # for annotate, we want the queryset without filters so that joins don't affect the annotations
-            query_set_without_filters = self.model.objects.filter(
+            query_set_without_filters = self.model.objects.using(self._db).filter(
                 id__in=Subquery(id_subquery)
             )
             time = logger.debug("finished get query_set_without_filters", time=time)


### PR DESCRIPTION
Fix https://github.com/laminlabs/pfizer-lamin-usage/issues/369

The function makes an additional query during building the dataframe and it is done to the default database even if the queryset is from another database.