### PR TITLE
🥅 Raise an error on write streaming for artifacts with `overwrite_version=False`

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -2835,13 +2835,19 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         ) and mode == "w"
         is_zarr_w = suffix == ".zarr" and mode == "r+"
 
-        if mode != "r" and not (is_tiledbsoma_w or is_zarr_w):
-            raise ValueError(
-                f"It is not allowed to open a {suffix} object with mode='{mode}'. "
-                "You can open all supported formats with mode='r', "
-                "a tiledbsoma store with mode='w', "
-                "AnnData or SpatialData zarr store with mode='r+'."
-            )
+        if mode != "r":
+            if not (is_tiledbsoma_w or is_zarr_w):
+                raise ValueError(
+                    f"It is not allowed to open a {suffix} object with `mode='{mode}'`. "
+                    "You can open all supported formats with `mode='r'`, "
+                    "a tiledbsoma store with `mode='w'`, "
+                    "AnnData or SpatialData zarr store with `mode='r+'`."
+                )
+            elif not self.overwrite_versions:
+                raise ValueError(
+                    "It is not possible to open artifacts having `overwrite_versions=False` "
+                    "in non-read mode (other than `mode='r'`)."
+                )
         # consider the case where an object is already locally cached
         localpath = setup_settings.paths.cloud_to_local_no_update(
             filepath, cache_key=cache_key

--- a/tests/storage/test_streaming.py
+++ b/tests/storage/test_streaming.py
@@ -300,6 +300,20 @@ def test_from_lazy():
     artifact.delete(permanent=True, storage=True)
 
 
+def test_zarr_open_mode_overwrite_versions_false():
+    lazy = ln.Artifact.from_lazy(
+        suffix=".zarr", overwrite_versions=False, key="mydata_overwrite_false.zarr"
+    )
+    store = zarr.open(lazy.path, mode="w")
+    store["test"] = np.array(["test"])
+    artifact = lazy.save()
+
+    with pytest.raises(ValueError, match="overwrite_versions=False"):
+        artifact.open(mode="r+")
+
+    artifact.delete(permanent=True, storage=True)
+
+
 def test_from_lazy_cloud():
     previous_storage = ln.setup.settings.storage.root_as_str
     ln.settings.storage = "s3://lamindb-test/storage"


### PR DESCRIPTION
Now `artifact.open(mode="w")` for artifacts with `overwrite_versions=False` raises an error. This is needed to prevent changes to the artifact files that are expected to be immutable.