### PR TITLE
🦺 Safer transfer of artifacts to other storage locations

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -149,22 +149,21 @@ if TYPE_CHECKING:
     from tiledbsoma import Experiment as SOMAExperiment
     from tiledbsoma import Measurement as SOMAMeasurement
 
-    from lamindb.base.types import StrField
-    from lamindb.core.storage._backed_access import (
+    from ..base.types import (
+        ArtifactKind,
+        StrField,
+    )
+    from ..core.storage._backed_access import (
         AnnDataAccessor,
         BackedAccessor,
         SpatialDataAccessor,
     )
-    from lamindb.core.storage.types import ScverseDataStructures
-    from lamindb.models.query_manager import RelatedManager
-
-    from ..base.types import (
-        ArtifactKind,
-    )
+    from ..core.storage.types import ScverseDataStructures
     from ._label_manager import LabelManager
     from .block import ArtifactBlock
     from .collection import Collection
     from .project import Project, Reference
+    from .query_manager import RelatedManager
     from .record import Record
     from .transform import Transform
 
@@ -3204,9 +3203,18 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         return self
 
 
-def _sorted_sizes(fs: AbstractFileSystem, root: str) -> list[int]:
-    objects = fs.find(root, detail=True)
+def _sorted_sizes(fs: AbstractFileSystem, path: str) -> list[int]:
+    objects = fs.find(path, detail=True)
     return sorted(info["size"] for info in objects.values())
+
+
+def _rm_catch_error(fs: AbstractFileSystem, path: str) -> Exception | None:
+    if fs.exists(path):
+        try:
+            fs.rm(path, recursive=True)
+        except Exception as rm_exc:
+            return rm_exc
+    return None
 
 
 def _transfer_artifact_to_storage(
@@ -3229,15 +3237,18 @@ def _transfer_artifact_to_storage(
     logger.important(
         f"transferring artifact from '{source_path_str}' to '{target_path_str}'"
     )
-    fs.cp(source_path_str, target_path_str, recursive=True)
+    try:
+        fs.copy(source_path_str, target_path_str, recursive=True, on_error="raise")
+    except Exception as e:
+        message = "Failed to copy artifact to target storage during transfer."
+        cleanup_error = _rm_catch_error(fs, target_path_str)
+        if cleanup_error is not None:
+            message += f" Cleanup of copied target also failed: {cleanup_error}"
+        raise RuntimeError(message) from e
     # check that the sizes of the files are the same
     if _sorted_sizes(fs, source_path_str) != _sorted_sizes(fs, target_path_str):
-        if fs.exists(target_path_str):
-            try:
-                fs.rm(target_path_str, recursive=True)
-            except Exception as rm_exc:
-                cleanup_error = rm_exc
         message = "Transfer verification failed: copied artifact does not match source."
+        cleanup_error = _rm_catch_error(fs, target_path_str)
         if cleanup_error is not None:
             message += " Cleanup of copied target also failed."
         raise RuntimeError(message) from cleanup_error

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -139,6 +139,7 @@ if TYPE_CHECKING:
 
     import pandas as pd
     from anndata import AnnData
+    from fsspec import AbstractFileSystem
     from lamindb_setup.types import UPathStr
     from mudata import MuData  # noqa: TC004
     from polars import LazyFrame as PolarsLazyFrame
@@ -3203,6 +3204,11 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         return self
 
 
+def _sorted_sizes(fs: AbstractFileSystem, root: str) -> list[int]:
+    objects = fs.find(root, detail=True)
+    return sorted(info["size"] for info in objects.values())
+
+
 def _transfer_artifact_to_storage(
     artifact: Artifact, storage: Storage, access_token: str | None = None
 ):
@@ -3223,7 +3229,25 @@ def _transfer_artifact_to_storage(
     logger.important(
         f"transferring artifact from '{source_path_str}' to '{target_path_str}'"
     )
-    fs.mv(source_path_str, target_path_str, recursive=True)
+    fs.cp(source_path_str, target_path_str, recursive=True)
+    # check that the sizes of the files are the same
+    if _sorted_sizes(fs, source_path_str) != _sorted_sizes(fs, target_path_str):
+        if fs.exists(target_path_str):
+            try:
+                fs.rm(target_path_str, recursive=True)
+            except Exception as rm_exc:
+                cleanup_error = rm_exc
+        message = "Transfer verification failed: copied artifact does not match source."
+        if cleanup_error is not None:
+            message += " Cleanup of copied target also failed."
+        raise RuntimeError(message) from cleanup_error
+
+    try:
+        fs.rm(source_path_str, recursive=True)
+    except Exception as exc:
+        raise RuntimeError(
+            f"Transfer verification succeeded but failed to remove source '{source_path_str}'."
+        ) from exc
 
     artifact.storage_id = storage.id
 

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1863,7 +1863,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         return self.schemas
 
     @property
-    def path(self) -> Path:
+    def path(self) -> UPath:
         """Path.
 
         Example::

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3231,14 +3231,14 @@ def _transfer_artifact_to_storage(
     source_path_str = str(source_path)
     target_path_str = str(target_path)
     assert not fs.exists(target_path_str), (
-        f"Cannot transfer artifact to {target_path_str} because it already exists."
+        f"Cannot transfer artifact to '{target_path_str}' because it already exists."
     )
 
     logger.important(
         f"transferring artifact from '{source_path_str}' to '{target_path_str}'"
     )
     try:
-        fs.copy(source_path_str, target_path_str, recursive=True, on_error="raise")
+        fs.copy(source_path_str, target_path_str, recursive=True)
     except Exception as e:
         message = "Failed to copy artifact to target storage during transfer."
         cleanup_error = _rm_catch_error(fs, target_path_str)
@@ -3255,10 +3255,10 @@ def _transfer_artifact_to_storage(
 
     try:
         fs.rm(source_path_str, recursive=True)
-    except Exception as exc:
-        raise RuntimeError(
-            f"Transfer verification succeeded but failed to remove source '{source_path_str}'."
-        ) from exc
+    except Exception as e:
+        logger.error(
+            f"copying to '{target_path_str}' succeeded but failed to remove source '{source_path_str}': {e}"
+        )
 
     artifact.storage_id = storage.id
 

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -1012,6 +1012,26 @@ def test_transfer_artifact_exception_handling():
             artifact_module._transfer_artifact_to_storage(artifact_mismatch, storage)
         assert rm_mock.call_count == 1
 
+    # source-removal branch: transfer succeeds but rm(source) fails and is logged
+    artifact_rm_fail = SimpleNamespace(path=source_path, storage_id=None)
+    with (
+        patch.object(
+            artifact_module,
+            "_s",
+            return_value=SimpleNamespace(
+                auto_storage_key_from_artifact=lambda _: "target-artifact"
+            ),
+        ),
+        patch.object(
+            artifact_module, "transfer_fs", return_value=FakeFS(rm_error=RuntimeError())
+        ),
+        patch.object(artifact_module, "_sorted_sizes", side_effect=[[1], [1]]),
+        patch.object(artifact_module.logger, "error") as logger_error_mock,
+    ):
+        artifact_module._transfer_artifact_to_storage(artifact_rm_fail, storage)
+        assert artifact_rm_fail.storage_id == storage.id
+        assert logger_error_mock.call_count == 1
+
 
 @pytest.mark.parametrize("suffix", [".txt", "", None])
 def test_auto_storage_key_from_artifact_uid(suffix):

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -8,7 +8,8 @@ Also see `test_artifact_folders.py` for tests of folder-like artifacts.
 import shutil
 import sys
 from pathlib import Path, PurePosixPath
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
 
 import anndata as ad
 import h5py
@@ -915,6 +916,74 @@ def test_recreate_after_artifact_moved_in_storage(ccaplog):
 # -------------------------------------------------------------------------------------
 # Storage
 # -------------------------------------------------------------------------------------
+
+
+def test_transfer_artifact_exception_handling():
+    import lamindb.models.artifact as artifact_module
+
+    class FakeFS:
+        def __init__(self, copy_error: Exception | None = None):
+            self.copy_error = copy_error
+
+        def exists(self, path: str) -> bool:
+            return False
+
+        def copy(self, source: str, target: str, recursive: bool = True):
+            if self.copy_error is not None:
+                raise self.copy_error
+
+        def rm(self, path: str, recursive: bool = True):
+            return None
+
+    source_path = UPath("s3://lamindb-ci/source-artifact")
+    storage = SimpleNamespace(path=UPath("s3://lamindb-ci"), id=42)
+
+    # copy branch: copy fails and cleanup helper is included in the message
+    artifact_copy = SimpleNamespace(path=source_path, storage_id=None)
+    with (
+        patch.object(
+            artifact_module,
+            "_s",
+            return_value=SimpleNamespace(
+                auto_storage_key_from_artifact=lambda _: "target-artifact"
+            ),
+        ),
+        patch.object(
+            artifact_module,
+            "transfer_fs",
+            return_value=FakeFS(copy_error=ValueError("copy failed")),
+        ),
+        patch.object(
+            artifact_module,
+            "_rm_catch_error",
+            return_value=RuntimeError("rm failed"),
+        ) as rm_mock,
+    ):
+        with pytest.raises(RuntimeError, match="Failed to copy artifact"):
+            artifact_module._transfer_artifact_to_storage(artifact_copy, storage)
+        assert rm_mock.call_count == 1
+
+    # verification branch: sorted sizes mismatch triggers cleanup helper
+    artifact_mismatch = SimpleNamespace(path=source_path, storage_id=None)
+    with (
+        patch.object(
+            artifact_module,
+            "_s",
+            return_value=SimpleNamespace(
+                auto_storage_key_from_artifact=lambda _: "target-artifact"
+            ),
+        ),
+        patch.object(artifact_module, "transfer_fs", return_value=FakeFS()),
+        patch.object(artifact_module, "_sorted_sizes", side_effect=[[1], [2]]),
+        patch.object(
+            artifact_module,
+            "_rm_catch_error",
+            return_value=RuntimeError("rm failed"),
+        ) as rm_mock,
+    ):
+        with pytest.raises(RuntimeError, match="Transfer verification failed"):
+            artifact_module._transfer_artifact_to_storage(artifact_mismatch, storage)
+        assert rm_mock.call_count == 1
 
 
 @pytest.mark.parametrize("suffix", [".txt", "", None])

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -922,21 +922,48 @@ def test_transfer_artifact_exception_handling():
     import lamindb.models.artifact as artifact_module
 
     class FakeFS:
-        def __init__(self, copy_error: Exception | None = None):
+        def __init__(
+            self,
+            copy_error: Exception | None = None,
+            exists: bool = False,
+            rm_error: Exception | None = None,
+        ):
             self.copy_error = copy_error
+            self._exists = exists
+            self.rm_error = rm_error
+            self.rm_calls = 0
 
         def exists(self, path: str) -> bool:
-            return False
+            return self._exists
 
         def copy(self, source: str, target: str, recursive: bool = True):
             if self.copy_error is not None:
                 raise self.copy_error
 
         def rm(self, path: str, recursive: bool = True):
-            return None
+            self.rm_calls += 1
+            if self.rm_error is not None:
+                raise self.rm_error
 
     source_path = UPath("s3://lamindb-ci/source-artifact")
     storage = SimpleNamespace(path=UPath("s3://lamindb-ci"), id=42)
+
+    # _rm_catch_error helper branches
+    fs_missing = FakeFS(exists=False)
+    assert (
+        artifact_module._rm_catch_error(fs_missing, "s3://lamindb-ci/missing") is None
+    )
+    assert fs_missing.rm_calls == 0
+
+    fs_ok = FakeFS(exists=True)
+    assert artifact_module._rm_catch_error(fs_ok, "s3://lamindb-ci/target") is None
+    assert fs_ok.rm_calls == 1
+
+    rm_error = RuntimeError("rm failed")
+    fs_fail = FakeFS(exists=True, rm_error=rm_error)
+    returned_error = artifact_module._rm_catch_error(fs_fail, "s3://lamindb-ci/target")
+    assert returned_error is rm_error
+    assert fs_fail.rm_calls == 1
 
     # copy branch: copy fails and cleanup helper is included in the message
     artifact_copy = SimpleNamespace(path=source_path, storage_id=None)

--- a/tests/permissions/scripts/check_lamin_dev.py
+++ b/tests/permissions/scripts/check_lamin_dev.py
@@ -80,6 +80,7 @@ try:
 
     # move the artifact to another storage location
     space_test_move = ln.Space.get(name="test-move")
+    original_path = artifact.path
     artifact.space = space_test_move
     # cancel save
     with patch("builtins.input", return_value="x"):
@@ -89,6 +90,7 @@ try:
         artifact.save()
     assert artifact.space == space_test_move
     assert artifact.storage in ln.Storage.filter(space=space_test_move)
+    assert not original_path.exists()
     assert artifact.path.as_posix().startswith(artifact.storage.root)
     assert artifact.path.exists()
 
@@ -96,6 +98,7 @@ try:
     assert artifact_dir.space == space
     assert artifact_dir.path.is_dir()
     assert artifact_dir.storage in ln.Storage.filter(space=space)
+    original_path_dir = artifact_dir.path
 
     artifact_dir.space = space_test_move
     # save to the new storage location
@@ -103,6 +106,7 @@ try:
         artifact_dir.save()
     assert artifact_dir.space == space_test_move
     assert artifact_dir.storage in ln.Storage.filter(space=space_test_move)
+    assert not original_path_dir.exists()
     assert artifact_dir.path.as_posix().startswith(artifact_dir.storage.root)
     assert artifact_dir.path.is_dir()
 

--- a/tests/permissions/scripts/check_lamin_dev.py
+++ b/tests/permissions/scripts/check_lamin_dev.py
@@ -106,6 +106,7 @@ try:
         artifact_dir.save()
     assert artifact_dir.space == space_test_move
     assert artifact_dir.storage in ln.Storage.filter(space=space_test_move)
+    original_path_dir.fs.invalidate_cache()
     assert not original_path_dir.exists()
     assert artifact_dir.path.as_posix().startswith(artifact_dir.storage.root)
     assert artifact_dir.path.is_dir()


### PR DESCRIPTION
Adds validation that the artifact was copied properly to another storage location on transfer to another space by comparing file sizes.