### PR TITLE
🥅 Correct error for unmanaged storages in storage settings setters

### DIFF
--- a/lamindb/core/_settings.py
+++ b/lamindb/core/_settings.py
@@ -38,7 +38,7 @@ VERBOSITY_TO_STR: dict[int, str] = dict(
 )
 
 
-def raise_if_storage_managed_by_other_instance(storage) -> None:
+def raise_if_storage_not_managed_by_current_instance(storage) -> None:
     storage_instance_uid = storage.instance_uid
     if storage_instance_uid != setup_settings.instance.uid:
         raise ValueError(
@@ -224,7 +224,7 @@ class Settings:
                 return None
             set_managed_storage(path, **kwargs)
         else:
-            raise_if_storage_managed_by_other_instance(exists)
+            raise_if_storage_not_managed_by_current_instance(exists)
             ssettings = StorageSettings(
                 root=exists.root,
                 region=exists.region,
@@ -270,7 +270,7 @@ class Settings:
             if response != "y":
                 return None
         else:
-            raise_if_storage_managed_by_other_instance(exists)
+            raise_if_storage_not_managed_by_current_instance(exists)
         ln_setup.settings.instance.local_storage = local_root
 
     @property

--- a/lamindb/core/_settings.py
+++ b/lamindb/core/_settings.py
@@ -40,6 +40,10 @@ VERBOSITY_TO_STR: dict[int, str] = dict(
 
 def raise_if_storage_not_managed_by_current_instance(storage) -> None:
     storage_instance_uid = storage.instance_uid
+    if storage_instance_uid is None:
+        raise ValueError(
+            f"Storage '{storage.root}' is not managed by any instance, cannot write to it from here."
+        )
     if storage_instance_uid != setup_settings.instance.uid:
         raise ValueError(
             f"Storage '{storage.root}' exists in another instance ({storage_instance_uid}), cannot write to it from here."

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -43,3 +43,31 @@ def test_local_storage_setter_raises_on_foreign_managed_storage(tmp_path):
         == f"ValueError: Storage '{storage.root}' exists in another instance (_not_exists_), cannot write to it from here."
     )
     storage.delete()
+
+
+def test_storage_setter_raises_on_unmanaged_storage(tmp_path):
+    storage = ln.Storage(root=(tmp_path / "unmanaged-storage").as_posix()).save()
+    storage.instance_uid = None
+    storage.save()
+
+    with pytest.raises(ValueError) as error:
+        ln.settings.storage = storage.root
+    assert (
+        error.exconly()
+        == f"ValueError: Storage '{storage.root}' is not managed by any instance, cannot write to it from here."
+    )
+    storage.delete()
+
+
+def test_local_storage_setter_raises_on_unmanaged_storage(tmp_path):
+    storage = ln.Storage(root=(tmp_path / "unmanaged-local-storage").as_posix()).save()
+    storage.instance_uid = None
+    storage.save()
+
+    with pytest.raises(ValueError) as error:
+        ln.settings.local_storage = storage.root
+    assert (
+        error.exconly()
+        == f"ValueError: Storage '{storage.root}' is not managed by any instance, cannot write to it from here."
+    )
+    storage.delete()


### PR DESCRIPTION
If the storage passed to the setter (`ln.settings.storage`, `ln.settings.local_storage`) is not managed, raise an error explaining that the storage is not managed.