### PR TITLE
✨ Move artifact to a new storage location on key change

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1313,7 +1313,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             ),
         ]
 
-    _TRACK_FIELDS = ("space_id", "is_latest", "suffix")
+    _TRACK_FIELDS = ("space_id", "is_latest", "suffix", "key")
 
     _len_full_uid: int = 20
     _len_stem_uid: int = 16
@@ -1773,12 +1773,12 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                 if not self.path.exists():
                     logger.warning(f"updating previous key {self.key} to new key {key}")
                     self.key = key
+                    # Keep tracked state aligned with this internal dedup-time key
+                    # normalization so save() doesn't treat it as a user key edit.
+                    self._original_values["key"] = key
                     assert self.path.exists(), (  # noqa: S101
                         f"The underlying file for artifact {self} does not exist anymore, clean up the artifact record."
                     )  # noqa: S101
-                    self._skip_key_change_check = (
-                        True  # otherwise not allowed to change real keys
-                    )
                 else:
                     logger.warning(
                         f"key {self.key} on existing artifact differs from passed key {key}, keeping original key; update manually if needed or pass skip_hash_lookup if you want to duplicate the artifact"
@@ -2683,8 +2683,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                     self._clear_storagekey = key
                     warn_msg = ""
                 self.key = new_key
-                # update old key with the new one so that checks in record pass
-                self._old_key = new_key
+                self._original_values["key"] = new_key
                 logger.warning(
                     f"replacing the file will replace key '{key}' with '{new_key}'{warn_msg}"
                     f" and delete '{self._clear_storagekey}' upon `save()`"
@@ -2694,8 +2693,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                 self._clear_storagekey = _s().auto_storage_key_from_artifact(self)
                 # might replace None with None, not a big deal
                 self.key = new_key
-                # update the old key with the new one so that checks in record pass
-                self._old_key = new_key
+                self._original_values["key"] = new_key
 
         self.suffix = new_suffix
         self.size = kwargs["size"]
@@ -3096,6 +3094,40 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
 
         access_token = kwargs.pop("access_token", None)
 
+        if self._field_changed("key", check_is_saved=False):
+            new_key = self.key
+            if new_key is None:
+                raise InvalidArgument("Cannot update an artifact key to None.")
+            new_key_suffix = extract_suffix_from_path(
+                PurePosixPath(new_key), arg_name="key"
+            )
+            if new_key_suffix != self.suffix:
+                raise InvalidArgument(
+                    f"The suffix '{new_key_suffix}' of the provided key is incorrect, it should be '{self.suffix}'."
+                )
+            # Virtual key updates are metadata-only because physical storage keys are
+            # uid-based.
+            if self._key_is_virtual:
+                self._original_values["key"] = new_key
+            else:
+                if self._state.adding:
+                    raise InvalidArgument(
+                        "Cannot update the key of an artifact before it is saved."
+                    )
+                if self.storage.instance_uid is None:
+                    raise InvalidArgument(
+                        "Cannot update the key of an artifact in a storage location that is not managed by an instance."
+                    )
+                old_key = self._original_values["key"]
+                if old_key is None:
+                    raise InvalidArgument(
+                        "Cannot update a non-virtual artifact key from None."
+                    )
+                if not _handle_non_virtual_key_change_on_save(
+                    self, old_key=old_key, new_key=new_key
+                ):
+                    return None
+
         if self._field_changed("suffix", check_is_saved=False):
             if self._state.adding:
                 raise InvalidArgument(
@@ -3105,28 +3137,8 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                 raise InvalidArgument(
                     "Cannot update the suffix of an artifact in a storage location that is not managed by an instance."
                 )
-            suffix = self.suffix
-            # depends on whether key is virtual or real key is present
-            source_or_target_path = self.path
-            source_path_str = source_or_target_path.with_suffix(
-                self._original_values["suffix"]
-            ).as_posix()
-            target_path_str = source_or_target_path.with_suffix(suffix).as_posix()
-            # ask for confirmation
-            # TODO: add a way to disable confirmation
-            response = input(
-                f"You are about to move artifact from '{source_path_str}' to '{target_path_str}'.\n"
-                "Continue? (y/n) "
-            )
-            if response != "y":
-                logger.warning("saving was cancelled")
+            if not _handle_suffix_change_on_save(self):
                 return None
-            # source_path and target_path are on the same filesystem
-            _safe_move(source_or_target_path.fs, source_path_str, target_path_str)
-            _update_artifact_keys_with_suffix(self, suffix)
-            # Keep tracked values in sync so consecutive suffix updates on the same
-            # in-memory instance trigger a move each time.
-            self._original_values["suffix"] = suffix
 
         # when space is passed in init, storage is ignored, so space - storage consistency is enforced there
         if (
@@ -3280,9 +3292,64 @@ def _update_artifact_keys_with_suffix(artifact: Artifact, suffix: str):
     if key is not None:
         new_key = PurePosixPath(key).with_suffix(suffix).as_posix()
         artifact.key = new_key
-        artifact._old_key = new_key
     if real_key is not None:
         artifact._real_key = PurePosixPath(real_key).with_suffix(suffix).as_posix()
+
+
+def _confirm_artifact_move(source_path_str: str, target_path_str: str) -> bool:
+    # ask for confirmation
+    # TODO: add a way to disable confirmation
+    response = input(
+        f"You are about to move artifact from '{source_path_str}' to '{target_path_str}'.\n"
+        "Continue? (y/n) "
+    )
+    if response != "y":
+        logger.warning("saving was cancelled")
+        return False
+    return True
+
+
+def _handle_non_virtual_key_change_on_save(
+    artifact: Artifact, *, old_key: str, new_key: str
+) -> bool:
+    # _real_key should actually be None here because it goes with virtual key
+    source_storage_key = (
+        artifact._real_key if artifact._real_key is not None else old_key
+    )
+    source_path = artifact.storage.path / source_storage_key
+    # key was updated, so artifact.path is the new path
+    target_path_str = artifact.path.as_posix()
+    source_path_str = source_path.as_posix()
+    if not _confirm_artifact_move(source_path_str, target_path_str):
+        return False
+    _safe_move(source_path.fs, source_path_str, target_path_str)
+    if artifact._real_key is not None:
+        artifact._real_key = new_key
+    # Keep tracked values in sync so repeated saves don't trigger another move.
+    artifact._original_values["key"] = new_key
+    # If key change already applied the suffix transition, skip suffix handling below.
+    artifact._original_values["suffix"] = artifact.suffix
+    return True
+
+
+def _handle_suffix_change_on_save(artifact: Artifact) -> bool:
+    suffix = artifact.suffix
+    # depends on whether key is virtual or real key is present
+    source_or_target_path = artifact.path
+    source_path_str = source_or_target_path.with_suffix(
+        artifact._original_values["suffix"]
+    ).as_posix()
+    target_path_str = source_or_target_path.with_suffix(suffix).as_posix()
+    if not _confirm_artifact_move(source_path_str, target_path_str):
+        return False
+    # source_path and target_path are on the same filesystem
+    _safe_move(source_or_target_path.fs, source_path_str, target_path_str)
+    _update_artifact_keys_with_suffix(artifact, suffix)
+    # Keep tracked values in sync so consecutive suffix updates on the same
+    # in-memory instance trigger a move each time.
+    artifact._original_values["suffix"] = suffix
+    artifact._original_values["key"] = artifact.key
+    return True
 
 
 def _sorted_sizes(fs: AbstractFileSystem, path: str) -> list[int]:

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -9,7 +9,7 @@ import shutil
 import sys
 from collections import defaultdict
 from itertools import chain
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -45,7 +45,6 @@ from lamindb_setup.core._docs import doc_args
 from lamindb_setup.core._hub_core import connect_instance_hub
 from lamindb_setup.core._settings_store import instance_settings_file
 from lamindb_setup.core.django import DBToken, db_token_manager
-from lamindb_setup.core.upath import extract_suffix_from_path
 from upath import UPath
 
 from lamindb.base.users import current_user_id
@@ -69,7 +68,6 @@ from ..base.types import (
 from ..base.uids import base62_12
 from ..errors import (
     FieldValidationError,
-    InvalidArgument,
     NoWriteAccess,
     ValidationError,
 )
@@ -81,7 +79,6 @@ if TYPE_CHECKING:
 
     import pandas as pd
 
-    from .artifact import Artifact
     from .block import BranchBlock, SpaceBlock
     from .project import Project
     from .query_manager import RelatedManager
@@ -1068,7 +1065,7 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
         # track original values of fields that are tracked for changes
         self._populate_tracked_fields()
         # TODO: refactor to use _TRACK_FIELDS
-        track_current_key_and_name_values(self)
+        track_current_name_value(self)
 
     # used in __init__
     # populates the _original_values dictionary with the original values of the tracked fields
@@ -1148,7 +1145,6 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
             init_self_from_db(self, pre_existing_record)
         else:
             # TODO: refactor to use _TRACK_FIELDS
-            check_key_change(self)
             check_name_change(self)
             try:
                 # save versioned record in presence of self._revises
@@ -1262,7 +1258,7 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                 else:
                     raise
             # call the below in case a user makes more updates to the record
-            track_current_key_and_name_values(self)
+            track_current_name_value(self)
         # perform transfer of many-to-many fields
         # only supported for Artifact and Collection records
         if db is not None and db != "default" and using_key is None:
@@ -2205,14 +2201,10 @@ def transfer_to_default_db(
     return None
 
 
-def track_current_key_and_name_values(record: SQLRecord):
-    from lamindb.models import Artifact
-
+def track_current_name_value(record: SQLRecord):
     # below, we're using __dict__ to avoid triggering the refresh from the database
     # which can lead to a recursion
-    if isinstance(record, Artifact):
-        record._old_key = record.__dict__.get("key")  # type: ignore
-    elif hasattr(record, "_name_field"):
+    if hasattr(record, "_name_field"):
         record._old_name = record.__dict__.get(record._name_field)
 
 
@@ -2234,7 +2226,7 @@ def check_name_change(record: SQLRecord):
     ):
         return
 
-    # checked in check_key_change or not checked at all
+    # key-like records are not checked here
     if isinstance(record, (Artifact, Collection, Transform)):
         return
 
@@ -2280,42 +2272,6 @@ def check_name_change(record: SQLRecord):
                     f"{n} artifact{s} no longer match{es} the feature name in storage: {artifact_uids}\n"
                     "  → consider re-curating"
                 )
-
-
-def check_key_change(record: Artifact):
-    """Errors if a record's key has falsely changed."""
-    from .artifact import Artifact
-
-    if not isinstance(record, Artifact) or not hasattr(record, "_old_key"):
-        return
-    if hasattr(record, "_skip_key_change_check") and record._skip_key_change_check:
-        return
-
-    old_key = record._old_key  # type: ignore
-    new_key = record.key
-
-    if old_key != new_key:
-        if not record._key_is_virtual:
-            raise InvalidArgument(
-                f"Changing a non-virtual key of an artifact is not allowed! You tried to change it from '{old_key}' to '{new_key}'."
-            )
-        if old_key is not None:
-            old_key_suffix = extract_suffix_from_path(
-                PurePosixPath(old_key), arg_name="key"
-            )
-            assert old_key_suffix == record.suffix, (  # noqa: S101
-                old_key_suffix,
-                record.suffix,
-            )
-        else:
-            old_key_suffix = record.suffix
-        new_key_suffix = extract_suffix_from_path(
-            PurePosixPath(new_key), arg_name="key"
-        )
-        if old_key_suffix != new_key_suffix:
-            raise InvalidArgument(
-                f"The suffix '{new_key_suffix}' of the provided key is incorrect, it should be '{old_key_suffix}'."
-            )
 
 
 def format_field_value(value: datetime | str | Any, none: str = "None") -> str:

--- a/lamindb/models/storage.py
+++ b/lamindb/models/storage.py
@@ -32,8 +32,6 @@ from .run import TracksRun, TracksUpdates
 from .sqlrecord import Space, SQLRecord
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from lamindb_setup.types import StorageType
     from upath import UPath
 
@@ -325,7 +323,7 @@ class Storage(SQLRecord, TracksRun, TracksUpdates):
         return self.region
 
     @property
-    def path(self) -> Path | UPath:
+    def path(self) -> UPath:
         """Path.
 
         Uses the `.root` field and converts it into a `Path` or `UPath`.

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -1567,6 +1567,52 @@ def test_update_non_virtual_key_for_registered_storage_file_invalid_suffix(
     artifact.delete(permanent=True, storage=False)
 
 
+def test_update_key_to_none_raises_invalid_argument(
+    registered_storage_file_and_folder,
+):
+    test_filepath, _ = registered_storage_file_and_folder
+    artifact = ln.Artifact(test_filepath).save()
+    artifact.key = None
+
+    with pytest.raises(InvalidArgument) as error:
+        artifact.save()
+    assert (
+        error.exconly()
+        == "lamindb.errors.InvalidArgument: Cannot update an artifact key to None."
+    )
+
+    artifact.delete(permanent=True, storage=False)
+
+
+def test_update_non_virtual_key_before_save_raises_invalid_argument(tsv_file):
+    artifact = ln.Artifact(tsv_file, key="before-save.tsv", _key_is_virtual=False)
+    artifact.key = "after-edit.tsv"
+
+    with pytest.raises(InvalidArgument) as error:
+        artifact.save()
+    assert (
+        error.exconly()
+        == "lamindb.errors.InvalidArgument: Cannot update the key of an artifact before it is saved."
+    )
+
+
+def test_update_non_virtual_key_in_unmanaged_storage_raises_invalid_argument():
+    url = (
+        "https://raw.githubusercontent.com/laminlabs/lamindb/refs/heads/main/README.md"
+    )
+    artifact = ln.Artifact(url, description="test unmanaged key update").save()
+    assert not artifact._key_is_virtual
+    artifact.key = "laminlabs/lamindb/refs/heads/main/README-renamed.md"
+    with pytest.raises(InvalidArgument) as error:
+        artifact.save()
+    assert (
+        error.exconly()
+        == "lamindb.errors.InvalidArgument: Cannot update the key of an artifact in a storage location that is not managed by an instance."
+    )
+
+    artifact.delete(permanent=True, storage=False)
+
+
 def test_save_url_with_virtual_key_and_unmanaged_suffix_update_error():
     url = (
         "https://raw.githubusercontent.com/laminlabs/lamindb/refs/heads/main/README.md"

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -177,13 +177,6 @@ def test_create_from_path_file(get_test_filepaths, key_is_virtual, key, descript
     else:
         assert artifact.key == key
         assert artifact._key_is_virtual == key_is_virtual
-        # changing non-virtual key is not allowed
-        if not key_is_virtual:
-            with pytest.raises(InvalidArgument):
-                artifact.key = "new_key"
-                artifact.save()
-            # need to change the key back to the original key
-            artifact.key = key
         if is_in_registered_storage:
             # this would only hit if the key matches the correct key
             assert artifact.storage.root == root_dir.resolve().as_posix()
@@ -1488,7 +1481,7 @@ def test_update_suffix_for_registered_storage_with_real_key(
     assert target_path.exists()
     assert not source_path.exists()
 
-    artifact.delete(permanent=True, storage=True)
+    artifact.delete(permanent=True, storage=False)
 
 
 def test_update_suffix_for_registered_storage_folder_artifact(
@@ -1518,7 +1511,60 @@ def test_update_suffix_for_registered_storage_folder_artifact(
     assert target_path.suffix == ".zarr"
     assert not source_path.exists()
 
-    artifact.delete(permanent=True, storage=True)
+    artifact.delete(permanent=True, storage=False)
+
+
+def test_update_non_virtual_key_for_registered_storage_file(
+    registered_storage_file_and_folder,
+):
+    test_filepath, _ = registered_storage_file_and_folder
+    artifact = ln.Artifact(test_filepath).save()
+    assert not artifact._key_is_virtual
+    assert artifact._real_key is None
+    assert artifact.key is not None
+
+    source_path = artifact.path
+    source_key = artifact.key
+    target_key = (
+        PurePosixPath(source_key)
+        .with_name("suffix_fixture_file_renamed.csv")
+        .as_posix()
+    )
+    artifact.key = target_key
+    with patch("builtins.input", return_value="n"):
+        assert artifact.save() is None
+    assert source_path.exists()
+
+    artifact = ln.Artifact.get(uid=artifact.uid)
+    assert artifact.key == source_key
+    artifact.key = target_key
+    with patch("builtins.input", return_value="y"):
+        artifact.save()
+
+    target_path = artifact.path
+    assert artifact.key == target_key
+    assert target_path.exists()
+    assert not source_path.exists()
+
+    artifact.delete(permanent=True, storage=False)
+
+
+def test_update_non_virtual_key_for_registered_storage_file_invalid_suffix(
+    registered_storage_file_and_folder,
+):
+    test_filepath, _ = registered_storage_file_and_folder
+    artifact = ln.Artifact(test_filepath).save()
+    assert artifact.key is not None
+
+    artifact.key = PurePosixPath(artifact.key).with_suffix(".tsv").as_posix()
+    with pytest.raises(InvalidArgument) as error:
+        artifact.save()
+    assert (
+        error.exconly()
+        == "lamindb.errors.InvalidArgument: The suffix '.tsv' of the provided key is incorrect, it should be '.csv'."
+    )
+
+    artifact.delete(permanent=True, storage=False)
 
 
 def test_save_url_with_virtual_key_and_unmanaged_suffix_update_error():


### PR DESCRIPTION
This PR enables updating `artifact.key` in a controlled way inside `artifact.save()` for non-virtual keys.

Example:
```python
import lamindb as ln
# Non-virtual artifact (real storage path key)
artifact = ln.Artifact("local_file.csv", key="data/local_file.csv", _key_is_virtual=False).save()
# Rename key (will move underlying object and ask for confirmation)
artifact.key = "data/local_file_renamed.csv"
artifact.save() # confirm moving the artifact to the new path
```
