### PR TITLE
🐛 Fix feature describe for wetlab.Compound

### DIFF
--- a/lamindb/models/_django.py
+++ b/lamindb/models/_django.py
@@ -179,10 +179,11 @@ def get_artifact_or_run_with_related(
         else:
             label_field = "value"
         related_model = link_model._meta.get_field(label_field).related_model
+        # manually include "name" as wetlab.Compound.name is a TextField due to no length limitation
         char_field_names = [
             field.name
             for field in related_model._meta.concrete_fields
-            if isinstance(field, CharField)
+            if isinstance(field, CharField) or field.name == "name"
         ]
         name_field = get_name_field(related_model)
         label_field_name = f"{label_field}__{name_field}"
@@ -382,7 +383,7 @@ def get_schema_m2m_relations(artifact: Artifact, slot_schema: dict, limit: int =
         related_names[name] = related_model.__get_name_with_module__()
 
     schema_m2m = (
-        Schema.objects.using(artifact._state.db)
+        Schema.using(artifact._state.db)
         .filter(id__in=slot_schema.keys())
         .annotate(**annotations)
         .values("id", *annotations.keys())

--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -186,7 +186,7 @@ def _get_categoricals_postgres(
     # e.g. feature_dict = {1: ('tissue', 'cat[bionty.Tissue.ontology_id]'), 2: ('cell_type', 'cat[bionty.CellType]')}
     feature_dict = {
         id: (name, dtype)
-        for id, name, dtype in Feature.objects.using(self._state.db).values_list(
+        for id, name, dtype in Feature.using(self._state.db).values_list(
             "id", "name", "dtype"
         )
     }


### PR DESCRIPTION
The error only occurs when there are two `wetlab.Compound` features with the same name.

Before | After
--- | ---
<img width="866" height="414" alt="Screenshot 2025-11-21 at 12 44 24" src="https://github.com/user-attachments/assets/0a7ae1c5-0a92-4b65-a69d-e7b82447db5b" /> | <img width="895" height="401" alt="Screenshot 2025-11-21 at 12 44 07" src="https://github.com/user-attachments/assets/f8ab991d-b9b5-4735-bac4-23c567e41884" />

There is still some logic in describing that replies on feature names instead of uids, will do a proper refactor in another PR.