### PR TITLE
✨ Make it easy to re-run scripts by tracking `cli_args`

### DIFF
--- a/docs/track.ipynb
+++ b/docs/track.ipynb
@@ -346,6 +346,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "You can also access the CLI arguments used to start the run directly:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "run.cli_args"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "You can also track run features in analogy to artifact features.\n",
     "\n",
     "In contrast to params, features are validated against the `Feature` registry and allow to express relationships with entities in your registries.\n",

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -88,6 +88,18 @@ def get_notebook_key_colab() -> str:
     return key
 
 
+def get_cli_args() -> str | None:
+    """Returns the CLI arguments used to invoke a script.
+
+    Returns None if not run as a script (e.g., in Jupyter, interactive shell).
+    """
+    # check if run as a script (not interactive/notebook/imported)
+    # and whether arguments have been passed
+    if len(sys.argv) > 1 and sys.argv[0] and sys.argv[0].endswith(".py"):
+        return " ".join(sys.argv[1:])
+    return None
+
+
 def pretty_pypackages(dependencies: dict) -> str:
     deps_list = []
     for pkg, ver in dependencies.items():
@@ -549,6 +561,10 @@ class Context:
             self._logging_message_track += "\n→ params: " + ", ".join(
                 f"{key}={value!r}" for key, value in run.params.items()
             )
+        cli_args = get_cli_args()
+        if cli_args:
+            logger.important(f"script invoked with: {cli_args}")
+            run.cli_args = cli_args
         run.save()  # need to save now
         if features is not None:
             run.features.add_values(features)

--- a/lamindb/models/_describe.py
+++ b/lamindb/models/_describe.py
@@ -355,12 +355,13 @@ def describe_run(
     )
     append_branch_space_created_at_created_by(record, two_column_items, fk_data)
     add_two_column_items_to_tree(tree, two_column_items)
-    if record.params:
-        params = tree.add(Text("Params", style="bold dark_orange"))
-        for key, value in record.params.items():
-            params.add(f"{key}: {value}")
-    if features_tree:
-        tree.add(features_tree)
+    if record.cli_args:
+        display_text(
+            record.cli_args.strip(),
+            "cli_args",
+            tree,
+            max_lines=4,
+        )
     if record.report_id:
         display_text(
             strip_ansi_from_string(record.report.load(is_run_input=False).strip()),
@@ -377,6 +378,12 @@ def describe_run(
             max_lines=4,
             uid=record.environment.uid[:7],
         )
+    if record.params:
+        params = tree.add(Text("Params", style="bold dark_orange"))
+        for key, value in record.params.items():
+            params.add(f"{key}: {value}")
+    if features_tree:
+        tree.add(features_tree)
     return tree
 
 

--- a/lamindb/models/run.py
+++ b/lamindb/models/run.py
@@ -7,6 +7,7 @@ from django.db.models import (
     CASCADE,
     PROTECT,
 )
+from lamin_utils import logger
 from lamindb_setup import _check_instance_setup
 
 from lamindb.base.fields import (
@@ -263,6 +264,9 @@ class Run(SQLRecord):
         app_label = "lamindb"
 
     _name_field: str = "started_at"
+    _aux_fields: dict[str, tuple[str, type]] = {
+        "0": ("cli_args", str),
+    }
 
     id: int = models.BigAutoField(primary_key=True)
     """Internal id, valid only in one DB instance."""
@@ -444,6 +448,22 @@ class Run(SQLRecord):
             2: "aborted",
         }
         return status_dict.get(self._status_code, "unknown")
+
+    @property
+    def cli_args(self) -> str | None:
+        """CLI arguments if the run was invoked from the command line."""
+        if self._aux is not None and "af" in self._aux and "0" in self._aux["af"]:  # type: ignore
+            return self._aux["af"]["0"]  # type: ignore
+        else:
+            return None
+
+    @cli_args.setter
+    def cli_args(self, value: str) -> None:
+        if not isinstance(value, str) or not (value):
+            logger.warning("did not set empty or non-string cli_args")
+            return
+        self._aux = self._aux or {}
+        self._aux.setdefault("af", {})["0"] = value
 
     @property
     def features(self) -> FeatureManager:

--- a/tests/core/test_track.py
+++ b/tests/core/test_track.py
@@ -227,13 +227,15 @@ def test_create_or_load_transform():
 def test_run_scripts():
     # regular execution
     result = subprocess.run(  # noqa: S602
-        f"python {SCRIPTS_DIR / 'script-to-test-versioning.py'}",
+        f"python {SCRIPTS_DIR / 'script-to-test-versioning.py --param 42'}",
         shell=True,
         capture_output=True,
     )
     assert result.returncode == 0
     assert "created Transform('Ro1gl7n8YrdH0000'" in result.stdout.decode()
     assert "started new Run(" in result.stdout.decode()
+    transform = ln.Transform.get("Ro1gl7n8YrdH0000")
+    assert transform.latest_run.cli_args == "--param 42"
 
     # updated key (filename change)
     result = subprocess.run(  # noqa: S602
@@ -243,6 +245,8 @@ def test_run_scripts():
     )
     assert result.returncode == 0
     assert "renaming transform" in result.stdout.decode()
+    transform = ln.Transform.get(key="script-to-test-filename-change.py")
+    assert transform.latest_run.cli_args is None
 
     # version already taken
     result = subprocess.run(  # noqa: S602


### PR DESCRIPTION
`ln.track()` now populates a `run.cli_args` field in case it's run from a Python script.

This it easy to know the exact command for re-running a script.

Also `describe()` now has a corresponding section.

<img width="748" height="387" alt="image" src="https://github.com/user-attachments/assets/1cbec4a7-81e2-400f-9b29-9f839d84894a" />