### PR TITLE
🚸 Add `Record.from_dataframe()` and bulk saving of records

### DIFF
--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -1332,6 +1332,121 @@ class FeatureManager:
                 seen_uids.add(feature.uid)
         return merged
 
+    @staticmethod
+    def _raise_not_validated_values(
+        not_validated_values: dict[str, tuple[str, list[str]]],
+    ) -> None:
+        if not not_validated_values:
+            return None
+        hint = ""
+        for key, (field, values_list) in not_validated_values.items():
+            key_str = "ln.Record" if key == "Record" else key
+            create_true = ", create=True" if "bionty." not in key else ""
+            hint += f"  records = {key_str}.from_values({values_list}, field='{field}'{create_true}).save()\n"
+        msg = (
+            f"These values could not be validated: {dict(not_validated_values)}\n"
+            f"Here is how to create records for them:\n\n{hint}"
+        )
+        raise ValidationError(msg)
+
+    def _collect_record_feature_writes(
+        self,
+        *,
+        record,
+        feature_objects: list[Feature],
+        dictionary: dict[str, Any],
+        values_by_feature_uid: dict[str, Any] | None,
+        feature_json_values: list,
+        links_by_model: dict,
+        not_validated_values: dict[str, tuple[str, list[str]]],
+    ) -> None:
+        from ..base.dtypes import is_iterable_of_sqlrecord
+        from .can_curate import CanCurate
+        from .record import RecordJson
+
+        for feature in feature_objects:
+            if (
+                values_by_feature_uid is not None
+                and feature.uid in values_by_feature_uid
+            ):
+                value = values_by_feature_uid[feature.uid]
+            else:
+                value = dictionary[feature.name]
+            if value is None:
+                continue
+            if not (
+                feature.dtype_as_str.startswith("cat")
+                or feature.dtype_as_str.startswith("list[cat")
+            ):
+                _, converted_value, _ = infer_convert_dtype_key_value(
+                    key=feature.name, value=value, dtype_str=feature.dtype_as_str
+                )
+                feature_json_values.append(
+                    RecordJson(record=record, feature=feature, value=converted_value)
+                )
+                continue
+
+            if isinstance(value, SQLRecord) or is_iterable_of_sqlrecord(value):
+                if isinstance(value, SQLRecord):
+                    label_records = [value]
+                else:
+                    label_records = value  # type: ignore
+            else:
+                if isinstance(value, str):
+                    values = [value]  # type: ignore
+                else:
+                    values = value  # type: ignore
+                if feature._dtype_str == "cat":
+                    feature._dtype_str = "cat[ULabel]"
+                    feature.save()
+                    result = {
+                        "registry_str": "ULabel",
+                        "registry": ULabel,
+                        "field": ULabel.name,
+                    }
+                else:
+                    result = parse_dtype(feature._dtype_str)[0]
+                if issubclass(result["registry"], CanCurate):  # type: ignore
+                    validated = result["registry"].validate(  # type: ignore
+                        values, field=result["field"], mute=True
+                    )
+                    values_array = np.array(values)
+                    validated_values = values_array[validated]
+                    if validated.sum() != len(values):
+                        not_validated_values[result["registry_str"]] = (  # type: ignore
+                            result["field_str"],
+                            values_array[~validated].tolist(),
+                        )
+                    label_records = result["registry"].from_values(  # type: ignore
+                        validated_values, field=result["field"], mute=True
+                    )
+                else:
+                    label_records = result["registry"].filter(  # type: ignore
+                        **{f"{result['field_str']}__in": values}
+                    )
+                    if len(label_records) != len(values):
+                        raise ValidationError(
+                            f"Some of these values for {result['registry_str']} do not exist: {values}"
+                        )
+            for label_record in label_records:
+                if label_record._state.adding:
+                    raise ValidationError(
+                        f"Please save {label_record} before annotation."
+                    )
+                link_model, value_field_name, _ = get_categorical_link_info(
+                    record.__class__,
+                    label_record.__class__,
+                    instance=getattr(record._state, "db", None),
+                )
+                links_by_model[link_model].append(
+                    link_model(
+                        record_id=record.id,
+                        feature_id=feature.id,
+                        **{f"{value_field_name}_id": label_record.id},
+                    )
+                )
+        return None
+
     def add_values(
         self,
         values: dict[str | Feature, Any],
@@ -1455,9 +1570,31 @@ class FeatureManager:
     ):
         from ..base.dtypes import is_iterable_of_sqlrecord
         from .can_curate import CanCurate
-        from .record import RecordJson
 
         host_is_record = self._host.__class__.__name__ == "Record"
+        if host_is_record:
+            feature_json_values: list[SQLRecord] = []
+            links_by_model: dict[type[SQLRecord], list[SQLRecord]] = defaultdict(list)
+            record_not_validated_values: dict[str, tuple[str, list[str]]] = {}
+            self._collect_record_feature_writes(
+                record=self._host,
+                feature_objects=feature_objects,
+                dictionary=dictionary,
+                values_by_feature_uid=values_by_feature_uid,
+                feature_json_values=feature_json_values,
+                links_by_model=links_by_model,
+                not_validated_values=record_not_validated_values,
+            )
+            self._raise_not_validated_values(record_not_validated_values)
+            if feature_json_values:
+                save(feature_json_values)
+            for links in links_by_model.values():
+                try:
+                    save(links, ignore_conflicts=False)
+                except Exception:
+                    save(links, ignore_conflicts=True)
+            return None
+
         features_labels = defaultdict(list)
         feature_json_values = []
         not_validated_values: dict[str, tuple[str, list[str]]] = {}
@@ -1479,11 +1616,7 @@ class FeatureManager:
                     key=feature.name, value=value, dtype_str=feature.dtype_as_str
                 )
                 filter_kwargs = {"feature": feature, "value": converted_value}
-                if host_is_record:
-                    filter_kwargs["record"] = self._host
-                    feature_value = RecordJson(**filter_kwargs)
-                else:
-                    feature_value, _ = JsonValue.get_or_create(**filter_kwargs)
+                feature_value, _ = JsonValue.get_or_create(**filter_kwargs)
                 feature_json_values.append(feature_value)
             else:
                 if isinstance(value, SQLRecord) or is_iterable_of_sqlrecord(value):
@@ -1521,7 +1654,7 @@ class FeatureManager:
                         )
                         values_array = np.array(values)
                         validated_values = values_array[validated]
-                        key = result["registry_str"]
+                        result["registry_str"]
                         if validated.sum() != len(values):
                             not_validated_values[result["registry_str"]] = (  # type: ignore
                                 result["field_str"],
@@ -1543,22 +1676,10 @@ class FeatureManager:
                     ]
         # TODO: given we had already validated prior to calling _add_values, this blog below should never be reached
         # refactor this out if possible
-        if not_validated_values:
-            hint = ""
-            for key, (field, values_list) in not_validated_values.items():
-                key_str = "ln.Record" if key == "Record" else key
-                create_true = ", create=True" if "bionty." not in key else ""
-                hint += f"  records = {key_str}.from_values({values_list}, field='{field}'{create_true}).save()\n"
-            msg = (
-                f"These values could not be validated: {dict(not_validated_values)}\n"
-                f"Here is how to create records for them:\n\n{hint}"
-            )
-            raise ValidationError(msg)
+        self._raise_not_validated_values(not_validated_values)
         if features_labels:
             self._add_label_feature_links(features_labels)
-        if feature_json_values and host_is_record:
-            save(feature_json_values)
-        elif feature_json_values:
+        if feature_json_values:
             to_insertjson_values = [
                 record for record in feature_json_values if record._state.adding
             ]
