### PR TITLE
🚸 Serialize `Path`, `UPath`, and handle `None` params

### DIFF
--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1283,7 +1283,7 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             type: Feature type of all created features
             mute: Whether to mute dtype inference and feature creation warnings
         """
-        from lamindb.models._feature_manager import infer_feature_type_convert_json
+        from lamindb.models._feature_manager import infer_convert_dtype_key_value
 
         field = Feature.name if field is None else field
         registry = field.field.model  # type: ignore
@@ -1292,7 +1292,7 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
 
         dtypes = {}
         for key, value in dictionary.items():
-            dtype, _, message = infer_feature_type_convert_json(key, value, mute=mute)
+            dtype, _, message = infer_convert_dtype_key_value(key, value, mute=mute)
             if dtype == "cat ? str":
                 dtype = "str"
             elif dtype == "list[cat ? str]":

--- a/tests/core/test_track_script_or_notebook.py
+++ b/tests/core/test_track_script_or_notebook.py
@@ -12,11 +12,34 @@ from lamindb.core._context import (
     LogStreamTracker,
     context,
     detect_and_process_source_code_file,
+    serialize_params_to_json,
 )
 from lamindb.errors import TrackNotCalled, ValidationError
+from lamindb_setup.core.upath import UPath
 
 SCRIPTS_DIR = Path(__file__).parent.resolve() / "scripts"
 NOTEBOOKS_DIR = Path(__file__).parent.resolve() / "notebooks"
+
+
+def test_serialize_params_to_json():
+    a_path = Path("/some/local/folder")
+    a_upath = UPath("s3://bucket/key")
+    params = {
+        "path_key": a_path,
+        "none_key": None,
+        "upath_key": a_upath,
+        "str_key": "plain",
+    }
+    result = serialize_params_to_json(params)
+    # None is omitted
+    assert "none_key" not in result
+    # Path is serialized to posix string
+    assert result["path_key"] == "/some/local/folder"
+    # UPath is serialized to posix string
+    assert result["upath_key"] == "s3://bucket/key"
+    # Other values unchanged
+    assert result["str_key"] == "plain"
+    assert set(result.keys()) == {"path_key", "upath_key", "str_key"}
 
 
 def test_track_basic_invocation():


### PR DESCRIPTION
```python
def test_serialize_params_to_json():
    a_path = Path("/some/local/folder")
    a_upath = UPath("s3://bucket/key")
    params = {
        "path_key": a_path,
        "none_key": None,
        "upath_key": a_upath,
        "str_key": "plain",
    }
    result = serialize_params_to_json(params)
    # None is omitted
    assert "none_key" not in result
    # Path is serialized to posix string
    assert result["path_key"] == "/some/local/folder"
    # UPath is serialized to posix string
    assert result["upath_key"] == "s3://bucket/key"
    # Other values unchanged
    assert result["str_key"] == "plain"
    assert set(result.keys()) == {"path_key", "upath_key", "str_key"}
```