### PR TITLE
🐛 Fix version family mapping when registering existing files and add more extensive tests for Croissant file parameterization

### DIFF
--- a/lamindb/examples/croissant/__init__.py
+++ b/lamindb/examples/croissant/__init__.py
@@ -11,7 +11,9 @@ import json
 from pathlib import Path
 
 
-def mini_immuno(n_files: int = 1, filepath_prefix: str = "") -> list[Path]:
+def mini_immuno(
+    n_files: int = 1, filepath_prefix: str = "", strip_version: bool = False
+) -> list[Path]:
     """Return paths to the mini immuno dataset and its metadata as a Croissant file.
 
     Args:
@@ -42,6 +44,8 @@ def mini_immuno(n_files: int = 1, filepath_prefix: str = "") -> list[Path]:
     if filepath_prefix:
         assert data["distribution"][0]["@id"] == "mini_immuno.anndata.zarr"  # noqa: S101
         data["distribution"][0]["@id"] = str(Path(filepath_prefix) / dataset1_path.name)
+    if strip_version:
+        data.pop("version", None)
     if n_files == 2:
         file_mini_csv()
         if filepath_prefix:

--- a/lamindb/examples/croissant/__init__.py
+++ b/lamindb/examples/croissant/__init__.py
@@ -11,35 +11,47 @@ import json
 from pathlib import Path
 
 
-def mini_immuno(n_files: int = 1) -> list[Path]:
+def mini_immuno(n_files: int = 1, filepath_prefix: str = "") -> list[Path]:
     """Return paths to the mini immuno dataset and its metadata as a Croissant file.
 
     Args:
         n_files: Number of files inside the croissant file. Default is 1.
+        filepath_prefix: Move the dataset and references to it in a specific directory.
 
     Example
 
         ::
 
             croissant_path, dataset1_path = ln.examples.croissant.mini_immuno()
