### PR TITLE
🚸 Add the current branch by default for filtering

### DIFF
--- a/lamindb/models/query_set.py
+++ b/lamindb/models/query_set.py
@@ -169,8 +169,12 @@ def process_expressions(queryset: QuerySet, expressions: dict) -> dict:
                     expressions_have_branch = True
                     break
             if not expressions_have_branch:
-                # set the current branch by default
-                expressions["branch_id"] = setup_settings.branch.id
+                # add the current branch by default
+                branch_id = setup_settings.branch.id
+                if branch_id == 1:
+                    expressions["branch_id"] = 1
+                else:
+                    expressions["branch_id__in"] = [1, branch_id]
             else:
                 # if branch_id is None, do not apply a filter
                 # otherwise, it would mean filtering for NULL values, which doesn't make

--- a/lamindb/models/query_set.py
+++ b/lamindb/models/query_set.py
@@ -13,6 +13,7 @@ from django.db import models
 from django.db.models import F, ForeignKey, ManyToManyField, Q, Subquery
 from django.db.models.fields.related import ForeignObjectRel
 from lamin_utils import logger
+from lamindb_setup import settings as setup_settings
 from lamindb_setup.core import deprecated
 from lamindb_setup.core._docs import doc_args
 
@@ -168,8 +169,8 @@ def process_expressions(queryset: QuerySet, expressions: dict) -> dict:
                     expressions_have_branch = True
                     break
             if not expressions_have_branch:
-                # TODO: should be set to the current default branch
-                expressions["branch_id"] = 1
+                # set the current branch by default
+                expressions["branch_id"] = setup_settings.branch.id
             else:
                 # if branch_id is None, do not apply a filter
                 # otherwise, it would mean filtering for NULL values, which doesn't make


### PR DESCRIPTION
This PR enables to query via `.filter()` and `.get()` on the current branch by adding the branch to the branches list on which the querying is done.

This means that instead of only the main branch queries are performed on the main and current branches if no branch is specified in the query expressions.