### PR TITLE
✨ Allow users to transfer artifacts between storage locations

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3071,7 +3071,15 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             )
 
         if self._field_changed("space_id") and self.storage.instance_uid is not None:
-            _transfer_artifact_to_space(self, self.space_id)
+            # todo: select from multiple storages if available
+            storage = Storage.connect(self._state.db).get(space_id=self.space_id)
+            if storage.instance_uid is not None:
+                # try to transfer if both storages are writable / managed by an instance
+                _transfer_artifact_to_storage(self, storage)
+            else:
+                raise ValueError(
+                    "The target storage is not managed by an instance. Please select a different storage location."
+                )
 
         if transfer not in {"record", "annotations"}:
             raise ValueError(
@@ -3176,8 +3184,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         return self
 
 
-def _transfer_artifact_to_space(artifact: Artifact, space_id: int):
-    storage = Storage.connect(artifact._state.db).get(space_id=space_id)
+def _transfer_artifact_to_storage(artifact: Artifact, storage: Storage):
     storage_key = _s().auto_storage_key_from_artifact(artifact)
 
     source_path = artifact.path

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3069,28 +3069,30 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             # probbaly we should restrict to storages with managed credentials
             and (artifact_storage := self.storage).instance_uid is not None
         ):
+            space = self.space
             storage_type = artifact_storage.type
             storages = Storage.connect(self._state.db).filter(
-                space_id=self.space_id, instance_uid__isnull=False, type=storage_type
+                space=space, instance_uid__isnull=False, type=storage_type
             )
             n_storages = storages.count()
             if n_storages == 0:
                 raise ValueError(
-                    f"No {storage_type} storage locations managed by an instance found for the space."
+                    f"No {storage_type} storage locations managed by an instance found for the space '{space.name}'."
                 )
             elif n_storages > 1:
                 storages = storages.order_by("id")
                 roots_str = "\n".join(
                     f"{i}: {storage.root}" for i, storage in enumerate(storages)
                 )
