### PR TITLE
:children_crossing: Better docs & single data lineage in `Collection.cache()`

### DIFF
--- a/lamindb/models/collection.py
+++ b/lamindb/models/collection.py
@@ -545,17 +545,17 @@ class Collection(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
     def cache(self, is_run_input: bool | None = None) -> list[UPath]:
         """Download cloud artifacts in collection to local cache.
 
-        Follows synching logic: only caches outdated artifacts.
+        Follows syncing logic: only downloads outdated artifacts.
 
-        Returns paths to locally cached on-disk artifacts.
+        Returns ordered paths to locally cached on-disk artifacts via `.ordered_artifacts.all()`:
 
         Args:
             is_run_input: Whether to track this collection as run input.
         """
         path_list = []
         for artifact in self.ordered_artifacts.all():
-            path_list.append(artifact.cache())
-        # is it really needed if tracking is done in self.ordered_artifacts.all()? - Sergei
+            # do not want to track data lineage on the artifact level
+            path_list.append(artifact.cache(is_run_input=False))
         _track_run_input(self, is_run_input)
         return path_list
 

--- a/lamindb/models/collection.py
+++ b/lamindb/models/collection.py
@@ -437,7 +437,6 @@ class Collection(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
 
         dataframe = _open_dataframe(paths, engine=engine, **kwargs)
         # track only if successful
-        # is it really needed if tracking is done in self.ordered_artifacts.all()? - Sergei
         _track_run_input(self, is_run_input)
         return dataframe
 
@@ -538,7 +537,6 @@ class Collection(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             dtype,
         )
         # track only if successful
-        # is it really needed if tracking is done in self.ordered_artifacts.all()? - Sergei
         _track_run_input(self, is_run_input)
         return ds
 
@@ -573,7 +571,6 @@ class Collection(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         artifacts = self.ordered_artifacts.all()
         concat_object = _load_concat_artifacts(artifacts, join, **kwargs)
         # only call it here because there might be errors during load or concat
-        # is it really needed if tracking is done in self.ordered_artifacts.all()? - Sergei
         _track_run_input(self, is_run_input)
         return concat_object
 
@@ -640,7 +637,7 @@ class Collection(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         you non-deterministic order.
 
         Using the property `.ordered_artifacts` allows to iterate through a set
-        that's ordered in the order of creation.
+        that's ordered by the order of the list that created the collection.
         """
         return self.artifacts.order_by("links_collection__id")
 


### PR DESCRIPTION
We don't duplicate the lineage information for `Collection.cache()` anymore.

Before | After
--- | ---
https://lamin.ai/laminlabs/lamindata/transform/67YwGo1PrjRp0000/nMKuBkPSVRS1jjVv | https://lamin.ai/laminlabs/lamindata/transform/67YwGo1PrjRp0000/4grVSj6U665AvKTJ
<img width="500" height="524" alt="image" src="https://github.com/user-attachments/assets/105f16dc-4ec2-491b-aa67-5e06738b4b43" /> | <img width="500" height="699" alt="image" src="https://github.com/user-attachments/assets/7e959e71-0a05-4910-8138-be181f928917" />
<img width="500" height="860" alt="image" src="https://github.com/user-attachments/assets/ba277675-5da2-4fff-acf3-9a295c045282" /> | <img width="500" height="747" alt="image" src="https://github.com/user-attachments/assets/04cf23ba-d264-480d-859b-835571df165d" />