+            croissant_path, dataset1_path, dataset2_path = ln.examples.croissant.mini_immuno(n_files=2)
     """
     from ..datasets import file_mini_csv
     from ..datasets.mini_immuno import get_dataset1
 
     adata = get_dataset1(otype="AnnData")
-    dataset1_path = Path("mini_immuno.anndata.zarr")
+    if filepath_prefix:
+        dataset1_path = Path(filepath_prefix) / "mini_immuno.anndata.zarr"
+    else:
+        dataset1_path = Path("mini_immuno.anndata.zarr")
     adata.write_zarr(dataset1_path)
     orig_croissant_path = (
         Path(__file__).parent / "mini_immuno.anndata.zarr_metadata.json"
     )
     with open(orig_croissant_path, encoding="utf-8") as f:
         data = json.load(f)
+    if filepath_prefix:
+        assert data["distribution"][0]["@id"] == "mini_immuno.anndata.zarr"  # noqa: S101
+        data["distribution"][0]["@id"] = str(Path(filepath_prefix) / dataset1_path.name)
     if n_files == 2:
-        dataset2_path = file_mini_csv()
+        file_mini_csv()
+        if filepath_prefix:
+            dataset2_path = Path(filepath_prefix) / "mini.csv"
+        else:
+            dataset2_path = Path("mini.csv")
         data["distribution"].append(
             {
                 "@type": "sc:FileObject",
-                "@id": "mini.csv",
+                "@id": dataset2_path.as_posix(),
                 "name": "mini.csv",
                 "encodingFormat": "text/csv",
             }

--- a/lamindb/integrations/_croissant.py
+++ b/lamindb/integrations/_croissant.py
@@ -55,10 +55,10 @@ def curate_from_croissant(
 
     # Extract basic metadata
     dataset_name = data["name"]
-    description = data.get("description", "")
-    version = data.get("version", "1.0")
-    license_info = data.get("license", "")
-    project_name = data.get("cr:projectName", "")
+    description = data.get("description", None)
+    version = data.get("version", None)
+    license_info = data.get("license", None)
+    project_name = data.get("cr:projectName", None)
 
     # Create license feature and label if license info exists
     license_label = None
@@ -113,7 +113,9 @@ def curate_from_croissant(
         if len(file_distributions) == 1:
             # it doesn't make sense to have the dataset name on the individual
             # artifact if it's part of a collection
-            artifact_description = f"{dataset_name} - {description}"
+            artifact_description = dataset_name
+            if description is not None:
+                artifact_description += f" - {description}"
         else:
             artifact_description = None
         artifact = ln.Artifact(  # type: ignore

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1033,7 +1033,7 @@ def delete_permanently(artifact: Artifact, storage: bool, using_key: str):
         delete_in_storage = storage is None or storage
     else:
         # for artifacts with non-virtual semantic storage keys (key is not None)
-        # ask for extra-confirmation
+        # ask for extra-confirmation if storage is None
         if storage is None:
             response = input(
                 f"Are you sure to want to delete {path}? (y/n) You can't undo"

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -418,24 +418,6 @@ def get_artifact_kwargs_from_data(
         skip_check_exists,
         is_replace=is_replace,
     )
-    stat_or_artifact = get_stat_or_artifact(
-        path=path,
-        key=key,
-        instance=using_key,
-        is_replace=is_replace,
-    )
-    if isinstance(stat_or_artifact, Artifact):
-        existing_artifact = stat_or_artifact
-        if run is not None:
-            existing_artifact._populate_subsequent_runs(run)
-        return existing_artifact, None
-    else:
-        size, hash, hash_type, n_files, revises = stat_or_artifact
-
-    if revises is not None:  # update provisional_uid
-        provisional_uid, revises = create_uid(revises=revises, version=version)
-        if settings.cache_dir in path.parents:
-            path = path.rename(path.with_name(f"{provisional_uid}{suffix}"))
 
     check_path_in_storage = False
     if use_existing_storage_key:
@@ -455,6 +437,25 @@ def get_artifact_kwargs_from_data(
         check_path_in_storage = True
     else:
         storage = storage
+
+    stat_or_artifact = get_stat_or_artifact(
+        path=path,
+        key=key,
+        instance=using_key,
+        is_replace=is_replace,
+    )
+    if isinstance(stat_or_artifact, Artifact):
+        existing_artifact = stat_or_artifact
+        if run is not None:
+            existing_artifact._populate_subsequent_runs(run)
+        return existing_artifact, None
+    else:
+        size, hash, hash_type, n_files, revises = stat_or_artifact
+
+    if revises is not None:  # update provisional_uid
+        provisional_uid, revises = create_uid(revises=revises, version=version)
+        if settings.cache_dir in path.parents:
+            path = path.rename(path.with_name(f"{provisional_uid}{suffix}"))
 
     log_storage_hint(
         check_path_in_storage=check_path_in_storage,

--- a/tests/curators/test_curate_from_croissant.py
+++ b/tests/curators/test_curate_from_croissant.py
@@ -10,8 +10,6 @@ def test_curate_artifact_from_croissant(filepath_prefix: str | None):
         n_files=1, filepath_prefix=filepath_prefix
     )
     artifact1 = ln.integrations.curate_from_croissant(croissant_path)
-    croissant_path.unlink()
-    shutil.rmtree(dataset1_path)
     assert (
         artifact1.description
         == "Mini immuno dataset - A few samples from the immunology dataset"
@@ -28,6 +26,31 @@ def test_curate_artifact_from_croissant(filepath_prefix: str | None):
     )
     project_label = artifact1.projects.get(name="Mini Immuno Project")
 
+    # now mutate the dataset and create a new version
+    croissant_path, dataset1_path = ln.examples.croissant.mini_immuno(
+        n_files=1, filepath_prefix=filepath_prefix, strip_version=True
+    )
+    dummy_file_path = dataset1_path / "dummy_file.txt"
+    dummy_file_path.write_text("dummy file")
+
+    artifact2 = ln.integrations.curate_from_croissant(croissant_path)
+    assert artifact2.description == artifact1.description
+    assert artifact2.key == artifact1.key
+    assert artifact2.version is None
+    assert artifact2.stem_uid == artifact1.stem_uid
+    assert artifact2.uid != artifact1.uid
+    assert (
+        artifact2._key_is_virtual
+        if filepath_prefix is None
+        else not artifact1._key_is_virtual
+    )
+    license_label = artifact2.ulabels.get(
+        name="https://creativecommons.org/licenses/by/4.0/"
+    )
+    project_label = artifact2.projects.get(name="Mini Immuno Project")
+
+    shutil.rmtree(dataset1_path)
+    croissant_path.unlink()
     artifact1.delete(permanent=True, storage=True)  # because of real storage key
     project_label.delete(permanent=True)
     license_label.delete(permanent=True)


### PR DESCRIPTION
Prior to this PR an implicitly inferred artifact key did _not_ lead to mapping artifacts into the same version family, and hence presented inconsistent and unintuitive behavior.

The bug is fixed in the current PR along with adding more comprehensive tests in the context of croissant-file-based ingestion, covering re-ingestion (which is how the bug was surfaced).