### PR TITLE
✨ Add explicit `key_is_virtual` argument to `Artifact.__init__(...)`

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1147,6 +1147,8 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         storage: `Storage | None = None` The storage location for the artifact. If `None`, uses the default (:attr:`~lamindb.core.Settings.storage`).
         skip_hash_lookup: `bool = False` Skip the hash lookup so that a new artifact is created even if an artifact with the same hash already exists.
             Empty files are always treated as if this were `True` because empty content hashes are not used for deduplication.
+        key_is_virtual: `bool | None = None` Whether to use a virtual key for managed storage paths.
+            If `None`, use :attr:`~lamindb.core.CreationSettings._artifact_use_virtual_keys`.
 
     Examples:
 

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1149,6 +1149,9 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             Empty files are always treated as if this were `True` because empty content hashes are not used for deduplication.
         key_is_virtual: `bool | None = None` Whether to use a virtual key for managed storage paths.
             If `None`, use :attr:`~lamindb.core.CreationSettings._artifact_use_virtual_keys`.
+            Inspect the current default via `ln.settings.creation._artifact_use_virtual_keys`
+            (default is `True`) and change it globally, e.g.,
+            `ln.settings.creation._artifact_use_virtual_keys = False`.
 
     Examples:
 

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1151,6 +1151,8 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             If `None`, uses the current default via :attr:`~lamindb.core.CreationSettings._artifact_use_virtual_keys`.
             Inspect the current default via `ln.settings.creation._artifact_use_virtual_keys`
             and change it globally, e.g., `ln.settings.creation._artifact_use_virtual_keys = False`.
+            If `True`, `key` is treated as metadata for versioning/querying and the on-storage path is auto-generated from the artifact `uid`.
+            If `False`, `key` is treated as the concrete relative storage path for writes in managed storage.
 
     Examples:
 

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1148,10 +1148,9 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         skip_hash_lookup: `bool = False` Skip the hash lookup so that a new artifact is created even if an artifact with the same hash already exists.
             Empty files are always treated as if this were `True` because empty content hashes are not used for deduplication.
         key_is_virtual: `bool | None = None` Whether to use a virtual key for managed storage paths.
-            If `None`, use :attr:`~lamindb.core.CreationSettings._artifact_use_virtual_keys`.
+            If `None`, uses the current default via :attr:`~lamindb.core.CreationSettings._artifact_use_virtual_keys`.
             Inspect the current default via `ln.settings.creation._artifact_use_virtual_keys`
-            (default is `True`) and change it globally, e.g.,
-            `ln.settings.creation._artifact_use_virtual_keys = False`.
+            and change it globally, e.g., `ln.settings.creation._artifact_use_virtual_keys = False`.
 
     Examples:
 

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -570,7 +570,7 @@ def get_artifact_kwargs_from_data(
         if key_is_virtual is not None and key_is_virtual != real_key_is_set:
             raise ValueError(
                 f"Passing a path in an existing storage {'with' if real_key_is_set else 'without'} "
-                f"a virtual key and _key_is_virtual={key_is_virtual} is incompatible."
+                f"a virtual key and key_is_virtual={key_is_virtual} is incompatible."
             )
         # we use an actual storage key if key is not provided explicitly
         set_key_is_virtual = real_key_is_set
@@ -1583,6 +1583,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         branch: Branch | None = None,
         space: Space | None = None,
         skip_hash_lookup: bool = False,
+        key_is_virtual: bool | None = None,
     ): ...
 
     @overload
@@ -1630,7 +1631,14 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         skip_hash_lookup: bool = kwargs.pop("skip_hash_lookup", False)
         to_disk_kwargs: dict[str, Any] | None = kwargs.pop("to_disk_kwargs", None)
         format = kwargs.pop("format", None)
+
+        key_is_virtual = kwargs.pop("key_is_virtual", None)
         _key_is_virtual = kwargs.pop("_key_is_virtual", None)
+        if key_is_virtual is not None:
+            if _key_is_virtual is not None:
+                raise ValueError("Do not pass both key_is_virtual and _key_is_virtual.")
+            _key_is_virtual = key_is_virtual
+
         _is_internal_call = kwargs.pop("_is_internal_call", False)
         skip_check_exists = kwargs.pop("skip_check_exists", False)
 
