### PR TITLE
📝 More extensive documentation for `Artifact.otype`

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1096,8 +1096,10 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
 
         .. dropdown:: Storage formats & object types
 
+            The `Artifact` registry tracks the storage format via :attr:`suffix` and an abstract object type via :attr:`otype`.
+
             ================  ======================================  ================  ====================================================================
-            description       :attr:`suffix`                          :attr:`otype`     Python types
+            description       :attr:`suffix`                          :attr:`otype`     Python type examples
             ================  ======================================  ================  ====================================================================
             table             `.csv`, `.tsv`, `.parquet`, `.ipc`      `"DataFrame"`     `pandas.DataFrame`, `polars.DataFrame`, `pyarrow.Table`
             annotated matrix  `.h5ad`, `.zarr`, `.h5mu`               `"AnnData"`       `anndata.AnnData`
@@ -1108,9 +1110,12 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             unstructured      `.fastq`, `.pdf`, `.vcf`, `.html`       ---               ---
             ================  ======================================  ================  ====================================================================
 
-            LaminDB makes some default choices (e.g., serialize a `DataFrame` as a `.parquet` file).
+            You can map storage formats onto **R types**, e.g., an `AnnData` might be accessed via `anndataR`.
 
-            You can also map storage formats onto **R types**, e.g., an annotated matrix might be accessed via an `ExpressionSet` or a `SingleCellExperiment` object in R.
+            Because `otype` accepts any `str`, you can define custom object types that enable queries & logic
+            that you need, e.g., `"SingleCellExperiment"` or `"MyCustomZarrDataStructure"`.
+
+            LaminDB makes some default choices (e.g., serialize a `DataFrame` as a `.parquet` file).
 
         .. dropdown:: Will artifacts get duplicated?
 


### PR DESCRIPTION
# Note under `Artifact`

Before | After
--- | ---
<img width="779" height="485" alt="image" src="https://github.com/user-attachments/assets/90b64a44-b30e-4cf4-96df-d150120f3d55" /> | <img width="775" height="798" alt="image" src="https://github.com/user-attachments/assets/669149a5-3ab9-4007-a6d0-5a3b9a87a931" />

# Documentation of field

Before | After
--- | ---
<img width="720" height="209" alt="image" src="https://github.com/user-attachments/assets/e194a999-0ba1-493d-bbfe-ea9f991d8dd2" /> | <img width="767" height="277" alt="image" src="https://github.com/user-attachments/assets/0962800b-e51f-4dce-b8bc-af3cde7b68e8" />

# Family of `from_...` constructors

They now all state that they populate `otype`.

---

Addresses:

- https://github.com/laminlabs/pfizer-lamin-usage/issues/639