### PR TITLE
💄 Better way of displaying the schema slot identifier type in `.describe()`

### DIFF
--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -470,7 +470,7 @@ def describe_features(
             _create_feature_table(
                 Text.assemble(
                     (slot, "violet"),
-                    (f" [{schema.n}{schema_itype}]", "violet"),
+                    (f" ({schema.n}{schema_itype})", "dim"),
                 ),
                 "",
                 feature_rows,

--- a/tests/core/test_describe_and_df_calls.py
+++ b/tests/core/test_describe_and_df_calls.py
@@ -176,12 +176,12 @@ def test_curate_df():
         artifact.features.describe(return_str=True)
         == """Artifact .h5ad · AnnData · dataset
 ├── Dataset features
-│   ├── obs • 4             [Feature]
+│   ├── obs (4)
 │   │   cell_type_by_expe…  bionty.CellType         B cell, CD8-positive, alpha…
 │   │   cell_type_by_model  bionty.CellType         B cell, T cell
 │   │   perturbation        Record                  DMSO, IFNG
 │   │   sample_note         str
-│   └── var.T • 3           [bionty.Gene.ensembl_…
+│   └── var.T (3 bionty.G…
 │       CD8A                num
 │       CD4                 num
 │       CD14                num


### PR DESCRIPTION
Before | After
--- | ---
<img width="730" height="317" alt="image" src="https://github.com/user-attachments/assets/5b159938-aa1e-4bef-9bcf-6baca998e06b" /> | <img width="735" height="322" alt="image" src="https://github.com/user-attachments/assets/25edeed0-24ab-4359-8749-834cbdfb5134" />


Also see:

- https://github.com/laminlabs/lamindb/pull/3185

Internal [Slack thread](https://laminlabs.slack.com/archives/C03Q5TXF797/p1760681660000429).
