### PR TITLE
🐛 Fix sheet export for features with dtype list of categoricals if there wasn't also the corresponding non-list one

### DIFF
--- a/lamindb/models/query_set.py
+++ b/lamindb/models/query_set.py
@@ -450,9 +450,9 @@ def get_feature_annotate_kwargs(
         )
     # Get the categorical features
     cat_feature_types = {
-        feature.dtype.replace("cat[", "").replace("]", "")
+        feature.dtype.replace("list[", "").replace("cat[", "").replace("]", "")
         for feature in feature_qs
-        if feature.dtype.startswith("cat[")
+        if feature.dtype.startswith("cat[") or feature.dtype.startswith("list[cat[")
     }
     # Get relationships of labels and features
     link_models_on_models = {


### PR DESCRIPTION
Because the tests create an object with all feature dtypes, we didn't catch a bug for an isolated categorical list `dtype`.

This PR fixes it and adds the test.

```python
df = test_sheet.type_to_dataframe()
result = df.to_dict(orient="records")[0]
assert result["feature_cell_lines"] == {"A549 cell", "HEK293"}
```