### PR TITLE
🚸 Enable `skip_hash_lookup` in transform

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1034,7 +1034,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         space: `Space | None = None` The space of the artifact. If `None`, uses the current space.
         storage: `Storage | None = None` The storage location for the artifact. If `None`, uses the default storage location.
             You can see and set the default storage location in :attr:`~lamindb.core.Settings.storage`.
-        skip_hash_lookup: Skip the hash lookup so that a new artifact is created even if an identical artifact already exists.
+        skip_hash_lookup: `bool = False` Skip the hash lookup so that a new collection is created even if an artifact with the same hash already exists.
 
     Examples:
 

--- a/lamindb/models/collection.py
+++ b/lamindb/models/collection.py
@@ -94,11 +94,13 @@ class Collection(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         artifacts: `Artifact | list[Artifact]` One or several artifacts.
         key: `str` A file-path like key, analogous to the `key` parameter of `Artifact` and `Transform`.
         description: `str | None = None` A description.
-        revises: `Collection | None = None` An old version of the collection.
-        run: `Run | None = None` The run that creates the collection.
         meta: `Artifact | None = None` An artifact that defines metadata for the collection.
         reference: `str | None = None` A simple reference, e.g. an external ID or a URL.
         reference_type: `str | None = None` A way to indicate to indicate the type of the simple reference `"url"`.
+        run: `Run | None = None` The run that creates the collection.
+        revises: `Collection | None = None` An old version of the collection.
+        skip_hash_lookup: `bool = False` Skip the hash lookup so that a new collection is created even if a collection with the same hash already exists.
+
 
     See Also:
         :class:`~lamindb.Artifact`

--- a/tests/core/test_transform_from_git.py
+++ b/tests/core/test_transform_from_git.py
@@ -50,10 +50,23 @@ entrypoint: myentrypoint
 commit:""")
 
 
-def test_transform_custom_key():
+def test_transform_custom_key_and_hash_lookup():
     # test auto-inferred latest commit hash
-    transform1 = ln.Transform.from_git(url=TEST_URL, path="main.nf", key="mypipeline")
+    transform1 = ln.Transform.from_git(
+        url=TEST_URL, path="main.nf", key="mypipeline"
+    ).save()
     assert transform1.key == "mypipeline"
+    # trigger hash look up
+    transform2 = ln.Transform.from_git(url=TEST_URL, path="main.nf", key="mypipeline2")
+    assert transform1 == transform2
+    assert transform2.key == "mypipeline"
+    # trigger hash look up
+    transform2 = ln.Transform.from_git(
+        url=TEST_URL, path="main.nf", key="mypipeline2", skip_hash_lookup=True
+    )
+    assert transform1 != transform2
+    assert transform2.key == "mypipeline2"
+    transform1.delete(permanent=True)
 
 
 def test_transform_from_git_failure_modes():


### PR DESCRIPTION
This adds the `skip_hash_lookup` argument, which is parallel to what we have for `Artifact` and `Collection` and useful in some cases.

For example:

```python
transform = ln.Transform.from_git(
    url=TEST_URL, path="main.nf", key="mypipeline2", skip_hash_lookup=True
)
```