@@ -1943,17 +2064,13 @@ class FeatureManager:
                 self._host.features._add_schema(schema_self, slot)
 
 
-def add_values_to_records(records: Iterable[Record]) -> None:
-    """Bulk-add lazy feature dictionaries for records.
+def bulk_set_features_in_records(records: Iterable[Record]) -> None:
+    """Bulk-set lazy feature dictionaries for records.
 
     Intended for records created via ``Record(features=...)`` and persisted with
     ``ln.save([...])``.
     """
     from lamindb.curators.core import ExperimentalDictCurator
-
-    from ..base.dtypes import is_iterable_of_sqlrecord
-    from .can_curate import CanCurate
-    from .record import RecordJson
 
     records_with_features = [
         record
@@ -1963,8 +2080,8 @@ def add_values_to_records(records: Iterable[Record]) -> None:
     if len(records_with_features) == 0:
         return None
 
-    feature_json_values = []
-    links_by_model = defaultdict(list)
+    feature_json_values: list[SQLRecord] = []
+    links_by_model: dict[type[SQLRecord], list[SQLRecord]] = defaultdict(list)
     not_validated_values: dict[str, tuple[str, list[str]]] = {}
     for record in records_with_features:
         manager = record.features
@@ -2007,95 +2124,16 @@ def add_values_to_records(records: Iterable[Record]) -> None:
             feature_objects = manager._merge_feature_objects(
                 explicit_features, looked_up_features
             )
-        for feature in feature_objects:
-            if feature.uid in values_by_feature_uid:
-                value = values_by_feature_uid[feature.uid]
-            else:
-                value = dictionary[feature.name]
-            if value is None:
-                continue
-            if not (
-                feature.dtype_as_str.startswith("cat")
-                or feature.dtype_as_str.startswith("list[cat")
-            ):
-                _, converted_value, _ = infer_convert_dtype_key_value(
-                    key=feature.name, value=value, dtype_str=feature.dtype_as_str
-                )
-                feature_json_values.append(
-                    RecordJson(record=record, feature=feature, value=converted_value)
-                )
-                continue
-
-            if isinstance(value, SQLRecord) or is_iterable_of_sqlrecord(value):
-                if isinstance(value, SQLRecord):
-                    label_records = [value]
-                else:
-                    label_records = value  # type: ignore
-            else:
-                if isinstance(value, str):
-                    values = [value]  # type: ignore
-                else:
-                    values = value  # type: ignore
-                if feature._dtype_str == "cat":
-                    feature._dtype_str = "cat[ULabel]"
-                    feature.save()
-                    result = {
-                        "registry_str": "ULabel",
-                        "registry": ULabel,
-                        "field": ULabel.name,
-                    }
-                else:
-                    result = parse_dtype(feature._dtype_str)[0]
-                if issubclass(result["registry"], CanCurate):  # type: ignore
-                    validated = result["registry"].validate(  # type: ignore
-                        values, field=result["field"], mute=True
-                    )
-                    values_array = np.array(values)
-                    validated_values = values_array[validated]
-                    if validated.sum() != len(values):
-                        not_validated_values[result["registry_str"]] = (  # type: ignore
-                            result["field_str"],
-                            values_array[~validated].tolist(),
-                        )
-                    label_records = result["registry"].from_values(  # type: ignore
-                        validated_values, field=result["field"], mute=True
-                    )
-                else:
-                    label_records = result["registry"].filter(  # type: ignore
-                        **{f"{result['field_str']}__in": values}
-                    )
-                    if len(label_records) != len(values):
-                        raise ValidationError(
-                            f"Some of these values for {result['registry_str']} do not exist: {values}"
-                        )
-            for label_record in label_records:
-                if label_record._state.adding:
-                    raise ValidationError(
-                        f"Please save {label_record} before annotation."
-                    )
-                link_model, value_field_name, _ = get_categorical_link_info(
-                    record.__class__,
-                    label_record.__class__,
-                    instance=getattr(record._state, "db", None),
-                )
-                links_by_model[link_model].append(
-                    link_model(
-                        record_id=record.id,
-                        feature_id=feature.id,
-                        **{f"{value_field_name}_id": label_record.id},
-                    )
-                )
-    if not_validated_values:
-        hint = ""
-        for key, (field, values_list) in not_validated_values.items():
-            key_str = "ln.Record" if key == "Record" else key
-            create_true = ", create=True" if "bionty." not in key else ""
-            hint += f"  records = {key_str}.from_values({values_list}, field='{field}'{create_true}).save()\n"
-        msg = (
-            f"These values could not be validated: {dict(not_validated_values)}\n"
-            f"Here is how to create records for them:\n\n{hint}"
+        manager._collect_record_feature_writes(
+            record=record,
+            feature_objects=feature_objects,
+            dictionary=dictionary,
+            values_by_feature_uid=values_by_feature_uid,
+            feature_json_values=feature_json_values,
+            links_by_model=links_by_model,
+            not_validated_values=not_validated_values,
         )
-        raise ValidationError(msg)
+    FeatureManager._raise_not_validated_values(not_validated_values)
     if feature_json_values:
         save(feature_json_values)
     for links in links_by_model.values():

--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -1654,7 +1654,6 @@ class FeatureManager:
                         )
                         values_array = np.array(values)
                         validated_values = values_array[validated]
-                        result["registry_str"]
                         if validated.sum() != len(values):
                             not_validated_values[result["registry_str"]] = (  # type: ignore
                                 result["field_str"],
@@ -1674,7 +1673,7 @@ class FeatureManager:
                     features_labels[result["registry_str"]] += [  # type: ignore
                         (feature, label_record) for label_record in label_records
                     ]
-        # TODO: given we had already validated prior to calling _add_values, this blog below should never be reached
+        # TODO: given we had already validated prior to calling _add_values, this block below should never be reached
         # refactor this out if possible
         self._raise_not_validated_values(not_validated_values)
         if features_labels:
@@ -2067,8 +2066,8 @@ class FeatureManager:
 def bulk_set_features_in_records(records: Iterable[Record]) -> None:
     """Bulk-set lazy feature dictionaries for records.
 
