### PR TITLE
🔊 Log writing in-memory objects into cache on artifact creation

### DIFF
--- a/lamindb/core/storage/_tiledbsoma.py
+++ b/lamindb/core/storage/_tiledbsoma.py
@@ -221,7 +221,7 @@ def save_tiledbsoma_experiment(
         assert len(adata_objects) == 1  # noqa: S101
         n_observations = adata_objects[0].n_obs
 
-    logger.important(f"Writing the tiledbsoma store to {storepath_str}")
+    logger.important(f"writing the tiledbsoma store to {storepath_str}")
     experiment_exists: bool | None = None
     for adata_obj in adata_objects:
         # do not recheck if True

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -286,6 +286,7 @@ def process_data(
             format.pop("suffix", None)
         else:
             format = {}
+        logger.important("writing the in-memory object into cache")
         write_to_disk(data, path, **format)
         use_existing_storage_key = False
 


### PR DESCRIPTION
When an artifact is created from an in-memory object, it is written to disk, and this can take some time. It is better to explicitly log this to explain the user why this takes time.