### PR TITLE
🚸 Raise canonical `InstanceNotFoundError` in `Registry.connect()`

### DIFF
--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -36,6 +36,8 @@ from django.db.models.functions import Lower
 from lamin_utils import colors, logger
 from lamindb_setup import settings as setup_settings
 from lamindb_setup._connect_instance import (
+    INSTANCE_NOT_FOUND_MESSAGE,
+    InstanceNotFoundError,
     get_owner_name_from_identifier,
     load_instance_settings,
     update_db_using_local,
@@ -808,9 +810,10 @@ class Registry(ModelBase):
         if not settings_file.exists():
             result = connect_instance_hub(owner=owner, name=name)
             if isinstance(result, str):
-                raise RuntimeError(
-                    f"Failed to load instance {instance}, please check your permissions!"
+                message = INSTANCE_NOT_FOUND_MESSAGE.format(
+                    owner=owner, name=name, hub_result=result
                 )
+                raise InstanceNotFoundError(message)
             iresult, storage = result
             # this can happen if querying via an old instance name
             if [iresult.get("owner"), iresult["name"]] == current_instance_owner_name:

--- a/tests/core/test_sqlrecord.py
+++ b/tests/core/test_sqlrecord.py
@@ -413,6 +413,14 @@ def test_unsaved_relationship_modification_attempts():
     af.delete(permanent=True)
 
 
+def test_failed_connect():
+    with pytest.raises(ln.setup.errors.InstanceNotFoundError) as error:
+        ln.Artifact.connect("laminlabs/lamindata-not-existing")
+    assert error.exconly().startswith(
+        "lamindb_setup.errors.InstanceNotFoundError: 'laminlabs/lamindata-not-existing' not found: 'instance-not-found'"
+    )
+
+
 def test_unsaved_model_different_instance():
     af = ln.Artifact.connect("laminlabs/lamindata").get(
         key="scrna/micro-macfarland2020.h5ad"


### PR DESCRIPTION
Better error type.