-                storage_id: int = int(
-                    input(
-                        "Select a storage location from the following options:"
-                        f" \n{roots_str}\n"
-                        "Enter the number: "
-                    )
+                choice = input(
+                    f"Select a storage location of type '{storage_type}' from the target space '{space.name}':"
+                    f" \n{roots_str}\n"
+                    "Enter the number or 'x' to cancel: "
                 )
-                storage = storages[storage_id]
+                if choice == "x":
+                    logger.warning("saving was cancelled")
+                    return None
+                storage = storages[int(choice)]
             else:
                 storage = storages.one()
             if artifact_storage != storage:

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3063,7 +3063,10 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         access_token = kwargs.pop("access_token", None)
         # when space is passed in init, storage is ignored, so space - storage consistency is enforced there
         # note that storage is not editable after creation
-        if self._field_changed("space_id") and self.storage.instance_uid is not None:
+        if (
+            self._field_changed("space_id")
+            and (artifact_storage := self.storage).instance_uid is not None
+        ):
             storages = Storage.connect(self._state.db).filter(
                 space_id=self.space_id, instance_uid__isnull=False
             )
@@ -3087,8 +3090,14 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                 storage = storages[storage_id]
             else:
                 storage = storages.one()
-            # try to transfer if both storages are writable / managed by an instance
-            _transfer_artifact_to_storage(self, storage, access_token=access_token)
+            if artifact_storage != storage:
+                # try to transfer if both storages are writable / managed by an instance
+                _transfer_artifact_to_storage(self, storage, access_token=access_token)
+            else:
+                # this can happen if the space of the storage was changed before saving the artifact
+                logger.info(
+                    f"artifact is already in the storage location {storage.root}"
+                )
 
         if transfer not in {"record", "annotations"}:
             raise ValueError(

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3064,15 +3064,19 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         # when space is passed in init, storage is ignored, so space - storage consistency is enforced there
         if (
             self._field_changed("space_id")
+            # here we check for storages managed by any instance
+            # not necessarily with managed credentials
+            # probbaly we should restrict to storages with managed credentials
             and (artifact_storage := self.storage).instance_uid is not None
         ):
+            storage_type = artifact_storage.type
             storages = Storage.connect(self._state.db).filter(
-                space_id=self.space_id, instance_uid__isnull=False
+                space_id=self.space_id, instance_uid__isnull=False, type=storage_type
             )
             n_storages = storages.count()
             if n_storages == 0:
                 raise ValueError(
-                    "No storage locations managed by an instance found for the space."
+                    f"No {storage_type} storage locations managed by an instance found for the space."
                 )
             elif n_storages > 1:
                 storages = storages.order_by("id")

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3210,11 +3210,20 @@ def _transfer_artifact_to_storage(
 
     source_path = artifact.path
     target_path = storage.path / storage_key
-    assert source_path != target_path
+    assert source_path != target_path, "Cannot transfer to the same path."
 
     fs = transfer_fs(source_path, target_path, access_token=access_token)
-    logger.important(f"transferring artifact from {source_path} to {target_path}")
-    fs.mv(str(source_path), str(target_path), recursive=True)
+
+    source_path_str = str(source_path)
+    target_path_str = str(target_path)
+    assert not fs.exists(target_path_str), (
+        f"Cannot transfer artifact to {target_path_str} because it already exists."
+    )
+
+    logger.important(
+        f"transferring artifact from '{source_path_str}' to '{target_path_str}'"
+    )
+    fs.mv(source_path_str, target_path_str, recursive=True)
 
     artifact.storage_id = storage.id
 

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3188,8 +3188,7 @@ def _transfer_artifact_to_space(artifact: Artifact, space_id: int):
     logger.info(f"transferring artifact from {source_path} to {target_path}")
     fs.mv(str(source_path), str(target_path), recursive=True)
 
-    if artifact.storage_id != storage.id:
-        artifact.storage_id = storage.id
+    artifact.storage_id = storage.id
 
 
 # can't really just call .cache in .load because of double tracking

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3062,7 +3062,6 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
 
         access_token = kwargs.pop("access_token", None)
         # when space is passed in init, storage is ignored, so space - storage consistency is enforced there
-        # note that storage is not editable after creation
         if (
             self._field_changed("space_id")
             and (artifact_storage := self.storage).instance_uid is not None

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3098,6 +3098,8 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             if artifact_storage != storage:
                 # try to transfer if both storages are writable / managed by an instance
                 _transfer_artifact_to_storage(self, storage, access_token=access_token)
+            else:
+                logger.important("artifact is already in the target storage location")
 
         if transfer not in {"record", "annotations"}:
             raise ValueError(

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3071,16 +3071,31 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             )
 
         if self._field_changed("space_id") and self.storage.instance_uid is not None:
-            # todo: select from multiple storages if available
-            storage = Storage.connect(self._state.db).get(space_id=self.space_id)
-            if storage.instance_uid is not None:
-                # try to transfer if both storages are writable / managed by an instance
-                _transfer_artifact_to_storage(self, storage)
-            else:
+            storages = Storage.connect(self._state.db).filter(
+                space_id=self.space_id, instance_uid__isnull=False
+            )
+            n_storages = storages.count()
+            if n_storages == 0:
                 raise ValueError(
-                    "The target storage is not managed by an instance. "
-                    "Please select a different storage location."
+                    "No storage locations managed by an instance found for the space."
                 )
+            elif n_storages > 1:
+                storages = storages.order_by("id")
+                roots_str = "\n".join(
+                    f"{i}: {storage.root}" for i, storage in enumerate(storages)
+                )
+                storage_id: int = int(
+                    input(
+                        "Select a storage location from the following options:"
+                        f" \n{roots_str}\n"
+                        "Enter the number: "
+                    )
+                )
+                storage = storages[storage_id]
+            else:
+                storage = storages.one()
+            # try to transfer if both storages are writable / managed by an instance
+            _transfer_artifact_to_storage(self, storage)
 
         if transfer not in {"record", "annotations"}:
             raise ValueError(

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3096,11 +3096,6 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             if artifact_storage != storage:
                 # try to transfer if both storages are writable / managed by an instance
                 _transfer_artifact_to_storage(self, storage, access_token=access_token)
-            else:
-                # this can happen if the space of the storage was changed before saving the artifact
-                logger.info(
-                    f"artifact is already in the storage location {storage.root}"
-                )
 
         if transfer not in {"record", "annotations"}:
             raise ValueError(
@@ -3214,7 +3209,7 @@ def _transfer_artifact_to_storage(
     assert source_path != target_path
 
     fs = transfer_fs(source_path, target_path, access_token=access_token)
-    logger.info(f"transferring artifact from {source_path} to {target_path}")
+    logger.important(f"transferring artifact from {source_path} to {target_path}")
     fs.mv(str(source_path), str(target_path), recursive=True)
 
     artifact.storage_id = storage.id

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3078,7 +3078,8 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                 _transfer_artifact_to_storage(self, storage)
             else:
                 raise ValueError(
-                    "The target storage is not managed by an instance. Please select a different storage location."
+                    "The target storage is not managed by an instance. "
+                    "Please select a different storage location."
                 )
 
         if transfer not in {"record", "annotations"}:

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3059,17 +3059,10 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             and self.branch_id != -1  # skip on soft deletion
         ):
             logger.warning("you are saving to a non-latest version of the artifact")
+
+        access_token = kwargs.pop("access_token", None)
         # when space is passed in init, storage is ignored, so space - storage consistency is enforced there
         # note that storage is not editable after creation
-        if (
-            self._field_changed("space_id")
-            and (artifact_storage := self.storage).instance_uid is not None
-            and artifact_storage.space_id == self._original_values["space_id"]
-        ):
-            raise ValueError(
-                "Space cannot be changed because the artifact is in the storage location of another space."
-            )
-
         if self._field_changed("space_id") and self.storage.instance_uid is not None:
             storages = Storage.connect(self._state.db).filter(
                 space_id=self.space_id, instance_uid__isnull=False
@@ -3095,7 +3088,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             else:
                 storage = storages.one()
             # try to transfer if both storages are writable / managed by an instance
-            _transfer_artifact_to_storage(self, storage)
+            _transfer_artifact_to_storage(self, storage, access_token=access_token)
 
         if transfer not in {"record", "annotations"}:
             raise ValueError(
@@ -3108,7 +3101,6 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         store_kwargs = kwargs.pop(
             "store_kwargs", {}
         )  # kwargs for .upload_from in the end
-        access_token = kwargs.pop("access_token", None)
         local_path = None
         if upload and setup_settings.instance.keep_artifacts_local:
             # switch local storage location to cloud
@@ -3200,14 +3192,16 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         return self
 
 
-def _transfer_artifact_to_storage(artifact: Artifact, storage: Storage):
+def _transfer_artifact_to_storage(
+    artifact: Artifact, storage: Storage, access_token: str | None = None
+):
     storage_key = _s().auto_storage_key_from_artifact(artifact)
 
     source_path = artifact.path
     target_path = storage.path / storage_key
     assert source_path != target_path
 
-    fs = transfer_fs(source_path, target_path)
+    fs = transfer_fs(source_path, target_path, access_token=access_token)
     logger.info(f"transferring artifact from {source_path} to {target_path}")
     fs.mv(str(source_path), str(target_path), recursive=True)
 

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -24,6 +24,7 @@ from lamindb_setup.core.upath import (
     extract_suffix_from_path,
     get_stat_dir_cloud,
     get_stat_file_cloud,
+    transfer_fs,
 )
 from lamindb_setup.types import UPathStr
 
@@ -3069,6 +3070,9 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                 "Space cannot be changed because the artifact is in the storage location of another space."
             )
 
+        if self._field_changed("space_id") and self.storage.instance_uid is not None:
+            _transfer_artifact_to_space(self, self.space_id)
+
         if transfer not in {"record", "annotations"}:
             raise ValueError(
                 f"transfer should be either 'record' or 'annotations', not {transfer}"
@@ -3170,6 +3174,22 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         if hasattr(self, "_local_filepath"):
             del self._local_filepath
         return self
+
+
+def _transfer_artifact_to_space(artifact: Artifact, space_id: int):
+    storage = Storage.connect(artifact._state.db).get(space_id=space_id)
+    storage_key = _s().auto_storage_key_from_artifact(artifact)
+
+    source_path = artifact.path
+    target_path = storage.path / storage_key
+    assert source_path != target_path
+
+    fs = transfer_fs(source_path, target_path)
+    logger.info(f"transferring artifact from {source_path} to {target_path}")
+    fs.mv(str(source_path), str(target_path), recursive=True)
+
+    if artifact.storage_id != storage.id:
+        artifact.storage_id = storage.id
 
 
 # can't really just call .cache in .load because of double tracking

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -1297,7 +1297,7 @@ def test_artifact_space_change(tsv_file):
     with pytest.raises(ValueError) as err:
         artifact.save()
     assert (
-        "No local storage locations managed by an instance found for the space."
+        "No local storage locations managed by an instance found for the space"
         in err.exconly()
     )
     # test after getting from the db
@@ -1306,7 +1306,7 @@ def test_artifact_space_change(tsv_file):
     with pytest.raises(ValueError) as err:
         artifact.save()
     assert (
-        "No local storage locations managed by an instance found for the space."
+        "No local storage locations managed by an instance found for the space"
         in err.exconly()
     )
 

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -1297,7 +1297,7 @@ def test_artifact_space_change(tsv_file):
     with pytest.raises(ValueError) as err:
         artifact.save()
     assert (
-        "No storage locations managed by an instance found for the space."
+        "No local storage locations managed by an instance found for the space."
         in err.exconly()
     )
     # test after getting from the db
@@ -1306,7 +1306,7 @@ def test_artifact_space_change(tsv_file):
     with pytest.raises(ValueError) as err:
         artifact.save()
     assert (
-        "No storage locations managed by an instance found for the space."
+        "No local storage locations managed by an instance found for the space."
         in err.exconly()
     )
 

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -1297,7 +1297,7 @@ def test_artifact_space_change(tsv_file):
     with pytest.raises(ValueError) as err:
         artifact.save()
     assert (
-        "Space cannot be changed because the artifact is in the storage location of another space."
+        "No storage locations managed by an instance found for the space."
         in err.exconly()
     )
     # test after getting from the db
@@ -1306,7 +1306,7 @@ def test_artifact_space_change(tsv_file):
     with pytest.raises(ValueError) as err:
         artifact.save()
     assert (
-        "Space cannot be changed because the artifact is in the storage location of another space."
+        "No storage locations managed by an instance found for the space."
         in err.exconly()
     )
 

--- a/tests/permissions/scripts/check_lamin_dev.py
+++ b/tests/permissions/scripts/check_lamin_dev.py
@@ -1,4 +1,5 @@
 import subprocess
+from unittest.mock import patch
 
 import lamindb as ln
 import pytest
@@ -67,6 +68,20 @@ try:
     assert artifact.storage in ln.Storage.filter(space=space)
     assert ln.context.transform.space == space
     assert ln.context.run.space == space
+
+    # move the artifact to another storage location
+    space_test_move = ln.Space.get(name="test-move")
+    artifact.space = space_test_move
+    # cancel save
+    with patch("builtins.input", return_value="x"):
+        artifact.save()
+    # save to the new storage location
+    with patch("builtins.input", return_value="1"):
+        artifact.save()
+    assert artifact.space == space_test_move
+    assert artifact.storage in ln.Storage.filter(space=space_test_move)
+    assert artifact.path.as_posix().startswith(artifact.storage.root)
+    assert artifact.path.exists()
 
     # update the space of the storage location
     space2 = ln.Space.get(name="Our test space for CI 2")

--- a/tests/permissions/scripts/check_lamin_dev.py
+++ b/tests/permissions/scripts/check_lamin_dev.py
@@ -54,11 +54,20 @@ try:
     ) is not None:
         artifact_cleanup.delete(permanent=True)
 
+    # cleanup if the directory artifact already exists
+    artifact_dir = ln.Artifact("./scripts", key="mytest-dir")
+    if (
+        artifact_cleanup := ln.Artifact.filter(hash=artifact_dir.hash).one_or_none()
+    ) is not None:
+        artifact_cleanup.delete(permanent=True)
+
     artifact = ln.Artifact(".gitignore", key="mytest").save()
+    artifact_dir = ln.Artifact("./scripts", key="mytest-dir").save()
 
     # check that exist
     ln.ULabel.get(name="My test ulabel in test space")
     ln.Artifact.get(key="mytest")
+    ln.Artifact.get(key="mytest-dir")
 
     assert ulabel.space == space  # ulabel should end up in the restricted space
     assert artifact.space == space
@@ -82,6 +91,20 @@ try:
     assert artifact.storage in ln.Storage.filter(space=space_test_move)
     assert artifact.path.as_posix().startswith(artifact.storage.root)
     assert artifact.path.exists()
+
+    # move the directory artifact to another storage location
+    assert artifact_dir.space == space
+    assert artifact_dir.path.is_dir()
+    assert artifact_dir.storage in ln.Storage.filter(space=space)
+
+    artifact_dir.space = space_test_move
+    # save to the new storage location
+    with patch("builtins.input", return_value="0"):
+        artifact_dir.save()
+    assert artifact_dir.space == space_test_move
+    assert artifact_dir.storage in ln.Storage.filter(space=space_test_move)
+    assert artifact_dir.path.as_posix().startswith(artifact_dir.storage.root)
+    assert artifact_dir.path.is_dir()
 
     # update the space of the storage location
     space2 = ln.Space.get(name="Our test space for CI 2")
@@ -117,6 +140,7 @@ finally:
         (
             ulabel,
             artifact,
+            artifact_dir,
             ln.context.transform.latest_run,
             ln.context.transform,
             storage_loc,

--- a/tests/tiledbsoma/conftest.py
+++ b/tests/tiledbsoma/conftest.py
@@ -34,6 +34,9 @@ def pytest_sessionfinish(session: pytest.Session):
     logger.set_verbosity(1)
     if Path("./default_storage_tiledbsoma").exists():
         shutil.rmtree("./default_storage_tiledbsoma")
+    upath = ln_setup.core.upath.UPath("s3://lamindb-test/tiledbsoma")
+    if upath.exists():
+        upath.rmdir()
     ln.setup.delete("lamindb-unit-tests-tiledbsoma", force=True)
     del os.environ["LAMIN_TESTING"]
 


### PR DESCRIPTION
Requires https://github.com/laminlabs/lamindb-setup/pull/1325

This PR adds support for moving an `Artifact` between `storage` locations when its `space` is changed and the target `space` uses a different managed `storage`.

Example:
```python
import lamindb as ln
# existing artifact in space A
artifact = ln.Artifact.get(key="myartifact")
# move artifact to space B
target_space = ln.Space.get(name="test-move")
artifact.space = target_space
artifact.save() # moves to the storage of the space B
```

