### PR TITLE
:art: Add safeguards against non-latest `revises` argument on saving a versioned sqlrecord

### DIFF
--- a/lamindb/models/_is_versioned.py
+++ b/lamindb/models/_is_versioned.py
@@ -41,6 +41,7 @@ class IsVersioned(models.Model):
         **kwargs,
     ):
         self._revises = kwargs.pop("revises", None)
+        self._refresh_revises_if_stale = kwargs.pop("_refresh_revises_if_stale", False)
         super().__init__(*args, **kwargs)
 
     @property

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -380,12 +380,17 @@ def get_stat_or_artifact(
         skip_hash_lookup = True
     previous_artifact_version = None
     artifacts_qs = Artifact.objects.using(instance)
-    query_key_revises = (
+    # Only run key-based lineage inference when creating a new artifact version from key.
+    # If explicit `revises` was passed in the constructor, this flag is False so that we
+    # do not override/validate lineage from key lookup during init.
+    # Also skip on replace(): replacement updates content in-place and must not create
+    # a new version lineage from key.
+    should_lookup_key_lineage = (
         key is not None and not is_replace and not skip_key_revises_lookup
     )
     if skip_hash_lookup:
         artifact_with_same_hash_exists = False
-        if query_key_revises:
+        if should_lookup_key_lineage:
             # only search for a previous version of the artifact
             # ignoring hash
             queryset_same_hash_or_same_key = artifacts_qs.filter(
@@ -413,7 +418,9 @@ def get_stat_or_artifact(
             queryset_same_hash_or_same_key = artifacts_qs.filter(
                 ~Q(branch_id=-1),
                 (Q(hash=hash) | Q(key=key, storage=storage))
-                if query_key_revises
+                # Key lookup is conditionally included only for inferred lineage. For
+                # explicit `revises`, we only need hash dedup and should skip key lineage.
+                if should_lookup_key_lineage
                 else Q(hash=hash),
             ).order_by("-created_at", "-id")
             queryset_same_hash = queryset_same_hash_or_same_key.filter(hash=hash)
@@ -421,7 +428,7 @@ def get_stat_or_artifact(
     if key is not None and not is_replace:
         if (
             not artifact_with_same_hash_exists
-            and query_key_revises
+            and should_lookup_key_lineage
             and queryset_same_hash_or_same_key.exists()
         ):
             queryset_same_key = queryset_same_hash_or_same_key.filter(is_latest=True)

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -443,10 +443,8 @@ def get_stat_or_artifact(
                 f"creating new artifact version for key '{key}' in storage '{storage.root}'"
             )
             previous_artifact_version = queryset_same_key.first()
-            assert previous_artifact_version is not None  # noqa: S101
     if artifact_with_same_hash_exists:
         artifact_with_same_hash = queryset_same_hash.first()
-        assert artifact_with_same_hash is not None  # noqa: S101
         logger.important(
             f"returning artifact with same hash: {artifact_with_same_hash}; to track this artifact as an input, use: ln.Artifact.get()"
         )

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1644,6 +1644,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         using_key = kwargs.pop("using_key", None)
         description: str | None = kwargs.pop("description", None)
         revises: Artifact | None = kwargs.pop("revises", None)
+        refresh_revises_if_stale = revises is None
         if revises is not None:
             if not isinstance(revises, Artifact):
                 raise TypeError("`revises` has to be of type `Artifact`")
@@ -1882,6 +1883,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         kwargs["space"] = space
         kwargs["otype"] = otype
         kwargs["revises"] = revises
+        kwargs["_refresh_revises_if_stale"] = refresh_revises_if_stale
         # this check needs to come down here because key might be populated from an
         # existing file path during get_artifact_kwargs_from_data()
         if (

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -348,6 +348,7 @@ def get_stat_or_artifact(
     is_replace: bool = False,
     instance: str | None = None,
     skip_hash_lookup: bool = False,
+    skip_key_revises_lookup: bool = False,
 ) -> Union[tuple[int, str | None, str | None, int | None, Artifact | None], Artifact]:
     """Retrieves file statistics or an existing artifact based on the path, hash, and key."""
     n_files = None
@@ -379,18 +380,21 @@ def get_stat_or_artifact(
         skip_hash_lookup = True
     previous_artifact_version = None
     artifacts_qs = Artifact.objects.using(instance)
+    query_key_revises = (
+        key is not None and not is_replace and not skip_key_revises_lookup
+    )
     if skip_hash_lookup:
         artifact_with_same_hash_exists = False
-        if key is not None and not is_replace:
+        if query_key_revises:
             # only search for a previous version of the artifact
             # ignoring hash
             queryset_same_hash_or_same_key = artifacts_qs.filter(
                 ~Q(branch_id=-1),
                 key=key,
                 storage=storage,
-            ).order_by("-created_at")
+            ).order_by("-created_at", "-id")
         else:
-            queryset_same_hash_or_same_key = []
+            queryset_same_hash_or_same_key = artifacts_qs.none()
     else:
         # this purposefully leaves out the storage location and key that we have
         # in the hard database unique constraints
@@ -399,7 +403,7 @@ def get_stat_or_artifact(
         # if this is not desired, set skip_hash_lookup=True
         if key is None or is_replace:
             queryset_same_hash = artifacts_qs.filter(~Q(branch_id=-1), hash=hash)
-            artifact_with_same_hash_exists = queryset_same_hash.count() > 0
+            artifact_with_same_hash_exists = queryset_same_hash.exists()
         else:
             # the following query achieves one more thing beyond hash lookup
             # it allows us to find a previous version of the artifact based on
@@ -408,21 +412,33 @@ def get_stat_or_artifact(
             # see the `previous_artifact_version` variable below
             queryset_same_hash_or_same_key = artifacts_qs.filter(
                 ~Q(branch_id=-1),
-                Q(hash=hash) | Q(key=key, storage=storage),
-            ).order_by("-created_at")
+                (Q(hash=hash) | Q(key=key, storage=storage))
+                if query_key_revises
+                else Q(hash=hash),
+            ).order_by("-created_at", "-id")
             queryset_same_hash = queryset_same_hash_or_same_key.filter(hash=hash)
-            artifact_with_same_hash_exists = queryset_same_hash.count() > 0
+            artifact_with_same_hash_exists = queryset_same_hash.exists()
     if key is not None and not is_replace:
         if (
             not artifact_with_same_hash_exists
-            and queryset_same_hash_or_same_key.count() > 0
+            and query_key_revises
+            and queryset_same_hash_or_same_key.exists()
         ):
+            queryset_same_key = queryset_same_hash_or_same_key.filter(is_latest=True)
+            if not queryset_same_key.exists():
+                raise ValidationError(
+                    "Cannot create a new artifact version: matching non-trashed artifacts "
+                    f"exist for key '{key}' in storage '{storage.root}', but none has "
+                    "`is_latest=True`."
+                )
             logger.important(
                 f"creating new artifact version for key '{key}' in storage '{storage.root}'"
             )
-            previous_artifact_version = queryset_same_hash_or_same_key[0]
+            previous_artifact_version = queryset_same_key.first()
+            assert previous_artifact_version is not None  # noqa: S101
     if artifact_with_same_hash_exists:
-        artifact_with_same_hash = queryset_same_hash[0]
+        artifact_with_same_hash = queryset_same_hash.first()
+        assert artifact_with_same_hash is not None  # noqa: S101
         logger.important(
             f"returning artifact with same hash: {artifact_with_same_hash}; to track this artifact as an input, use: ln.Artifact.get()"
         )
@@ -482,6 +498,7 @@ def get_artifact_kwargs_from_data(
     skip_hash_lookup: bool = False,
     to_disk_kwargs: dict[str, Any] | None = None,
     key_is_virtual: bool | None = None,
+    skip_key_revises_lookup: bool = False,
 ):
     memory_rep, path, suffix, storage, use_existing_storage_key = process_data(
         provisional_uid,
@@ -515,6 +532,7 @@ def get_artifact_kwargs_from_data(
         instance=using_key,
         is_replace=is_replace,
         skip_hash_lookup=skip_hash_lookup,
+        skip_key_revises_lookup=skip_key_revises_lookup,
     )
     if not isinstance(path, LocalPathClasses):
         local_filepath = None
@@ -1775,6 +1793,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             skip_hash_lookup=skip_hash_lookup,
             to_disk_kwargs=to_disk_kwargs,
             key_is_virtual=_key_is_virtual,
+            skip_key_revises_lookup=revises is not None,
         )
 
         def set_private_attributes():

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -381,17 +381,17 @@ def get_stat_or_artifact(
         skip_hash_lookup = True
     previous_artifact_version = None
     artifacts_qs = Artifact.objects.using(instance)
-    # Only run key-based lineage inference when creating a new artifact version from key.
+    # Only run key-based latest version lookup when creating a new artifact version from key.
     # If explicit `revises` was passed in the constructor, this flag is False so that we
-    # do not override/validate lineage from key lookup during init.
+    # do not override/validate version from key lookup during init.
     # Also skip on replace(): replacement updates content in-place and must not create
-    # a new version lineage from key.
-    should_lookup_key_lineage = (
+    # a new version from key.
+    should_lookup_key_version = (
         key is not None and not is_replace and not skip_key_revises_lookup
     )
     if skip_hash_lookup:
         artifact_with_same_hash_exists = False
-        if should_lookup_key_lineage:
+        if should_lookup_key_version:
             # only search for a previous version of the artifact
             # ignoring hash
             queryset_same_hash_or_same_key = artifacts_qs.filter(
@@ -419,9 +419,9 @@ def get_stat_or_artifact(
             queryset_same_hash_or_same_key = artifacts_qs.filter(
                 ~Q(branch_id=-1),
                 (Q(hash=hash) | Q(key=key, storage=storage))
-                # Key lookup is conditionally included only for inferred lineage. For
-                # explicit `revises`, we only need hash dedup and should skip key lineage.
-                if should_lookup_key_lineage
+                # Key lookup is conditionally included only for inferred latest version. For
+                # explicit `revises`, we only need hash dedup and should skip key latest version lookup.
+                if should_lookup_key_version
                 else Q(hash=hash),
             ).order_by("-created_at", "-id")
             queryset_same_hash = queryset_same_hash_or_same_key.filter(hash=hash)
@@ -429,7 +429,7 @@ def get_stat_or_artifact(
     if key is not None and not is_replace:
         if (
             not artifact_with_same_hash_exists
-            and should_lookup_key_lineage
+            and should_lookup_key_version
             and queryset_same_hash_or_same_key.exists()
         ):
             queryset_same_key = queryset_same_hash_or_same_key.filter(is_latest=True)

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -40,6 +40,7 @@ from ..core._compat import with_package_obj
 from ..core._settings import settings
 from ..errors import (
     FieldValidationError,
+    IntegrityError,
     InvalidArgument,
     NoStorageLocationForSpace,
     NoWriteAccess,
@@ -433,7 +434,7 @@ def get_stat_or_artifact(
         ):
             queryset_same_key = queryset_same_hash_or_same_key.filter(is_latest=True)
             if not queryset_same_key.exists():
-                raise ValidationError(
+                raise IntegrityError(
                     "Cannot create a new artifact version: matching non-trashed artifacts "
                     f"exist for key '{key}' in storage '{storage.root}', but none has "
                     "`is_latest=True`."

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1175,28 +1175,27 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                         if has_branch_id:
                             should_demote = revises.branch_id == self.branch_id
                         if should_demote:
-                            if not revises.is_latest:
-                                if getattr(self, "_refresh_revises_if_stale", False):
-                                    revises.refresh_from_db(fields=["is_latest"])
-                                    if not revises.is_latest:
-                                        latest_revises_qs = (
-                                            revises.__class__.objects.filter(
-                                                uid__startswith=revises.stem_uid,
-                                                is_latest=True,
-                                            )
+                            if not revises.is_latest and getattr(
+                                self, "_revises_was_passed_explicitly", False
+                            ):
+                                revises.refresh_from_db(fields=["is_latest"])
+                                if not revises.is_latest:
+                                    latest_revises_qs = (
+                                        revises.__class__.objects.filter(
+                                            uid__startswith=revises.stem_uid,
+                                            is_latest=True,
                                         )
-                                        if has_branch_id:
-                                            latest_revises_qs = (
-                                                latest_revises_qs.filter(
-                                                    branch_id=self.branch_id
-                                                )
-                                            )
-                                        latest_revises = latest_revises_qs.order_by(
-                                            "-created_at", "-id"
-                                        ).first()
-                                        if latest_revises is not None:
-                                            revises = latest_revises
-                                            self._revises = latest_revises
+                                    )
+                                    if has_branch_id:
+                                        latest_revises_qs = latest_revises_qs.filter(
+                                            branch_id=self.branch_id
+                                        )
+                                    latest_revises = latest_revises_qs.order_by(
+                                        "-created_at", "-id"
+                                    ).first()
+                                    if latest_revises is not None:
+                                        revises = latest_revises
+                                        self._revises = latest_revises
                             if not revises.is_latest:
                                 raise ValidationError(
                                     "Cannot revise a non-latest record: "

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1176,7 +1176,7 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                             should_demote = revises.branch_id == self.branch_id
                         if should_demote:
                             if not revises.is_latest and getattr(
-                                self, "_revises_was_passed_explicitly", False
+                                self, "_refresh_revises_if_stale", False
                             ):
                                 revises.refresh_from_db(fields=["is_latest"])
                                 if not revises.is_latest:

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1160,7 +1160,33 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                         if hasattr(revises, "branch_id") and hasattr(self, "branch_id"):
                             should_demote = revises.branch_id == self.branch_id
                         if should_demote:
-                            assert revises.is_latest  # noqa: S101
+                            if not revises.is_latest:
+
+                                def _format_versioned_record(
+                                    record: IsVersioned,
+                                ) -> str:
+                                    details: list[str] = []
+                                    for field_name in (
+                                        "uid",
+                                        "key",
+                                        "version",
+                                        "branch_id",
+                                    ):
+                                        value = getattr(record, field_name, None)
+                                        if value is not None:
+                                            details.append(f"{field_name}={value}")
+                                    class_name = record.__class__.__name__
+                                    if not details:
+                                        return class_name
+                                    return f"{class_name}({', '.join(details)})"
+
+                                raise AssertionError(
+                                    "Cannot revise a non-latest record: "
+                                    f"revises={_format_versioned_record(revises)} (is_latest=False), "
+                                    f"new={_format_versioned_record(self)}. "
+                                    "This usually means a newer revision was created concurrently "
+                                    "or an older record was selected for `revises`."
+                                )
                             revises.is_latest = False
                             revises._revises = None  # ensure we don't start a recursion
                             revises.save()

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1180,7 +1180,7 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                                         return class_name
                                     return f"{class_name}({', '.join(details)})"
 
-                                raise AssertionError(
+                                raise ValidationError(
                                     "Cannot revise a non-latest record: "
                                     f"revises={_format_versioned_record(revises)} (is_latest=False), "
                                     f"new={_format_versioned_record(self)}. "

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -134,6 +134,23 @@ def _format_versioned_record(record: IsVersioned) -> str:
     return f"{class_name}({', '.join(details)})"
 
 
+def _pull_latest_version_if_stale(
+    record: IsVersioned, branch_id: int | None = None
+) -> IsVersioned:
+    record.refresh_from_db(fields=["is_latest"])
+    if not record.is_latest:
+        latest_version_qs = record.__class__.objects.filter(
+            uid__startswith=record.stem_uid,
+            is_latest=True,
+        )
+        if branch_id is not None:
+            latest_version_qs = latest_version_qs.filter(branch_id=branch_id)
+        latest_version = latest_version_qs.order_by("-created_at", "-id").first()
+        if latest_version is not None:
+            return latest_version
+    return record
+
+
 # -------------------------------------------------------------------------------------
 # A note on required fields at the SQLRecord level
 #
@@ -1167,35 +1184,22 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                 # save versioned record in presence of self._revises
                 if isinstance(self, IsVersioned) and self._revises is not None:
                     revises = self._revises
+                    # For branch-aware models (SQLRecord), keep source-branch latest
+                    # intact and only demote within the same branch. For other
+                    # versioned models (e.g. blocks), keep previous behavior.
+                    should_demote = True
+                    has_branch_id = hasattr(revises, "branch_id") and hasattr(
+                        self, "branch_id"
+                    )
+                    if has_branch_id:
+                        should_demote = revises.branch_id == self.branch_id
                     with transaction.atomic():
-                        # For branch-aware models (SQLRecord), keep source-branch latest
-                        # intact and only demote within the same branch. For other
-                        # versioned models (e.g. blocks), keep previous behavior.
-                        has_branch_id = hasattr(revises, "branch_id") and hasattr(
-                            self, "branch_id"
-                        )
-                        should_demote = True
-                        if has_branch_id:
-                            should_demote = revises.branch_id == self.branch_id
                         if should_demote:
-                            revises.refresh_from_db(fields=["is_latest"])
-                            if not revises.is_latest and getattr(
-                                self, "_refresh_revises_if_stale", False
-                            ):
-                                latest_revises_qs = revises.__class__.objects.filter(
-                                    uid__startswith=revises.stem_uid,
-                                    is_latest=True,
+                            if getattr(self, "_refresh_revises_if_stale", False):
+                                revises = _pull_latest_version_if_stale(
+                                    revises, self.branch_id if has_branch_id else None
                                 )
-                                if has_branch_id:
-                                    latest_revises_qs = latest_revises_qs.filter(
-                                        branch_id=self.branch_id
-                                    )
-                                latest_revises = latest_revises_qs.order_by(
-                                    "-created_at", "-id"
-                                ).first()
-                                if latest_revises is not None:
-                                    revises = latest_revises
-                                    self._revises = latest_revises
+                                self._revises = revises
                             if not revises.is_latest:
                                 raise LaminIntegrityError(
                                     "Cannot revise a non-latest record: "

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1175,27 +1175,24 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                         if has_branch_id:
                             should_demote = revises.branch_id == self.branch_id
                         if should_demote:
+                            revises.refresh_from_db(fields=["is_latest"])
                             if not revises.is_latest and getattr(
                                 self, "_refresh_revises_if_stale", False
                             ):
-                                revises.refresh_from_db(fields=["is_latest"])
-                                if not revises.is_latest:
-                                    latest_revises_qs = (
-                                        revises.__class__.objects.filter(
-                                            uid__startswith=revises.stem_uid,
-                                            is_latest=True,
-                                        )
+                                latest_revises_qs = revises.__class__.objects.filter(
+                                    uid__startswith=revises.stem_uid,
+                                    is_latest=True,
+                                )
+                                if has_branch_id:
+                                    latest_revises_qs = latest_revises_qs.filter(
+                                        branch_id=self.branch_id
                                     )
-                                    if has_branch_id:
-                                        latest_revises_qs = latest_revises_qs.filter(
-                                            branch_id=self.branch_id
-                                        )
-                                    latest_revises = latest_revises_qs.order_by(
-                                        "-created_at", "-id"
-                                    ).first()
-                                    if latest_revises is not None:
-                                        revises = latest_revises
-                                        self._revises = latest_revises
+                                latest_revises = latest_revises_qs.order_by(
+                                    "-created_at", "-id"
+                                ).first()
+                                if latest_revises is not None:
+                                    revises = latest_revises
+                                    self._revises = latest_revises
                             if not revises.is_latest:
                                 raise ValidationError(
                                     "Cannot revise a non-latest record: "

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1168,10 +1168,35 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                         # For branch-aware models (SQLRecord), keep source-branch latest
                         # intact and only demote within the same branch. For other
                         # versioned models (e.g. blocks), keep previous behavior.
+                        has_branch_id = hasattr(revises, "branch_id") and hasattr(
+                            self, "branch_id"
+                        )
                         should_demote = True
-                        if hasattr(revises, "branch_id") and hasattr(self, "branch_id"):
+                        if has_branch_id:
                             should_demote = revises.branch_id == self.branch_id
                         if should_demote:
+                            if not revises.is_latest:
+                                if getattr(self, "_refresh_revises_if_stale", False):
+                                    revises.refresh_from_db(fields=["is_latest"])
+                                    if not revises.is_latest:
+                                        latest_revises_qs = (
+                                            revises.__class__.objects.filter(
+                                                uid__startswith=revises.stem_uid,
+                                                is_latest=True,
+                                            )
+                                        )
+                                        if has_branch_id:
+                                            latest_revises_qs = (
+                                                latest_revises_qs.filter(
+                                                    branch_id=self.branch_id
+                                                )
+                                            )
+                                        latest_revises = latest_revises_qs.order_by(
+                                            "-created_at", "-id"
+                                        ).first()
+                                        if latest_revises is not None:
+                                            revises = latest_revises
+                                            self._revises = latest_revises
                             if not revises.is_latest:
                                 raise ValidationError(
                                     "Cannot revise a non-latest record: "

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -119,6 +119,18 @@ def _is_branch_sensitive_model(model: type[BaseSQLRecord]) -> bool:
     ) or model.__name__ in BRANCH_SENSITIVE_BLOCK_MODEL_NAMES
 
 
+def _format_versioned_record(record: IsVersioned) -> str:
+    details: list[str] = []
+    for field_name in ("uid", "key", "version", "branch_id"):
+        value = getattr(record, field_name, None)
+        if value is not None:
+            details.append(f"{field_name}={value}")
+    class_name = record.__class__.__name__
+    if not details:
+        return class_name
+    return f"{class_name}({', '.join(details)})"
+
+
 # -------------------------------------------------------------------------------------
 # A note on required fields at the SQLRecord level
 #
@@ -1161,25 +1173,6 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                             should_demote = revises.branch_id == self.branch_id
                         if should_demote:
                             if not revises.is_latest:
-
-                                def _format_versioned_record(
-                                    record: IsVersioned,
-                                ) -> str:
-                                    details: list[str] = []
-                                    for field_name in (
-                                        "uid",
-                                        "key",
-                                        "version",
-                                        "branch_id",
-                                    ):
-                                        value = getattr(record, field_name, None)
-                                        if value is not None:
-                                            details.append(f"{field_name}={value}")
-                                    class_name = record.__class__.__name__
-                                    if not details:
-                                        return class_name
-                                    return f"{class_name}({', '.join(details)})"
-
                                 raise ValidationError(
                                     "Cannot revise a non-latest record: "
                                     f"revises={_format_versioned_record(revises)} (is_latest=False), "

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -137,7 +137,6 @@ def _format_versioned_record(record: IsVersioned) -> str:
 def _pull_latest_version_if_stale(
     record: IsVersioned, branch_id: int | None = None
 ) -> IsVersioned:
-    record.refresh_from_db(fields=["is_latest"])
     if not record.is_latest:
         latest_version_qs = record.__class__.objects.filter(
             uid__startswith=record.stem_uid,
@@ -1195,6 +1194,7 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                         should_demote = revises.branch_id == self.branch_id
                     with transaction.atomic():
                         if should_demote:
+                            revises.refresh_from_db(fields=["is_latest"])
                             if getattr(self, "_refresh_revises_if_stale", False):
                                 revises = _pull_latest_version_if_stale(
                                     revises, self.branch_id if has_branch_id else None

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -71,6 +71,9 @@ from ..errors import (
     NoWriteAccess,
     ValidationError,
 )
+from ..errors import (
+    IntegrityError as LaminIntegrityError,
+)
 from ._is_versioned import IsVersioned, _adjust_is_latest_when_deleting_is_versioned
 from .query_manager import QueryManager, _lookup, _search
 
@@ -1194,7 +1197,7 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                                     revises = latest_revises
                                     self._revises = latest_revises
                             if not revises.is_latest:
-                                raise ValidationError(
+                                raise LaminIntegrityError(
                                     "Cannot revise a non-latest record: "
                                     f"revises={_format_versioned_record(revises)} (is_latest=False), "
                                     f"new={_format_versioned_record(self)}. "

--- a/lamindb/models/transform.py
+++ b/lamindb/models/transform.py
@@ -260,6 +260,7 @@ class Transform(SQLRecord, IsVersioned):
         key: str | None = kwargs.pop("key", None)
         description: str | None = kwargs.pop("description", None)
         revises: Transform | None = kwargs.pop("revises", None)
+        refresh_revises_if_stale = revises is None
         version_tag: str | None = kwargs.pop("version_tag", kwargs.pop("version", None))
         kind: TransformKind | None = kwargs.pop("kind", None)
         type: TransformKind | None = kwargs.pop("type", None)
@@ -358,6 +359,7 @@ class Transform(SQLRecord, IsVersioned):
             hash=hash,
             _has_consciously_provided_uid=has_consciously_provided_uid,
             revises=revises,
+            _refresh_revises_if_stale=refresh_revises_if_stale,
             branch=branch,
             branch_id=branch_id,
             space=space,

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -34,8 +34,8 @@ from lamindb.core.storage.paths import (
 )
 from lamindb.errors import (
     FieldValidationError,
+    IntegrityError,
     InvalidArgument,
-    ValidationError,
 )
 from lamindb.models.artifact import (
     data_is_scversedatastructure,
@@ -925,7 +925,7 @@ def test_explicit_revises_skips_key_lineage_latest_check(
         # Key-based revises inference should now fail because no matching latest exists.
         df.iloc[0, 0] = 202
         with pytest.raises(
-            ValidationError,
+            IntegrityError,
             match="matching non-trashed artifacts exist",
         ):
             ln.Artifact.from_dataframe(df, key=key, description="v3-inferred")

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -35,6 +35,7 @@ from lamindb.core.storage.paths import (
 from lamindb.errors import (
     FieldValidationError,
     InvalidArgument,
+    ValidationError,
 )
 from lamindb.models.artifact import (
     data_is_scversedatastructure,
@@ -903,6 +904,42 @@ def test_revise_recreate_artifact(example_dataframe: pd.DataFrame, ccaplog):
         ccaplog.text.count("you are saving to a non-latest version of the artifact")
         == 1
     )
+
+
+def test_explicit_revises_skips_key_lineage_latest_check(
+    example_dataframe: pd.DataFrame,
+):
+    df = example_dataframe.copy()
+    key = "skip-key-lineage-latest-check.parquet"
+    artifact_v1 = ln.Artifact.from_dataframe(df, key=key, description="v1").save()
+    df.iloc[0, 0] = 101
+    artifact_v2 = ln.Artifact.from_dataframe(df, key=key, description="v2").save()
+    try:
+        stem_uid = artifact_v1.stem_uid
+        ln.Artifact.objects.filter(uid__startswith=stem_uid).update(is_latest=False)
+        artifact_v1.refresh_from_db()
+        artifact_v2.refresh_from_db()
+        assert not artifact_v1.is_latest
+        assert not artifact_v2.is_latest
+
+        # Key-based revises inference should now fail because no matching latest exists.
+        df.iloc[0, 0] = 202
+        with pytest.raises(
+            ValidationError,
+            match="matching non-trashed artifacts exist",
+        ):
+            ln.Artifact.from_dataframe(df, key=key, description="v3-inferred")
+
+        # Explicit revises should bypass key-lineage inference during init.
+        artifact_v3 = ln.Artifact.from_dataframe(
+            df, key=key, description="v3-explicit", revises=artifact_v2
+        )
+        assert artifact_v3._revises is not None
+    finally:
+        for artifact in ln.Artifact.objects.filter(
+            uid__startswith=artifact_v1.stem_uid
+        ):
+            artifact.delete(permanent=True)
 
 
 def test_delete_and_restore_artifact(example_dataframe: pd.DataFrame):

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -924,13 +924,11 @@ def test_explicit_revises_skips_key_lineage_latest_check(
 
         # Key-based revises inference should now fail because no matching latest exists.
         df.iloc[0, 0] = 202
-        with pytest.raises(
-            IntegrityError,
-            match="matching non-trashed artifacts exist",
-        ):
+        with pytest.raises(IntegrityError) as error:
             ln.Artifact.from_dataframe(df, key=key, description="v3-inferred")
+        assert "matching non-trashed artifacts exist" in str(error.value)
 
-        # Explicit revises should bypass key-lineage inference during init.
+        # Explicit revises should bypass selecting a previous version by key during init.
         artifact_v3 = ln.Artifact.from_dataframe(
             df, key=key, description="v3-explicit", revises=artifact_v2
         )

--- a/tests/core/test_is_versioned.py
+++ b/tests/core/test_is_versioned.py
@@ -1,7 +1,7 @@
 import lamindb as ln
 import pandas as pd
 import pytest
-from lamindb.errors import ValidationError
+from lamindb.errors import IntegrityError
 from lamindb.models._is_versioned import (
     _adjust_is_latest_when_deleting_is_versioned,
     bump_version,
@@ -226,7 +226,7 @@ def test_transform_versioning_across_branches_preserves_main_latest():
         branch.delete(permanent=True)
 
 
-def test_stale_revises_raises_validation_error():
+def test_stale_revises_raises_integrity_error():
     transform_v1 = ln.Transform(
         key="stale-revises-validation-error",
         source_code="v1",
@@ -254,7 +254,7 @@ def test_stale_revises_raises_validation_error():
             kind="pipeline",
         ).save()
 
-        with pytest.raises(ValidationError) as error:
+        with pytest.raises(IntegrityError) as error:
             transform_pending.save()
         message = str(error.value)
         assert "Cannot revise a non-latest record" in message
@@ -296,7 +296,7 @@ def test_inferred_revises_refreshes_and_requeries_latest():
 
         # If refresh/requery is disabled, save should fail on stale revises.
         transform_pending._refresh_revises_if_stale = False
-        with pytest.raises(ValidationError):
+        with pytest.raises(IntegrityError):
             transform_pending.save()
 
         # Re-enable behavior and verify save now succeeds.

--- a/tests/core/test_is_versioned.py
+++ b/tests/core/test_is_versioned.py
@@ -296,8 +296,9 @@ def test_inferred_revises_refreshes_and_requeries_latest():
 
         # If refresh/requery is disabled, save should fail on stale revises.
         transform_pending._refresh_revises_if_stale = False
-        with pytest.raises(IntegrityError):
+        with pytest.raises(IntegrityError) as error:
             transform_pending.save()
+        assert "Cannot revise a non-latest record" in str(error.value)
 
         # Re-enable behavior and verify save now succeeds.
         transform_pending._refresh_revises_if_stale = True

--- a/tests/core/test_is_versioned.py
+++ b/tests/core/test_is_versioned.py
@@ -245,6 +245,7 @@ def test_stale_revises_raises_validation_error():
             source_code="v3",
             kind="pipeline",
         )
+        assert not transform_pending._refresh_revises_if_stale
         # Simulate a concurrent writer demoting transform_v2 after init but before save.
         ln.Transform(
             key="stale-revises-validation-error",
@@ -287,6 +288,7 @@ def test_inferred_revises_refreshes_and_requeries_latest():
         )
         assert transform_pending._revises is not None
         assert transform_pending._revises.uid == transform_v2.uid
+        assert transform_pending._refresh_revises_if_stale
 
         # Simulate stale latest flags without creating a new version.
         ln.Transform.objects.filter(id=transform_v2.id).update(is_latest=False)

--- a/tests/core/test_is_versioned.py
+++ b/tests/core/test_is_versioned.py
@@ -267,6 +267,42 @@ def test_stale_revises_raises_validation_error():
             record.delete(permanent=True)
 
 
+def test_inferred_revises_refreshes_and_requeries_latest():
+    transform_v1 = ln.Transform(
+        key="stale-inferred-revises-requery",
+        source_code="v1",
+        kind="pipeline",
+    ).save()
+    transform_v2 = ln.Transform(
+        key="stale-inferred-revises-requery",
+        revises=transform_v1,
+        source_code="v2",
+        kind="pipeline",
+    ).save()
+    try:
+        transform_pending = ln.Transform(
+            key="stale-inferred-revises-requery",
+            source_code="v3",
+            kind="pipeline",
+        )
+        assert transform_pending._revises is not None
+        assert transform_pending._revises.uid == transform_v2.uid
+
+        # Simulate stale latest flags without creating a new version.
+        ln.Transform.objects.filter(id=transform_v2.id).update(is_latest=False)
+        ln.Transform.objects.filter(id=transform_v1.id).update(is_latest=True)
+
+        # Inferred revises should refresh and re-query latest instead of failing early.
+        transform_pending.save()
+        transform_pending.refresh_from_db()
+        assert transform_pending.is_latest
+    finally:
+        for record in ln.Transform.objects.filter(
+            uid__startswith=transform_v1.uid[:-4]
+        ):
+            record.delete(permanent=True)
+
+
 def test_path_rename():
     # this is related to renames inside _add_to_version_family
     with open("test_new_path.txt", "w") as f:

--- a/tests/core/test_is_versioned.py
+++ b/tests/core/test_is_versioned.py
@@ -294,8 +294,15 @@ def test_inferred_revises_refreshes_and_requeries_latest():
         ln.Transform.objects.filter(id=transform_v2.id).update(is_latest=False)
         ln.Transform.objects.filter(id=transform_v1.id).update(is_latest=True)
 
-        # Inferred revises should refresh and re-query latest instead of failing early.
+        # If refresh/requery is disabled, save should fail on stale revises.
+        transform_pending._refresh_revises_if_stale = False
+        with pytest.raises(ValidationError):
+            transform_pending.save()
+
+        # Re-enable behavior and verify save now succeeds.
+        transform_pending._refresh_revises_if_stale = True
         transform_pending.save()
+        assert transform_pending.is_latest
         transform_pending.refresh_from_db()
         assert transform_pending.is_latest
     finally:

--- a/tests/core/test_is_versioned.py
+++ b/tests/core/test_is_versioned.py
@@ -1,6 +1,7 @@
 import lamindb as ln
 import pandas as pd
 import pytest
+from lamindb.errors import ValidationError
 from lamindb.models._is_versioned import (
     _adjust_is_latest_when_deleting_is_versioned,
     bump_version,
@@ -223,6 +224,47 @@ def test_transform_versioning_across_branches_preserves_main_latest():
             for record in ln.Transform.objects.filter(uid__startswith=uid):
                 record.delete(permanent=True)
         branch.delete(permanent=True)
+
+
+def test_stale_revises_raises_validation_error():
+    transform_v1 = ln.Transform(
+        key="stale-revises-validation-error",
+        source_code="v1",
+        kind="pipeline",
+    ).save()
+    transform_v2 = ln.Transform(
+        key="stale-revises-validation-error",
+        revises=transform_v1,
+        source_code="v2",
+        kind="pipeline",
+    ).save()
+    try:
+        transform_pending = ln.Transform(
+            key="stale-revises-validation-error",
+            revises=transform_v2,
+            source_code="v3",
+            kind="pipeline",
+        )
+        # Simulate a concurrent writer demoting transform_v2 after init but before save.
+        ln.Transform(
+            key="stale-revises-validation-error",
+            revises=transform_v2,
+            source_code="v4",
+            kind="pipeline",
+        ).save()
+
+        with pytest.raises(ValidationError) as error:
+            transform_pending.save()
+        message = str(error.value)
+        assert "Cannot revise a non-latest record" in message
+        assert f"revises=Transform(uid={transform_v2.uid}" in message
+        assert "key=stale-revises-validation-error" in message
+        assert "new=Transform(uid=" in message
+    finally:
+        for record in ln.Transform.objects.filter(
+            uid__startswith=transform_v1.uid[:-4]
+        ):
+            record.delete(permanent=True)
 
 
 def test_path_rename():

--- a/tests/core/test_is_versioned.py
+++ b/tests/core/test_is_versioned.py
@@ -262,9 +262,7 @@ def test_stale_revises_raises_integrity_error():
         assert "key=stale-revises-validation-error" in message
         assert "new=Transform(uid=" in message
     finally:
-        for record in ln.Transform.objects.filter(
-            uid__startswith=transform_v1.uid[:-4]
-        ):
+        for record in ln.Transform.filter(uid__startswith=transform_v1.stem_uid):
             record.delete(permanent=True)
 
 
@@ -291,8 +289,8 @@ def test_inferred_revises_refreshes_and_requeries_latest():
         assert transform_pending._refresh_revises_if_stale
 
         # Simulate stale latest flags without creating a new version.
-        ln.Transform.objects.filter(id=transform_v2.id).update(is_latest=False)
-        ln.Transform.objects.filter(id=transform_v1.id).update(is_latest=True)
+        ln.Transform.filter(id=transform_v2.id).update(is_latest=False)
+        ln.Transform.filter(id=transform_v1.id).update(is_latest=True)
 
         # If refresh/requery is disabled, save should fail on stale revises.
         transform_pending._refresh_revises_if_stale = False
@@ -307,9 +305,7 @@ def test_inferred_revises_refreshes_and_requeries_latest():
         transform_pending.refresh_from_db()
         assert transform_pending.is_latest
     finally:
-        for record in ln.Transform.objects.filter(
-            uid__startswith=transform_v1.uid[:-4]
-        ):
+        for record in ln.Transform.filter(uid__startswith=transform_v1.stem_uid):
             record.delete(permanent=True)
 
 


### PR DESCRIPTION
Improve versioning robustness and errors for `revises` handling for versioned sqlrecords, especially artifacts.

Replaces brittle latest-version assertions with IntegrityError, refreshes/rechecks stale inferred `revises`, and tightens artifact key-based previous-version lookup behavior with targeted tests.