### PR TITLE
🚸 Allow validation of genes to pass without indicating organism

### DIFF
--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -1478,8 +1478,8 @@ class CatVector:
                 values_array, field=self._field, **filter_kwargs, mute=True
             )
             validated_labels, non_validated_labels = (
-                values_array[validated_mask],
-                values_array[~validated_mask],
+                values_array[validated_mask].tolist(),
+                values_array[~validated_mask].tolist(),
             )
             records = _from_values(
                 validated_labels,

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -141,7 +141,9 @@ def test_record_features_add_remove_values():
         "feature_run": run.uid,
     }
 
+    bt.settings.organism = "mouse"
     test_record.features.add_values(test_values)
+    bt.settings.organism = "human"
     assert test_record.features.get_values() == test_values
 
     # all empty sheet
@@ -394,6 +396,7 @@ def test_record_features_add_remove_values():
 
     # clean up rest
     test_record.delete(permanent=True)
+    print(ln.Record.filter(is_type=False).to_dataframe())
     sheet.delete(permanent=True)
     feature_str.delete(permanent=True)
     feature_list_str.delete(permanent=True)


### PR DESCRIPTION
This is a temporary solution that allows non-human genes to pass validation when an organism isn't passed, if they are already in the registry. A refactor that upstreams this behavior will come.