### PR TITLE
📝 Render return type annotations of `Artifact.open()` in docs

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -2481,10 +2481,13 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
     ):
         """Open a dataset for streaming.
 
-        Works for `pyarrow` or `polars` compatible formats
-        (`.parquet`, `.csv`, `.ipc` etc. files or directories with such files),
-        `AnnData` (`.h5ad`, `.zarr`), `SpatialData` (`.zarr`),
-        generic `hdf5` and `zarr`, `tiledbsoma` objects (`.tiledbsoma`).
+        Works for the following object types (storage formats):
+
+        - `DataFrame` (`.parquet`, `.csv`, `.ipc` files or directories with such files)
+        - `AnnData` (`.h5ad`, `.zarr`)
+        - `SpatialData` (`.zarr`)
+        - `tiledbsoma` (`.tiledbsoma`)
+        - generic arrays (`.h5`, `.zarr`)
 
         Args:
             mode: can be `"r"` or `"w"` (write mode) for `tiledbsoma` stores,


### PR DESCRIPTION
Before | After
--- | ---
<img width="776" height="575" alt="image" src="https://github.com/user-attachments/assets/e6df6ec5-6b77-4c25-b238-7d390e5a3bc5" /> | <img width="783" height="823" alt="image" src="https://github.com/user-attachments/assets/96f0a81d-beb9-4488-b71f-d6fe31e118e3" />


Needs:

- https://github.com/laminlabs/lndocs/pull/146

Addresses:

- https://github.com/laminlabs/lamindb/issues/2736