### PR TITLE
🚸 Improve UX of auto-selected managed storage locations for a space

### DIFF
--- a/lamindb/core/_settings.py
+++ b/lamindb/core/_settings.py
@@ -42,7 +42,7 @@ def raise_if_storage_managed_by_other_instance(storage) -> None:
     storage_instance_uid = storage.instance_uid
     if storage_instance_uid != setup_settings.instance.uid:
         raise ValueError(
-            f"Storage {storage.root} exists in another instance ({storage_instance_uid}), cannot write to it from here."
+            f"Storage '{storage.root}' exists in another instance ({storage_instance_uid}), cannot write to it from here."
         )
 
 

--- a/lamindb/core/_settings.py
+++ b/lamindb/core/_settings.py
@@ -39,12 +39,10 @@ VERBOSITY_TO_STR: dict[int, str] = dict(
 
 
 def raise_if_storage_managed_by_other_instance(storage) -> None:
-    if (
-        storage.instance_uid is not None
-        and storage.instance_uid != ln_setup.settings.instance.uid
-    ):
+    storage_instance_uid = storage.instance_uid
+    if storage_instance_uid != setup_settings.instance.uid:
         raise ValueError(
-            f"Storage {storage.root} exists in another instance ({storage.instance_uid}), cannot write to it from here."
+            f"Storage {storage.root} exists in another instance ({storage_instance_uid}), cannot write to it from here."
         )
 
 

--- a/lamindb/core/_settings.py
+++ b/lamindb/core/_settings.py
@@ -38,6 +38,20 @@ VERBOSITY_TO_STR: dict[int, str] = dict(
 )
 
 
+def raise_if_storage_managed_by_other_instance(
+    *,
+    storage_root: str,
+    storage_instance_uid: str | None,
+) -> None:
+    if (
+        storage_instance_uid is not None
+        and storage_instance_uid != ln_setup.settings.instance.uid
+    ):
+        raise ValueError(
+            f"Storage {storage_root} exists in another instance ({storage_instance_uid}), cannot write to it from here."
+        )
+
+
 class Settings:
     """Settings.
 
@@ -216,10 +230,9 @@ class Settings:
                 return None
             set_managed_storage(path, **kwargs)
         else:
-            if exists.instance_uid != ln_setup.settings.instance.uid:
-                raise ValueError(
-                    f"Storage {root_as_str} exists in another instance ({exists.instance_uid}), cannot write to it from here."
-                )
+            raise_if_storage_managed_by_other_instance(
+                storage_root=root_as_str, storage_instance_uid=exists.instance_uid
+            )
             ssettings = StorageSettings(
                 root=exists.root,
                 region=exists.region,
@@ -265,10 +278,10 @@ class Settings:
             if response != "y":
                 return None
         else:
-            if exists.instance_uid != ln_setup.settings.instance.uid:
-                raise ValueError(
-                    f"Storage {ssettings.root_as_str} exists in another instance ({exists.instance_uid}), cannot write to it from here."
-                )
+            raise_if_storage_managed_by_other_instance(
+                storage_root=ssettings.root_as_str,
+                storage_instance_uid=exists.instance_uid,
+            )
         ln_setup.settings.instance.local_storage = local_root
 
     @property

--- a/lamindb/core/_settings.py
+++ b/lamindb/core/_settings.py
@@ -38,17 +38,13 @@ VERBOSITY_TO_STR: dict[int, str] = dict(
 )
 
 
-def raise_if_storage_managed_by_other_instance(
-    *,
-    storage_root: str,
-    storage_instance_uid: str | None,
-) -> None:
+def raise_if_storage_managed_by_other_instance(storage) -> None:
     if (
-        storage_instance_uid is not None
-        and storage_instance_uid != ln_setup.settings.instance.uid
+        storage.instance_uid is not None
+        and storage.instance_uid != ln_setup.settings.instance.uid
     ):
         raise ValueError(
-            f"Storage {storage_root} exists in another instance ({storage_instance_uid}), cannot write to it from here."
+            f"Storage {storage.root} exists in another instance ({storage.instance_uid}), cannot write to it from here."
         )
 
 
@@ -230,9 +226,7 @@ class Settings:
                 return None
             set_managed_storage(path, **kwargs)
         else:
-            raise_if_storage_managed_by_other_instance(
-                storage_root=root_as_str, storage_instance_uid=exists.instance_uid
-            )
+            raise_if_storage_managed_by_other_instance(exists)
             ssettings = StorageSettings(
                 root=exists.root,
                 region=exists.region,
@@ -278,10 +272,7 @@ class Settings:
             if response != "y":
                 return None
         else:
-            raise_if_storage_managed_by_other_instance(
-                storage_root=ssettings.root_as_str,
-                storage_instance_uid=exists.instance_uid,
-            )
+            raise_if_storage_managed_by_other_instance(exists)
         ln_setup.settings.instance.local_storage = local_root
 
     @property

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -595,9 +595,6 @@ def get_artifact_kwargs_from_data(
         "key": key,
         "size": size,
         "storage_id": storage.id,
-        # passing both the id and the object
-        # to make them both available immediately
-        # after object creation
         "n_files": n_files,
         "_overwrite_versions": overwrite_versions,  # True for folder, False for file
         "n_observations": None,  # to implement

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3102,11 +3102,6 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             logger.warning("you are saving to a non-latest version of the artifact")
 
         access_token = kwargs.pop("access_token", None)
-        if self.storage.instance_uid != ln_setup.settings.instance.uid:
-            root_as_str = self.storage.root
-            raise ValueError(
-                f"Storage {root_as_str} exists in another instance ({self.storage.instance_uid}), cannot write to it from here."
-            )
 
         if self._field_changed("key", check_is_saved=False):
             new_key = self.key
@@ -3132,6 +3127,11 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                     raise InvalidArgument(
                         "Cannot update the key of an artifact in a storage location that is not managed by an instance."
                     )
+                if self.storage.instance_uid != ln_setup.settings.instance.uid:
+                    root_as_str = self.storage.root
+                    raise ValueError(
+                        f"Storage {root_as_str} exists in another instance ({self.storage.instance_uid}), cannot write to it from here."
+                    )
                 old_key = self._original_values["key"]
                 if old_key is None:
                     raise InvalidArgument(
@@ -3150,6 +3150,11 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             if self.storage.instance_uid is None:
                 raise InvalidArgument(
                     "Cannot update the suffix of an artifact in a storage location that is not managed by an instance."
+                )
+            if self.storage.instance_uid != ln_setup.settings.instance.uid:
+                root_as_str = self.storage.root
+                raise ValueError(
+                    f"Storage {root_as_str} exists in another instance ({self.storage.instance_uid}), cannot write to it from here."
                 )
             if not _handle_suffix_change_on_save(self):
                 return None
@@ -3229,6 +3234,15 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             )
 
         flag_complete = has_local_filepath and getattr(self, "_to_store", False)
+        if (
+            flag_complete
+            and self.storage.instance_uid is not None
+            and self.storage.instance_uid != ln_setup.settings.instance.uid
+        ):
+            root_as_str = self.storage.root
+            raise ValueError(
+                f"Storage {root_as_str} exists in another instance ({self.storage.instance_uid}), cannot write to it from here."
+            )
         # _storage_ongoing indicates whether the storage saving / upload process is ongoing
         if flag_complete:
             self._storage_ongoing = True  # will be updated to False once complete

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1698,7 +1698,9 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                 logger.warning(
                     "storage argument ignored as storage information from space takes precedence"
                 )
-            storage_locs_for_space = Storage.filter(space=space)
+            storage_locs_for_space = Storage.filter(
+                space=space, instance_uid=setup_settings.instance.uid
+            ).order_by("id")
             n_storage_locs_for_space = len(storage_locs_for_space)
             if n_storage_locs_for_space == 0:
                 raise NoStorageLocationForSpace(
@@ -1709,8 +1711,15 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             else:
                 storage = storage_locs_for_space.first()
                 if n_storage_locs_for_space > 1:
+                    other_storage_locs = ",".join(
+                        f"{s.root}" for s in storage_locs_for_space[1:]
+                    )
                     logger.warning(
-                        f"more than one storage location for space {space}, choosing {storage}"
+                        f"more than one storage location is managed by this instance for space {space},\n"
+                        f"choosing root={storage.root}\n"
+                    )
+                    logger.important_hint(
+                        f"to choose one of the other storage locations ({other_storage_locs}), pass `storage` to the Artifact constructor"
                     )
         otype = kwargs.pop("otype") if "otype" in kwargs else None
         if isinstance(path, str) and path.startswith("s3:///"):
@@ -3093,6 +3102,11 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             logger.warning("you are saving to a non-latest version of the artifact")
 
         access_token = kwargs.pop("access_token", None)
+        if self.storage.instance_uid != ln_setup.settings.instance.uid:
+            root_as_str = self.storage.root
+            raise ValueError(
+                f"Storage {root_as_str} exists in another instance ({self.storage.instance_uid}), cannot write to it from here."
+            )
 
         if self._field_changed("key", check_is_saved=False):
             new_key = self.key

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -538,6 +538,9 @@ def get_artifact_kwargs_from_data(
             returned_privates = privates  # re-upload necessary
         else:
             returned_privates = {"key": key}
+        returned_privates["is_artifact_storage_managed_by_current_instance"] = (
+            existing_artifact.storage.instance_uid == setup_settings.instance.uid
+        )
         return existing_artifact, returned_privates
     else:
         size, hash, hash_type, n_files, revises = stat_or_artifact
@@ -578,6 +581,11 @@ def get_artifact_kwargs_from_data(
             if key_is_virtual is None
             else key_is_virtual
         )
+
+    # needed to check if the artifact storage is managed by the current instance on artifact init
+    privates["is_artifact_storage_managed_by_current_instance"] = (
+        storage.instance_uid == setup_settings.instance.uid
+    )
 
     kwargs = {
         "uid": provisional_uid,
@@ -1767,7 +1775,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
 
                 if (
                     self._to_store
-                    and self.storage.instance_uid != setup_settings.instance.uid
+                    and not privates["is_artifact_storage_managed_by_current_instance"]
                 ):
                     raise ValueError(
                         "Cannot create an artifact in a storage location that is not managed by the current instance."

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3127,10 +3127,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                     raise InvalidArgument(
                         "Cannot update the key of an artifact in a storage location that is not managed by an instance."
                     )
-                raise_if_storage_managed_by_other_instance(
-                    storage_root=self.storage.root,
-                    storage_instance_uid=self.storage.instance_uid,
-                )
+                raise_if_storage_managed_by_other_instance(self.storage)
                 old_key = self._original_values["key"]
                 if old_key is None:
                     raise InvalidArgument(
@@ -3150,10 +3147,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                 raise InvalidArgument(
                     "Cannot update the suffix of an artifact in a storage location that is not managed by an instance."
                 )
-            raise_if_storage_managed_by_other_instance(
-                storage_root=self.storage.root,
-                storage_instance_uid=self.storage.instance_uid,
-            )
+            raise_if_storage_managed_by_other_instance(self.storage)
             if not _handle_suffix_change_on_save(self):
                 return None
 
@@ -3233,10 +3227,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
 
         flag_complete = has_local_filepath and getattr(self, "_to_store", False)
         if flag_complete:
-            raise_if_storage_managed_by_other_instance(
-                storage_root=self.storage.root,
-                storage_instance_uid=self.storage.instance_uid,
-            )
+            raise_if_storage_managed_by_other_instance(self.storage)
         # _storage_ongoing indicates whether the storage saving / upload process is ongoing
         if flag_complete:
             self._storage_ongoing = True  # will be updated to False once complete

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -37,7 +37,7 @@ from ..base.fields import (
 from ..base.users import current_user_id
 from ..base.utils import deprecated, strict_classmethod
 from ..core._compat import with_package_obj
-from ..core._settings import raise_if_storage_managed_by_other_instance, settings
+from ..core._settings import settings
 from ..errors import (
     FieldValidationError,
     InvalidArgument,
@@ -1765,6 +1765,14 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                 self._memory_rep = privates["memory_rep"]
                 self._to_store = not privates["check_path_in_storage"]
 
+                if (
+                    self._to_store
+                    and self.storage.instance_uid != setup_settings.instance.uid
+                ):
+                    raise ValueError(
+                        "Cannot create an artifact in a storage location that is not managed by the current instance."
+                    )
+
         # an object with the same hash already exists
         if isinstance(kwargs_or_artifact, Artifact):
             from .sqlrecord import init_self_from_db, update_attributes
@@ -3103,6 +3111,14 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
 
         access_token = kwargs.pop("access_token", None)
 
+        current_instance_uid = setup_settings.instance.uid
+
+        artifact_storage = self.storage
+        artifact_storage_instance_uid = artifact_storage.instance_uid
+        is_not_artifact_storage_managed_by_current_instance = (
+            artifact_storage_instance_uid != current_instance_uid
+        )
+
         if self._field_changed("key", check_is_saved=False):
             new_key = self.key
             if new_key is None:
@@ -3123,11 +3139,11 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                     raise InvalidArgument(
                         "Cannot update the key of an artifact before it is saved."
                     )
-                if self.storage.instance_uid is None:
+                if is_not_artifact_storage_managed_by_current_instance:
                     raise InvalidArgument(
-                        "Cannot update the key of an artifact in a storage location that is not managed by an instance."
+                        "Cannot update a non-virtual key of an artifact"
+                        " in a storage location that is not managed by the current instance."
                     )
-                raise_if_storage_managed_by_other_instance(self.storage)
                 old_key = self._original_values["key"]
                 if old_key is None:
                     raise InvalidArgument(
@@ -3143,11 +3159,11 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                 raise InvalidArgument(
                     "Cannot update the suffix of an artifact before it is saved."
                 )
-            if self.storage.instance_uid is None:
+            if is_not_artifact_storage_managed_by_current_instance:
                 raise InvalidArgument(
-                    "Cannot update the suffix of an artifact in a storage location that is not managed by an instance."
+                    "Cannot update the suffix of an artifact"
+                    " in a storage location that is not managed by the current instance."
                 )
-            raise_if_storage_managed_by_other_instance(self.storage)
             if not _handle_suffix_change_on_save(self):
                 return None
 
@@ -3156,18 +3172,23 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             self._field_changed("space_id")
             # here we check for storages managed by any instance
             # not necessarily with managed credentials
-            # probbaly we should restrict to storages with managed credentials
-            and (artifact_storage := self.storage).instance_uid is not None
+            # we check if the artifact storage is managed by the current instance further
+            and artifact_storage_instance_uid is not None
         ):
+            if is_not_artifact_storage_managed_by_current_instance:
+                raise ValueError(
+                    "Cannot change the space of an artifact"
+                    " in a storage location that is not managed by the current instance."
+                )
             space = self.space
             storage_type = artifact_storage.type
             storages = Storage.connect(self._state.db).filter(
-                space=space, instance_uid__isnull=False, type=storage_type
+                space=space, instance_uid=current_instance_uid, type=storage_type
             )
             n_storages = storages.count()
             if n_storages == 0:
                 raise ValueError(
-                    f"No {storage_type} storage locations managed by an instance found for the space '{space.name}'."
+                    f"No {storage_type} storage locations managed by the current instance found for the space '{space.name}'."
                 )
             elif n_storages > 1:
                 storages = storages.order_by("id")
@@ -3227,9 +3248,11 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
 
         flag_complete = has_local_filepath and getattr(self, "_to_store", False)
         if flag_complete:
-            raise_if_storage_managed_by_other_instance(self.storage)
-        # _storage_ongoing indicates whether the storage saving / upload process is ongoing
-        if flag_complete:
+            if is_not_artifact_storage_managed_by_current_instance:
+                raise ValueError(
+                    "Cannot save an artifact to a storage location that is not managed by the current instance."
+                )
+            # _storage_ongoing indicates whether the storage saving / upload process is ongoing
             self._storage_ongoing = True  # will be updated to False once complete
 
         self._save_skip_storage(**kwargs)

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -37,7 +37,7 @@ from ..base.fields import (
 from ..base.users import current_user_id
 from ..base.utils import deprecated, strict_classmethod
 from ..core._compat import with_package_obj
-from ..core._settings import settings
+from ..core._settings import raise_if_storage_managed_by_other_instance, settings
 from ..errors import (
     FieldValidationError,
     InvalidArgument,
@@ -1701,7 +1701,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             storage_locs_for_space = Storage.filter(
                 space=space, instance_uid=setup_settings.instance.uid
             ).order_by("id")
-            n_storage_locs_for_space = len(storage_locs_for_space)
+            n_storage_locs_for_space = storage_locs_for_space.count()
             if n_storage_locs_for_space == 0:
                 raise NoStorageLocationForSpace(
                     "No storage location found for space.\n"
@@ -3127,11 +3127,10 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                     raise InvalidArgument(
                         "Cannot update the key of an artifact in a storage location that is not managed by an instance."
                     )
-                if self.storage.instance_uid != ln_setup.settings.instance.uid:
-                    root_as_str = self.storage.root
-                    raise ValueError(
-                        f"Storage {root_as_str} exists in another instance ({self.storage.instance_uid}), cannot write to it from here."
-                    )
+                raise_if_storage_managed_by_other_instance(
+                    storage_root=self.storage.root,
+                    storage_instance_uid=self.storage.instance_uid,
+                )
                 old_key = self._original_values["key"]
                 if old_key is None:
                     raise InvalidArgument(
@@ -3151,11 +3150,10 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                 raise InvalidArgument(
                     "Cannot update the suffix of an artifact in a storage location that is not managed by an instance."
                 )
-            if self.storage.instance_uid != ln_setup.settings.instance.uid:
-                root_as_str = self.storage.root
-                raise ValueError(
-                    f"Storage {root_as_str} exists in another instance ({self.storage.instance_uid}), cannot write to it from here."
-                )
+            raise_if_storage_managed_by_other_instance(
+                storage_root=self.storage.root,
+                storage_instance_uid=self.storage.instance_uid,
+            )
             if not _handle_suffix_change_on_save(self):
                 return None
 
@@ -3234,14 +3232,10 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             )
 
         flag_complete = has_local_filepath and getattr(self, "_to_store", False)
-        if (
-            flag_complete
-            and self.storage.instance_uid is not None
-            and self.storage.instance_uid != ln_setup.settings.instance.uid
-        ):
-            root_as_str = self.storage.root
-            raise ValueError(
-                f"Storage {root_as_str} exists in another instance ({self.storage.instance_uid}), cannot write to it from here."
+        if flag_complete:
+            raise_if_storage_managed_by_other_instance(
+                storage_root=self.storage.root,
+                storage_instance_uid=self.storage.instance_uid,
             )
         # _storage_ongoing indicates whether the storage saving / upload process is ongoing
         if flag_complete:

--- a/lamindb/models/storage.py
+++ b/lamindb/models/storage.py
@@ -44,12 +44,12 @@ class Storage(SQLRecord, TracksRun, TracksUpdates):
     A storage location is either a directory (local or a folder in the cloud) or
     an entire S3/GCP bucket.
 
-    A storage location is written to by at most one LaminDB instance: the location’s *writing instance*.
-    Some locations are not managed with LaminDB and, hence, do not have a writing instance.
+    A storage location is written to by at most one LaminDB instance: the location’s *managing instance*.
+    Some locations are not managed with LaminDB and, hence, do not have a managing instance.
 
     .. dropdown:: Writable vs. read-only storage locations
 
-        The `instance_uid` field of `Storage` defines its *writing instance*.
+        The `instance_uid` field of `Storage` defines its *managing instance*.
         Only if a storage location's `instance_uid` matches your current instance's `uid` (`ln.settings.instance_uid`),
         you can write to it.
         All other storage locations are read-only in your current instance.
@@ -59,7 +59,7 @@ class Storage(SQLRecord, TracksRun, TracksUpdates):
         .. image:: https://lamin-site-assets.s3.amazonaws.com/.lamindb/eHDmIOAxLEoqZ2oK0000.png
            :width: 400px
 
-        Some storage locations are not written to by any LaminDB instance, hence, their `instance_uid` is `None`.
+        Some storage locations are not managed by any LaminDB instance, hence, their `instance_uid` is `None`.
 
     .. dropdown:: Managing access to storage locations across instances
 

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -1607,7 +1607,7 @@ def test_update_non_virtual_key_in_unmanaged_storage_raises_invalid_argument():
         artifact.save()
     assert (
         error.exconly()
-        == "lamindb.errors.InvalidArgument: Cannot update the key of an artifact in a storage location that is not managed by an instance."
+        == "lamindb.errors.InvalidArgument: Cannot update a non-virtual key of an artifact in a storage location that is not managed by the current instance."
     )
 
     artifact.delete(permanent=True, storage=False)
@@ -1632,7 +1632,7 @@ def test_save_url_with_virtual_key_and_unmanaged_suffix_update_error():
         InvalidArgument,
         match=(
             "Cannot update the suffix of an artifact in a storage location "
-            "that is not managed by an instance."
+            "that is not managed by the current instance."
         ),
     ):
         artifact.save()
@@ -1648,7 +1648,7 @@ def test_artifact_space_change(tsv_file):
     with pytest.raises(ValueError) as err:
         artifact.save()
     assert (
-        "No local storage locations managed by an instance found for the space"
+        "No local storage locations managed by the current instance found for the space"
         in err.exconly()
     )
     # test after getting from the db
@@ -1657,7 +1657,7 @@ def test_artifact_space_change(tsv_file):
     with pytest.raises(ValueError) as err:
         artifact.save()
     assert (
-        "No local storage locations managed by an instance found for the space"
+        "No local storage locations managed by the current instance found for the space"
         in err.exconly()
     )
 

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -1612,17 +1612,15 @@ def test_update_non_virtual_key_in_unmanaged_storage_raises_invalid_argument():
     artifact.delete(permanent=True, storage=False)
 
 
-def test_create_artifact_in_foreign_managed_storage_raises_value_error(
-    tsv_file, monkeypatch
-):
-    foreign_instance_uid = "_not_exists_"
+def test_create_artifact_in_foreign_managed_storage_raises_value_error(tsv_file):
     storage = ln.settings.storage.record
-    monkeypatch.setattr(storage, "instance_uid", foreign_instance_uid)
-
-    with pytest.raises(
-        ValueError,
-        match=(
-            "Cannot create an artifact in a storage location that is not managed by the current instance."
+    with (
+        patch.object(storage, "instance_uid", "_not_exists_"),
+        pytest.raises(
+            ValueError,
+            match=(
+                "Cannot create an artifact in a storage location that is not managed by the current instance."
+            ),
         ),
     ):
         ln.Artifact(tsv_file, storage=storage)
@@ -1656,18 +1654,20 @@ def test_save_url_with_virtual_key_and_unmanaged_suffix_update_error():
 
 
 def test_change_space_for_artifact_in_foreign_managed_storage_raises_value_error(
-    tsv_file, monkeypatch
+    tsv_file,
 ):
     artifact = ln.Artifact(tsv_file, key="space-change-foreign-storage.tsv").save()
-    foreign_instance_uid = "_not_exists_"
-    monkeypatch.setattr(artifact.storage, "instance_uid", foreign_instance_uid)
-
-    space = ln.Space(name="test space foreign storage", uid="foreignspace").save()
+    space = ln.Space(
+        name="test space change in foreign storage", uid="foreignspace"
+    ).save()
     artifact.space = space
-    with pytest.raises(
-        ValueError,
-        match=(
-            "Cannot change the space of an artifact in a storage location that is not managed by the current instance."
+    with (
+        patch.object(artifact.storage, "instance_uid", "_not_exists_"),
+        pytest.raises(
+            ValueError,
+            match=(
+                "Cannot change the space of an artifact in a storage location that is not managed by the current instance."
+            ),
         ),
     ):
         artifact.save()
@@ -1676,17 +1676,15 @@ def test_change_space_for_artifact_in_foreign_managed_storage_raises_value_error
     space.delete(permanent=True)
 
 
-def test_save_artifact_to_foreign_managed_storage_raises_value_error(
-    tsv_file, monkeypatch
-):
+def test_save_artifact_to_foreign_managed_storage_raises_value_error(tsv_file):
     artifact = ln.Artifact(tsv_file, key="save-foreign-storage.tsv")
-    foreign_instance_uid = "_not_exists_"
-    monkeypatch.setattr(artifact.storage, "instance_uid", foreign_instance_uid)
-
-    with pytest.raises(
-        ValueError,
-        match=(
-            "Cannot save an artifact to a storage location that is not managed by the current instance."
+    with (
+        patch.object(artifact.storage, "instance_uid", "_not_exists_"),
+        pytest.raises(
+            ValueError,
+            match=(
+                "Cannot save an artifact to a storage location that is not managed by the current instance."
+            ),
         ),
     ):
         artifact.save()

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -25,7 +25,6 @@ from _dataset_fixtures import (  # noqa
     get_small_mdata,
     get_small_sdata,
 )
-from lamindb.core._settings import settings
 from lamindb.core.loaders import load_fcs, load_to_memory, load_tsv
 from lamindb.core.storage.paths import (
     AUTO_KEY_PREFIX,
@@ -1214,7 +1213,7 @@ def test_serialize_paths():
     up_str = "s3://lamindb-ci/test-unknown-storage-in-core-tests/test.csv"
     up_upath = UPath(up_str)
 
-    storage = settings._storage_settings.record
+    storage = ln.settings.storage.record
     using_key = None
 
     _, filepath, _, _, _ = process_data(
@@ -1613,6 +1612,22 @@ def test_update_non_virtual_key_in_unmanaged_storage_raises_invalid_argument():
     artifact.delete(permanent=True, storage=False)
 
 
+def test_create_artifact_in_foreign_managed_storage_raises_value_error(
+    tsv_file, monkeypatch
+):
+    foreign_instance_uid = "_not_exists_"
+    storage = ln.settings.storage.record
+    monkeypatch.setattr(storage, "instance_uid", foreign_instance_uid)
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Cannot create an artifact in a storage location that is not managed by the current instance."
+        ),
+    ):
+        ln.Artifact(tsv_file, storage=storage)
+
+
 def test_save_url_with_virtual_key_and_unmanaged_suffix_update_error():
     url = (
         "https://raw.githubusercontent.com/laminlabs/lamindb/refs/heads/main/README.md"
@@ -1638,6 +1653,43 @@ def test_save_url_with_virtual_key_and_unmanaged_suffix_update_error():
         artifact.save()
 
     artifact.delete(permanent=True, storage=False)
+
+
+def test_change_space_for_artifact_in_foreign_managed_storage_raises_value_error(
+    tsv_file, monkeypatch
+):
+    artifact = ln.Artifact(tsv_file, key="space-change-foreign-storage.tsv").save()
+    foreign_instance_uid = "_not_exists_"
+    monkeypatch.setattr(artifact.storage, "instance_uid", foreign_instance_uid)
+
+    space = ln.Space(name="test space foreign storage", uid="foreignspace").save()
+    artifact.space = space
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Cannot change the space of an artifact in a storage location that is not managed by the current instance."
+        ),
+    ):
+        artifact.save()
+
+    artifact.delete(permanent=True)
+    space.delete(permanent=True)
+
+
+def test_save_artifact_to_foreign_managed_storage_raises_value_error(
+    tsv_file, monkeypatch
+):
+    artifact = ln.Artifact(tsv_file, key="save-foreign-storage.tsv")
+    foreign_instance_uid = "_not_exists_"
+    monkeypatch.setattr(artifact.storage, "instance_uid", foreign_instance_uid)
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Cannot save an artifact to a storage location that is not managed by the current instance."
+        ),
+    ):
+        artifact.save()
 
 
 def test_artifact_space_change(tsv_file):

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -1,4 +1,5 @@
 import lamindb as ln
+import pytest
 
 
 def test_settings_repr():
@@ -12,3 +13,33 @@ def test_settings_repr():
     assert content.find("instance:") < content.find("storage:")
     assert content.find("storage:") < content.find("verbosity:")
     assert content.find("verbosity:") < content.find("track_run_inputs:")
+
+
+def test_storage_setter_raises_on_foreign_managed_storage(tmp_path):
+    storage = ln.Storage(root=(tmp_path / "foreign-managed-storage").as_posix()).save()
+    storage.instance_uid = "_not_exists_"
+    storage.save()
+
+    with pytest.raises(ValueError) as error:
+        ln.settings.storage = storage.root
+    assert (
+        error.exconly()
+        == f"ValueError: Storage '{storage.root}' exists in another instance (_not_exists_), cannot write to it from here."
+    )
+    storage.delete()
+
+
+def test_local_storage_setter_raises_on_foreign_managed_storage(tmp_path):
+    storage = ln.Storage(
+        root=(tmp_path / "foreign-managed-local-storage").as_posix()
+    ).save()
+    storage.instance_uid = "_not_exists_"
+    storage.save()
+
+    with pytest.raises(ValueError) as error:
+        ln.settings.local_storage = storage.root
+    assert (
+        error.exconly()
+        == f"ValueError: Storage '{storage.root}' exists in another instance (_not_exists_), cannot write to it from here."
+    )
+    storage.delete()

--- a/tests/core/test_storage.py
+++ b/tests/core/test_storage.py
@@ -1,6 +1,7 @@
 import concurrent.futures
 
 import lamindb as ln
+import pytest
 
 
 # we need this test both in the core and the storage/cloud tests
@@ -13,6 +14,36 @@ def test_reference_storage_location(ccaplog):
         "referenced read-only storage location at s3://lamindata, is managed by instance with uid 4XIuR0tvaiXM"
         in ccaplog.text
     )
+
+
+def test_storage_setter_raises_on_foreign_managed_storage(tmp_path):
+    storage = ln.Storage(root=(tmp_path / "foreign-managed-storage").as_posix()).save()
+    storage.instance_uid = "_not_exists_"
+    storage.save()
+
+    with pytest.raises(ValueError) as error:
+        ln.settings.storage = storage.root
+    assert (
+        error.exconly()
+        == f"ValueError: Storage '{storage.root}' exists in another instance (_not_exists_), cannot write to it from here."
+    )
+    storage.delete()
+
+
+def test_local_storage_setter_raises_on_foreign_managed_storage(tmp_path):
+    storage = ln.Storage(
+        root=(tmp_path / "foreign-managed-local-storage").as_posix()
+    ).save()
+    storage.instance_uid = "_not_exists_"
+    storage.save()
+
+    with pytest.raises(ValueError) as error:
+        ln.settings.local_storage = storage.root
+    assert (
+        error.exconly()
+        == f"ValueError: Storage '{storage.root}' exists in another instance (_not_exists_), cannot write to it from here."
+    )
+    storage.delete()
 
 
 def test_create_storage_locations_parallel():

--- a/tests/core/test_storage.py
+++ b/tests/core/test_storage.py
@@ -1,7 +1,6 @@
 import concurrent.futures
 
 import lamindb as ln
-import pytest
 
 
 # we need this test both in the core and the storage/cloud tests
@@ -14,36 +13,6 @@ def test_reference_storage_location(ccaplog):
         "referenced read-only storage location at s3://lamindata, is managed by instance with uid 4XIuR0tvaiXM"
         in ccaplog.text
     )
-
-
-def test_storage_setter_raises_on_foreign_managed_storage(tmp_path):
-    storage = ln.Storage(root=(tmp_path / "foreign-managed-storage").as_posix()).save()
-    storage.instance_uid = "_not_exists_"
-    storage.save()
-
-    with pytest.raises(ValueError) as error:
-        ln.settings.storage = storage.root
-    assert (
-        error.exconly()
-        == f"ValueError: Storage '{storage.root}' exists in another instance (_not_exists_), cannot write to it from here."
-    )
-    storage.delete()
-
-
-def test_local_storage_setter_raises_on_foreign_managed_storage(tmp_path):
-    storage = ln.Storage(
-        root=(tmp_path / "foreign-managed-local-storage").as_posix()
-    ).save()
-    storage.instance_uid = "_not_exists_"
-    storage.save()
-
-    with pytest.raises(ValueError) as error:
-        ln.settings.local_storage = storage.root
-    assert (
-        error.exconly()
-        == f"ValueError: Storage '{storage.root}' exists in another instance (_not_exists_), cannot write to it from here."
-    )
-    storage.delete()
 
 
 def test_create_storage_locations_parallel():


### PR DESCRIPTION
Strengthens instance-ownership safeguards for storage operations by requiring `artifacts` and settings storage targets to be managed by the current instance