-    Intended for records created via ``Record(features=...)`` and persisted with
-    ``ln.save([...])``.
+    Intended for records created via `Record(features=...)` and persisted with
+    `ln.save([...])`.
     """
     from lamindb.curators.core import ExperimentalDictCurator
 

--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -1941,3 +1941,168 @@ class FeatureManager:
                     artifact_id=self._host.id, slot=slot
                 ).delete()
                 self._host.features._add_schema(schema_self, slot)
+
+
+def add_values_to_records(records: Iterable[Record]) -> None:
+    """Bulk-add lazy feature dictionaries for records.
+
+    Intended for records created via ``Record(features=...)`` and persisted with
+    ``ln.save([...])``.
+    """
+    from lamindb.curators.core import ExperimentalDictCurator
+
+    from ..base.dtypes import is_iterable_of_sqlrecord
+    from .can_curate import CanCurate
+    from .record import RecordJson
+
+    records_with_features = [
+        record
+        for record in records
+        if hasattr(record, "_features") and record._features is not None
+    ]
+    if len(records_with_features) == 0:
+        return None
+
+    feature_json_values = []
+    links_by_model = defaultdict(list)
+    not_validated_values: dict[str, tuple[str, list[str]]] = {}
+    for record in records_with_features:
+        manager = record.features
+        (
+            dictionary,
+            string_key_values,
+            explicit_features,
+            values_by_feature_uid,
+        ) = manager._resolve_feature_value_dictionary(record._features)
+        keys = dictionary.keys()
+        if isinstance(keys, DICT_KEYS_TYPE):
+            keys = list(keys)  # type: ignore
+        schema = None
+        if record.type is not None and record.type.schema is not None:
+            schema = record.type.schema
+        if schema is not None:
+            ExperimentalDictCurator(dictionary, schema).validate()
+            member_ids = set(schema.members.values_list("id", flat=True))
+            features_not_in_schema = [
+                feature.name
+                for feature in explicit_features
+                if feature.id not in member_ids
+            ]
+            if features_not_in_schema:
+                raise ValidationError(
+                    "These feature keys are not in the provided schema: "
+                    f"{features_not_in_schema}"
+                )
+            looked_up_features = schema.members.filter(name__in=keys)
+            feature_objects = manager._merge_feature_objects(
+                explicit_features, looked_up_features
+            )
+        else:
+            if string_key_values:
+                looked_up_features = manager._get_feature_objects(
+                    string_key_values, Feature.name
+                )
+            else:
+                looked_up_features = Feature.objects.none()
+            feature_objects = manager._merge_feature_objects(
+                explicit_features, looked_up_features
+            )
+        for feature in feature_objects:
+            if feature.uid in values_by_feature_uid:
+                value = values_by_feature_uid[feature.uid]
+            else:
+                value = dictionary[feature.name]
+            if value is None:
+                continue
+            if not (
+                feature.dtype_as_str.startswith("cat")
+                or feature.dtype_as_str.startswith("list[cat")
+            ):
+                _, converted_value, _ = infer_convert_dtype_key_value(
+                    key=feature.name, value=value, dtype_str=feature.dtype_as_str
+                )
+                feature_json_values.append(
+                    RecordJson(record=record, feature=feature, value=converted_value)
+                )
+                continue
+
+            if isinstance(value, SQLRecord) or is_iterable_of_sqlrecord(value):
+                if isinstance(value, SQLRecord):
+                    label_records = [value]
+                else:
+                    label_records = value  # type: ignore
+            else:
+                if isinstance(value, str):
+                    values = [value]  # type: ignore
+                else:
+                    values = value  # type: ignore
+                if feature._dtype_str == "cat":
+                    feature._dtype_str = "cat[ULabel]"
+                    feature.save()
+                    result = {
+                        "registry_str": "ULabel",
+                        "registry": ULabel,
+                        "field": ULabel.name,
+                    }
+                else:
+                    result = parse_dtype(feature._dtype_str)[0]
+                if issubclass(result["registry"], CanCurate):  # type: ignore
+                    validated = result["registry"].validate(  # type: ignore
+                        values, field=result["field"], mute=True
+                    )
+                    values_array = np.array(values)
+                    validated_values = values_array[validated]
+                    if validated.sum() != len(values):
+                        not_validated_values[result["registry_str"]] = (  # type: ignore
+                            result["field_str"],
+                            values_array[~validated].tolist(),
+                        )
+                    label_records = result["registry"].from_values(  # type: ignore
+                        validated_values, field=result["field"], mute=True
+                    )
+                else:
+                    label_records = result["registry"].filter(  # type: ignore
+                        **{f"{result['field_str']}__in": values}
+                    )
+                    if len(label_records) != len(values):
+                        raise ValidationError(
+                            f"Some of these values for {result['registry_str']} do not exist: {values}"
+                        )
+            for label_record in label_records:
+                if label_record._state.adding:
+                    raise ValidationError(
+                        f"Please save {label_record} before annotation."
+                    )
+                link_model, value_field_name, _ = get_categorical_link_info(
+                    record.__class__,
+                    label_record.__class__,
+                    instance=getattr(record._state, "db", None),
+                )
+                links_by_model[link_model].append(
+                    link_model(
+                        record_id=record.id,
+                        feature_id=feature.id,
+                        **{f"{value_field_name}_id": label_record.id},
+                    )
+                )
+    if not_validated_values:
+        hint = ""
+        for key, (field, values_list) in not_validated_values.items():
+            key_str = "ln.Record" if key == "Record" else key
+            create_true = ", create=True" if "bionty." not in key else ""
+            hint += f"  records = {key_str}.from_values({values_list}, field='{field}'{create_true}).save()\n"
+        msg = (
+            f"These values could not be validated: {dict(not_validated_values)}\n"
+            f"Here is how to create records for them:\n\n{hint}"
+        )
+        raise ValidationError(msg)
+    if feature_json_values:
+        save(feature_json_values)
+    for links in links_by_model.values():
+        try:
+            save(links, ignore_conflicts=False)
+        except Exception:
+            save(links, ignore_conflicts=True)
+    for record in records_with_features:
+        del record._features
+    return None

--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -2069,7 +2069,9 @@ def bulk_set_features_in_records(records: Iterable[Record]) -> None:
     Intended for records created via `Record(features=...)` and persisted with
     `ln.save([...])`.
     """
