### PR TITLE
🎨 Raise error in curators when dtype is list but values are not

### DIFF
--- a/lamindb/base/dtypes.py
+++ b/lamindb/base/dtypes.py
@@ -8,8 +8,8 @@ def is_list_of_type(value: Any, expected_type: Any) -> bool:
     """Helper function to check if a value is either of expected_type or a list of that type, or a mix of both in a nested structure."""
     if isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
         # handle nested lists recursively
-        return all(is_list_of_type(item, expected_type) for item in value)
-    return isinstance(value, expected_type)
+        return all(isinstance(item, expected_type) for item in value)
+    return False
 
 
 def check_dtype(expected_type: Any) -> Callable:

--- a/tests/curators/test_curators_advanced.py
+++ b/tests/curators/test_curators_advanced.py
@@ -18,6 +18,18 @@ def lists_df():
 
 
 @pytest.fixture(scope="module")
+def cat_df():
+    return pd.DataFrame(
+        {
+            "sample_id": [["sample1", "sample2"], ["sample2"], ["sample3"]],
+            "dose": [[1.2, 2.3], [1.2], [2.3]],
+            "cell_type": [["B cell", "T cell"], ["B cell"], ["T cell"]],
+            "tissue": ["blood", "blood", "lung"],
+        }
+    )
+
+
+@pytest.fixture(scope="module")
 def nested_cat_df():
     return pd.DataFrame(
         {
@@ -72,7 +84,7 @@ def nested_cat_schema():
     ln.Record.filter().delete(permanent=True)
 
 
-def test_curator_df_multivalue(lists_df, lists_schema):
+def test_curator_df_multivalue(lists_df, lists_schema, cat_df):
     curator = ln.curators.DataFrameCurator(lists_df, lists_schema)
     with pytest.raises(ValidationError):
         curator.validate()
@@ -86,6 +98,11 @@ def test_curator_df_multivalue(lists_df, lists_schema):
     assert lists_df["tissue"].tolist() == [["blood", "lung"], ["blood"], ["lung"]]
 
     assert curator.validate() is None
+
+    # test with cat_df which has a non-list tissue
+    curator = ln.curators.DataFrameCurator(cat_df, lists_schema)
+    with pytest.raises(ValidationError):
+        curator.validate()
 
 
 def test_curators_df_nested_cat(nested_cat_df, nested_cat_schema):


### PR DESCRIPTION
Resolves: https://github.com/laminlabs/lamindb/issues/3160

Now raises error if any member of the values aren't lists.

```python

# tissue column doesn't contain lists
df = pd.DataFrame(
        {
            "sample_id": [["sample1", "sample2"], ["sample2"], ["sample3"]],
            "dose": [[1.2, 2.3], [1.2], [2.3]],
            "cell_type": [["B cell", "T cell"], ["B cell"], ["T cell"]],
            "tissue": ["blood", "blood", "lung"],
        }
    )

schema = ln.Schema(
    name="lists schema cat",
    features=[
        ln.Feature(name="sample_id", dtype=list[str]).save(),
        ln.Feature(name="dose", dtype=list[float]).save(),
        ln.Feature(name="cell_type", dtype=list[str]).save(),
        ln.Feature(name="tissue", dtype=list[bt.Tissue]).save(),
    ],
).save()

curator = ln.curators.DataFrameCurator(df, schema)
with pytest.raises(ValidationError):
    curator.validate()
```