### PR TITLE
🐛 Fix deletion of folder artifacts from trash

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -985,7 +985,7 @@ def add_labels(
             )
 
 
-def delete_permanently(artifact: Artifact, storage: bool, using_key: str):
+def delete_permanently(artifact: Artifact, storage: bool | None, using_key: str):
     # need to grab file path before deletion
     try:
         path, _ = _s().filepath_from_artifact(artifact, using_key)

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -999,7 +999,12 @@ def delete_permanently(artifact: Artifact, storage: bool, using_key: str):
         logger.important(
             "deleting all versions of this artifact because they all share the same store"
         )
-        for version in artifact.versions.all():  # includes artifact
+        # artifact.versions pulls only versions that are not in trash
+        # this query set below contains all versions including those that are in trash
+        versions = Artifact.objects.using(artifact._state.db).filter(
+            uid__startswith=artifact.stem_uid
+        )
+        for version in versions:
             _delete_skip_storage(version)
     else:
         artifact._delete_skip_storage()

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -349,6 +349,26 @@ def test_create_from_path_overwrite_versions_false(get_test_filepaths):
     artifact3.delete(permanent=True, storage=False)
 
 
+def test_delete_permanently_from_trash_folder(tmp_path):
+    folder_path = tmp_path / "folder-overwrite-versions"
+    folder_path.mkdir()
+    (folder_path / "v1.txt").write_text("v1")
+    key = f"{tmp_path.name}/folder-overwrite-versions"
+
+    artifact = ln.Artifact(folder_path, key=key).save()
+    assert artifact.overwrite_versions
+
+    # First soft-delete (move to trash), then delete permanently.
+    artifact.delete()
+    artifact.refresh_from_db()
+    assert artifact.branch_id == -1
+
+    with patch("builtins.input", return_value="y"):
+        artifact.delete()
+
+    assert ln.Artifact.objects.filter(uid__startswith=artifact.stem_uid).count() == 0
+
+
 def test_create_from_path_set_branch():
     branch = ln.Branch(name="contrib1").save()
     artifact1 = ln.Artifact(".gitignore", key="test", branch=branch).save()


### PR DESCRIPTION
Fix https://github.com/pfizer-collab/laminlabs/issues/896

Folder artifacts (having `overwrite_versions` `True`) are not deleted properly after repeated delete from trash. This PR fixes the bug.