### PR TITLE
⬆️ Upgrade `universal_pathlib` to `0.3.10`

### DIFF
--- a/lamindb/base/types.py
+++ b/lamindb/base/types.py
@@ -13,7 +13,7 @@ Central object types
 Basic types
 -----------
 
-.. autoclass:: UPathStr
+.. autoclass:: AnyPathStr
 .. autoclass:: StrField
 .. autoclass:: ListLike
 .. autoclass:: FieldAttr
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Literal, Union
 
 import numpy as np
 from django.db.models.query_utils import DeferredAttribute as FieldAttr
-from lamindb_setup.types import UPathStr  # noqa: F401
+from lamindb_setup.types import AnyPathStr  # noqa: F401
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -37,8 +37,6 @@ from ._track_environment import track_python_environment
 if TYPE_CHECKING:
     from types import FrameType, TracebackType
 
-    from lamindb_setup.types import UPathStr
-
     from lamindb.base.types import TransformKind
     from lamindb.models import Artifact, Branch, Project, Space
 
@@ -58,7 +56,7 @@ def get_key_from_module(caller_module: str) -> str:
 
 def detect_and_process_source_code_file(
     *,
-    path: UPathStr | None,
+    path: str | Path | None,
     transform_kind: TransformKind | None = None,
 ) -> tuple[Path, TransformKind, str, str, str | None]:
     """Track source code file and determine transform metadata.

--- a/lamindb/core/_mapped_collection.py
+++ b/lamindb/core/_mapped_collection.py
@@ -21,7 +21,7 @@ from .storage._anndata_accessor import (
 )
 
 if TYPE_CHECKING:
-    from lamindb_setup.types import UPathStr
+    from lamindb_setup.types import AnyPathStr
 
 
 class _Connect:
@@ -106,7 +106,7 @@ class MappedCollection:
 
     def __init__(
         self,
-        path_list: list[UPathStr],
+        path_list: list[AnyPathStr],
         layers_keys: str | list[str] | None = None,
         obs_keys: str | list[str] | None = None,
         obsm_keys: str | list[str] | None = None,
@@ -367,7 +367,7 @@ class MappedCollection:
         return [i for i, vrs in enumerate(self.var_list) if not vrs.equals(vars)]
 
     def _check_csc_raise_error(
-        self, elem: GroupType | ArrayType, key: str, path: UPathStr
+        self, elem: GroupType | ArrayType, key: str, path: AnyPathStr
     ):
         if isinstance(elem, ArrayTypes):  # type: ignore
             return

--- a/lamindb/core/_settings.py
+++ b/lamindb/core/_settings.py
@@ -19,6 +19,7 @@ from .subsettings._creation_settings import CreationSettings, creation_settings
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+    from pathlib import Path
 
     from lamindb_setup.types import AnyPathStr
     from upath import UPath
@@ -250,7 +251,7 @@ class Settings:
         return ln_setup.settings.instance.local_storage
 
     @local_storage.setter
-    def local_storage(self, local_root: AnyPathStr):
+    def local_storage(self, local_root: Path | str):
         import lamindb as ln
 
         # note duplication with storage setter!

--- a/lamindb/core/_settings.py
+++ b/lamindb/core/_settings.py
@@ -19,8 +19,8 @@ from .subsettings._creation_settings import CreationSettings, creation_settings
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
-    from pathlib import Path
 
+    from lamindb_setup.types import AnyPathStr
     from upath import UPath
 
 
@@ -195,7 +195,7 @@ class Settings:
         return self._storage_settings
 
     @storage.setter
-    def storage(self, path_kwargs: str | Path | UPath | tuple[str | UPath, Mapping]):
+    def storage(self, path_kwargs: AnyPathStr | tuple[AnyPathStr, Mapping]):
         from ..models import Storage
 
         if isinstance(path_kwargs, tuple):
@@ -250,7 +250,7 @@ class Settings:
         return ln_setup.settings.instance.local_storage
 
     @local_storage.setter
-    def local_storage(self, local_root: Path):
+    def local_storage(self, local_root: AnyPathStr):
         import lamindb as ln
 
         # note duplication with storage setter!

--- a/lamindb/core/loaders.py
+++ b/lamindb/core/loaders.py
@@ -49,7 +49,11 @@ def load_fcs(*args, **kwargs) -> AnnData:
     return readfcs.read(*args, **kwargs)
 
 
-def load_csv(path: str | Path, **kwargs) -> DataFrame:
+# for types below note that local UPaths are subclasses of Path
+# so Path(UPath(...)) properly coerces local UPaths and throws an error for cloud UPaths
+
+
+def load_csv(path: AnyPathStr, **kwargs) -> DataFrame:
     """Load `.csv` file to `DataFrame`."""
     import pandas as pd
 
@@ -57,7 +61,7 @@ def load_csv(path: str | Path, **kwargs) -> DataFrame:
     return pd.read_csv(path_sanitized, **kwargs)
 
 
-def load_parquet(path: str | Path, **kwargs) -> DataFrame:
+def load_parquet(path: AnyPathStr, **kwargs) -> DataFrame:
     """Load `.parquet` file to `DataFrame`."""
     import pandas as pd
 
@@ -65,7 +69,7 @@ def load_parquet(path: str | Path, **kwargs) -> DataFrame:
     return pd.read_parquet(path_sanitized, **kwargs)
 
 
-def load_tsv(path: str | Path, **kwargs) -> DataFrame:
+def load_tsv(path: AnyPathStr, **kwargs) -> DataFrame:
     """Load `.tsv` file to `DataFrame`."""
     import pandas as pd
 
@@ -73,18 +77,18 @@ def load_tsv(path: str | Path, **kwargs) -> DataFrame:
     return pd.read_csv(path_sanitized, sep="\t", **kwargs)
 
 
-def load_h5ad(filepath, **kwargs) -> AnnData:
+def load_h5ad(filepath: AnyPathStr, **kwargs) -> AnnData:
     """Load an `.h5ad` file to `AnnData`."""
     from anndata import read_h5ad
 
-    fs, filepath = infer_filesystem(filepath)
+    fs, filepath_str = infer_filesystem(filepath)
     compression = kwargs.pop("compression", "infer")
-    with fs.open(filepath, mode="rb", compression=compression) as file:
+    with fs.open(filepath_str, mode="rb", compression=compression) as file:
         adata = read_h5ad(file, backed=False, **kwargs)
         return adata
 
 
-def load_h5mu(filepath: str | Path, **kwargs) -> MuData:
+def load_h5mu(filepath: AnyPathStr, **kwargs) -> MuData:
     """Load an `.h5mu` file to `MuData`."""
     import mudata as md
 
@@ -100,7 +104,7 @@ def load_zarr(storepath, **kwargs):  # type: ignore
     return _load_zarr(storepath, **kwargs)
 
 
-def load_html(path: str | Path) -> None | str | Path:
+def load_html(path: AnyPathStr) -> None | AnyPathStr:
     """Display `.html` in ipython, otherwise return path."""
     if is_run_from_ipython:
         path_sanitized = Path(path)
@@ -122,7 +126,7 @@ def load_html(path: str | Path) -> None | str | Path:
         return path
 
 
-def load_json(path: str | Path) -> dict[str, Any] | list[Any]:
+def load_json(path: AnyPathStr) -> dict[str, Any] | list[Any]:
     """Load `.json` to `dict`."""
     import json
 
@@ -132,7 +136,7 @@ def load_json(path: str | Path) -> dict[str, Any] | list[Any]:
     return data
 
 
-def load_yaml(path: str | Path) -> dict[str, Any] | list[Any]:
+def load_yaml(path: AnyPathStr) -> dict[str, Any] | list[Any]:
     """Load `.yaml` to `dict`."""
     import yaml  # type: ignore
 
@@ -142,7 +146,7 @@ def load_yaml(path: str | Path) -> dict[str, Any] | list[Any]:
     return data
 
 
-def load_image(path: str | Path) -> None | str | Path:
+def load_image(path: AnyPathStr) -> None | AnyPathStr:
     """Display `.jpg`, `.gif` or `.png` in ipython, otherwise return path."""
     if is_run_from_ipython:
         from IPython.display import Image, display
@@ -154,7 +158,7 @@ def load_image(path: str | Path) -> None | str | Path:
         return path
 
 
-def load_svg(path: str | Path) -> None | str | Path:
+def load_svg(path: AnyPathStr) -> None | AnyPathStr:
     """Display `.svg` in ipython, otherwise return path."""
     if is_run_from_ipython:
         from IPython.display import SVG, display
@@ -166,13 +170,13 @@ def load_svg(path: str | Path) -> None | str | Path:
         return path
 
 
-def load_txt(path: str | Path) -> str:
+def load_txt(path: AnyPathStr) -> str:
     """Load `.txt` file to `str`."""
     path_sanitized = Path(path)
     return path_sanitized.read_text(encoding="utf-8")
 
 
-def load_rds(path: str | Path) -> str | Path:
+def load_rds(path: AnyPathStr) -> AnyPathStr:
     """Just warn when trying to load `.rds`."""
     logger.warning("Please use `laminr` to load `.rds` files")
     return path

--- a/lamindb/core/loaders.py
+++ b/lamindb/core/loaders.py
@@ -50,10 +50,10 @@ def load_fcs(*args, **kwargs) -> AnnData:
 
 
 # for types below note that local UPaths are subclasses of Path
-# so Path(UPath(...)) properly coerces local UPaths and throws an error for cloud UPaths
+# Path(UPath(...)) properly coerces local UPaths and throws an error for cloud UPaths
 
 
-def load_csv(path: AnyPathStr, **kwargs) -> DataFrame:
+def load_csv(path: Path | str, **kwargs) -> DataFrame:
     """Load `.csv` file to `DataFrame`."""
     import pandas as pd
 
@@ -61,7 +61,7 @@ def load_csv(path: AnyPathStr, **kwargs) -> DataFrame:
     return pd.read_csv(path_sanitized, **kwargs)
 
 
-def load_parquet(path: AnyPathStr, **kwargs) -> DataFrame:
+def load_parquet(path: Path | str, **kwargs) -> DataFrame:
     """Load `.parquet` file to `DataFrame`."""
     import pandas as pd
 
@@ -69,7 +69,7 @@ def load_parquet(path: AnyPathStr, **kwargs) -> DataFrame:
     return pd.read_parquet(path_sanitized, **kwargs)
 
 
-def load_tsv(path: AnyPathStr, **kwargs) -> DataFrame:
+def load_tsv(path: Path | str, **kwargs) -> DataFrame:
     """Load `.tsv` file to `DataFrame`."""
     import pandas as pd
 
@@ -88,7 +88,7 @@ def load_h5ad(filepath: AnyPathStr, **kwargs) -> AnnData:
         return adata
 
 
-def load_h5mu(filepath: AnyPathStr, **kwargs) -> MuData:
+def load_h5mu(filepath: Path | str, **kwargs) -> MuData:
     """Load an `.h5mu` file to `MuData`."""
     import mudata as md
 
@@ -104,7 +104,7 @@ def load_zarr(storepath, **kwargs):  # type: ignore
     return _load_zarr(storepath, **kwargs)
 
 
-def load_html(path: AnyPathStr) -> None | AnyPathStr:
+def load_html(path: Path | str) -> None | Path | str:
     """Display `.html` in ipython, otherwise return path."""
     if is_run_from_ipython:
         path_sanitized = Path(path)
@@ -126,7 +126,7 @@ def load_html(path: AnyPathStr) -> None | AnyPathStr:
         return path
 
 
-def load_json(path: AnyPathStr) -> dict[str, Any] | list[Any]:
+def load_json(path: Path | str) -> dict[str, Any] | list[Any]:
     """Load `.json` to `dict`."""
     import json
 
@@ -136,7 +136,7 @@ def load_json(path: AnyPathStr) -> dict[str, Any] | list[Any]:
     return data
 
 
-def load_yaml(path: AnyPathStr) -> dict[str, Any] | list[Any]:
+def load_yaml(path: Path | str) -> dict[str, Any] | list[Any]:
     """Load `.yaml` to `dict`."""
     import yaml  # type: ignore
 
@@ -146,7 +146,7 @@ def load_yaml(path: AnyPathStr) -> dict[str, Any] | list[Any]:
     return data
 
 
-def load_image(path: AnyPathStr) -> None | AnyPathStr:
+def load_image(path: Path | str) -> None | Path | str:
     """Display `.jpg`, `.gif` or `.png` in ipython, otherwise return path."""
     if is_run_from_ipython:
         from IPython.display import Image, display
@@ -158,7 +158,7 @@ def load_image(path: AnyPathStr) -> None | AnyPathStr:
         return path
 
 
-def load_svg(path: AnyPathStr) -> None | AnyPathStr:
+def load_svg(path: Path | str) -> None | Path | str:
     """Display `.svg` in ipython, otherwise return path."""
     if is_run_from_ipython:
         from IPython.display import SVG, display
@@ -170,13 +170,13 @@ def load_svg(path: AnyPathStr) -> None | AnyPathStr:
         return path
 
 
-def load_txt(path: AnyPathStr) -> str:
+def load_txt(path: Path | str) -> str:
     """Load `.txt` file to `str`."""
     path_sanitized = Path(path)
     return path_sanitized.read_text(encoding="utf-8")
 
 
-def load_rds(path: AnyPathStr) -> AnyPathStr:
+def load_rds(path: Path | str) -> Path | str:
     """Just warn when trying to load `.rds`."""
     logger.warning("Please use `laminr` to load `.rds` files")
     return path

--- a/lamindb/core/loaders.py
+++ b/lamindb/core/loaders.py
@@ -29,7 +29,7 @@ from lamindb_setup.core.upath import (
 
 if TYPE_CHECKING:
     from anndata import AnnData
-    from lamindb_setup.types import UPathStr
+    from lamindb_setup.types import AnyPathStr
     from mudata import MuData
     from pandas import DataFrame
 
@@ -49,7 +49,7 @@ def load_fcs(*args, **kwargs) -> AnnData:
     return readfcs.read(*args, **kwargs)
 
 
-def load_csv(path: UPathStr, **kwargs) -> DataFrame:
+def load_csv(path: str | Path, **kwargs) -> DataFrame:
     """Load `.csv` file to `DataFrame`."""
     import pandas as pd
 
@@ -57,7 +57,7 @@ def load_csv(path: UPathStr, **kwargs) -> DataFrame:
     return pd.read_csv(path_sanitized, **kwargs)
 
 
-def load_parquet(path: UPathStr, **kwargs) -> DataFrame:
+def load_parquet(path: str | Path, **kwargs) -> DataFrame:
     """Load `.parquet` file to `DataFrame`."""
     import pandas as pd
 
@@ -65,7 +65,7 @@ def load_parquet(path: UPathStr, **kwargs) -> DataFrame:
     return pd.read_parquet(path_sanitized, **kwargs)
 
 
-def load_tsv(path: UPathStr, **kwargs) -> DataFrame:
+def load_tsv(path: str | Path, **kwargs) -> DataFrame:
     """Load `.tsv` file to `DataFrame`."""
     import pandas as pd
 
@@ -84,7 +84,7 @@ def load_h5ad(filepath, **kwargs) -> AnnData:
         return adata
 
 
-def load_h5mu(filepath: UPathStr, **kwargs) -> MuData:
+def load_h5mu(filepath: str | Path, **kwargs) -> MuData:
     """Load an `.h5mu` file to `MuData`."""
     import mudata as md
 
@@ -100,10 +100,11 @@ def load_zarr(storepath, **kwargs):  # type: ignore
     return _load_zarr(storepath, **kwargs)
 
 
-def load_html(path: UPathStr) -> None | UPathStr:
+def load_html(path: str | Path) -> None | str | Path:
     """Display `.html` in ipython, otherwise return path."""
     if is_run_from_ipython:
-        with open(path, encoding="utf-8") as f:
+        path_sanitized = Path(path)
+        with path_sanitized.open(encoding="utf-8") as f:
             html_content = f.read()
         # Extract the body content using regular expressions
         body_content = re.findall(
@@ -121,52 +122,57 @@ def load_html(path: UPathStr) -> None | UPathStr:
         return path
 
 
-def load_json(path: UPathStr) -> dict[str, Any] | list[Any]:
+def load_json(path: str | Path) -> dict[str, Any] | list[Any]:
     """Load `.json` to `dict`."""
     import json
 
-    with open(path) as f:
+    path_sanitized = Path(path)
+    with path_sanitized.open(encoding="utf-8") as f:
         data = json.load(f)
     return data
 
 
-def load_yaml(path: UPathStr) -> dict[str, Any] | list[Any]:
+def load_yaml(path: str | Path) -> dict[str, Any] | list[Any]:
     """Load `.yaml` to `dict`."""
     import yaml  # type: ignore
 
-    with open(path) as f:
+    path_sanitized = Path(path)
+    with path_sanitized.open(encoding="utf-8") as f:
         data = yaml.safe_load(f)
     return data
 
 
-def load_image(path: UPathStr) -> None | UPathStr:
+def load_image(path: str | Path) -> None | str | Path:
     """Display `.jpg`, `.gif` or `.png` in ipython, otherwise return path."""
     if is_run_from_ipython:
         from IPython.display import Image, display
 
-        display(Image(filename=path))
+        path_sanitized = Path(path)
+        display(Image(filename=path_sanitized.as_posix()))
         return None
     else:
         return path
 
 
-def load_svg(path: UPathStr) -> None | UPathStr:
+def load_svg(path: str | Path) -> None | str | Path:
     """Display `.svg` in ipython, otherwise return path."""
     if is_run_from_ipython:
         from IPython.display import SVG, display
 
-        display(SVG(filename=path))
+        path_sanitized = Path(path)
+        display(SVG(filename=path_sanitized.as_posix()))
         return None
     else:
         return path
 
 
-def load_txt(path: Path) -> str:
+def load_txt(path: str | Path) -> str:
     """Load `.txt` file to `str`."""
-    return path.read_text(encoding="utf-8")
+    path_sanitized = Path(path)
+    return path_sanitized.read_text(encoding="utf-8")
 
 
-def load_rds(path: UPathStr) -> UPathStr:
+def load_rds(path: str | Path) -> str | Path:
     """Just warn when trying to load `.rds`."""
     logger.warning("Please use `laminr` to load `.rds` files")
     return path
@@ -205,8 +211,8 @@ SUPPORTED_SUFFIXES = [sfx for sfx in FILE_LOADERS.keys() if sfx != ".rds"]
 
 
 def load_to_memory(
-    filepath: UPathStr, **kwargs
-) -> DataFrame | ScverseDataStructures | dict[str, Any] | list[Any] | UPathStr | None:
+    filepath: AnyPathStr, **kwargs
+) -> DataFrame | ScverseDataStructures | dict[str, Any] | list[Any] | AnyPathStr | None:
     """Load a file into memory.
 
     Returns the filepath if no in-memory form is found.

