### PR TITLE
🥅 Better error message for trying to write on a public connection.

### DIFF
--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -982,9 +982,10 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                 elif (
                     isinstance(e, ProgrammingError)
                     and "permission denied for table" in error_msg
-                    and setup_settings.instance._db_permissions == "public"
+                    and (isettings := setup_settings.instance)._db_permissions
+                    == "public"
                 ):
-                    slug = setup_settings.instance.slug
+                    slug = isettings.slug
                     raise NoWriteAccess(
                         f"You are trying to write to '{slug}' with public (read-only) permissions.\n"
                         "Please contact administrators to make you a collaborator if you need write access.\n"


### PR DESCRIPTION
Before | After
--- | ---
<img width="1622" height="509" alt="image" src="https://github.com/user-attachments/assets/87437eb3-58b0-4b67-8a74-d3ba7394367b" /> | <img width="2314" height="628" alt="image" src="https://github.com/user-attachments/assets/5b0a4a83-e4ae-45f7-9678-869c3c558218" />