### PR TITLE
⚡️ Speed up bulk import of records by factor 15

### DIFF
--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -1359,6 +1359,8 @@ class FeatureManager:
         feature_json_values: list,
         links_by_model: dict,
         not_validated_values: dict[str, tuple[str, list[str]]],
+        resolved_records_by_feature_id: dict[int, dict[Any, list[SQLRecord]]]
+        | None = None,
     ) -> None:
         from ..base.dtypes import is_iterable_of_sqlrecord
         from .can_curate import CanCurate
@@ -1406,7 +1408,40 @@ class FeatureManager:
                     }
                 else:
                     result = parse_dtype(feature._dtype_str)[0]
-                if issubclass(result["registry"], CanCurate):  # type: ignore
+                cached_records = None
+                if (
+                    resolved_records_by_feature_id is not None
+                    and feature.id in resolved_records_by_feature_id
+                ):
+                    cached_records = resolved_records_by_feature_id[feature.id]
+                if cached_records is not None:
+                    if isinstance(value, str):
+                        values_for_lookup = [value]
+                    else:
+                        values_for_lookup = value  # type: ignore
+                    if isinstance(values_for_lookup, (list, tuple, np.ndarray, set)):
+                        values_for_lookup = list(values_for_lookup)
+                    else:
+                        values_for_lookup = [values_for_lookup]
+                    label_records = []
+                    not_validated_for_feature = []
+                    for lookup_value in values_for_lookup:
+                        normalized_lookup = (
+                            lookup_value.item()
+                            if isinstance(lookup_value, np.generic)
+                            else lookup_value
+                        )
+                        mapped_records = cached_records.get(normalized_lookup)
+                        if mapped_records is None:
+                            not_validated_for_feature.append(normalized_lookup)
+                        else:
+                            label_records.extend(mapped_records)
+                    if not_validated_for_feature:
+                        not_validated_values[result["registry_str"]] = (  # type: ignore
+                            result["field_str"],
+                            not_validated_for_feature,
+                        )
+                elif issubclass(result["registry"], CanCurate):  # type: ignore
                     validated = result["registry"].validate(  # type: ignore
                         values, field=result["field"], mute=True
                     )
@@ -2122,13 +2157,29 @@ def bulk_set_features_in_records(records: Iterable[Record]) -> None:
             and not feature.dtype_as_str.startswith("list[cat")
         ):
             dataframe[feature.name] = dataframe[feature.name].astype("category")
-    DataFrameCurator(dataframe, batch_schema).validate()
+    curator = DataFrameCurator(dataframe, batch_schema)
+    curator.validate()
 
     members_by_name: dict[str, list[Feature]] = defaultdict(list)
     schema_member_ids: set[int] = set()
+    resolved_records_by_feature_id: dict[int, dict[Any, list[SQLRecord]]] = {}
     for feature in schema_features:
         members_by_name[feature.name].append(feature)
         schema_member_ids.add(feature.id)
+        if not (
+            feature.dtype_as_str.startswith("cat")
+            or feature.dtype_as_str.startswith("list[cat")
+        ):
+            continue
+        cat_vector = curator.cat._cat_vectors.get(feature.name)
+        if cat_vector is None or cat_vector.records is None:
+            continue
+        cache_for_feature: dict[Any, list[SQLRecord]] = defaultdict(list)
+        for label_record in cat_vector.records:
+            key = getattr(label_record, cat_vector._field_name)
+            normalized_key = key.item() if isinstance(key, np.generic) else key
+            cache_for_feature[normalized_key].append(label_record)
+        resolved_records_by_feature_id[feature.id] = dict(cache_for_feature)
 
     feature_json_values: list[SQLRecord] = []
     links_by_model: dict[type[SQLRecord], list[SQLRecord]] = defaultdict(list)
@@ -2165,6 +2216,7 @@ def bulk_set_features_in_records(records: Iterable[Record]) -> None:
             feature_json_values=feature_json_values,
             links_by_model=links_by_model,
             not_validated_values=not_validated_values,
+            resolved_records_by_feature_id=resolved_records_by_feature_id,
         )
     FeatureManager._raise_not_validated_values(not_validated_values)
     if feature_json_values:

--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -1408,6 +1408,14 @@ class FeatureManager:
                     }
                 else:
                     result = parse_dtype(feature._dtype_str)[0]
