### PR TITLE
🚸 Limit name search upon record creation to records of same type

### DIFF
--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -306,8 +306,11 @@ def suggest_records_with_similar_names(
     # but this isn't reliable: https://laminlabs.slack.com/archives/C04FPE8V01W/p1737812808563409
     # the below needs to be .first() because there might be multiple records with the same
     # name field in case the record is versioned (e.g. for Transform key)
-    if hasattr(record, "type"):
-        subset = record.__class__.filter(type=record.type)
+    if hasattr(record.__class__, "type"):
+        if kwargs.get("type", None) is None:
+            subset = record.__class__.filter(type__isnull=True)
+        else:
+            subset = record.__class__.filter(type=kwargs["type"])
     else:
         subset = record.__class__
     exact_match = subset.filter(**{name_field: kwargs[name_field]}).first()

--- a/tests/core/test_record.py
+++ b/tests/core/test_record.py
@@ -33,3 +33,18 @@ def test_record_plural_type_warning(ccaplog):
         "name 'MyThings' for type ends with 's', in case you're naming with plural, consider the singular for a type name"
         in ccaplog.text
     )
+
+
+def test_name_lookup():
+    my_type = ln.Record(name="MyType", is_type=True).save()
+    label1 = ln.Record(name="label 1", type=my_type).save()
+    label2 = ln.Record(name="label 1", type=my_type)
+    assert label2 == label1
+    label2 = ln.Record(name="label 1")
+    assert label2 != label1
+    label2.save()
+    label3 = ln.Record(name="label 1")
+    assert label3 == label2
+    label2.delete(permanent=True)
+    label1.delete(permanent=True)
+    my_type.delete(permanent=True)


### PR DESCRIPTION
This is consistent with the behavior of folders in file systems.

```python
def test_name_lookup():
    my_type = ln.Record(name="MyType", is_type=True).save()
    label1 = ln.Record(name="label 1", type=my_type).save()
    label2 = ln.Record(name="label 1", type=my_type)
    assert label2 == label1
    label2 = ln.Record(name="label 1")
    assert label2 != label1
    label2.save()
    label3 = ln.Record(name="label 1")
    assert label3 == label2
```

The DB-level constraint we recently introduced for `Record` enforces a similar constraint.

- https://github.com/laminlabs/lamindb/pull/3126