### PR TITLE
:wrench: Introduce a `skip_hash_lookup` argument for `Artifact`

### DIFF
--- a/tests/core/test_artifact.py
+++ b/tests/core/test_artifact.py
@@ -305,6 +305,15 @@ def test_revise_artifact(df):
     assert artifact_new.key == key  # old key
     assert artifact_new.description == "test1 updated"
 
+    # re-create while skipping hash lookup
+    artifact_new = ln.Artifact.from_dataframe(
+        df,
+        key="my-test-dataset1-new.parquet",
+        skip_hash_lookup=True,
+    )
+    assert artifact_new != artifact_r3
+    assert artifact_new.key == "my-test-dataset1-new.parquet"
+
     with pytest.raises(TypeError) as error:
         ln.Artifact.from_dataframe(
             df, description="test1a", revises=ln.Record(name="test")


### PR DESCRIPTION
In the artifact docs:

<img width="500" height="187" alt="image" src="https://github.com/user-attachments/assets/cd83299b-2d4e-4cfa-8fe4-cee8eea8a011" />

<img width="500" height="637" alt="image" src="https://github.com/user-attachments/assets/1cf5991c-62ec-4762-8d44-a0207768dccc" />

Frequent request, e.g. here:

- https://github.com/pfizer-rd/lamin/issues/303