+                # Fast path for dataframe-originated record batches:
+                # `bulk_set_features_in_records()` now runs a single `DataFrameCurator`
+                # pass and pre-resolves categorical values to label records.
+                #
+                # The cache key is feature.id and the nested key is the normalized
+                # raw value found in the dataframe. Using this cache here avoids
+                # running per-row `validate()` + `from_values()` calls, which used
+                # to duplicate work already done by the curator.
                 cached_records = None
                 if (
                     resolved_records_by_feature_id is not None
@@ -1433,6 +1441,9 @@ class FeatureManager:
                         )
                         mapped_records = cached_records.get(normalized_lookup)
                         if mapped_records is None:
+                            # Keep the same error aggregation behavior as before:
+                            # unresolved categorical values are collected and raised
+                            # in one ValidationError after all records are processed.
                             not_validated_for_feature.append(normalized_lookup)
                         else:
                             label_records.extend(mapped_records)
@@ -1442,6 +1453,13 @@ class FeatureManager:
                             not_validated_for_feature,
                         )
                 elif issubclass(result["registry"], CanCurate):  # type: ignore
+                    # Fallback path for non-batch callers (e.g. direct
+                    # `record.features.add_values()` on an individual record).
+                    #
+                    # Those flows do not build dataframe-level caches, so we keep
+                    # the original registry-backed validation and resolution logic.
+                    # This branch should not be hot for the dataframe batch import
+                    # path because that path provides `resolved_records_by_feature_id`.
                     validated = result["registry"].validate(  # type: ignore
                         values, field=result["field"], mute=True
                     )
@@ -2157,6 +2175,11 @@ def bulk_set_features_in_records(records: Iterable[Record]) -> None:
             and not feature.dtype_as_str.startswith("list[cat")
         ):
             dataframe[feature.name] = dataframe[feature.name].astype("category")
+    # Single-pass dataframe curation:
+    # validate schema and resolve categoricals once for the entire batch.
+    #
+    # The resolved label records are then reused below when creating per-record
+    # link rows, avoiding repeated registry calls for each row.
     curator = DataFrameCurator(dataframe, batch_schema)
     curator.validate()
 
@@ -2174,6 +2197,12 @@ def bulk_set_features_in_records(records: Iterable[Record]) -> None:
         cat_vector = curator.cat._cat_vectors.get(feature.name)
         if cat_vector is None or cat_vector.records is None:
             continue
+        # Build lookup cache:
+        #   feature.id -> raw value -> [resolved label records]
+        #
+        # We intentionally keep a list of records per value to support
+        # list-categorical and potential multi-match cases consistently with
+        # existing link creation semantics.
         cache_for_feature: dict[Any, list[SQLRecord]] = defaultdict(list)
         for label_record in cat_vector.records:
             key = getattr(label_record, cat_vector._field_name)

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -53,6 +53,68 @@ IMPORTS_UID = "W3WdiFRZTvTJajNp"
 SCHEMA_IMPORTS_UID = "DGZkj4yhGWMJE5fu"
 
 
+class RecordBatch:
+    """DataFrame-backed batch created by :meth:`Record.from_dataframe`."""
+
+    def __init__(
+        self,
+        *,
+        cls: type[Record],
+        df: pd.DataFrame,
+        resolved_type: Record,
+        name_field: str,
+    ) -> None:
+        self._cls = cls
+        self._df = df
+        self._resolved_type = resolved_type
+        self._name_field = name_field
+        self._records: list[Record] | None = None
+
+    def __len__(self) -> int:
+        return len(self._df)
+
+    @property
+    def type(self) -> Record:
+        return self._resolved_type
+
+    def _build_records(self) -> list[Record]:
+        import pandas as pd
+
+        records: list[Record] = []
+        row_dicts = self._df.to_dict(orient="records")
+        for row in row_dicts:
+            if self._name_field in row:
+                name = row.pop(self._name_field)
+            elif "name" in row:
+                name = row.pop("name")
+            else:
+                name = None
+            if pd.api.types.is_scalar(name) and pd.isna(name):
+                name = None
+
+            features: dict[str, Any] = {}
+            for key, value in row.items():
+                if pd.api.types.is_scalar(value) and pd.isna(value):
+                    continue
+                features[key] = value
+
+            record_kwargs: dict[str, Any] = {"type": self._resolved_type}
+            if features:
+                record_kwargs["features"] = features
+            records.append(self._cls(name=name, **record_kwargs))
+        return records
+
+    def save(self) -> SQLRecordList[Record]:
+        """Persist all records and their feature values."""
+        from .query_set import SQLRecordList
+        from .save import save as ln_save
+
+        if self._records is None:
+            self._records = self._build_records()
+        ln_save(self._records)
+        return SQLRecordList(self._records)
+
+
 class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates):
     """Flexible records with sheets & markdown pages.
 
@@ -413,10 +475,10 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         *,
         type: Record | str,
         name_field: str = "__lamindb_record_name__",
-    ) -> SQLRecordList[Record]:
-        """Construct records from a dataframe for bulk saving.
+    ) -> RecordBatch:
+        """Construct a dataframe-backed batch of records for bulk saving.
 
-        Returns unsaved records. Follow with `records.save()` or `ln.save(records)`.
+        Returns a :class:`RecordBatch`. Follow with `records.save()`.
 
         Args:
             df: A dataframe where rows represent records.
@@ -443,7 +505,6 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         """
         import pandas as pd
 
