### PR TITLE
✨ Move artifact to a new storage location on suffix change

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -2707,9 +2707,9 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         # no need to upload if new file is already in storage
         self._to_store = not check_path_in_storage
 
-        # update old suffix with the new one so that checks in record pass
+        # update old suffix with the new one so that the check in artifact save pass
         # replace() supports changing the suffix
-        self._old_suffix = self.suffix
+        self._original_values["suffix"] = self.suffix
 
     def open(
         self,
@@ -3089,6 +3089,13 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             logger.warning("you are saving to a non-latest version of the artifact")
 
         access_token = kwargs.pop("access_token", None)
+
+        if self._field_changed("suffix"):
+            old_suffix = self._original_values.get("suffix")
+            raise InvalidArgument(
+                f"Changing the `.suffix` of an artifact is not allowed! You tried to change it from '{old_suffix}' to '{self.suffix}'."
+            )
+
         # when space is passed in init, storage is ignored, so space - storage consistency is enforced there
         if (
             self._field_changed("space_id")

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3093,7 +3093,8 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         if self._field_changed("suffix"):
             old_suffix = self._original_values.get("suffix")
             raise InvalidArgument(
-                f"Changing the `.suffix` of an artifact is not allowed! You tried to change it from '{old_suffix}' to '{self.suffix}'."
+                "Changing the `.suffix` of an artifact is not allowed! "
+                f"You tried to change it from '{old_suffix}' to '{self.suffix}'."
             )
 
         # when space is passed in init, storage is ignored, so space - storage consistency is enforced there

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3109,6 +3109,9 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             # source_path and target_path are on the same filesystem
             _safe_move(source_path.fs, source_path.as_posix(), target_path.as_posix())
             _update_artifact_keys_with_suffix(self, suffix)
+            # Keep tracked values in sync so consecutive suffix updates on the same
+            # in-memory instance trigger a move each time.
+            self._original_values["suffix"] = suffix
 
         # when space is passed in init, storage is ignored, so space - storage consistency is enforced there
         if (
@@ -3150,6 +3153,9 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                 _transfer_artifact_to_storage(self, storage, access_token=access_token)
             else:
                 logger.important("artifact is already in the target storage location")
+            # Keep tracked values in sync after handling a space update so
+            # repeated saves don't keep re-running this branch.
+            self._original_values["space_id"] = self.space_id
 
         if transfer not in {"record", "annotations"}:
             raise ValueError(

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3099,17 +3099,13 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
 
         # when space is passed in init, storage is ignored, so space - storage consistency is enforced there
         if (
-            self._field_changed("space_id")
+            not self._state.adding
+            and self._field_changed("space_id")
             # here we check for storages managed by any instance
             # not necessarily with managed credentials
             # probbaly we should restrict to storages with managed credentials
             and (artifact_storage := self.storage).instance_uid is not None
         ):
-            if self._state.adding:
-                raise ValueError(
-                    "Changing `.space` of an artifact in a storage location managed by an instance "
-                    "is not allowed before saving."
-                )
             space = self.space
             storage_type = artifact_storage.type
             storages = Storage.connect(self._state.db).filter(

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3091,16 +3091,24 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         access_token = kwargs.pop("access_token", None)
 
         if self._field_changed("suffix"):
-            old_suffix = self._original_values.get("suffix")
-            raise InvalidArgument(
-                "Changing the `.suffix` of an artifact is not allowed! "
-                f"You tried to change it from '{old_suffix}' to '{self.suffix}'."
+            if self.storage.instance_uid is None:
+                raise InvalidArgument(
+                    "Cannot update the suffix of an artifact in a storage location that is not managed by an instance."
+                )
+            suffix = self.suffix
+            # depends on whether key is virtual or real key is present
+            source_or_target_path = self.path
+            source_path = source_or_target_path.with_suffix(
+                self._original_values["suffix"]
             )
+            target_path = source_or_target_path.with_suffix(suffix)
+            # source_path and target_path are on the same filesystem
+            _safe_move(source_path.fs, source_path.as_posix(), target_path.as_posix())
+            _update_artifact_keys_with_suffix(self, suffix)
 
         # when space is passed in init, storage is ignored, so space - storage consistency is enforced there
         if (
-            not self._state.adding
-            and self._field_changed("space_id")
+            self._field_changed("space_id")
             # here we check for storages managed by any instance
             # not necessarily with managed credentials
             # probbaly we should restrict to storages with managed credentials
@@ -3134,6 +3142,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                 storage = storages.one()
             if artifact_storage != storage:
                 # try to transfer if both storages are writable / managed by an instance
+                # replaces artifact.storage with the new storage if successful
                 _transfer_artifact_to_storage(self, storage, access_token=access_token)
             else:
                 logger.important("artifact is already in the target storage location")
@@ -3238,6 +3247,19 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         if hasattr(self, "_local_filepath"):
             del self._local_filepath
         return self
+
+
+def _update_artifact_keys_with_suffix(artifact: Artifact, suffix: str):
+    key = artifact.key
+    real_key = artifact._real_key
+
+    if key is not None:
+        new_key = PurePosixPath(key).with_suffix(suffix).as_posix()
+        artifact.key = new_key
+        artifact._old_key = new_key
+
+    if real_key is not None:
+        artifact._real_key = PurePosixPath(real_key).with_suffix(suffix).as_posix()
 
 
 def _sorted_sizes(fs: AbstractFileSystem, path: str) -> list[int]:

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3252,12 +3252,10 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
 def _update_artifact_keys_with_suffix(artifact: Artifact, suffix: str):
     key = artifact.key
     real_key = artifact._real_key
-
     if key is not None:
         new_key = PurePosixPath(key).with_suffix(suffix).as_posix()
         artifact.key = new_key
         artifact._old_key = new_key
-
     if real_key is not None:
         artifact._real_key = PurePosixPath(real_key).with_suffix(suffix).as_posix()
 

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3082,7 +3082,9 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         """
         if (
             not self._state.adding
-            and not self._field_changed("is_latest")  # skip on is_latest change
+            # skip on is_latest change
+            # no need to check if saved because it is checked above
+            and not self._field_changed("is_latest", check_is_saved=False)
             and not self.is_latest
             and self.branch_id != -1  # skip on soft deletion
         ):

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3253,6 +3253,36 @@ def _rm_catch_error(fs: AbstractFileSystem, path: str) -> Exception | None:
     return None
 
 
+def _safe_move(fs: AbstractFileSystem, source: str, target: str):
+    if fs.exists(target):
+        raise FileExistsError(
+            f"Cannot transfer artifact to '{target}' because it already exists."
+        )
+    logger.important(f"transferring artifact from '{source}' to '{target}'")
+    try:
+        fs.copy(source, target, recursive=True)
+    except Exception as e:
+        message = "Failed to copy artifact to target storage during transfer."
+        cleanup_error = _rm_catch_error(fs, target)
+        if cleanup_error is not None:
+            message += f" Cleanup of copied target also failed: {cleanup_error}"
+        raise RuntimeError(message) from e
+    # check that the sizes of the files are the same
+    if _sorted_sizes(fs, source) != _sorted_sizes(fs, target):
+        message = "Transfer verification failed: copied artifact does not match source."
+        cleanup_error = _rm_catch_error(fs, target)
+        if cleanup_error is not None:
+            message += " Cleanup of copied target also failed."
+        raise RuntimeError(message) from cleanup_error
+
+    try:
+        fs.rm(source, recursive=True)
+    except Exception as e:
+        logger.error(
+            f"copying to '{target}' succeeded but failed to remove source '{source}': {e}"
+        )
+
+
 def _transfer_artifact_to_storage(
     artifact: Artifact, storage: Storage, access_token: str | None = None
 ):
@@ -3260,41 +3290,15 @@ def _transfer_artifact_to_storage(
 
     source_path = artifact.path
     target_path = storage.path / storage_key
-    assert source_path != target_path, "Cannot transfer to the same path."
+    if source_path == target_path:
+        raise ValueError("Cannot transfer to the same path.")
 
     fs = transfer_fs(source_path, target_path, access_token=access_token)
 
     source_path_str = str(source_path)
     target_path_str = str(target_path)
-    assert not fs.exists(target_path_str), (
-        f"Cannot transfer artifact to '{target_path_str}' because it already exists."
-    )
 
-    logger.important(
-        f"transferring artifact from '{source_path_str}' to '{target_path_str}'"
-    )
-    try:
-        fs.copy(source_path_str, target_path_str, recursive=True)
-    except Exception as e:
-        message = "Failed to copy artifact to target storage during transfer."
-        cleanup_error = _rm_catch_error(fs, target_path_str)
-        if cleanup_error is not None:
-            message += f" Cleanup of copied target also failed: {cleanup_error}"
-        raise RuntimeError(message) from e
-    # check that the sizes of the files are the same
-    if _sorted_sizes(fs, source_path_str) != _sorted_sizes(fs, target_path_str):
-        message = "Transfer verification failed: copied artifact does not match source."
-        cleanup_error = _rm_catch_error(fs, target_path_str)
-        if cleanup_error is not None:
-            message += " Cleanup of copied target also failed."
-        raise RuntimeError(message) from cleanup_error
-
-    try:
-        fs.rm(source_path_str, recursive=True)
-    except Exception as e:
-        logger.error(
-            f"copying to '{target_path_str}' succeeded but failed to remove source '{source_path_str}': {e}"
-        )
+    _safe_move(fs, source_path_str, target_path_str)
 
     artifact.storage_id = storage.id
 

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1313,7 +1313,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             ),
         ]
 
-    _TRACK_FIELDS = ("space_id", "is_latest")
+    _TRACK_FIELDS = ("space_id", "is_latest", "suffix")
 
     _len_full_uid: int = 20
     _len_stem_uid: int = 16

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3105,6 +3105,11 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             # probbaly we should restrict to storages with managed credentials
             and (artifact_storage := self.storage).instance_uid is not None
         ):
+            if self._state.adding:
+                raise ValueError(
+                    "Changing `.space` of an artifact in a storage location managed by an instance "
+                    "is not allowed before saving."
+                )
             space = self.space
             storage_type = artifact_storage.type
             storages = Storage.connect(self._state.db).filter(

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3090,7 +3090,11 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
 
         access_token = kwargs.pop("access_token", None)
 
-        if self._field_changed("suffix"):
+        if self._field_changed("suffix", check_is_saved=False):
+            if self._state.adding:
+                raise InvalidArgument(
+                    "Cannot update the suffix of an artifact before it is saved."
+                )
             if self.storage.instance_uid is None:
                 raise InvalidArgument(
                     "Cannot update the suffix of an artifact in a storage location that is not managed by an instance."

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3104,12 +3104,21 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             suffix = self.suffix
             # depends on whether key is virtual or real key is present
             source_or_target_path = self.path
-            source_path = source_or_target_path.with_suffix(
+            source_path_str = source_or_target_path.with_suffix(
                 self._original_values["suffix"]
+            ).as_posix()
+            target_path_str = source_or_target_path.with_suffix(suffix).as_posix()
+            # ask for confirmation
+            # TODO: add a way to disable confirmation
+            response = input(
+                f"You are about to move artifact from '{source_path_str}' to '{target_path_str}'.\n"
+                "Continue? (y/n) "
             )
-            target_path = source_or_target_path.with_suffix(suffix)
+            if response != "y":
+                logger.warning("saving was cancelled")
+                return None
             # source_path and target_path are on the same filesystem
-            _safe_move(source_path.fs, source_path.as_posix(), target_path.as_posix())
+            _safe_move(source_or_target_path.fs, source_path_str, target_path_str)
             _update_artifact_keys_with_suffix(self, suffix)
             # Keep tracked values in sync so consecutive suffix updates on the same
             # in-memory instance trigger a move each time.
@@ -3152,7 +3161,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             if artifact_storage != storage:
                 # try to transfer if both storages are writable / managed by an instance
                 # replaces artifact.storage with the new storage if successful
-                _transfer_artifact_to_storage(self, storage, access_token=access_token)
+                _move_artifact_to_storage(self, storage, access_token=access_token)
             else:
                 logger.important("artifact is already in the target storage location")
             # Keep tracked values in sync after handling a space update so
@@ -3289,9 +3298,9 @@ def _rm_catch_error(fs: AbstractFileSystem, path: str) -> Exception | None:
 def _safe_move(fs: AbstractFileSystem, source: str, target: str):
     if fs.exists(target):
         raise FileExistsError(
-            f"Cannot transfer artifact to '{target}' because it already exists."
+            f"Cannot move artifact to '{target}' because it already exists."
         )
-    logger.important(f"transferring artifact from '{source}' to '{target}'")
+    logger.important(f"moving artifact from '{source}' to '{target}'")
     try:
         fs.copy(source, target, recursive=True)
     except Exception as e:
@@ -3302,7 +3311,7 @@ def _safe_move(fs: AbstractFileSystem, source: str, target: str):
         raise RuntimeError(message) from e
     # check that the sizes of the files are the same
     if _sorted_sizes(fs, source) != _sorted_sizes(fs, target):
-        message = "Transfer verification failed: copied artifact does not match source."
+        message = "Move verification failed: copied artifact does not match source."
         cleanup_error = _rm_catch_error(fs, target)
         if cleanup_error is not None:
             message += " Cleanup of copied target also failed."
@@ -3316,7 +3325,7 @@ def _safe_move(fs: AbstractFileSystem, source: str, target: str):
         )
 
 
-def _transfer_artifact_to_storage(
+def _move_artifact_to_storage(
     artifact: Artifact, storage: Storage, access_token: str | None = None
 ):
     storage_key = _s().auto_storage_key_from_artifact(artifact)
@@ -3324,7 +3333,7 @@ def _transfer_artifact_to_storage(
     source_path = artifact.path
     target_path = storage.path / storage_key
     if source_path == target_path:
-        raise ValueError("Cannot transfer to the same path.")
+        raise ValueError("Cannot move to the same path.")
 
     fs = transfer_fs(source_path, target_path, access_token=access_token)
 

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1093,8 +1093,6 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
     def _field_changed(self, field_name: str) -> bool:
         """Check if the field has changed since the record was saved."""
         # use _id fields for foreign keys in field_name
-        if self._state.adding:
-            return False
         # check if the field is tracked for changes
         track_fields = self._TRACK_FIELDS
         assert track_fields is not None, (

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1093,6 +1093,8 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
     def _field_changed(self, field_name: str) -> bool:
         """Check if the field has changed since the record was saved."""
         # use _id fields for foreign keys in field_name
+        if self._state.adding:
+            return False
         # check if the field is tracked for changes
         track_fields = self._TRACK_FIELDS
         assert track_fields is not None, (

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -16,7 +16,6 @@ from typing import (
     Literal,
     NamedTuple,
     TypeVar,
-    Union,
     overload,
 )
 
@@ -88,7 +87,6 @@ if TYPE_CHECKING:
     from .query_manager import RelatedManager
     from .query_set import SQLRecordList
     from .run import Run, User
-    from .transform import Transform
     from .ulabel import ULabel
 
 
@@ -2214,7 +2212,6 @@ def track_current_key_and_name_values(record: SQLRecord):
     # which can lead to a recursion
     if isinstance(record, Artifact):
         record._old_key = record.__dict__.get("key")  # type: ignore
-        record._old_suffix = record.__dict__.get("suffix")  # type: ignore
     elif hasattr(record, "_name_field"):
         record._old_name = record.__dict__.get(record._name_field)
 
@@ -2285,7 +2282,7 @@ def check_name_change(record: SQLRecord):
                 )
 
 
-def check_key_change(record: Union[Artifact, Transform]):
+def check_key_change(record: Artifact):
     """Errors if a record's key has falsely changed."""
     from .artifact import Artifact
 
@@ -2293,10 +2290,6 @@ def check_key_change(record: Union[Artifact, Transform]):
         return
     if hasattr(record, "_skip_key_change_check") and record._skip_key_change_check:
         return
-    if record._old_suffix != record.suffix:  # type: ignore
-        raise InvalidArgument(
-            f"Changing the `.suffix` of an artifact is not allowed! You tried to change it from '{record._old_suffix}' to '{record.suffix}'."  # type: ignore
-        )
 
     old_key = record._old_key  # type: ignore
     new_key = record.key

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1090,10 +1090,10 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
         else:
             self._original_values = None
 
-    def _field_changed(self, field_name: str) -> bool:
+    def _field_changed(self, field_name: str, check_is_saved: bool = True) -> bool:
         """Check if the field has changed since the record was saved."""
         # use _id fields for foreign keys in field_name
-        if self._state.adding:
+        if check_is_saved and self._state.adding:
             return False
         # check if the field is tracked for changes
         track_fields = self._TRACK_FIELDS

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -121,6 +121,28 @@ def get_test_filepaths(request):  # -> Tuple[bool, Path, Path, Path, str]
     shutil.rmtree(test_dirpath)
 
 
+@pytest.fixture(scope="function")
+def registered_storage_file_and_folder():
+    root_dir = Path("./registered_storage_suffix_fixture")
+    storage_root = root_dir.resolve().as_posix()
+    if ln.Storage.filter(root=storage_root).one_or_none() is None:
+        ln.Storage(root=storage_root, type="local").save()
+
+    test_dirpath = root_dir / "suffix_fixture_dir"
+    test_dirpath.mkdir(parents=True, exist_ok=True)
+    test_filepath = test_dirpath / "suffix_fixture_file.csv"
+    test_filepath.write_text("a,b\n1,2\n")
+
+    folder_path = root_dir / "suffix_fixture_folder"
+    folder_path.mkdir(parents=True, exist_ok=True)
+    (folder_path / "nested.txt").write_text("content")
+
+    yield test_filepath, folder_path
+
+    shutil.rmtree(test_dirpath, ignore_errors=True)
+    shutil.rmtree(folder_path, ignore_errors=True)
+
+
 @pytest.fixture(scope="session")
 def example_dataframe():
     return pd.DataFrame({"feat1": [1, 2], "feat2": [3, 4]})

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -1440,6 +1440,62 @@ def test_get_by_path(example_dataframe: pd.DataFrame):
     storage.delete()
 
 
+def test_update_suffix_for_registered_storage_with_real_key(
+    registered_storage_file_and_folder,
+):
+    test_filepath, folder_path = registered_storage_file_and_folder
+    assert folder_path.exists() and folder_path.is_dir()
+
+    artifact = ln.Artifact(test_filepath, key="my_file.csv").save()
+    assert artifact._real_key is not None
+    assert artifact.path.suffix == ".csv"
+
+    source_path = artifact.path
+    artifact.suffix = ".tsv"
+    artifact.save()
+
+    target_path = artifact.path
+    assert artifact.suffix == ".tsv"
+    assert artifact.key is not None
+    assert artifact.key.endswith(".tsv")
+    assert artifact._real_key is not None
+    assert artifact._real_key.endswith(".tsv")
+    assert target_path.suffix == ".tsv"
+    assert target_path.exists()
+    assert not source_path.exists()
+
+    artifact.delete(permanent=True, storage=True)
+
+
+def test_update_suffix_for_registered_storage_folder_artifact(
+    registered_storage_file_and_folder,
+):
+    _, folder_path = registered_storage_file_and_folder
+    artifact = ln.Artifact(folder_path, key="dataset").save()
+
+    assert artifact._real_key is not None
+    assert artifact.suffix == ""
+    assert artifact.path.exists()
+    assert artifact.path.is_dir()
+
+    source_path = artifact.path
+    artifact.suffix = ".zarr"
+    artifact.save()
+
+    target_path = artifact.path
+    assert artifact.suffix == ".zarr"
+    assert artifact.key is not None
+    assert artifact.key.endswith(".zarr")
+    assert artifact._real_key is not None
+    assert artifact._real_key.endswith(".zarr")
+    assert target_path.exists()
+    assert target_path.is_dir()
+    assert target_path.suffix == ".zarr"
+    assert not source_path.exists()
+
+    artifact.delete(permanent=True, storage=True)
+
+
 def test_save_url_with_virtual_key_and_unmanaged_suffix_update_error():
     url = (
         "https://raw.githubusercontent.com/laminlabs/lamindb/refs/heads/main/README.md"

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -1464,7 +1464,7 @@ def test_update_suffix_for_registered_storage_with_real_key(
     assert target_path.exists()
     assert not source_path.exists()
 
-    artifact.delete(permanent=True, storage=True)
+    artifact.delete(permanent=True)
 
 
 def test_update_suffix_for_registered_storage_folder_artifact(
@@ -1493,7 +1493,7 @@ def test_update_suffix_for_registered_storage_folder_artifact(
     assert target_path.suffix == ".zarr"
     assert not source_path.exists()
 
-    artifact.delete(permanent=True, storage=True)
+    artifact.delete(permanent=True)
 
 
 def test_save_url_with_virtual_key_and_unmanaged_suffix_update_error():

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -475,7 +475,7 @@ def test_create_from_dataframe(example_dataframe: pd.DataFrame):
         == "lamindb.errors.InvalidArgument: The suffix '' of the provided key is incorrect, it should be '.parquet'."
     )
 
-    # key and suffix can now be updated together
+    # virtual key and suffix can now be updated together
     artifact.key = "my-test-dataset"
     artifact.suffix = ""
     artifact.save()

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -441,16 +441,25 @@ def test_create_from_dataframe(example_dataframe: pd.DataFrame):
     parquet_path = artifact.path
     assert parquet_path.exists()
     assert parquet_path.suffix == ".parquet"
-
+    # test cancelling the move
     artifact.suffix = ".whatever"
-    artifact.save()
+    with patch("builtins.input", return_value="n"):
+        assert artifact.save() is None
+    assert parquet_path.exists()
+
+    artifact = ln.Artifact.get(description="test1")
+    assert artifact.suffix == ".parquet"
+    artifact.suffix = ".whatever"
+    with patch("builtins.input", return_value="y"):
+        artifact.save()
     assert artifact.suffix == ".whatever"
     whatever_path = artifact.path
     assert whatever_path.exists()
     assert whatever_path.suffix == ".whatever"
     assert not parquet_path.exists()
     artifact.suffix = ".parquet"
-    artifact.save()
+    with patch("builtins.input", return_value="y"):
+        artifact.save()
     assert artifact.suffix == ".parquet"
     parquet_path_restored = artifact.path
     assert parquet_path_restored.exists()
@@ -478,13 +487,15 @@ def test_create_from_dataframe(example_dataframe: pd.DataFrame):
     # virtual key and suffix can now be updated together
     artifact.key = "my-test-dataset"
     artifact.suffix = ""
-    artifact.save()
+    with patch("builtins.input", return_value="y"):
+        artifact.save()
     assert artifact.suffix == ""
     assert artifact.key == "my-test-dataset"
 
     # changing the suffix updates the key suffix as well
     artifact.suffix = ".parquet"
-    artifact.save()
+    with patch("builtins.input", return_value="y"):
+        artifact.save()
     assert artifact.key == "my-test-dataset.parquet"
 
     # coming from a .parquet key, test changing the key to no suffix
@@ -942,7 +953,7 @@ def test_recreate_after_artifact_moved_in_storage(ccaplog):
 # -------------------------------------------------------------------------------------
 
 
-def test_transfer_artifact_exception_handling():
+def test_move_artifact_exception_handling():
     import lamindb.models.artifact as artifact_module
 
     class FakeFS:
@@ -1011,7 +1022,7 @@ def test_transfer_artifact_exception_handling():
         ) as rm_mock,
     ):
         with pytest.raises(RuntimeError, match="Failed to copy artifact"):
-            artifact_module._transfer_artifact_to_storage(artifact_copy, storage)
+            artifact_module._move_artifact_to_storage(artifact_copy, storage)
         assert rm_mock.call_count == 1
 
     # target exists branch: raises before attempting copy
@@ -1027,7 +1038,7 @@ def test_transfer_artifact_exception_handling():
         patch.object(artifact_module, "transfer_fs", return_value=FakeFS(exists=True)),
     ):
         with pytest.raises(FileExistsError, match="already exists"):
-            artifact_module._transfer_artifact_to_storage(artifact_exists, storage)
+            artifact_module._move_artifact_to_storage(artifact_exists, storage)
 
     # same source and target path is rejected early
     artifact_same_path = SimpleNamespace(path=source_path, storage_id=None)
@@ -1038,8 +1049,8 @@ def test_transfer_artifact_exception_handling():
             auto_storage_key_from_artifact=lambda _: "source-artifact"
         ),
     ):
-        with pytest.raises(ValueError, match="Cannot transfer to the same path"):
-            artifact_module._transfer_artifact_to_storage(artifact_same_path, storage)
+        with pytest.raises(ValueError, match="Cannot move to the same path"):
+            artifact_module._move_artifact_to_storage(artifact_same_path, storage)
 
     # verification branch: sorted sizes mismatch triggers cleanup helper
     artifact_mismatch = SimpleNamespace(path=source_path, storage_id=None)
@@ -1059,11 +1070,11 @@ def test_transfer_artifact_exception_handling():
             return_value=RuntimeError("rm failed"),
         ) as rm_mock,
     ):
-        with pytest.raises(RuntimeError, match="Transfer verification failed"):
-            artifact_module._transfer_artifact_to_storage(artifact_mismatch, storage)
+        with pytest.raises(RuntimeError, match="Move verification failed"):
+            artifact_module._move_artifact_to_storage(artifact_mismatch, storage)
         assert rm_mock.call_count == 1
 
-    # source-removal branch: transfer succeeds but rm(source) fails and is logged
+    # source-removal branch: move succeeds but rm(source) fails and is logged
     artifact_rm_fail = SimpleNamespace(path=source_path, storage_id=None)
     with (
         patch.object(
@@ -1079,7 +1090,7 @@ def test_transfer_artifact_exception_handling():
         patch.object(artifact_module, "_sorted_sizes", side_effect=[[1], [1]]),
         patch.object(artifact_module.logger, "error") as logger_error_mock,
     ):
-        artifact_module._transfer_artifact_to_storage(artifact_rm_fail, storage)
+        artifact_module._move_artifact_to_storage(artifact_rm_fail, storage)
         assert artifact_rm_fail.storage_id == storage.id
         assert logger_error_mock.call_count == 1
 
@@ -1452,7 +1463,8 @@ def test_update_suffix_for_registered_storage_with_real_key(
 
     source_path = artifact.path
     artifact.suffix = ".tsv"
-    artifact.save()
+    with patch("builtins.input", return_value="y"):
+        artifact.save()
 
     target_path = artifact.path
     assert artifact.suffix == ".tsv"
@@ -1480,7 +1492,8 @@ def test_update_suffix_for_registered_storage_folder_artifact(
 
     source_path = artifact.path
     artifact.suffix = ".zarr"
-    artifact.save()
+    with patch("builtins.input", return_value="y"):
+        artifact.save()
 
     target_path = artifact.path
     assert artifact.suffix == ".zarr"

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -424,13 +424,12 @@ def test_create_from_dataframe(example_dataframe: pd.DataFrame):
         == "lamindb.errors.InvalidArgument: The suffix '' of the provided key is incorrect, it should be '.parquet'."
     )
     artifact.key = None  # restore
-    artifact.suffix = ".whatever"  # try changing suffix
-    with pytest.raises(ln.errors.InvalidArgument) as error:
+    artifact.suffix = ".whatever"  # changing suffix before first save is invalid
+    with pytest.raises(
+        ln.errors.InvalidArgument,
+        match="Cannot update the suffix of an artifact before it is saved.",
+    ):
         artifact.save()
-    assert (
-        error.exconly()
-        == "lamindb.errors.InvalidArgument: Changing the `.suffix` of an artifact is not allowed! You tried to change it from '.parquet' to '.whatever'."
-    )
     artifact.suffix = ".parquet"
     artifact.save()
     # check that the local filepath has been cleared
@@ -439,15 +438,24 @@ def test_create_from_dataframe(example_dataframe: pd.DataFrame):
 
     # now get an artifact from the database
     artifact = ln.Artifact.get(description="test1")
+    parquet_path = artifact.path
+    assert parquet_path.exists()
+    assert parquet_path.suffix == ".parquet"
 
-    artifact.suffix = ".whatever"  # try changing suffix
-    with pytest.raises(ln.errors.InvalidArgument) as error:
-        artifact.save()
-    assert (
-        error.exconly()
-        == "lamindb.errors.InvalidArgument: Changing the `.suffix` of an artifact is not allowed! You tried to change it from '.parquet' to '.whatever'."
-    )
+    artifact.suffix = ".whatever"
+    artifact.save()
+    assert artifact.suffix == ".whatever"
+    whatever_path = artifact.path
+    assert whatever_path.exists()
+    assert whatever_path.suffix == ".whatever"
+    assert not parquet_path.exists()
     artifact.suffix = ".parquet"
+    artifact.save()
+    assert artifact.suffix == ".parquet"
+    parquet_path_restored = artifact.path
+    assert parquet_path_restored.exists()
+    assert parquet_path_restored.suffix == ".parquet"
+    assert not whatever_path.exists()
 
     # coming from `key is None` that setting a key with different suffix is not allowed
     artifact.key = "my-test-dataset.suffix"
@@ -467,19 +475,15 @@ def test_create_from_dataframe(example_dataframe: pd.DataFrame):
         == "lamindb.errors.InvalidArgument: The suffix '' of the provided key is incorrect, it should be '.parquet'."
     )
 
-    # try a joint update where both suffix and key are changed
+    # key and suffix can now be updated together
     artifact.key = "my-test-dataset"
     artifact.suffix = ""
-    with pytest.raises(ln.errors.InvalidArgument) as error:
-        artifact.save()
-    assert (
-        error.exconly()
-        == "lamindb.errors.InvalidArgument: Changing the `.suffix` of an artifact is not allowed! You tried to change it from '.parquet' to ''."
-    )
+    artifact.save()
+    assert artifact.suffix == ""
+    assert artifact.key == "my-test-dataset"
 
-    # because this is a parquet artifact, we can set a key with a .parquet suffix
-    artifact.suffix = ".parquet"  # restore proper suffix
-    artifact.key = "my-test-dataset.parquet"
+    # changing the suffix updates the key suffix as well
+    artifact.suffix = ".parquet"
     artifact.save()
     assert artifact.key == "my-test-dataset.parquet"
 
@@ -1009,6 +1013,33 @@ def test_transfer_artifact_exception_handling():
         with pytest.raises(RuntimeError, match="Failed to copy artifact"):
             artifact_module._transfer_artifact_to_storage(artifact_copy, storage)
         assert rm_mock.call_count == 1
+
+    # target exists branch: raises before attempting copy
+    artifact_exists = SimpleNamespace(path=source_path, storage_id=None)
+    with (
+        patch.object(
+            artifact_module,
+            "_s",
+            return_value=SimpleNamespace(
+                auto_storage_key_from_artifact=lambda _: "target-artifact"
+            ),
+        ),
+        patch.object(artifact_module, "transfer_fs", return_value=FakeFS(exists=True)),
+    ):
+        with pytest.raises(FileExistsError, match="already exists"):
+            artifact_module._transfer_artifact_to_storage(artifact_exists, storage)
+
+    # same source and target path is rejected early
+    artifact_same_path = SimpleNamespace(path=source_path, storage_id=None)
+    with patch.object(
+        artifact_module,
+        "_s",
+        return_value=SimpleNamespace(
+            auto_storage_key_from_artifact=lambda _: "source-artifact"
+        ),
+    ):
+        with pytest.raises(ValueError, match="Cannot transfer to the same path"):
+            artifact_module._transfer_artifact_to_storage(artifact_same_path, storage)
 
     # verification branch: sorted sizes mismatch triggers cleanup helper
     artifact_mismatch = SimpleNamespace(path=source_path, storage_id=None)

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -1440,7 +1440,7 @@ def test_get_by_path(example_dataframe: pd.DataFrame):
     storage.delete()
 
 
-def test_save_url_with_virtual_key():
+def test_save_url_with_virtual_key_and_unmanaged_suffix_update_error():
     url = (
         "https://raw.githubusercontent.com/laminlabs/lamindb/refs/heads/main/README.md"
     )
@@ -1448,10 +1448,21 @@ def test_save_url_with_virtual_key():
     artifact = ln.Artifact(url, key=key).save()
 
     assert artifact._real_key == "laminlabs/lamindb/refs/heads/main/README.md"
+    assert artifact.storage.instance_uid is None
 
     cache_path_str = artifact._cache_path.as_posix()
     assert not cache_path_str.startswith("http")
     assert cache_path_str.endswith(key)
+
+    artifact.suffix = ".txt"
+    with pytest.raises(
+        InvalidArgument,
+        match=(
+            "Cannot update the suffix of an artifact in a storage location "
+            "that is not managed by an instance."
+        ),
+    ):
+        artifact.save()
 
     artifact.delete(permanent=True, storage=False)
 

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -1476,7 +1476,7 @@ def test_update_suffix_for_registered_storage_with_real_key(
     assert target_path.exists()
     assert not source_path.exists()
 
-    artifact.delete(permanent=True)
+    artifact.delete(permanent=True, storage=True)
 
 
 def test_update_suffix_for_registered_storage_folder_artifact(
@@ -1506,7 +1506,7 @@ def test_update_suffix_for_registered_storage_folder_artifact(
     assert target_path.suffix == ".zarr"
     assert not source_path.exists()
 
-    artifact.delete(permanent=True)
+    artifact.delete(permanent=True, storage=True)
 
 
 def test_save_url_with_virtual_key_and_unmanaged_suffix_update_error():


### PR DESCRIPTION
`Artifact` update now supports safe move-on-change behavior for suffix.
Suffix change on saved artifacts now moves data in storage and updates metadata (`.key`, `._real_key`).

Example:
```python
artifact = ln.Artifact("./my_dataset_dir", key="datasets/my_dataset").save()
artifact.suffix = ".zarr"
artifact.save()  # confirm move
artifact.suffix = ".anndata.zarr"
artifact.save()  # confirm move again
```
After each confirmed save, the folder is moved to the new suffixed path and keys are updated accordingly.
