### PR TITLE
:children_crossing: Allow users to pass ids of foreign keys in `Artifact()` constructor

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1052,7 +1052,9 @@ def _sqlrecord_or_id(
     if sqlrecord is None and sqlrecord_id is None:
         return None
     elif sqlrecord is not None:
-        assert not check_type or isinstance(sqlrecord, model)
+        assert not check_type or isinstance(sqlrecord, model), (
+            f"Expected {model.__name__}, got {type(sqlrecord).__name__}."
+        )
         return sqlrecord
     elif sqlrecord_id is not None:
         return model.objects.get(id=sqlrecord_id)

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -1280,6 +1280,10 @@ def test_passing_foreign_keys_ids(tsv_file):
     first_run = ln.Run(transform).save()
     second_run = ln.Run(transform).save()
 
+    # check that passing a wrong type errors
+    with pytest.raises(AssertionError):
+        ln.Artifact(tsv_file, space=transform)
+
     with pytest.raises(ValueError) as err:
         ln.Artifact(tsv_file, run=first_run, run_id=first_run.id)
     assert "Do not pass both Run and its id at the same time." in err.exconly()


### PR DESCRIPTION
It is now possible to pass foreign key arguments such as `branch`, `space`, `storage`, `run` as sqlrecords or ids to `Artifact.__init__`:
```python
ln.Artifact(..., run=run) # run: Run
ln.Artifact(..., run_id=2)
```
Also fixes processing of `run_id`, now it is processed correctly for artifacts recreated due to the same hash as an existing artifact.

Fix 
https://github.com/laminlabs/nf-lamin/issues/115
https://github.com/laminlabs/pfizer-lamin-usage/issues/629