### PR TITLE
🐛 Fix DB snapshot sync

### DIFF
--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -522,9 +522,11 @@ def _synchronize_clone(storage_root: str) -> str | None:
         if cloud_db_path_gz.synchronize_to(
             local_sqlite_path_gz, error_no_origin=True, print_progress=True
         ):
-            with gzip.open(local_sqlite_path_gz, "rb") as f_in:
-                with open(local_sqlite_path, "wb") as f_out:
-                    shutil.copyfileobj(f_in, f_out)
+            with (
+                gzip.open(local_sqlite_path_gz, "rb") as f_in,
+                open(local_sqlite_path, "wb") as f_out,
+            ):
+                shutil.copyfileobj(f_in, f_out)
         return f"sqlite:///{local_sqlite_path}"
     except (FileNotFoundError, PermissionError):
         logger.debug("Clone not found. Falling back to normal access...")


### PR DESCRIPTION
We must always sync the `lamindb.gz` file. 