### PR TITLE
🚸 Add `describe()` to `QuerySet`

### DIFF
--- a/lamindb/models/query_set.py
+++ b/lamindb/models/query_set.py
@@ -838,17 +838,19 @@ def reshape_annotate_result(
                 # pandera expects timezone-naive datetime objects, and hence,
                 # we need to localize with None
                 result_encoded[feature.name] = pd.to_datetime(
-                    result_encoded[feature.name],
-                    format="ISO8601",
-                    utc=True
+                    result_encoded[feature.name], format="ISO8601", utc=True
                 ).dt.tz_localize(None)
             if feature.dtype == "date":
                 # see comments for datetime
-                result_encoded[feature.name] = pd.to_datetime(
-                    result_encoded[feature.name],
-                    format="ISO8601",
-                    utc=True,
-                ).dt.tz_localize(None).dt.date
+                result_encoded[feature.name] = (
+                    pd.to_datetime(
+                        result_encoded[feature.name],
+                        format="ISO8601",
+                        utc=True,
+                    )
+                    .dt.tz_localize(None)
+                    .dt.date
+                )
             if feature.dtype == "bool":
                 result_encoded[feature.name] = result_encoded[feature.name].astype(
                     "boolean"
@@ -1128,6 +1130,10 @@ class BasicQuerySet(models.QuerySet):
         features: bool | list[str] | str | None = None,
     ) -> pd.DataFrame:
         return self.to_dataframe(include=include, features=features)
+
+    def describe(self, return_str: bool = False) -> str | None:
+        """Describe the query set to learn about available fields."""
+        return self.model.describe(return_str=return_str)
 
     def delete(self, *args, permanent: bool | None = None, **kwargs):
         """Delete all records in the query set.

--- a/tests/core/test_queryset.py
+++ b/tests/core/test_queryset.py
@@ -1,8 +1,8 @@
 # .latest_version is tested in test_versioning.py
 
-
 import os
 import re
+import textwrap
 from contextlib import contextmanager
 
 import bionty as bt
@@ -98,6 +98,12 @@ def test_one_first():
     assert qs.one().handle == ln.setup.settings.user.handle
     assert qs.first().handle == ln.setup.settings.user.handle
     assert qs.one_or_none().handle == ln.setup.settings.user.handle
+
+    description = textwrap.dedent("""\
+    User
+      Simple fields
+    """).strip()
+    assert qs.describe(return_str=True).startswith(description)
 
     qs = ln.User.filter(handle="test")
     with pytest.raises(DoesNotExist):


### PR DESCRIPTION
This is in particular needed if users want to know what they can query for when they work with a `DB` object.

These are now parallel:

```python
import lamindb

db = ln.DB("account/name")

# the following two calls are parallel
db.Artifact.describe()
ln.Artifact.describe()
```