### PR TITLE
🩹 Skip hash lookup on empty files when creating an `artifact`

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -373,6 +373,10 @@ def get_stat_or_artifact(
             size, hash, hash_type = hash_file(path)
     if not check_hash:
         return size, hash, hash_type, n_files, None
+    # Empty files all share the same content hash; skip cross-artifact hash
+    # lookup so creating a new empty file path yields a new artifact.
+    if n_files is None and size == 0:
+        skip_hash_lookup = True
     previous_artifact_version = None
     artifacts_qs = Artifact.objects.using(instance)
     if skip_hash_lookup:

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1139,6 +1139,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         storage: `Storage | None = None` The storage location for the artifact. If `None`, uses the default storage location.
             You can see and set the default storage location in :attr:`~lamindb.core.Settings.storage`.
         skip_hash_lookup: `bool = False` Skip the hash lookup so that a new artifact is created even if an artifact with the same hash already exists.
+            Empty files are always treated as if this were `True` because empty content hashes are not used for deduplication.
 
     Examples:
 
@@ -1220,6 +1221,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         .. dropdown:: Will artifacts get duplicated?
 
             If an artifact with the exact same hash already exists, `Artifact()` returns the existing artifact.
+            Exception: empty files are not deduplicated by hash and create a new artifact.
 
             In concurrent workloads where the same artifact is created repeatedly at the exact same time, `.save()`
             detects the duplication and will return the existing artifact.

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -232,6 +232,26 @@ def test_create_from_path_file_with_explicit_key_is_virtual(
     artifact.delete(permanent=True, storage=True)
 
 
+def test_create_from_empty_files_skips_hash_lookup(tmp_path):
+    path_1 = tmp_path / "empty-1.txt"
+    path_2 = tmp_path / "empty-2.txt"
+    path_1.write_text("")
+    path_2.write_text("")
+
+    artifact_1 = ln.Artifact(path_1, key=f"{tmp_path.name}/empty-1.txt").save()
+    artifact_2 = ln.Artifact(path_2, key=f"{tmp_path.name}/empty-2.txt")
+
+    assert artifact_2.uid != artifact_1.uid
+    assert artifact_2.key == f"{tmp_path.name}/empty-2.txt"
+    assert artifact_2.hash == artifact_1.hash
+
+    artifact_2.save()
+    assert artifact_2.id != artifact_1.id
+
+    artifact_2.delete(permanent=True)
+    artifact_1.delete(permanent=True)
+
+
 @pytest.mark.parametrize("key", [None, "my_new_folder"])
 def test_create_from_path_folder(get_test_filepaths, key):
     # get variables from fixture


### PR DESCRIPTION
Skip hash-based deduplication for empty file artifacts in `get_stat_or_artifact()`, so creating a new empty file path no longer reuses an existing artifact purely due to identical empty-content hash.

Addresses https://github.com/laminlabs/lamindb/issues/3633