-    from lamindb.curators.core import ExperimentalDictCurator
+    import pandas as pd
+
+    from lamindb.curators.core import DataFrameCurator
 
     records_with_features = [
         record
@@ -2079,50 +2081,82 @@ def bulk_set_features_in_records(records: Iterable[Record]) -> None:
     if len(records_with_features) == 0:
         return None
 
-    feature_json_values: list[SQLRecord] = []
-    links_by_model: dict[type[SQLRecord], list[SQLRecord]] = defaultdict(list)
-    not_validated_values: dict[str, tuple[str, list[str]]] = {}
+    batch_schema: Schema | None = None
+    prepared_records: list[
+        tuple[Record, FeatureManager, dict[str, Any], list[Feature], dict[str, Any]]
+    ] = []
+    prepared_rows: list[dict[str, Any]] = []
     for record in records_with_features:
-        manager = record.features
-        (
-            dictionary,
-            string_key_values,
-            explicit_features,
-            values_by_feature_uid,
-        ) = manager._resolve_feature_value_dictionary(record._features)
-        keys = dictionary.keys()
-        if isinstance(keys, DICT_KEYS_TYPE):
-            keys = list(keys)  # type: ignore
         schema = None
         if record.type is not None and record.type.schema is not None:
             schema = record.type.schema
-        if schema is not None:
-            ExperimentalDictCurator(dictionary, schema).validate()
-            member_ids = set(schema.members.values_list("id", flat=True))
-            features_not_in_schema = [
-                feature.name
-                for feature in explicit_features
-                if feature.id not in member_ids
-            ]
-            if features_not_in_schema:
-                raise ValidationError(
-                    "These feature keys are not in the provided schema: "
-                    f"{features_not_in_schema}"
-                )
-            looked_up_features = schema.members.filter(name__in=keys)
-            feature_objects = manager._merge_feature_objects(
-                explicit_features, looked_up_features
+        if schema is None:
+            raise ValidationError(
+                "Bulk setting features in records requires all records to have the same non-null type schema."
             )
-        else:
-            if string_key_values:
-                looked_up_features = manager._get_feature_objects(
-                    string_key_values, Feature.name
-                )
-            else:
-                looked_up_features = Feature.objects.none()
-            feature_objects = manager._merge_feature_objects(
-                explicit_features, looked_up_features
+        if batch_schema is None:
+            batch_schema = schema
+        elif schema.id != batch_schema.id:
+            raise ValidationError(
+                "Bulk setting features in records requires all records to have the same type schema."
             )
+        manager = record.features
+        (
+            dictionary,
+            _,
+            explicit_features,
+            values_by_feature_uid,
+        ) = manager._resolve_feature_value_dictionary(record._features)
+        prepared_rows.append(dictionary)
+        prepared_records.append(
+            (record, manager, dictionary, explicit_features, values_by_feature_uid)
+        )
+
+    assert batch_schema is not None  # noqa: S101
+    schema_features = list(batch_schema.members.all())
+    dataframe = pd.DataFrame(prepared_rows)
+    for feature in schema_features:
+        if (
+            feature.name in dataframe
+            and feature.dtype_as_str.startswith("cat")
+            and not feature.dtype_as_str.startswith("list[cat")
+        ):
+            dataframe[feature.name] = dataframe[feature.name].astype("category")
+    DataFrameCurator(dataframe, batch_schema).validate()
+
+    members_by_name: dict[str, list[Feature]] = defaultdict(list)
+    schema_member_ids: set[int] = set()
+    for feature in schema_features:
+        members_by_name[feature.name].append(feature)
+        schema_member_ids.add(feature.id)
+
+    feature_json_values: list[SQLRecord] = []
+    links_by_model: dict[type[SQLRecord], list[SQLRecord]] = defaultdict(list)
+    not_validated_values: dict[str, tuple[str, list[str]]] = {}
+    for (
+        record,
+        manager,
+        dictionary,
+        explicit_features,
+        values_by_feature_uid,
+    ) in prepared_records:
+        keys = list(dictionary.keys())
+        features_not_in_schema = [
+            feature.name
+            for feature in explicit_features
+            if feature.id not in schema_member_ids
+        ]
+        if features_not_in_schema:
+            raise ValidationError(
+                "These feature keys are not in the provided schema: "
+                f"{features_not_in_schema}"
+            )
+        looked_up_features = [
+            feature for key in keys for feature in members_by_name.get(key, [])
+        ]
+        feature_objects = manager._merge_feature_objects(
+            explicit_features, looked_up_features
+        )
         manager._collect_record_feature_writes(
             record=record,
             feature_objects=feature_objects,

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -73,16 +73,13 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
 
     Examples:
 
-        Create a **record** and annotate it with features::
-
-            # create a record to track a sample
-            sample1 = ln.Record(name="Sample 1").save()
+        Create a **record** and initialize it with features::
 
             # create a feature if you don't yet have one
             gc_content = ln.Feature(name="gc_content", dtype=float).save()
 
-            # set a feature value for the record
-            sample1.features.set_values({"gc_content": 0.5})
+            # create a record to track a sample
+            sample1 = ln.Record(name="Sample 1", features={"gc_content": 0.5}).save()
 
             # describe the record
             sample1.describe()
@@ -327,6 +324,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         name: str | None = None,
         type: Record | None = None,
         is_type: bool = False,
+        features: dict[str | Feature, Any] | None = None,
         description: str | None = None,
         schema: Schema | None = None,
         reference: str | None = None,
@@ -352,6 +350,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         name: str = kwargs.pop("name", None)
         type: str | None = kwargs.pop("type", None)
         is_type: bool = kwargs.pop("is_type", False)
+        features: dict[str | Feature, Any] | None = kwargs.pop("features", None)
         description: str | None = kwargs.pop("description", None)
         schema: Schema | None = kwargs.pop("schema", None)
         reference: str | None = kwargs.pop("reference", None)
@@ -370,6 +369,8 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         if schema and not is_type:
             logger.important("passing schema, treating as type")
             is_type = True
+        if features is not None:
+            self._features = features
         super().__init__(
             name=name,
             type=type,
@@ -385,6 +386,14 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
             _skip_validation=_skip_validation,
             _aux=_aux,
         )
+
+    def save(self, *args, **kwargs) -> Record:
+        super().save(*args, **kwargs)
+        if hasattr(self, "_features"):
+            pending_features = self._features
+            self.features.add_values(pending_features)
+            del self._features
+        return self
 
     @property
     def features(self) -> FeatureManager:

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -117,6 +117,11 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
             #>            Experiment 1   ...
             #>            Experiment 2   ...
 
+        Bulk-create records from a dataframe via :meth:`~lamindb.Record.from_dataframe`::
+
+            records = ln.Record.from_dataframe(df, type=sample_sheet)
+            ln.save(records)
+
         If you try to set incomplete features in a record in a sheet, you'll get a validation error::
 
             sample2 = ln.Record(name="Sample 2", type=sample_sheet).save()
@@ -403,19 +408,26 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         cls,
         df: pd.DataFrame,
         *,
-        type: Record | None = None,
+        type: Record,
         name_field: str = "__lamindb_record_name__",
     ) -> SQLRecordList[Record]:
         """Construct records from a dataframe for bulk saving.
 
-        Returns unsaved records. Follow with ``records.save()`` or ``ln.save(records)``.
-
         Args:
             df: A dataframe where rows represent records.
-            type: Optional record type for all rows. For lazy bulk features, this
-                should be a type with a schema.
-            name_field: Column used for record names. Falls back to ``name`` if
+            type: Record type for all rows. If this
+                type is a sheet (`type.schema is not None`), feature values are
+                validated against that schema (for efficiency at save time).
+            name_field: Column used for record names. Falls back to `name` if
                 absent. If neither exists, records are created without names.
+
+        Examples:
+
+            Create records for a type and save through `records.save()`::
+
+                records = ln.Record.from_dataframe(df, type=sample_sheet)
+                records.save()
+
         """
         import pandas as pd
 
@@ -423,6 +435,10 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
 
         if not isinstance(df, pd.DataFrame):
             raise TypeError("`df` needs to be a pandas DataFrame.")
+        if not type.is_type:
+            raise ValueError("`type` needs to be a record type (`is_type=True`).")
+        if type.name is None:
+            raise ValueError("`type` needs to have a non-null `name`.")
 
         records: list[Record] = []
         row_dicts = df.to_dict(orient="records")
@@ -442,7 +458,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
                     continue
                 features[key] = value
 
-            record_kwargs: dict[str, Any] = {"type": type} if type is not None else {}
+            record_kwargs: dict[str, Any] = {"type": type}
             if features:
                 record_kwargs["features"] = features
             records.append(cls(name=name, **record_kwargs))

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -408,16 +408,22 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         cls,
         df: pd.DataFrame,
         *,
-        type: Record,
+        type: Record | str,
         name_field: str = "__lamindb_record_name__",
     ) -> SQLRecordList[Record]:
         """Construct records from a dataframe for bulk saving.
 
+        Returns unsaved records. Follow with `records.save()` or `ln.save(records)`.
+
         Args:
             df: A dataframe where rows represent records.
-            type: Record type for all rows. If this
-                type is a sheet (`type.schema is not None`), feature values are
-                validated against that schema (for efficiency at save time).
+            type: Record type for all rows as either a `Record` object or a
+                string. If passing a string, a new type with that name is created
+                under `Imports` with an inferred schema from the dataframe.
+                If that type name already exists, raise an error and pass an
+                existing `Record` object for reuse.
+                If the resolved type is a sheet (`type.schema is not None`), feature
+                values are validated against that schema at save time.
             name_field: Column used for record names. Falls back to `name` if
                 absent. If neither exists, records are created without names.
 
@@ -428,16 +434,48 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
                 records = ln.Record.from_dataframe(df, type=sample_sheet)
                 records.save()
 
+            Create a new import type and bulk-save records::
+
+                records = ln.Record.from_dataframe(df, type="my_df")
+                ln.save(records)
+
         """
         import pandas as pd
 
         from .query_set import SQLRecordList
+        from .schema import Schema
 
         if not isinstance(df, pd.DataFrame):
             raise TypeError("`df` needs to be a pandas DataFrame.")
-        if not type.is_type:
+        resolved_type: Record
+        if isinstance(type, str):
+            imports_type = cls.filter(name="Imports", is_type=True).one_or_none()
+            if imports_type is None:
+                imports_type = cls(name="Imports", is_type=True).save()
+            existing_type = cls.filter(
+                name=type, is_type=True, type=imports_type
+            ).one_or_none()
+            if existing_type is not None:
+                raise ValueError(
+                    f"type '{type}' already exists under 'Imports', please pass it as a Record object to reuse."
+                )
+            inferred_schema = Schema.from_dataframe(df, name=type)
+            if inferred_schema is None:
+                raise ValueError(
+                    "Could not infer a schema from dataframe columns. "
+                    "Ensure dataframe columns map to existing Features, or pass an existing Record type object."
+                )
+            resolved_type = cls(
+                name=type,
+                is_type=True,
+                type=imports_type,
+                schema=inferred_schema.save(),
+            ).save()
+        else:
+            resolved_type = type
+        if not resolved_type.is_type:
             raise ValueError("`type` needs to be a record type (`is_type=True`).")
-        if type.name is None:
+        if resolved_type.name is None:
             raise ValueError("`type` needs to have a non-null `name`.")
 
         records: list[Record] = []
@@ -458,7 +496,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
                     continue
                 features[key] = value
 
-            record_kwargs: dict[str, Any] = {"type": type}
+            record_kwargs: dict[str, Any] = {"type": resolved_type}
             if features:
                 record_kwargs["features"] = features
             records.append(cls(name=name, **record_kwargs))

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -49,6 +49,10 @@ if TYPE_CHECKING:
 
 
 # keep docstring in sync with test_record_docstring_examples in test_record_basics.py
+IMPORTS_UID = "W3WdiFRZTvTJajNp"
+SCHEMA_IMPORTS_UID = "DGZkj4yhGWMJE5fu"
+
+
 class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates):
     """Flexible metadata records.
 
@@ -449,9 +453,11 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
             raise TypeError("`df` needs to be a pandas DataFrame.")
         resolved_type: Record
         if isinstance(type, str):
-            imports_type = cls.filter(name="Imports", is_type=True).one_or_none()
+            imports_type = cls.filter(uid=IMPORTS_UID).one_or_none()
             if imports_type is None:
-                imports_type = cls(name="Imports", is_type=True).save()
+                imports_type = cls(name="Imports", is_type=True)
+                imports_type.uid = IMPORTS_UID
+                imports_type = imports_type.save()
             existing_type = cls.filter(
                 name=type, is_type=True, type=imports_type
             ).one_or_none()
@@ -459,17 +465,24 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
                 raise ValueError(
                     f"type '{type}' already exists under 'Imports', please pass it as a Record object to reuse."
                 )
+            imports_schema = Schema.filter(uid=SCHEMA_IMPORTS_UID).one_or_none()
+            if imports_schema is None:
+                imports_schema = Schema(name="Imports", is_type=True)
+                imports_schema.uid = SCHEMA_IMPORTS_UID
+                imports_schema = imports_schema.save()
             inferred_schema = Schema.from_dataframe(df, name=type)
             if inferred_schema is None:
                 raise ValueError(
                     "Could not infer a schema from dataframe columns. "
                     "Ensure dataframe columns map to existing Features, or pass an existing Record type object."
                 )
+            inferred_schema.type = imports_schema
+            inferred_schema = inferred_schema.save()
             resolved_type = cls(
                 name=type,
                 is_type=True,
                 type=imports_type,
-                schema=inferred_schema.save(),
+                schema=inferred_schema,
             ).save()
         else:
             resolved_type = type

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -80,7 +80,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
 
     Examples:
 
-        Create a **record** and initialize it with features::
+        Create a **record** with a single feature::
 
             # create a feature if you don't yet have one
             gc_content = ln.Feature(name="gc_content", dtype=float).save()
@@ -121,10 +121,9 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
             #>            Experiment 1   ...
             #>            Experiment 2   ...
 
-        Bulk-create records from a dataframe via :meth:`~lamindb.Record.from_dataframe`::
+        Import records from a dataframe :meth:`~lamindb.Record.from_dataframe`::
 
-            records = ln.Record.from_dataframe(df, type=sample_sheet)
-            ln.save(records)
+            records = ln.Record.from_dataframe(df, type="my_df").save()  # creates a type my_df with inferred schema
 
         If you try to set incomplete features in a record in a sheet, you'll get a validation error::
 
@@ -433,15 +432,13 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
 
         Examples:
 
-            Create records for a type and save through `records.save()`::
+            Create a new type and import records::
 
-                records = ln.Record.from_dataframe(df, type=sample_sheet)
-                records.save()
+                records = ln.Record.from_dataframe(df, type="my_df").save()
 
-            Create a new import type and bulk-save records::
+            Import records into an existing type::
 
-                records = ln.Record.from_dataframe(df, type="my_df")
-                ln.save(records)
+                records = ln.Record.from_dataframe(df, type=sample_sheet).save()
 
         """
         import pandas as pd

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -15,7 +15,7 @@ from lamindb.base.fields import (
     JSONField,
     TextField,
 )
-from lamindb.base.utils import class_and_instance_method
+from lamindb.base.utils import class_and_instance_method, strict_classmethod
 from lamindb.errors import FieldValidationError
 
 from ..base.uids import base62_16
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
     from .block import RecordBlock
     from .project import Project, RecordProject, RecordReference, Reference
     from .query_manager import RelatedManager
+    from .query_set import SQLRecordList
     from .schema import Schema
 
 
@@ -61,6 +62,8 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         type: `Record | None = None` The type of this record.
         is_type: `bool = False` Whether this record is a type (a record that
             classifies other records).
+        features: `dict[str | Feature, Any] | None = None` Lazy feature values
+            to persist on `.save()` or `ln.save([...])`.
         schema: `Schema | None = None` A schema defining allowed features for records of this type. Only applicable when `is_type=True`.
         reference: `str | None = None` For instance, an external ID or a URL.
         reference_type: `str | None = None` For instance, `"url"`.
@@ -394,6 +397,56 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
             self.features.add_values(pending_features)
             del self._features
         return self
+
+    @strict_classmethod
+    def from_dataframe(
+        cls,
+        df: pd.DataFrame,
+        *,
+        type: Record | None = None,
+        name_field: str = "__lamindb_record_name__",
+    ) -> SQLRecordList[Record]:
+        """Construct records from a dataframe for bulk saving.
+
+        Returns unsaved records. Follow with ``records.save()`` or ``ln.save(records)``.
+
+        Args:
+            df: A dataframe where rows represent records.
+            type: Optional record type for all rows. For lazy bulk features, this
+                should be a type with a schema.
+            name_field: Column used for record names. Falls back to ``name`` if
+                absent. If neither exists, records are created without names.
+        """
+        import pandas as pd
+
+        from .query_set import SQLRecordList
+
+        if not isinstance(df, pd.DataFrame):
+            raise TypeError("`df` needs to be a pandas DataFrame.")
+
+        records: list[Record] = []
+        row_dicts = df.to_dict(orient="records")
+        for row in row_dicts:
+            if name_field in row:
+                name = row.pop(name_field)
+            elif "name" in row:
+                name = row.pop("name")
+            else:
+                name = None
+            if pd.api.types.is_scalar(name) and pd.isna(name):
+                name = None
+
+            features: dict[str, Any] = {}
+            for key, value in row.items():
+                if pd.api.types.is_scalar(value) and pd.isna(value):
+                    continue
+                features[key] = value
+
+            record_kwargs: dict[str, Any] = {"type": type} if type is not None else {}
+            if features:
+                record_kwargs["features"] = features
+            records.append(cls(name=name, **record_kwargs))
+        return SQLRecordList(records)
 
     @property
     def features(self) -> FeatureManager:

--- a/lamindb/models/save.py
+++ b/lamindb/models/save.py
@@ -97,6 +97,15 @@ def save(
             from bionty.core import add_ontology
 
             add_ontology(non_artifacts_with_parents)
+        records_with_lazy_features = [
+            record
+            for record in non_artifacts
+            if record.__class__.__name__ == "Record" and hasattr(record, "_features")
+        ]
+        if records_with_lazy_features:
+            from ._feature_manager import add_values_to_records
+
+            add_values_to_records(records_with_lazy_features)
 
     if artifacts:
         with transaction.atomic():

--- a/lamindb/models/save.py
+++ b/lamindb/models/save.py
@@ -103,9 +103,9 @@ def save(
             if record.__class__.__name__ == "Record" and hasattr(record, "_features")
         ]
         if records_with_lazy_features:
-            from ._feature_manager import add_values_to_records
+            from ._feature_manager import bulk_set_features_in_records
 
-            add_values_to_records(records_with_lazy_features)
+            bulk_set_features_in_records(records_with_lazy_features)
 
     if artifacts:
         with transaction.atomic():

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -404,10 +404,6 @@ def validate_fields(record: SQLRecord, kwargs):
                 )
     # validate is_type
     if "is_type" in kwargs and "name" in kwargs and kwargs["is_type"]:
-        if kwargs["name"].endswith("s"):
-            logger.warning(
-                f"name '{kwargs['name']}' for type ends with 's', in case you're naming with plural, consider the singular for a type name"
-            )
         is_approx_pascal_case(kwargs["name"])
     if (
         "type" in kwargs

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -129,6 +129,20 @@ def test_record_from_dataframe_bulk_save_paths():
     score.delete(permanent=True)
 
 
+def test_record_from_dataframe_requires_named_type():
+    df = pd.DataFrame({"__lamindb_record_name__": ["x"], "score": [1.0]})
+    non_type_record = ln.Record(name="from-df-non-type").save()
+    unnamed_type = ln.Record(name="from-df-temp-type", is_type=True)
+    unnamed_type.name = None
+
+    with pytest.raises(ValueError, match="is_type=True"):
+        ln.Record.from_dataframe(df, type=non_type_record)
+    with pytest.raises(ValueError, match="non-null `name`"):
+        ln.Record.from_dataframe(df, type=unnamed_type)
+
+    non_type_record.delete(permanent=True)
+
+
 def test_feature_manager_raise_not_validated_values():
     from lamindb.models._feature_manager import FeatureManager
 

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -11,14 +11,11 @@ from lamindb.errors import FieldValidationError
 
 
 def test_record_docstring_examples():
-    # create a record to track a sample
-    sample1 = ln.Record(name="Sample 1").save()
-
     # create a feature if you don't yet have one
     gc_content = ln.Feature(name="gc_content", dtype=float).save()
 
-    # set a feature value for the record
-    sample1.features.set_values({"gc_content": 0.5})
+    # create a record to track a sample
+    sample1 = ln.Record(name="Sample 1", features={"gc_content": 0.5}).save()
 
     # describe the record
     sample1.describe()
@@ -77,7 +74,7 @@ def test_record_initialization():
     with pytest.raises(
         FieldValidationError,
         match=re.escape(
-            "Only name, type, is_type, description, schema, reference, reference_type are valid keyword arguments"
+            "Only name, type, is_type, features, description, schema, reference, reference_type are valid keyword arguments"
         ),
     ):
         ln.Record(x=1)
@@ -85,6 +82,17 @@ def test_record_initialization():
     with pytest.raises(ValueError) as error:
         ln.Record(1)
     assert error.exconly() == "ValueError: Only one non-keyword arg allowed"
+
+
+def test_record_lazy_features_on_save():
+    score_feature = ln.Feature(name="lazy_score", dtype=float).save()
+    record = ln.Record(name="lazy-record", features={"lazy_score": 0.7}).save()
+
+    assert not hasattr(record, "_features")
+    assert ln.Record.filter(lazy_score=0.7).one().id == record.id
+
+    record.delete(permanent=True)
+    score_feature.delete(permanent=True)
 
 
 def test_record_plural_type_warning(ccaplog):

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -143,6 +143,59 @@ def test_record_from_dataframe_requires_named_type():
     non_type_record.delete(permanent=True)
 
 
+def test_record_from_dataframe_with_string_type_creates_import_type():
+    score = ln.Feature(name="from-df-str-score", dtype=float).save()
+    df = pd.DataFrame(
+        {
+            "__lamindb_record_name__": ["from-df-str-a", "from-df-str-b"],
+            "from-df-str-score": [11.0, 12.0],
+        }
+    )
+    records = ln.Record.from_dataframe(df, type="from-df-str-type")
+    created_type = ln.Record.get(name="from-df-str-type", is_type=True)
+    imports_type = ln.Record.get(name="Imports", is_type=True)
+
+    assert len(records) == 2
+    assert all(record.type_id == created_type.id for record in records)
+    assert created_type.type_id == imports_type.id
+    assert created_type.schema_id is not None
+
+    ln.save(records)
+    assert (
+        ln.Record.get(name="from-df-str-a").features.get_values()["from-df-str-score"]
+        == 11.0
+    )
+
+    ln.Record.filter(name__in=["from-df-str-a", "from-df-str-b"]).delete(permanent=True)
+    ln.Record.filter(name="from-df-str-type").delete(permanent=True)
+    ln.Schema.filter(id=created_type.schema_id).delete(permanent=True)
+    score.delete(permanent=True)
+
+
+def test_record_from_dataframe_with_string_type_duplicate_name_errors():
+    score = ln.Feature(name="from-df-dup-score", dtype=float).save()
+    schema = ln.Schema([score], name="from-df-dup-schema").save()
+    imports_type = ln.Record.filter(name="Imports", is_type=True).one_or_none()
+    if imports_type is None:
+        imports_type = ln.Record(name="Imports", is_type=True).save()
+    ln.Record(
+        name="from-df-dup-type", is_type=True, schema=schema, type=imports_type
+    ).save()
+    df = pd.DataFrame(
+        {
+            "__lamindb_record_name__": ["from-df-dup-a"],
+            "from-df-dup-score": [21.0],
+        }
+    )
+
+    with pytest.raises(ValueError, match="already exists"):
+        ln.Record.from_dataframe(df, type="from-df-dup-type")
+
+    ln.Record.filter(name="from-df-dup-type").delete(permanent=True)
+    schema.delete(permanent=True)
+    score.delete(permanent=True)
+
+
 def test_feature_manager_raise_not_validated_values():
     from lamindb.models._feature_manager import FeatureManager
 

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -220,14 +220,6 @@ def test_feature_manager_raise_not_validated_values():
     )
 
 
-def test_record_plural_type_warning(ccaplog):
-    ln.Record(name="MyThings", is_type=True)
-    assert (
-        "name 'MyThings' for type ends with 's', in case you're naming with plural, consider the singular for a type name"
-        in ccaplog.text
-    )
-
-
 def test_name_lookup():
     my_type = ln.Record(name="MyType", is_type=True).save()
     label1 = ln.Record(name="label 1", type=my_type).save()

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -95,6 +95,40 @@ def test_record_lazy_features_on_save():
     score_feature.delete(permanent=True)
 
 
+def test_record_from_dataframe_bulk_save_paths():
+    score = ln.Feature(name="from-df-score", dtype=float).save()
+    schema = ln.Schema([score], name="from-df-schema").save()
+    sheet = ln.Record(name="from-df-sheet", is_type=True, schema=schema).save()
+    df = pd.DataFrame(
+        {
+            "__lamindb_record_name__": ["from-df-a", "from-df-b"],
+            "from-df-score": [1.0, 2.0],
+        }
+    )
+
+    records = ln.Record.from_dataframe(df, type=sheet)
+    assert len(records) == 2
+    records.save()
+    assert ln.Record.get(name="from-df-a").features.get_values()["from-df-score"] == 1.0
+
+    df2 = pd.DataFrame(
+        {
+            "__lamindb_record_name__": ["from-df-c"],
+            "from-df-score": [3.0],
+        }
+    )
+    records_2 = ln.Record.from_dataframe(df2, type=sheet)
+    ln.save(records_2)
+    assert ln.Record.get(name="from-df-c").features.get_values()["from-df-score"] == 3.0
+
+    ln.Record.filter(name__in=["from-df-a", "from-df-b", "from-df-c"]).delete(
+        permanent=True
+    )
+    ln.Record.filter(name="from-df-sheet").delete(permanent=True)
+    schema.delete(permanent=True)
+    score.delete(permanent=True)
+
+
 def test_record_plural_type_warning(ccaplog):
     ln.Record(name="MyThings", is_type=True)
     assert (

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -129,6 +129,30 @@ def test_record_from_dataframe_bulk_save_paths():
     score.delete(permanent=True)
 
 
+def test_feature_manager_raise_not_validated_values():
+    from lamindb.models._feature_manager import FeatureManager
+
+    assert FeatureManager._raise_not_validated_values({}) is None
+
+    with pytest.raises(ln.errors.ValidationError) as error:
+        FeatureManager._raise_not_validated_values(
+            {
+                "Record": ("name", ["missing-record"]),
+                "bionty.Gene": ("symbol", ["missing-gene"]),
+            }
+        )
+    message = str(error.value)
+    assert "These values could not be validated" in message
+    assert (
+        "records = ln.Record.from_values(['missing-record'], field='name', create=True).save()"
+        in message
+    )
+    assert (
+        "records = bionty.Gene.from_values(['missing-gene'], field='symbol').save()"
+        in message
+    )
+
+
 def test_record_plural_type_warning(ccaplog):
     ln.Record(name="MyThings", is_type=True)
     assert (

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 from django.db import IntegrityError
 from lamindb.errors import FieldValidationError
+from lamindb.models.record import IMPORTS_UID, SCHEMA_IMPORTS_UID
 
 
 def test_record_docstring_examples():
@@ -151,33 +152,57 @@ def test_record_from_dataframe_with_string_type_creates_import_type():
             "from-df-str-score": [11.0, 12.0],
         }
     )
-    records = ln.Record.from_dataframe(df, type="from-df-str-type")
-    created_type = ln.Record.get(name="from-df-str-type", is_type=True)
-    imports_type = ln.Record.get(name="Imports", is_type=True)
+    imports_type = ln.Record.filter(uid=IMPORTS_UID).one_or_none()
+    original_imports_name = None
+    if imports_type is not None:
+        original_imports_name = imports_type.name
+        imports_type.name = "from-df-renamed-imports-parent"
+        imports_type.save()
 
-    assert len(records) == 2
-    assert all(record.type_id == created_type.id for record in records)
-    assert created_type.type_id == imports_type.id
-    assert created_type.schema_id is not None
+    try:
+        records = ln.Record.from_dataframe(df, type="from-df-str-type")
+        created_type = ln.Record.get(name="from-df-str-type", is_type=True)
+        imports_type = ln.Record.get(uid=IMPORTS_UID)
 
-    ln.save(records)
-    assert (
-        ln.Record.get(name="from-df-str-a").features.get_values()["from-df-str-score"]
-        == 11.0
-    )
+        assert len(records) == 2
+        assert all(record.type_id == created_type.id for record in records)
+        assert created_type.type_id == imports_type.id
+        assert created_type.schema.type is not None
+        assert created_type.schema.type.uid == SCHEMA_IMPORTS_UID
+        assert created_type.schema_id is not None
 
-    ln.Record.filter(name__in=["from-df-str-a", "from-df-str-b"]).delete(permanent=True)
-    ln.Record.filter(name="from-df-str-type").delete(permanent=True)
-    ln.Schema.filter(id=created_type.schema_id).delete(permanent=True)
-    score.delete(permanent=True)
+        ln.save(records)
+        assert (
+            ln.Record.get(name="from-df-str-a").features.get_values()[
+                "from-df-str-score"
+            ]
+            == 11.0
+        )
+    finally:
+        created_type = ln.Record.filter(
+            name="from-df-str-type", is_type=True
+        ).one_or_none()
+        ln.Record.filter(name__in=["from-df-str-a", "from-df-str-b"]).delete(
+            permanent=True
+        )
+        ln.Record.filter(name="from-df-str-type").delete(permanent=True)
+        if created_type is not None and created_type.schema_id is not None:
+            ln.Schema.filter(id=created_type.schema_id).delete(permanent=True)
+        if original_imports_name is not None:
+            imports_type = ln.Record.get(uid=IMPORTS_UID)
+            imports_type.name = original_imports_name
+            imports_type.save()
+        score.delete(permanent=True)
 
 
 def test_record_from_dataframe_with_string_type_duplicate_name_errors():
     score = ln.Feature(name="from-df-dup-score", dtype=float).save()
     schema = ln.Schema([score], name="from-df-dup-schema").save()
-    imports_type = ln.Record.filter(name="Imports", is_type=True).one_or_none()
+    imports_type = ln.Record.filter(uid=IMPORTS_UID).one_or_none()
     if imports_type is None:
-        imports_type = ln.Record(name="Imports", is_type=True).save()
+        imports_type = ln.Record(name="Imports", is_type=True)
+        imports_type.uid = IMPORTS_UID
+        imports_type = imports_type.save()
     ln.Record(
         name="from-df-dup-type", is_type=True, schema=schema, type=imports_type
     ).save()

--- a/tests/core/test_save.py
+++ b/tests/core/test_save.py
@@ -79,14 +79,18 @@ def test_bulk_save_lazy_record_features():
     ln.Record(name="lazy-t-cell", type=cell_type).save()
     score_feature = ln.Feature(name="lazy-bulk-score", dtype=float).save()
     cell_feature = ln.Feature(name="lazy-bulk-cell", dtype=cell_type).save()
+    schema = ln.Schema([score_feature, cell_feature], name="lazy-bulk-schema").save()
+    sheet = ln.Record(name="lazy-sheet", is_type=True, schema=schema).save()
 
     records = [
         ln.Record(
             name="lazy-sample-1",
+            type=sheet,
             features={"lazy-bulk-score": 0.1, "lazy-bulk-cell": "lazy-b-cell"},
         ),
         ln.Record(
             name="lazy-sample-2",
+            type=sheet,
             features={"lazy-bulk-score": 0.2, "lazy-bulk-cell": "lazy-t-cell"},
         ),
     ]
@@ -104,10 +108,56 @@ def test_bulk_save_lazy_record_features():
     assert not hasattr(records[1], "_features")
 
     ln.Record.filter(name__in=["lazy-sample-1", "lazy-sample-2"]).delete(permanent=True)
+    ln.Record.filter(name="lazy-sheet").delete(permanent=True)
     ln.Record.filter(name__in=["lazy-b-cell", "lazy-t-cell"]).delete(permanent=True)
     ln.Record.filter(name="lazy-cell-type").delete(permanent=True)
+    schema.delete(permanent=True)
     score_feature.delete(permanent=True)
     cell_feature.delete(permanent=True)
+
+
+def test_bulk_save_lazy_record_features_requires_same_schema():
+    feature_a = ln.Feature(name="lazy-schema-a", dtype=float).save()
+    feature_b = ln.Feature(name="lazy-schema-b", dtype=float).save()
+    schema_a = ln.Schema([feature_a], name="lazy-schema-a").save()
+    schema_b = ln.Schema([feature_b], name="lazy-schema-b").save()
+    type_a = ln.Record(name="lazy-type-a", is_type=True, schema=schema_a).save()
+    type_b = ln.Record(name="lazy-type-b", is_type=True, schema=schema_b).save()
+
+    records = [
+        ln.Record(name="lazy-mixed-1", type=type_a, features={"lazy-schema-a": 1.0}),
+        ln.Record(name="lazy-mixed-2", type=type_b, features={"lazy-schema-b": 2.0}),
+    ]
+    with pytest.raises(
+        ln.errors.ValidationError,
+        match="same type schema",
+    ):
+        ln.save(records)
+
+    ln.Record.filter(name__in=["lazy-mixed-1", "lazy-mixed-2"]).delete(permanent=True)
+    ln.Record.filter(name__in=["lazy-type-a", "lazy-type-b"]).delete(permanent=True)
+    schema_a.delete(permanent=True)
+    schema_b.delete(permanent=True)
+    feature_a.delete(permanent=True)
+    feature_b.delete(permanent=True)
+
+
+def test_bulk_save_lazy_record_features_requires_schema():
+    unschematized_type = ln.Record(name="lazy-no-schema-type", is_type=True).save()
+
+    records = [
+        ln.Record(
+            name="lazy-no-schema-1", type=unschematized_type, features={"foo": 1.0}
+        )
+    ]
+    with pytest.raises(
+        ln.errors.ValidationError,
+        match="same non-null type schema",
+    ):
+        ln.save(records)
+
+    ln.Record.filter(name="lazy-no-schema-1").delete(permanent=True)
+    ln.Record.filter(name="lazy-no-schema-type").delete(permanent=True)
 
 
 def test_bulk_resave_trashed_records():

--- a/tests/core/test_save.py
+++ b/tests/core/test_save.py
@@ -73,6 +73,43 @@ def test_save_batch_size():
     assert ln.Record.filter(name__in=label_names).distinct().count() == 3
 
 
+def test_bulk_save_lazy_record_features():
+    cell_type = ln.Record(name="lazy-cell-type", is_type=True).save()
+    ln.Record(name="lazy-b-cell", type=cell_type).save()
+    ln.Record(name="lazy-t-cell", type=cell_type).save()
+    score_feature = ln.Feature(name="lazy-bulk-score", dtype=float).save()
+    cell_feature = ln.Feature(name="lazy-bulk-cell", dtype=cell_type).save()
+
+    records = [
+        ln.Record(
+            name="lazy-sample-1",
+            features={"lazy-bulk-score": 0.1, "lazy-bulk-cell": "lazy-b-cell"},
+        ),
+        ln.Record(
+            name="lazy-sample-2",
+            features={"lazy-bulk-score": 0.2, "lazy-bulk-cell": "lazy-t-cell"},
+        ),
+    ]
+    ln.save(records)
+
+    sample_1 = ln.Record.get(name="lazy-sample-1")
+    sample_2 = ln.Record.get(name="lazy-sample-2")
+    sample_1_values = sample_1.features.get_values()
+    sample_2_values = sample_2.features.get_values()
+    assert sample_1_values["lazy-bulk-score"] == 0.1
+    assert sample_2_values["lazy-bulk-score"] == 0.2
+    assert sample_1_values["lazy-bulk-cell"] == "lazy-b-cell"
+    assert sample_2_values["lazy-bulk-cell"] == "lazy-t-cell"
+    assert not hasattr(records[0], "_features")
+    assert not hasattr(records[1], "_features")
+
+    ln.Record.filter(name__in=["lazy-sample-1", "lazy-sample-2"]).delete(permanent=True)
+    ln.Record.filter(name__in=["lazy-b-cell", "lazy-t-cell"]).delete(permanent=True)
+    ln.Record.filter(name="lazy-cell-type").delete(permanent=True)
+    score_feature.delete(permanent=True)
+    cell_feature.delete(permanent=True)
+
+
 def test_bulk_resave_trashed_records():
     import bionty as bt
 

--- a/tests/profiling/import_records_from_dataframe.py
+++ b/tests/profiling/import_records_from_dataframe.py
@@ -1,0 +1,79 @@
+import argparse
+from datetime import datetime
+from random import Random
+from time import perf_counter
+
+import lamindb as ln
+import pandas as pd
+
+
+def generate_values(dtype: str, n_rows: int, rng: Random):
+    cell_types = [
+        "T cell",
+        "B cell",
+        "natural killer cell",
+        "monocyte",
+        "epithelial cell",
+    ]
+    if dtype in {"float", "num"}:
+        return [round(rng.uniform(0.0, 100.0), 3) for _ in range(n_rows)]
+    if dtype.startswith("cat["):
+        return [rng.choice(cell_types) for _ in range(n_rows)]
+    raise ValueError(f"Unsupported dtype: {dtype}")
+
+
+@ln.flow("JuJZZEsit1KV")
+def main(n_rows: int):
+    feature_names = [
+        "age_or_mean_of_age_range",
+        "array_col",
+        "cell_type_by_model",
+    ]
+    rng = Random(0)
+    features = ln.Feature.filter(name__in=feature_names)
+    dtypes_by_feature = {feature.name: feature.dtype_as_str for feature in features}
+
+    data: dict[str, list] = {}
+    print("Generating random dataframe values...")
+    for feature in features:
+        data[feature.name] = generate_values(
+            dtypes_by_feature[feature.name], n_rows, rng
+        )
+    df = pd.DataFrame(data)
+    print(df.head(5))
+
+    print("Running Record.from_dataframe()...")
+    from_dataframe_start = perf_counter()
+    records = ln.Record.from_dataframe(
+        df,
+        type=f"test-import-records-from-dataframe-{datetime.now().strftime('%Y-%m-%d-%H-%M-%S')}",
+    )
+    from_dataframe_duration_sec = perf_counter() - from_dataframe_start
+    print(f"... completed in {from_dataframe_duration_sec:.6f}s")
+
+    print("Saving records...")
+    save_start = perf_counter()
+    records.save()
+    save_duration_sec = perf_counter() - save_start
+    print(f"... completed in {save_duration_sec:.6f}s")
+
+    run = ln.context.run
+    params = run.params or {}
+    params.update(
+        {
+            "from_dataframe_duration_sec": round(from_dataframe_duration_sec, 6),
+            "save_duration_sec": round(save_duration_sec, 6),
+        }
+    )
+    run.params = params
+    run.save()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Prepare and optionally save test Records rows via Record.from_dataframe()."
+    )
+    parser.add_argument("--rows", type=int, default=100)
+    args = parser.parse_args()
+    ln.connect("laminlabs/lamindata")
+    main(n_rows=args.rows)


### PR DESCRIPTION
Two new more intuitive and more efficient ways of making records:

```python
ln.Record(features={...}).save()
ln.Record.from_dataframe(df, type="my_df).save()
```

This is much faster than individual record creation. Also see this follow-up PR that makes it fast, also within the lamindb 2.4.0 release:

- https://github.com/laminlabs/lamindb/pull/3649

Addresses:

- https://github.com/pfizer-collab/laminlabs/issues/860

TODO: Currently _invalid_ features are ignored in schema generation because this is how `Schema.from_dataframe()` behaves. This should be made more configurable in the future.