### PR TITLE
🚸 Replace organism warning with targeted message during validation error

### DIFF
--- a/docs/clinicore.md
+++ b/docs/clinicore.md
@@ -1,5 +1,0 @@
-# `clinicore`
-
-```{eval-rst}
-.. automodule:: clinicore
-```

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -1567,12 +1567,12 @@ class CatVector:
                     from bionty._organism import is_organism_required
 
                     if is_organism_required(registry):
-                        organism = {
+                        organism = (
                             valid_inspect_kwargs.get("organism", False)
                             or bt.settings.organism.name
-                        }
-                        check_organism = f"check organism {organism},"
-                warning_message += f"    → {check_organism}, fix typos, remove non-existent values, or save terms via: {colors.cyan(non_validated_hint_print)}"
+                        )
+                        check_organism = f"fix organism '{organism}', "
+                warning_message += f"    → {check_organism}fix typos, remove non-existent values, or save terms via: {colors.cyan(non_validated_hint_print)}"
                 if self._subtype_query_set is not None:
                     warning_message += f"\n    → a valid label for subtype '{self._subtype_str}' has to be one of {self._subtype_query_set.to_list('name')}"
             logger.info(f'mapping "{self._key}" on {colors.italic(model_field)}')

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -1561,7 +1561,18 @@ class CatVector:
             if n_non_validated > len(syn_mapper):
                 if syn_mapper:
                     warning_message += "\n    for remaining terms:\n"
-                warning_message += f"    → fix typos, remove non-existent values, or save terms via: {colors.cyan(non_validated_hint_print)}"
+                check_organism = ""
+                if registry.__base__.__name__ == "BioRecord":
+                    import bionty as bt
+                    from bionty._organism import is_organism_required
+
+                    if is_organism_required(registry):
+                        organism = {
+                            valid_inspect_kwargs.get("organism", False)
+                            or bt.settings.organism.name
+                        }
+                        check_organism = f"check organism {organism},"
+                warning_message += f"    → {check_organism}, fix typos, remove non-existent values, or save terms via: {colors.cyan(non_validated_hint_print)}"
                 if self._subtype_query_set is not None:
                     warning_message += f"\n    → a valid label for subtype '{self._subtype_str}' has to be one of {self._subtype_query_set.to_list('name')}"
             logger.info(f'mapping "{self._key}" on {colors.italic(model_field)}')

--- a/tests/curators/test_curators_examples.py
+++ b/tests/curators/test_curators_examples.py
@@ -469,7 +469,7 @@ def test_schema_no_match_ensembl():
     assert (
         error.exconly()
         == """lamindb.errors.ValidationError: 2 terms not validated in feature 'index': 'ENSG99999999998', 'ENSG99999999999'
-    → fix typos, remove non-existent values, or save terms via: curator.cat.add_new_from('index')"""
+    → fix organism 'human', fix typos, remove non-existent values, or save terms via: curator.cat.add_new_from('index')"""
     )
 
     schema.delete(permanent=True)
@@ -608,7 +608,7 @@ def test_anndata_curator_varT_curation():
                 ).save()
             assert error.exconly() == (
                 f"lamindb.errors.ValidationError: 1 term not validated in feature 'columns' in slot '{slot}': 'GeneTypo'\n"
-                f"    → fix typos, remove non-existent values, or save terms via: curator.slots['{slot}'].cat.add_new_from('columns')"
+                f"    → fix organism 'human', fix typos, remove non-existent values, or save terms via: curator.slots['{slot}'].cat.add_new_from('columns')"
             )
         else:
             for n_max_records in [2, 4]:
@@ -654,7 +654,7 @@ def test_anndata_curator_varT_curation_legacy(ccaplog):
                 ).save()
             assert error.exconly() == (
                 f"lamindb.errors.ValidationError: 1 term not validated in feature 'var_index' in slot '{slot}': 'GeneTypo'\n"
-                f"    → fix typos, remove non-existent values, or save terms via: curator.slots['{slot}'].cat.add_new_from('var_index')"
+                f"    → fix organism 'human', fix typos, remove non-existent values, or save terms via: curator.slots['{slot}'].cat.add_new_from('var_index')"
             )
         else:
             artifact = ln.Artifact.from_anndata(

--- a/tests/curators/test_curators_general.py
+++ b/tests/curators/test_curators_general.py
@@ -351,7 +351,7 @@ def test_schema_maximal_set_var():
         curator.validate()
     assert error.exconly() == (
         "lamindb.errors.ValidationError: 1 term not validated in feature 'columns' in slot 'var.T': 'NOT_VALID_ENSEMBL'\n"
-        "    → fix typos, remove non-existent values, or save terms via: curator.slots['var.T'].cat.add_new_from('columns')"
+        "    → fix organism 'human', fix typos, remove non-existent values, or save terms via: curator.slots['var.T'].cat.add_new_from('columns')"
     )
 
     # clean up


### PR DESCRIPTION
The frequency at which the warning is issued is excessive. It's annoying and a user will start ignoring it. For instance, here:

https://lamin.ai/laminlabs/lamindata/transform/M0BgdFXT7Az7

<img width="482" height="122" alt="image" src="https://github.com/user-attachments/assets/1250fb3e-a2f1-40d7-9fd3-24414f7e9c17" />

Instead, a targeted mention of the wrong organism being the reason for a validation error makes more sense IMO.

Hence this PR with the corresponding PR in bionty setting the warning to a debug level logging:

- https://github.com/laminlabs/bionty/pull/320