--- a/lamindb/core/storage/_anndata_accessor.py
+++ b/lamindb/core/storage/_anndata_accessor.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from fsspec.core import OpenFile
-    from lamindb_setup.types import UPathStr
+    from lamindb_setup.types import AnyPathStr
 
     from lamindb import Artifact
 
@@ -159,7 +159,7 @@ registry = AccessRegistry()
 
 
 @registry.register_open("h5py")
-def open(filepath: UPathStr, mode: str = "r", compression: str | None = "infer"):
+def open(filepath: AnyPathStr, mode: str = "r", compression: str | None = "infer"):
     fs, file_path_str = infer_filesystem(filepath)
     # we don't open compressed files directly because we need fsspec to uncompress on .open
     compression = (
@@ -301,7 +301,7 @@ if ZARR_INSTALLED:
     StorageTypes.append(zarr.Group)
 
     @registry.register_open("zarr")
-    def open(filepath: UPathStr, mode: Literal["r", "r+", "a", "w", "w-"] = "r"):
+    def open(filepath: AnyPathStr, mode: Literal["r", "r+", "a", "w", "w-"] = "r"):
         assert mode in {"r", "r+", "a", "w", "w-"}, f"Unknown mode {mode}!"  #  noqa: S101
 
         store = get_zarr_store(filepath)
@@ -856,7 +856,7 @@ class AnnDataAccessor(_AnnDataAttrsMixin):
 
 
 # get the number of observations in an anndata object or file fast and safely
-def _anndata_n_observations(object: UPathStr | AnnData) -> int | None:
+def _anndata_n_observations(object: AnyPathStr | AnnData) -> int | None:
     if isinstance(object, AnnData):
         return object.n_obs
 

--- a/lamindb/core/storage/_backed_access.py
+++ b/lamindb/core/storage/_backed_access.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Literal
 
 PYARROW_SUFFIXES = (".parquet", ".csv", ".json", ".orc", ".arrow", ".feather", ".ipc")
@@ -164,11 +163,10 @@ def _flat_suffixes(paths: UPath | list[UPath]) -> set[str]:
     # we don't check here that the filesystem is the same
     # but this is a requirement for pyarrow.dataset.dataset
     path_list = []
-    if isinstance(paths, Path):
-        paths = [paths]
-    for path in paths:
+    paths_list = paths if isinstance(paths, list) else [paths]
+    for path in paths_list:
         # assume http is always a file
-        if getattr(path, "protocol", None) not in {"http", "https"} and path.is_dir():
+        if path.protocol not in {"http", "https"} and path.is_dir():
             path_list += [p for p in path.rglob("*") if p.suffix != ""]
         else:
             path_list.append(path)
@@ -214,13 +212,14 @@ def _open_dataframe(
         )
 
     polars_without_fsspec = engine == "polars" and not kwargs.get("use_fsspec", False)
-    if (engine == "pyarrow" or polars_without_fsspec) and not isinstance(paths, Path):
+    paths_list = paths if isinstance(paths, list) else [paths]
+    if (engine == "pyarrow" or polars_without_fsspec) and len(paths_list) > 1:
         # this checks that the filesystem is the same for all paths
         # this is a requirement of pyarrow.dataset.dataset
-        fs = getattr(paths[0], "fs", None)
-        for path in paths[1:]:
+        fs = paths_list[0].fs
+        for path in paths_list[1:]:
             # this assumes that the filesystems are cached by fsspec
-            if getattr(path, "fs", None) is not fs:
+            if path.fs is not fs:
                 engine_msg = (
                     "polars engine without passing `use_fsspec=True`"
                     if engine == "polars"

--- a/lamindb/core/storage/_polars_lazy_df.py
+++ b/lamindb/core/storage/_polars_lazy_df.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from lamindb_setup.core.upath import _ensure_sync_with_fs, get_storage_region
@@ -87,11 +86,10 @@ def _open_polars_lazy_df(
     }
 
     path_list = []
-    if isinstance(paths, Path):
-        paths = [paths]
-    for path in paths:
+    paths_list = paths if isinstance(paths, list) else [paths]
+    for path in paths_list:
         # assume http is always a file
-        if getattr(path, "protocol", None) not in {"http", "https"} and path.is_dir():
+        if path.protocol not in {"http", "https"} and path.is_dir():
             path_list += [p for p in path.rglob("*") if p.suffix != ""]
         else:
             path_list.append(path)

--- a/lamindb/core/storage/_tiledbsoma.py
+++ b/lamindb/core/storage/_tiledbsoma.py
@@ -17,7 +17,7 @@ from lamindb_setup.core.upath import (
 from packaging import version
 
 if TYPE_CHECKING:
-    from lamindb_setup.types import UPathStr
+    from lamindb_setup.types import AnyPathStr
     from tiledbsoma import Collection as SOMACollection
     from tiledbsoma import Experiment as SOMAExperiment
     from tiledbsoma import Measurement as SOMAMeasurement
@@ -165,7 +165,7 @@ def _open_tiledbsoma(
 
 def save_tiledbsoma_experiment(
     # Artifact args
-    adatas: list[AnnData | UPathStr],
+    adatas: list[AnnData | AnyPathStr],
     key: str | None = None,
     description: str | None = None,
     run: Run | None = None,

--- a/lamindb/core/storage/_zarr.py
+++ b/lamindb/core/storage/_zarr.py
@@ -24,13 +24,13 @@ else:
 
 if TYPE_CHECKING:
     from fsspec import FSMap
-    from lamindb_setup.types import UPathStr
+    from lamindb_setup.types import AnyPathStr
 
     from lamindb.core.storage.types import ScverseDataStructures
 
 
 def get_zarr_store(
-    path: UPathStr, *, check: bool = False, create: bool = False
+    path: AnyPathStr, *, check: bool = False, create: bool = False
 ) -> str | S3FSMap | FSMap | Store:
     """Creates the correct object that can be used to open a zarr file depending on local or remote location."""
     storepath, storepath_str = UPath(path), str(path)
@@ -64,7 +64,7 @@ def _identify_zarr_type_from_storage(
 
 
 def identify_zarr_type(
-    storepath: UPathStr, *, check: bool = True
+    storepath: AnyPathStr, *, check: bool = True
 ) -> Literal["anndata", "mudata", "spatialdata", "unknown"]:
     """Identify whether a zarr store is AnnData, SpatialData, or unknown type."""
     suffixes = UPath(storepath).suffixes
@@ -87,7 +87,7 @@ def identify_zarr_type(
 
 
 def load_zarr(
-    storepath: UPathStr,
+    storepath: AnyPathStr,
     expected_type: Literal["anndata", "mudata", "spatialdata"] = None,
 ) -> ScverseDataStructures:
     """Loads a zarr store and returns the corresponding scverse data structure.

--- a/lamindb/core/storage/objects.py
+++ b/lamindb/core/storage/objects.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pathlib import PurePosixPath
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeAlias
 
 from lamindb.core._compat import (
@@ -129,9 +129,8 @@ def write_to_disk(dmem: SupportedDataTypes, filepath: AnyPathStr, **kwargs) -> N
 
 
 def _write_anndata(dmem: Any, filepath: AnyPathStr, **kwargs) -> None:
-    suffix = (
-        PurePosixPath(filepath).suffix if isinstance(filepath, str) else filepath.suffix
-    )
+    # Path(UPath(...)) properly coerces local UPaths and throws an error for cloud UPaths
+    suffix = Path(filepath).suffix
     if suffix == ".h5ad":
         dmem.write_h5ad(filepath, **kwargs)
         return
@@ -143,9 +142,8 @@ def _write_anndata(dmem: Any, filepath: AnyPathStr, **kwargs) -> None:
 
 
 def _write_dataframe(dmem: Any, filepath: AnyPathStr, **kwargs) -> None:
-    suffix = (
-        PurePosixPath(filepath).suffix if isinstance(filepath, str) else filepath.suffix
-    )
+    # Path(UPath(...)) properly coerces local UPaths and throws an error for cloud UPaths
+    suffix = Path(filepath).suffix
     if suffix == ".csv":
         dmem.to_csv(filepath, **kwargs)
         return

--- a/lamindb/core/storage/objects.py
+++ b/lamindb/core/storage/objects.py
@@ -8,7 +8,6 @@ from lamindb.core._compat import (
 )
 
 if TYPE_CHECKING:
-    from lamindb_setup.types import AnyPathStr
     from pandas import DataFrame
 
     from .types import ScverseDataStructures
@@ -96,7 +95,11 @@ def _infer_spatialdata_suffix(format: str | dict[str, Any] | None) -> str:
     )
 
 
-def write_to_disk(dmem: SupportedDataTypes, filepath: AnyPathStr, **kwargs) -> None:
+# for types below note that local UPaths are subclasses of Path
+# Path(UPath(...)) properly coerces local UPaths and throws an error for cloud UPaths
+
+
+def write_to_disk(dmem: SupportedDataTypes, filepath: Path | str, **kwargs) -> None:
     """Writes the passed in memory data to disk to a specified path."""
     if with_package_obj(
         dmem,
@@ -128,8 +131,7 @@ def write_to_disk(dmem: SupportedDataTypes, filepath: AnyPathStr, **kwargs) -> N
     raise NotImplementedError
 
 
-def _write_anndata(dmem: Any, filepath: AnyPathStr, **kwargs) -> None:
-    # Path(UPath(...)) properly coerces local UPaths and throws an error for cloud UPaths
+def _write_anndata(dmem: Any, filepath: Path | str, **kwargs) -> None:
     suffix = Path(filepath).suffix
     if suffix == ".h5ad":
         dmem.write_h5ad(filepath, **kwargs)
@@ -141,8 +143,7 @@ def _write_anndata(dmem: Any, filepath: AnyPathStr, **kwargs) -> None:
         raise NotImplementedError
 
 
-def _write_dataframe(dmem: Any, filepath: AnyPathStr, **kwargs) -> None:
-    # Path(UPath(...)) properly coerces local UPaths and throws an error for cloud UPaths
+def _write_dataframe(dmem: Any, filepath: Path | str, **kwargs) -> None:
     suffix = Path(filepath).suffix
     if suffix == ".csv":
         dmem.to_csv(filepath, **kwargs)

--- a/lamindb/core/storage/objects.py
+++ b/lamindb/core/storage/objects.py
@@ -8,7 +8,7 @@ from lamindb.core._compat import (
 )
 
 if TYPE_CHECKING:
-    from lamindb_setup.types import UPathStr
+    from lamindb_setup.types import AnyPathStr
     from pandas import DataFrame
 
     from .types import ScverseDataStructures
@@ -96,7 +96,7 @@ def _infer_spatialdata_suffix(format: str | dict[str, Any] | None) -> str:
     )
 
 
-def write_to_disk(dmem: SupportedDataTypes, filepath: UPathStr, **kwargs) -> None:
+def write_to_disk(dmem: SupportedDataTypes, filepath: AnyPathStr, **kwargs) -> None:
     """Writes the passed in memory data to disk to a specified path."""
     if with_package_obj(
         dmem,
@@ -128,8 +128,10 @@ def write_to_disk(dmem: SupportedDataTypes, filepath: UPathStr, **kwargs) -> Non
     raise NotImplementedError
 
 
-def _write_anndata(dmem: Any, filepath: UPathStr, **kwargs) -> None:
-    suffix = PurePosixPath(filepath).suffix
+def _write_anndata(dmem: Any, filepath: AnyPathStr, **kwargs) -> None:
+    suffix = (
+        PurePosixPath(filepath).suffix if isinstance(filepath, str) else filepath.suffix
+    )
     if suffix == ".h5ad":
         dmem.write_h5ad(filepath, **kwargs)
         return
@@ -140,8 +142,11 @@ def _write_anndata(dmem: Any, filepath: UPathStr, **kwargs) -> None:
         raise NotImplementedError
 
 
-def _write_dataframe(dmem: Any, filepath: UPathStr, **kwargs) -> None:
-    if filepath.suffix == ".csv":
+def _write_dataframe(dmem: Any, filepath: AnyPathStr, **kwargs) -> None:
+    suffix = (
+        PurePosixPath(filepath).suffix if isinstance(filepath, str) else filepath.suffix
+    )
+    if suffix == ".csv":
         dmem.to_csv(filepath, **kwargs)
         return
     dmem.to_parquet(filepath, **kwargs)

--- a/lamindb/core/storage/paths.py
+++ b/lamindb/core/storage/paths.py
@@ -15,7 +15,7 @@ from lamindb.core._settings import settings
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from lamindb_setup.types import UPathStr
+    from lamindb_setup.types import AnyPathStr
 
     from lamindb.models.artifact import Artifact
 
@@ -47,7 +47,7 @@ def auto_storage_key_from_artifact_uid(
     return storage_key
 
 
-def check_path_is_child_of_root(path: UPathStr, root: UPathStr) -> bool:
+def check_path_is_child_of_root(path: AnyPathStr, root: AnyPathStr) -> bool:
     if fsspec.utils.get_protocol(str(path)) != fsspec.utils.get_protocol(str(root)):
         return False
     path_upath = UPath(path)
@@ -144,7 +144,7 @@ def filepath_cache_key_from_artifact(
 
 
 def store_file_or_folder(
-    local_path: UPathStr, storage_path: UPath, print_progress: bool = True, **kwargs
+    local_path: AnyPathStr, storage_path: UPath, print_progress: bool = True, **kwargs
 ) -> None:
     """Store file or folder (localpath) at storagepath."""
     local_path = UPath(local_path)

--- a/lamindb/core/storage/paths.py
+++ b/lamindb/core/storage/paths.py
@@ -13,9 +13,7 @@ from lamindb_setup.core.upath import (
 from lamindb.core._settings import settings
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
-    from lamindb_setup.types import AnyPathStr
+    from lamindb_setup.types import AnyPath, AnyPathStr
 
     from lamindb.models.artifact import Artifact
 
@@ -195,15 +193,13 @@ def delete_storage_using_key(
 
 
 def delete_storage(
-    storagepath: Path, raise_file_not_found_error: bool = True
+    storagepath: AnyPath, raise_file_not_found_error: bool = True
 ) -> None | str:
     """Delete arbitrary artifact."""
     if storagepath.is_file():
         storagepath.unlink()
     elif storagepath.is_dir():
-        if isinstance(storagepath, LocalPathClasses) or not isinstance(
-            storagepath, UPath
-        ):
+        if isinstance(storagepath, LocalPathClasses):
             shutil.rmtree(storagepath)
         else:
             storagepath.rmdir()

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -1821,7 +1821,7 @@ class DataFrameCatManager:
         self._non_validated = None
         self._index = index
         self._artifact: Artifact = None  # pass the dataset as an artifact
-        self._dataset: Any = df  # pass the dataset as a UPathStr or data object
+        self._dataset: Any = df  # pass the dataset as an AnyPathStr or data object
         if isinstance(self._dataset, Artifact):
             self._artifact = self._dataset
             self._dataset = self._dataset.load(is_run_input=False)

--- a/lamindb/integrations/_croissant.py
+++ b/lamindb/integrations/_croissant.py
@@ -9,11 +9,13 @@ from lamin_utils import logger
 from lamindb_setup.core.upath import UPath
 
 if TYPE_CHECKING:
+    from lamindb_setup.types import AnyPathStr
+
     import lamindb as ln
 
 
 def curate_from_croissant(
-    croissant_data: str | Path | dict[str, Any],
+    croissant_data: AnyPathStr | dict[str, Any],
     run: ln.Run | None = None,
 ) -> ln.Artifact | ln.Collection:
     """Create annotated artifacts from a CroissantML file.
@@ -34,10 +36,11 @@ def curate_from_croissant(
     from ..models.artifact import check_path_in_existing_storage
 
     # Load CroissantML data
-    if isinstance(croissant_data, (str, Path)):
-        if not Path(croissant_data).exists():
+    if isinstance(croissant_data, (str, Path, UPath)):
+        croissant_path = UPath(croissant_data)
+        if not croissant_path.exists():
             raise FileNotFoundError(f"File not found: {croissant_data}")
-        with open(croissant_data, encoding="utf-8") as f:
+        with croissant_path.open(encoding="utf-8") as f:
             data = json.load(f)
     elif isinstance(croissant_data, dict):
         data = croissant_data
@@ -86,7 +89,7 @@ def curate_from_croissant(
         raise ValueError("No file distributions found in croissant data")
     for dist in file_distributions:
         file_id = dist.get("@id", "")
-        if Path(file_id).exists():
+        if UPath(file_id).exists():
             file_path = file_id
         else:
             content_url = dist.get("contentUrl", "")

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -26,7 +26,6 @@ from lamindb_setup.core.upath import (
     get_stat_dir_cloud,
     get_stat_file_cloud,
 )
-from lamindb_setup.types import UPathStr
 
 from ..base.fields import (
     BigIntegerField,
@@ -140,7 +139,7 @@ if TYPE_CHECKING:
     import pandas as pd
     from anndata import AnnData
     from fsspec import AbstractFileSystem
-    from lamindb_setup.types import UPathStr
+    from lamindb_setup.types import AnyPathStr
     from mudata import MuData  # noqa: TC004
     from polars import LazyFrame as PolarsLazyFrame
     from pyarrow.dataset import Dataset as PyArrowDataset
@@ -257,7 +256,7 @@ def process_pathlike(
 
 def process_data(
     provisional_uid: str,
-    data: UPathStr | pd.DataFrame | AnnData,
+    data: AnyPathStr | pd.DataFrame | AnnData,
     format: str | None,
     key: str | None,
     storage: Storage,
@@ -273,7 +272,7 @@ def process_data(
     if with_package_obj(data, "AnnData", "anndata", lambda obj: True)[0]:
         is_anndata = True
         is_pathlike = False
-    elif isinstance(data, (str, Path, UPath)):  # UPathStr, spelled out
+    elif isinstance(data, (str, Path, UPath)):
         is_anndata = False
         is_pathlike = True
     else:
@@ -452,15 +451,13 @@ def check_path_in_existing_storage(
 
 def get_relative_path_to_directory(
     path: PurePath | Path | UPath, directory: PurePath | Path | UPath
-) -> PurePath | Path:
+) -> PurePath | Path | UPath:
     if isinstance(directory, UPath) and not isinstance(directory, LocalPathClasses):
-        # UPath.relative_to() is not behaving as it should (2023-04-07)
-        # need to lstrip otherwise inconsistent behavior across trailing slashes
-        # see test_artifact.py: test_get_relative_path_to_directory
+        # this is safer for cloud paths such as http paths
         relpath = PurePath(
             path.as_posix().replace(directory.as_posix(), "").lstrip("/")
         )
-    elif isinstance(directory, Path):
+    elif isinstance(directory, LocalPathClasses):
         relpath = path.resolve().relative_to(directory.resolve())  # type: ignore
     elif isinstance(directory, PurePath):
         relpath = path.relative_to(directory)
@@ -642,11 +639,11 @@ def data_is_dataframe(data: Any) -> bool:
 
 
 def data_is_scversedatastructure(
-    data: ScverseDataStructures | UPathStr,
+    data: ScverseDataStructures | AnyPathStr,
     structure_type: Literal["AnnData", "MuData", "SpatialData"] | None = None,
     cloud_warning: bool = True,
 ) -> bool:
-    """Determine whether a specific in-memory object or a UPathstr is any or a specific scverse data structure."""
+    """Determine whether a specific in-memory object or a path is any or a specific scverse data structure."""
     file_suffix = None
     if structure_type == "AnnData":
         file_suffix = ".h5ad"
@@ -699,17 +696,17 @@ def data_is_scversedatastructure(
     return False
 
 
-def data_is_soma_experiment(data: SOMAExperiment | UPathStr) -> bool:
+def data_is_soma_experiment(data: SOMAExperiment | AnyPathStr) -> bool:
     # We are not importing tiledbsoma here to keep loaded modules minimal
     if hasattr(data, "__class__") and data.__class__.__name__ == "Experiment":
         return True
-    if isinstance(data, (str, Path)):
+    if isinstance(data, (str, Path, UPath)):
         return UPath(data).suffix == ".tiledbsoma"
     return False
 
 
 def check_otype_artifact(
-    data: UPathStr | pd.DataFrame | ScverseDataStructures,
+    data: AnyPathStr | pd.DataFrame | ScverseDataStructures,
     otype: str | None = None,
     cloud_warning: bool = True,
 ) -> str:
@@ -741,7 +738,7 @@ def check_otype_artifact(
         if not is_pathlike:
             logger.warning("data is a SpatialData, please use .from_spatialdata()")
         otype = "SpatialData"
-    elif not is_pathlike:  # UPath is a subclass of Path
+    elif not is_pathlike:
         raise TypeError("data has to be a string, Path, UPath")
     return otype
 
@@ -1130,7 +1127,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
     Some artifacts are table- or array-like, e.g., when stored as `.parquet`, `.h5ad`, `.zarr`, or `.tiledb`.
 
     Args:
-        path: `UPathStr` A path to a local or remote folder or file from which to create the artifact.
+        path: `AnyPathStr` A path to a local or remote folder or file from which to create the artifact.
         key: `str | None = None` A key within the storage location, e.g., `"myfolder/myfile.fcs"`. Artifacts with the same key form a version family.
         description: `str | None = None` A description.
         kind: `Literal["dataset", "model"] | str | None = None` Distinguish models from datasets from other files & folders.
@@ -1564,7 +1561,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
     @overload
     def __init__(
         self,
-        path: UPathStr,
+        path: AnyPathStr,
         *,
         key: str | None = None,
         description: str | None = None,
@@ -1635,7 +1632,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             )
         # below is for internal calls that require defining the storage location
         # ahead of constructing the Artifact
-        if isinstance(path, (str, Path)) and _s().AUTO_KEY_PREFIX in str(path):
+        if isinstance(path, (str, Path, UPath)) and _s().AUTO_KEY_PREFIX in str(path):
             if _is_internal_call:
                 if _key_is_virtual is False:
                     raise ValueError(
@@ -1928,7 +1925,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         idlike: int | str | None = None,
         *,
         key: str | None = None,
-        path: UPathStr | None = None,
+        path: AnyPathStr | None = None,
         is_run_input: bool | Run = False,
         **expressions,
     ) -> Artifact:
@@ -2042,7 +2039,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
     @classmethod
     def from_dataframe(
         cls,
-        df: pd.DataFrame | UPathStr,
+        df: pd.DataFrame | AnyPathStr,
         *,
         key: str | None = None,
         description: str | None = None,
@@ -2059,7 +2056,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         Sets `.otype` to `"DataFrame"` and populates `.n_observations`.
 
         Args:
-            df: A `DataFrame` object or a `UPathStr` pointing to a `DataFrame` in storage, e.g. a `.parquet` or `.csv` file.
+            df: A `DataFrame` object or an `AnyPathStr` pointing to a `DataFrame` in storage, e.g. a `.parquet` or `.csv` file.
             key: A relative path within default storage, e.g., `"myfolder/myfile.parquet"`.
             description: A description.
             revises: An old version of the artifact.
@@ -2171,7 +2168,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
     @classmethod
     def from_anndata(
         cls,
-        adata: Union[AnnData, UPathStr],
+        adata: Union[AnnData, AnyPathStr],
         *,
         key: str | None = None,
         description: str | None = None,
@@ -2299,7 +2296,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
     @classmethod
     def from_mudata(
         cls,
-        mdata: Union[MuData, UPathStr],
+        mdata: Union[MuData, AnyPathStr],
         *,
         key: str | None = None,
         description: str | None = None,
@@ -2345,7 +2342,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             kind="dataset",
             **kwargs,
         )
-        if not isinstance(mdata, UPathStr):
+        if not isinstance(mdata, (str, Path, UPath)):
             artifact.n_observations = mdata.n_obs
         if schema is not None:
             from ..curators import MuDataCurator
@@ -2359,7 +2356,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
     @classmethod
     def from_spatialdata(
         cls,
-        sdata: SpatialData | UPathStr,
+        sdata: SpatialData | AnyPathStr,
         *,
         key: str | None = None,
         description: str | None = None,
@@ -2437,7 +2434,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
     @classmethod
     def from_tiledbsoma(
         cls,
-        exp: SOMAExperiment | UPathStr,
+        exp: SOMAExperiment | AnyPathStr,
         *,
         key: str | None = None,
         description: str | None = None,
@@ -2469,7 +2466,11 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
 
         # SOMAExperiment.uri may have file:// prefix for local paths which needs stripping for filesystem access.
         # Other URI schemes (s3://, etc.) are preserved and supported.
-        exp = exp.uri.removeprefix("file://") if not isinstance(exp, UPathStr) else exp
+        exp = (
+            exp.uri.removeprefix("file://")
+            if not isinstance(exp, (str, Path, UPath))
+            else exp
+        )
 
         artifact = Artifact(  # type: ignore
             path=exp,
@@ -2489,7 +2490,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
     @classmethod
     def from_dir(
         cls,
-        path: UPathStr,
+        path: AnyPathStr,
         *,
         key: str | None = None,
         run: Run | None = None,
@@ -2600,7 +2601,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
 
     def replace(
         self,
-        data: Union[UPathStr, pd.DataFrame, AnnData, MuData],
+        data: Union[AnyPathStr, pd.DataFrame, AnnData, MuData],
         run: Run | bool | None = None,
         format: str | None = None,
     ) -> None:
@@ -2909,7 +2910,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         | ScverseDataStructures
         | dict[str, Any]
         | list[Any]
-        | UPathStr
+        | AnyPathStr
         | None
     ):
         """Cache artifact in local cache and then load it into memory.

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -2982,7 +2982,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
 
     def cache(
         self, *, is_run_input: bool | None = None, mute: bool = False, **kwargs
-    ) -> Path:
+    ) -> UPath:
         """Download cloud artifact to local cache.
 
         Follows synching logic: only caches an artifact if it's outdated in the local cache.

--- a/lamindb/models/artifact_set.py
+++ b/lamindb/models/artifact_set.py
@@ -14,7 +14,7 @@ from .collection import Collection, _load_concat_artifacts
 
 if TYPE_CHECKING:
     from anndata import AnnData
-    from lamindb_setup.types import UPathStr
+    from lamindb_setup.types import AnyPathStr
     from pandas import DataFrame
     from polars import LazyFrame as PolarsLazyFrame
     from pyarrow.dataset import Dataset as PyArrowDataset
@@ -130,7 +130,7 @@ class ArtifactSet(Iterable):
         return ds
 
 
-def artifacts_from_path(artifacts: ArtifactSet, path: UPathStr) -> ArtifactSet:
+def artifacts_from_path(artifacts: ArtifactSet, path: AnyPathStr) -> ArtifactSet:
     """Returns artifacts in the query set that are registered for the provided path."""
     from lamindb.models import BasicQuerySet, QuerySet
 

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -1142,6 +1142,14 @@ def test_get_relative_path_to_directory():
         "test-data/test.csv"
         == get_relative_path_to_directory(upath, directory=root).as_posix()
     )
+    local_upath_root = UPath(root.as_posix())
+    local_upath_file = UPath(upath.as_posix())
+    assert (
+        "test-data/test.csv"
+        == get_relative_path_to_directory(
+            local_upath_file, directory=local_upath_root
+        ).as_posix()
+    )
     with pytest.raises(TypeError) as error:
         get_relative_path_to_directory(upath, directory=".")
     assert error.exconly() == "TypeError: Directory not of type Path or UPath"

--- a/tests/no_instance/test_import_side_effects.py
+++ b/tests/no_instance/test_import_side_effects.py
@@ -57,13 +57,13 @@ PROBE_CASES = [
     ),
     (
         "backed_access pyarrow dataframe path stays anndata-free",
-        "from pathlib import Path\nimport pyarrow as pa\nimport pyarrow.parquet as pq\nfrom lamindb.core.storage._backed_access import backed_access\npath = Path('test_import_side_effects.parquet')\npq.write_table(pa.table({'col': [1]}), path)\ntry:\n    _ = backed_access(path, engine='pyarrow')\nfinally:\n    path.unlink(missing_ok=True)",
+        "from upath import UPath\nimport pyarrow as pa\nimport pyarrow.parquet as pq\nfrom lamindb.core.storage._backed_access import backed_access\npath = UPath('test_import_side_effects.parquet')\npq.write_table(pa.table({'col': [1]}), path.as_posix())\ntry:\n    _ = backed_access(path, engine='pyarrow')\nfinally:\n    if path.exists():\n        path.unlink()",
         {"anndata": False, "h5py": False, "pyarrow": True},
         ("pyarrow",),
     ),
     (
         "backed_access polars dataframe path stays light",
-        "from pathlib import Path\nfrom lamindb.core.storage._backed_access import backed_access\npath = Path('test_import_side_effects.csv')\npath.write_text('col\\n1\\n')\ntry:\n    _ = backed_access(path, engine='polars')\nfinally:\n    path.unlink(missing_ok=True)",
+        "from upath import UPath\nfrom lamindb.core.storage._backed_access import backed_access\npath = UPath('test_import_side_effects.csv')\nwith path.open('w') as f:\n    _ = f.write('col\\n1\\n')\ntry:\n    _ = backed_access(path, engine='polars')\nfinally:\n    if path.exists():\n        path.unlink()",
         LIGHT_IMPORTS,
         ("polars",),
     ),

--- a/tests/storage/test_streaming.py
+++ b/tests/storage/test_streaming.py
@@ -214,10 +214,14 @@ def test_infer_suffix():
 def test_write_to_disk():
     with pytest.raises(NotImplementedError):
         write_to_disk(ln.Artifact, "path")
+
     df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
     write_to_disk(df, "write_to_disk.csv")
-    assert Path("write_to_disk.csv").exists()
-    Path("write_to_disk.csv").unlink()
+
+    file_on_disk = Path("write_to_disk.csv")
+    assert file_on_disk.exists()
+
+    file_on_disk.unlink()
 
 
 def test_backed_bad_format(bad_adata_path):

--- a/tests/storage/test_streaming.py
+++ b/tests/storage/test_streaming.py
@@ -214,6 +214,10 @@ def test_infer_suffix():
 def test_write_to_disk():
     with pytest.raises(NotImplementedError):
         write_to_disk(ln.Artifact, "path")
+    df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+    write_to_disk(df, "write_to_disk.csv")
+    assert Path("write_to_disk.csv").exists()
+    Path("write_to_disk.csv").unlink()
 
 
 def test_backed_bad_format(bad_adata_path):
@@ -399,6 +403,7 @@ def test_open_dataframe_collection():
     df[:2].to_parquet(shard1, engine="pyarrow")
     df[2:].to_parquet(shard2, engine="pyarrow")
     # test checking and opening local paths
+    assert _flat_suffixes(shard1) == {".parquet"}
     assert _flat_suffixes([shard1, ln.UPath("some.csv")]) == {".parquet", ".csv"}
     assert _open_pyarrow_dataset([shard1, shard2]).to_table().to_pandas().equals(df)
 

--- a/tests/storage/test_streaming.py
+++ b/tests/storage/test_streaming.py
@@ -65,7 +65,7 @@ def test_anndata_io():
 
 @pytest.mark.parametrize("adata_format", ["h5ad", "zarr"])
 def test_backed_access(adata_format):
-    fp = ln.examples.datasets.anndata_file_pbmc68k_test()
+    fp = ln.UPath(ln.examples.datasets.anndata_file_pbmc68k_test())
     if adata_format == "zarr":
         adata = load_h5ad(fp)
 

--- a/tests/tiledbsoma/test_artifact_basics.py
+++ b/tests/tiledbsoma/test_artifact_basics.py
@@ -20,6 +20,7 @@ def test_create_from_soma_experiment(soma_experiment_file, adata_file):
 
 def test_data_is_soma_experiment_paths():
     assert data_is_soma_experiment("something.tiledbsoma")
+    assert data_is_soma_experiment(ln.UPath("something.tiledbsoma"))
 
 
 def test_data_is_soma_experiment(soma_experiment_file):


### PR DESCRIPTION
Requires https://github.com/laminlabs/lamindb-setup/pull/1206

Cloud `UPath` is not a subclass of `Path` anymore, this is why so many changes here. Local `UPath` is still a subclass of `Path`.