-        from .query_set import SQLRecordList
         from .schema import Schema
 
         if not isinstance(df, pd.DataFrame):
@@ -488,29 +549,12 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         if resolved_type.name is None:
             raise ValueError("`type` needs to have a non-null `name`.")
 
-        records: list[Record] = []
-        row_dicts = df.to_dict(orient="records")
-        for row in row_dicts:
-            if name_field in row:
-                name = row.pop(name_field)
-            elif "name" in row:
-                name = row.pop("name")
-            else:
-                name = None
-            if pd.api.types.is_scalar(name) and pd.isna(name):
-                name = None
-
-            features: dict[str, Any] = {}
-            for key, value in row.items():
-                if pd.api.types.is_scalar(value) and pd.isna(value):
-                    continue
-                features[key] = value
-
-            record_kwargs: dict[str, Any] = {"type": resolved_type}
-            if features:
-                record_kwargs["features"] = features
-            records.append(cls(name=name, **record_kwargs))
-        return SQLRecordList(records)
+        return RecordBatch(
+            cls=cls,
+            df=df,
+            resolved_type=resolved_type,
+            name_field=name_field,
+        )
 
     @property
     def features(self) -> FeatureManager:

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -119,7 +119,7 @@ def test_record_from_dataframe_bulk_save_paths():
         }
     )
     records_2 = ln.Record.from_dataframe(df2, type=sheet)
-    ln.save(records_2)
+    records_2.save()
     assert ln.Record.get(name="from-df-c").features.get_values()["from-df-score"] == 3.0
 
     ln.Record.filter(name__in=["from-df-a", "from-df-b", "from-df-c"]).delete(
@@ -165,13 +165,13 @@ def test_record_from_dataframe_with_string_type_creates_import_type():
         imports_type = ln.Record.get(uid=IMPORTS_UID)
 
         assert len(records) == 2
-        assert all(record.type_id == created_type.id for record in records)
+        assert records.type.id == created_type.id
         assert created_type.type_id == imports_type.id
         assert created_type.schema.type is not None
         assert created_type.schema.type.uid == SCHEMA_IMPORTS_UID
         assert created_type.schema_id is not None
 
-        ln.save(records)
+        records.save()
         assert (
             ln.Record.get(name="from-df-str-a").features.get_values()[
                 "from-df-str-score"


### PR DESCRIPTION
Improves performance of the not-yet-released implementation of `Record.from_dataframe()`:

- https://github.com/laminlabs/lamindb/pull/3634

Before | After
--- | ---
/ | 15x faster
<img width="1269" height="104" alt="image" src="https://github.com/user-attachments/assets/08dc011e-ae32-4509-84fb-7cea7e9cbf4e" /> | <img width="1259" height="107" alt="image" src="https://github.com/user-attachments/assets/29eb88e5-2184-407d-9116-8c5b9156adea" />

Performance at greater scale: https://lamin.ai/laminlabs/lamindata/transform/JuJZZEsit1KV

<img width="1263" height="377" alt="image" src="https://github.com/user-attachments/assets/13d68cad-cfaf-465e-aac0-173d6b0ca01e" />
