### PR TITLE
🔧 Add `.vitessce.json` to loaders

### DIFF
--- a/lamindb/core/loaders.py
+++ b/lamindb/core/loaders.py
@@ -168,6 +168,7 @@ FILE_LOADERS = {
     ".anndata.zarr": load_zarr,
     ".html": load_html,
     ".json": load_json,
+    ".vitessce.json": load_json,
     ".yaml": load_yaml,
     ".h5mu": load_h5mu,
     ".gif": load_image,


### PR DESCRIPTION
This adds support for loading `.vitessce.json` files. 