@@ -1644,7 +1652,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             if _is_internal_call:
                 if _key_is_virtual is False:
                     raise ValueError(
-                        "Do not pass _key_is_virtual=False with _is_internal_call=True."
+                        "Do not pass key_is_virtual=False with _is_internal_call=True."
                     )
                 is_automanaged_path = True
                 user_provided_key = key

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -207,7 +207,7 @@ def test_create_from_path_file_with_explicit_key_is_virtual(
         tsv_file,
         description="test explicit key is virtual",
         key=key,
-        _key_is_virtual=key_is_virtual,
+        key_is_virtual=key_is_virtual,
     )
     assert artifact.key == key
     assert artifact._key_is_virtual == key_is_virtual
@@ -221,6 +221,20 @@ def test_create_from_path_file_with_explicit_key_is_virtual(
         assert artifact.path == root / f".lamindb/{artifact.uid}.tsv"
 
     artifact.delete(permanent=True, storage=True)
+
+
+def test_create_from_path_file_with_both_key_is_virtual_args_raises(tsv_file):
+    with pytest.raises(ValueError) as error:
+        ln.Artifact(
+            tsv_file,
+            key="my_new_file.tsv",
+            key_is_virtual=True,
+            _key_is_virtual=False,
+        )
+    assert (
+        error.exconly()
+        == "ValueError: Do not pass both key_is_virtual and _key_is_virtual."
+    )
 
 
 def test_create_from_empty_files_skips_hash_lookup(tmp_path):
@@ -263,16 +277,16 @@ def test_create_from_path_folder(get_test_filepaths, key):
         with pytest.raises(ValueError) as error:
             ln.Artifact(test_dirpath, key=key, _key_is_virtual=False)
         assert error.exconly().startswith(
-            "ValueError: Passing a path in an existing storage with a virtual key and _key_is_virtual=False is incompatible."
+            "ValueError: Passing a path in an existing storage with a virtual key and key_is_virtual=False is incompatible."
         )
     else:
         assert artifact1._real_key is None
-    # check that passing _key_is_virtual=True is incompatible with a path in an existing storage without a virtual key
+    # check that passing key_is_virtual=True is incompatible with a path in an existing storage without a virtual key
     if key is None and is_in_registered_storage:
         with pytest.raises(ValueError) as error:
             ln.Artifact(test_dirpath, key=key, _key_is_virtual=True)
         assert error.exconly().startswith(
-            "ValueError: Passing a path in an existing storage without a virtual key and _key_is_virtual=True is incompatible."
+            "ValueError: Passing a path in an existing storage without a virtual key and key_is_virtual=True is incompatible."
         )
     assert artifact1.n_files == 3
     assert artifact1.hash == hash_test_dir
@@ -1584,7 +1598,7 @@ def test_update_key_to_none_raises_invalid_argument(
 
 
 def test_update_non_virtual_key_before_save_raises_invalid_argument(tsv_file):
-    artifact = ln.Artifact(tsv_file, key="before-save.tsv", _key_is_virtual=False)
+    artifact = ln.Artifact(tsv_file, key="before-save.tsv", key_is_virtual=False)
     artifact.key = "after-edit.tsv"
 
     with pytest.raises(InvalidArgument) as error:

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -275,7 +275,7 @@ def test_create_from_path_folder(get_test_filepaths, key):
         assert artifact1._real_key is not None
         # should fail because we are passing a path in an existing storage with a virtual key
         with pytest.raises(ValueError) as error:
-            ln.Artifact(test_dirpath, key=key, _key_is_virtual=False)
+            ln.Artifact(test_dirpath, key=key, key_is_virtual=False)
         assert error.exconly().startswith(
             "ValueError: Passing a path in an existing storage with a virtual key and key_is_virtual=False is incompatible."
         )
@@ -284,7 +284,7 @@ def test_create_from_path_folder(get_test_filepaths, key):
     # check that passing key_is_virtual=True is incompatible with a path in an existing storage without a virtual key
     if key is None and is_in_registered_storage:
         with pytest.raises(ValueError) as error:
-            ln.Artifact(test_dirpath, key=key, _key_is_virtual=True)
+            ln.Artifact(test_dirpath, key=key, key_is_virtual=True)
         assert error.exconly().startswith(
             "ValueError: Passing a path in an existing storage without a virtual key and key_is_virtual=True is incompatible."
         )


### PR DESCRIPTION
Expose `key_is_virtual` as the public `Artifact` constructor parameter: `ln.Artifact(..., key_is_virtual=False)`.