### PR TITLE
🐛 Resolve feature name clashes during usage of `artifact.features.add_values()`

### DIFF
--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -30,6 +30,7 @@ from lamindb.models.feature import (
     serialize_pandas_dtype,
     suggest_categorical_for_str_iterable,
 )
+from lamindb.models.has_parents import keep_topmost_matches
 from lamindb.models.save import save
 from lamindb.models.schema import DICT_KEYS_TYPE, Schema
 from lamindb.models.sqlrecord import (
@@ -1055,6 +1056,7 @@ class FeatureManager:
         registry = feature_field.field.model
         keys = list(dictionary.keys())
         feature_records = registry.from_values(keys, field=feature_field, mute=True)
+        feature_records = keep_topmost_matches(feature_records)
         if len(feature_records) != len(keys):
             not_validated_keys = [
                 key for key in keys if key not in feature_records.to_list("name")

--- a/tests/core/test_curator_basics.py
+++ b/tests/core/test_curator_basics.py
@@ -393,6 +393,7 @@ def test_df_curator_same_name_at_same_level():
     lab_b_type.delete(permanent=True)
 
 
+# also see test_features_name_duplicates_across_equal_levels
 def test_curator_schema_feature_mapping():
     lab_a_type = ln.Feature(name="LabA", is_type=True).save()
     feature1 = ln.Feature(name="sample_name", dtype="str", type=lab_a_type).save()


### PR DESCRIPTION
Added these tests:

```python
def test_features_name_duplicates_across_root_and_nested():
    feature1 = ln.Feature(name="sample_name", dtype=ln.Record).save()
    lab_a_type = ln.Feature(name="LabA", is_type=True).save()
    feature2 = ln.Feature(name="sample_name", dtype=ln.Record, type=lab_a_type).save()
    record_sample = ln.Record(name="sample").save()
    test_artifact = ln.Artifact(".gitignore", key="test_artifact").save()
    test_artifact.features.add_values({"sample_name": "sample"})
    assert test_artifact.features.get_values() == {"sample_name": "sample"}


# also see test_curator_schema_feature_mapping
def test_features_name_duplicates_across_equal_levels():
    lab_a_type = ln.Feature(name="LabA", is_type=True).save()
    feature1 = ln.Feature(name="sample_name", dtype=ln.Record, type=lab_a_type).save()
    lab_b_type = ln.Feature(name="LabB", is_type=True).save()
    feature2 = ln.Feature(name="sample_name", dtype=ln.Record, type=lab_b_type).save()
    schema1 = ln.Schema([feature1], name="Lab A schema").save()
    record_sample = ln.Record(name="sample").save()
    test_artifact = ln.Artifact(".gitignore", key="test_artifact").save()

    # cannot disambiguate without schema
    with pytest.raises(ln.errors.ValidationError) as error:
        test_artifact.features.add_values({"sample_name": "sample"})
    assert (
        "Ambiguous match for Feature 'sample_name': found 2 features at depth 1 (under types: ['LabA', 'LabB'])"
        in error.exconly()
    )

    # with schema, first one
    test_artifact.features.add_values({"sample_name": "sample"}, schema=schema1)
    assert test_artifact.features.get_values() == {"sample_name": "sample"}
    assert test_artifact.links_record.get().feature.type == lab_a_type

    test_artifact.delete(permanent=True)
    test_artifact = ln.Artifact(".gitignore", key="test_artifact").save()

    # now the other schema
    schema2 = ln.Schema([feature2], name="Lab B schema").save()
    test_artifact.features.add_values({"sample_name": "sample"}, schema=schema2)
    assert test_artifact.features.get_values() == {"sample_name": "sample"}
    assert test_artifact.links_record.get().feature.type == lab_b_type
```