### PR TITLE
🚸 Simplify the curator logs and advocate explicit object construction instead of `add_new_from()`

### DIFF
--- a/docs/curate.md
+++ b/docs/curate.md
@@ -21,8 +21,8 @@ In other guides, we've mostly covered annotation. In this guide we'll curate com
 ## Schema design patterns
 
 A {class}`~lamindb.Schema` is a specification that defines the expected structure, data types, and validation rules for a dataset.
-It is similar to a `pydantic.Model` for dictionaries, or a `pandera.Schema` & `pyarrow.lib.Schema` for tables, but supports more complicated data structures.
-Here is an [FAQ](/faq/pydantic-pandera) that compares LaminDB with `pydantic` and `pandera`.
+Other than `pydantic.Model` for dictionaries or `pandera.Schema` / `pyarrow.lib.Schema` for tables, a `lamindb` schema enables queries in a database and supports complex data structures.
+Here is an [FAQ](/faq/pydantic-pandera) that compares it with `pydantic` and `pandera`.
 
 Schemas ensure data consistency by defining:
 
@@ -50,8 +50,8 @@ Or for a composite data structure, like an `AnnData`:
 schema = ln.Schema(
     otype="AnnData",
     slots={
-        "obs": cell_metadata_schema,     # cell annotations
-        "var.T": gene_id_schema          # gene-derived features
+        "obs": cell_metadata_schema,     # (pseudocode) cell annotations
+        "var.T": gene_id_schema          # (pseudocode) gene-derived features
     }
 )
 ```
@@ -94,7 +94,7 @@ Use when: You need complete control over data structure and values.
 ```python
 # Only allows specified columns
 schema = ln.Schema(
-    features=[...],
+    features=[...],    # (pseudocode)
     minimal_set=True,  # whether all passed features are required
     maximal_set=False  # whether additional features are allowed
 )
@@ -140,6 +140,8 @@ Before creating a schema, ensure your registries have the right features and lab
 
 ### Step 3: Create your schema
 
+Let's instantiate the flexible schema we discussed earlier (available in our examples module):
+
 ```python
 schema = ln.examples.datasets.mini_immuno.define_mini_immuno_schema_flexible()
 schema.describe()
@@ -149,16 +151,18 @@ schema.describe()
 
 ### Step 4: Initialize Curator and first validation
 
-If you expect the validation to pass, you can directly register an artifact by providing the schema:
+:::{admonition} Shortcut
+If you expect the validation to pass, you can directly ingest a validated artifact via:
 
 ```python
-
 artifact = ln.Artifact.from_dataframe(df, key="examples/my_curated_dataset.parquet", schema=schema).save()
 ```
 
+:::
+
 <!-- #endregion -->
 
-The {meth}`~lamindb.curators.core.Curator.validate` method validates that your dataset adheres to the criteria defined by the `schema`.
+If you want full control over the validation process with access to standardization helpers, you can instantiate a `Curator` object. Its {meth}`~lamindb.curators.core.Curator.validate` method validates that your dataset adheres to the criteria defined by the `schema`.
 It identifies which values are already validated (exist in the registries) and which are potentially problematic (do not yet exist in our registries).
 
 ```python
@@ -273,7 +277,7 @@ schema = ln.Schema(
 
 <!-- #region -->
 
-**Issue**: "Terms not validated in feature 'perturbation'"
+**Issue**: "Terms not validated in feature 'cell_type'"
 
 ```
 2 terms not validated in feature 'cell_type': 'B-cell', 'CD8-pos alpha-beta T cell'
@@ -371,6 +375,7 @@ This pattern applies to any ontology where the same registry serves multiple org
 ## External data validation
 
 Since not all metadata is always stored within the dataset itself, it is also possible to validate external metadata.
+For instance, you might want to validate a separate metadata dictionary or JSON file against a schema before attaching it to your data.
 
 ```{eval-rst}
 .. literalinclude:: scripts/curate_dataframe_external_features.py
@@ -385,6 +390,7 @@ Since not all metadata is always stored within the dataset itself, it is also po
 ## Union dtypes
 
 Some metadata columns might validate against several registries.
+This script demonstrates how to configure a feature that accepts values from multiple sources, such as allowing either a gene symbol or an Ensembl ID.
 
 ```{eval-rst}
 .. literalinclude:: scripts/curate_dataframe_union_features.py
@@ -423,7 +429,7 @@ Under-the-hood, this uses the following build-in schema ({func}`~lamindb.example
    :language: python
 ```
 
-This schema tranposes the `var` DataFrame during curation, so that one validates and annotates the columns of `var.T`, i.e., `[ENSG00000153563, ENSG00000010610, ENSG00000170458]`.
+This schema transposes the `var` DataFrame during curation, so that one validates and annotates the columns of `var.T`, i.e., `[ENSG00000153563, ENSG00000010610, ENSG00000170458]`.
 If one doesn't transpose, one would annotate the columns of `var`, i.e., `[gene_symbol, gene_type]`.
 
 ```{eval-rst}
@@ -462,7 +468,7 @@ except ln.errors.ValidationError as error:
 As above, we leverage a lookup object with valid cell types to find the correct name.
 
 ```python
-valid_cell_types = curator.slots["obs"].cat.lookup()["cell_type_by_expert"]
+valid_cell_types = curator.slots["obs"].cat.lookup(public=True)["cell_type_by_expert"]
 adata.obs["cell_type_by_expert"] = adata.obs[
     "cell_type_by_expert"
 ].cat.rename_categories(
@@ -525,6 +531,9 @@ Here, we exemplary show how to curate such metadata for AnnData:
 
 ## MuData
 
+MuData objects contain multiple modalities, each with its own structure.
+The following script shows how to define and validate schemas across different modalities (e.g., RNA and ATAC) simultaneously.
+
 ```{eval-rst}
 .. literalinclude:: scripts/curate_mudata.py
    :language: python
@@ -536,6 +545,9 @@ Here, we exemplary show how to curate such metadata for AnnData:
 ```
 
 ## SpatialData
+
+For SpatialData, we need to validate annotations nested deep within the `.attrs` dictionary.
+This script illustrates how to target and curate these nested metadata fields.
 
 ```{eval-rst}
 .. literalinclude:: scripts/define_schema_spatialdata.py
@@ -558,6 +570,9 @@ Here, we exemplary show how to curate such metadata for AnnData:
 ```
 
 ## TiledbsomaExperiment
+
+TileDB-SOMA experiments store large-scale single-cell data on disk.
+Here we show how to validate the `obs` and `var` dataframes of a SOMA experiment without loading the entire dataset into memory.
 
 ```{eval-rst}
 .. literalinclude:: scripts/curate_soma_experiment.py

--- a/docs/curate.md
+++ b/docs/curate.md
@@ -118,7 +118,9 @@ import lamindb as ln
 ln.track()
 ```
 
-### Step 1: Load and examine your data
+We'll not be walking through the steps of curating a dataset.
+
+### (1) Load and examine your dataset
 
 We'll be working with the mini immuno dataset:
 
@@ -129,7 +131,7 @@ df = ln.examples.datasets.mini_immuno.get_dataset1(
 df
 ```
 
-### Step 2: Set up your metadata registries
+### (2) Set up your registries
 
 Before creating a schema, ensure your registries have the right features and labels:
 
@@ -138,7 +140,7 @@ Before creating a schema, ensure your registries have the right features and lab
    :language: python
 ```
 
-### Step 3: Create your schema
+### (3) Create your schema
 
 Let's instantiate the flexible schema we discussed earlier (available in our examples module):
 
@@ -149,7 +151,7 @@ schema.describe()
 
 <!-- #region -->
 
-### Step 4: Initialize Curator and first validation
+### (4) Validate the dataset
 
 :::{admonition} Shortcut
 If you expect the validation to pass, you can directly ingest a validated artifact via:
@@ -173,7 +175,7 @@ except ln.errors.ValidationError as error:
     print(error)
 ```
 
-### Step 5: Fix validation issues
+### (5) Fix validation errors
 
 Check the non-validated terms:
 
@@ -226,7 +228,7 @@ For the `perturbation` feature, we need to register new perturbations:
 ln.Record.from_values(["DMSO", "IFNG"], create=True).save()
 ```
 
-### Step 6: Save your curated dataset
+### (6) Save a validated & annotated dataset
 
 ```python
 artifact = curator.save_artifact(key="examples/my_curated_dataset.parquet")

--- a/docs/curate.md
+++ b/docs/curate.md
@@ -4,13 +4,11 @@ execute_via: python
 
 # Validate & standardize datasets
 
-Data curation with LaminDB ensures your datasets are **validated** and **queryable** through **annotation**.
-
 ```{raw} html
 <iframe width="560" height="315" src="https://www.youtube.com/embed/Ji6E7hTnReQ?si=K0OnU2MTGv4fIhFo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 ```
 
-Curating a dataset with LaminDB means three things:
+Curating a dataset means three things:
 
 - **Validate** that the dataset matches a desired schema.
 - **Standardize** the dataset (e.g., by fixing typos, mapping synonyms) or update registries if validation fails.
@@ -22,7 +20,6 @@ Here is a [guide](/faq/curate-any) for the underlying low-level API.
 Note: If you know either `pydantic` or `pandera`, here is an [FAQ](/faq/pydantic-pandera) that compares LaminDB with both of these tools.
 
 ```python
-# pip install lamindb
 !lamin init --storage ./test-curate --modules bionty
 ```
 
@@ -213,19 +210,15 @@ df["cell_type_by_expert"] = df["cell_type_by_expert"].cat.rename_categories(
 )
 ```
 
-For perturbation, we want to add the new values: "DMSO", "IFNG"
+For the `perturbation` feature, we want to add the new values: `"DMSO"`, `"IFNG"`
 
 ```python
-# this adds perturbations that were _not_ validated
-curator.cat.add_new_from("perturbation")
+ln.Record.from_values(["DMSO", "IFNG"], create=True).save()
 ```
 
-```python
-ln.Feature.get(name="perturbation")
-```
+Validate again:
 
 ```python
-# validate again
 curator.validate()
 ```
 
@@ -233,9 +226,6 @@ curator.validate()
 
 ```python
 artifact = curator.save_artifact(key="examples/my_curated_dataset.parquet")
-```
-
-```python
 artifact.describe()
 ```
 
@@ -288,9 +278,11 @@ schema = ln.Schema(
 ```
 2 terms not validated in feature 'cell_type': 'B-cell', 'CD8-pos alpha-beta T cell'
     1 synonym found: "B-cell" → "B cell"
-    → curate synonyms via: .standardize("cell_type")
+    → curate synonyms via: curator.cat.standardize("cell_type")
     for remaining terms:
-    → fix typos, remove non-existent values, or save terms via: curator.cat.add_new_from('cell_type')
+    → fix typos, remove non-existent values, or create objects via:
+
+  objects = bionty.CellType.from_values(['CD8-pos alpha-beta T cell'], field='name').save()
 ```
 
 **Solutions**:
@@ -313,8 +305,8 @@ df['cell_type'] = df['cell_type'].cat.rename_categories({
     'CD8-pos T cell': cell_types.cd8_positive_alpha_beta_t_cell.name
 })
 
-# Solution 4: Add new legitimate terms
-curator.cat.add_new_from("cell_type")
+# Solution 4: Create new legitimate objects
+objects = bt.CellType.from_values(["my_new_cell_type"]).save()
 ```
 
 <!-- #endregion -->
@@ -482,14 +474,6 @@ The validated `AnnData` can be subsequently saved as an {class}`~lamindb.Artifac
 
 ```python
 adata.obs.columns
-```
-
-```python
-curator.slots["var.T"].cat.add_new_from("columns")
-```
-
-```python
-curator.validate()
 ```
 
 ```python

--- a/docs/curate.md
+++ b/docs/curate.md
@@ -21,7 +21,7 @@ In other guides, we've mostly covered annotation. In this guide we'll curate com
 ## Schema design patterns
 
 A {class}`~lamindb.Schema` is a specification that defines the expected structure, data types, and validation rules for a dataset.
-Other than `pydantic.Model` for dictionaries or `pandera.Schema` / `pyarrow.lib.Schema` for tables, a `lamindb` schema enables queries in a database and supports complex data structures.
+Unlike `pydantic.Model` for dictionaries or `pandera.Schema` / `pyarrow.lib.Schema` for tables, a `lamindb` schema enables queries in a database and supports complex data structures.
 Here is an [FAQ](/faq/pydantic-pandera) that compares it with `pydantic` and `pandera`.
 
 Schemas ensure data consistency by defining:
@@ -181,9 +181,9 @@ Check the non-validated terms:
 curator.cat.non_validated
 ```
 
-For `cell_type_by_expert`, we saw 2 terms are not validated.
+For `cell_type_by_expert`, we see 2 terms are not validated.
 
-First, let's standardize synonym "B-cell" as suggested
+First, let's standardize the synonym "B-cell" as suggested:
 
 ```python
 curator.cat.standardize("cell_type_by_expert")
@@ -292,7 +292,7 @@ schema = ln.Schema(
 **Solutions**:
 
 ```python
-# Solution 1: Use automatic standardization if given hint (handles synonyms))
+# Solution 1: Use automatic standardization if given hint (handles synonyms)
 curator.cat.standardize('cell_type')
 
 # Solution 2: Manual mapping for complex cases
@@ -404,7 +404,7 @@ This script demonstrates how to configure a feature that accepts values from mul
 
 ## AnnData
 
-`AnnData` like all other data structures that follow is a composite structure that stores different arrays in different `slots`.
+`AnnData`, like all other data structures that follow, is a composite structure that stores different arrays in different `slots`.
 
 ### Allow a flexible schema
 
@@ -422,7 +422,7 @@ Let's run the script.
 !python scripts/curate_anndata_flexible.py
 ```
 
-Under-the-hood, this uses the following build-in schema ({func}`~lamindb.examples.schemas.anndata_ensembl_gene_ids_and_valid_features_in_obs`):
+Under-the-hood, this uses the following built-in schema ({func}`~lamindb.examples.schemas.anndata_ensembl_gene_ids_and_valid_features_in_obs`):
 
 ```{eval-rst}
 .. literalinclude:: scripts/define_schema_anndata_ensembl_gene_ids_and_valid_features_in_obs.py
@@ -507,7 +507,7 @@ Most datastructures support unstructured metadata stored as dictionaries:
 - MuData: `.uns` and `modality:uns`
 - SpatialData: `.attrs`
 
-Here, we exemplary show how to curate such metadata for AnnData:
+Here, we demonstrate how to curate such metadata for AnnData:
 
 ```{eval-rst}
 .. literalinclude:: scripts/define_schema_anndata_uns.py

--- a/docs/curate.md
+++ b/docs/curate.md
@@ -183,27 +183,22 @@ First, let's standardize synonym "B-cell" as suggested
 
 ```python
 curator.cat.standardize("cell_type_by_expert")
-```
-
-```python
 # now we have only one non-validated cell type left
 curator.cat.non_validated
 ```
 
-For "CD8-pos alpha-beta T cell", let's understand which cell type in the public ontology might be the actual match.
+For "CD8-pos alpha-beta T cell", let's understand which cell type in the public ontology might be the actual match:
 
 ```python
 # to check the correct spelling of categories, pass `public=True` to get a lookup object from public ontologies
 # use `lookup = curator.cat.lookup()` to get a lookup object of existing records in your instance
 lookup = curator.cat.lookup(public=True)
-lookup
-```
-
-```python
-# here is an example for the "cell_type" column
+# here is an example for the "cell_type_by_expert" feature
 cell_types = lookup["cell_type_by_expert"]
 cell_types.cd8_positive_alpha_beta_t_cell
 ```
+
+Now that we have a match, let's fix it:
 
 ```python
 # fix the cell type name
@@ -212,7 +207,7 @@ df["cell_type_by_expert"] = df["cell_type_by_expert"].cat.rename_categories(
 )
 ```
 
-Let's re-run validation:
+Re-run validation:
 
 ```python
 try:

--- a/docs/curate.md
+++ b/docs/curate.md
@@ -59,7 +59,7 @@ schema = ln.Schema(
 ```{dropdown} What are slots?
 
 For composite data structures, you need to specify which component contains which schema, for example, to validate both cell metadata in `.obs` and gene metadata in `.var` within the same schema.
-Each slot is a key like `"obs"` for AnnData observations,`"rna:var"` for MuData modalities, or `"attrs:nested:key"` for SpatialData annotations.
+Each slot is a key like `"obs"` for AnnData observations, `"rna:var"` for MuData modalities, or `"attrs:nested:key"` for SpatialData annotations.
 ```
 
 Before diving into curation, let's understand the different schema approaches and when to use each one.
@@ -191,7 +191,7 @@ curator.cat.standardize("cell_type_by_expert")
 curator.cat.non_validated
 ```
 
-For "CD8-pos alpha-beta T cell", let's understand which cell type in the public ontology might be the actual match:
+For "CD8-pos alpha-beta T cell", let's find out which cell type in the public ontology might be the actual match:
 
 ```python
 # to check the correct spelling of categories, pass `public=True` to get a lookup object from public ontologies
@@ -422,7 +422,7 @@ Let's run the script.
 !python scripts/curate_anndata_flexible.py
 ```
 
-Under-the-hood, this uses the following built-in schema ({func}`~lamindb.examples.schemas.anndata_ensembl_gene_ids_and_valid_features_in_obs`):
+Under the hood, this uses the following built-in schema ({func}`~lamindb.examples.schemas.anndata_ensembl_gene_ids_and_valid_features_in_obs`):
 
 ```{eval-rst}
 .. literalinclude:: scripts/define_schema_anndata_ensembl_gene_ids_and_valid_features_in_obs.py
@@ -465,7 +465,7 @@ except ln.errors.ValidationError as error:
     print(error)
 ```
 
-As above, we leverage a lookup object with valid cell types to find the correct name.
+As above, we leverage a lookup object with valid cell types to find the correct name:
 
 ```python
 valid_cell_types = curator.slots["obs"].cat.lookup(public=True)["cell_type_by_expert"]
@@ -500,7 +500,7 @@ artifact.describe()
 
 ## Unstructured dictionaries
 
-Most datastructures support unstructured metadata stored as dictionaries:
+Most data structures support unstructured metadata stored as dictionaries:
 
 - Pandas DataFrames: `.attrs`
 - AnnData: `.uns`

--- a/docs/curate.md
+++ b/docs/curate.md
@@ -11,13 +11,10 @@ execute_via: python
 Curating a dataset means three things:
 
 - **Validate** that the dataset matches a desired schema.
-- **Standardize** the dataset (e.g., by fixing typos, mapping synonyms) or update registries if validation fails.
+- If validation fails, **standardize** the dataset (e.g., by fixing typos, mapping synonyms) or update registries.
 - **Annotate** the dataset by linking it against metadata entities so that it becomes queryable.
 
-In this guide we'll curate common data structures.
-Here is a [guide](/faq/curate-any) for the underlying low-level API.
-
-Note: If you know either `pydantic` or `pandera`, here is an [FAQ](/faq/pydantic-pandera) that compares LaminDB with both of these tools.
+In other guides, we've mostly covered annotation. In this guide we'll curate common data structures focusing on validation and standardization.
 
 ```python
 !lamin init --storage ./test-curate --modules bionty
@@ -33,8 +30,9 @@ ln.track()
 
 ## Schema design patterns
 
-A {class}`~lamindb.Schema` in LaminDB is a specification that defines the expected structure, data types, and validation rules for a dataset.
-It is similar to `pydantic.Model` for dictionaries, and `pandera.Schema`, and `pyarrow.lib.Schema` for tables, but supporting more complicated data structures.
+A {class}`~lamindb.Schema` is a specification that defines the expected structure, data types, and validation rules for a dataset.
+It is similar to a `pydantic.Model` for dictionaries, or a `pandera.Schema` & `pyarrow.lib.Schema` for tables, but supports more complicated data structures.
+Here is an [FAQ](/faq/pydantic-pandera) that compares LaminDB with `pydantic` and `pandera`.
 
 Schemas ensure data consistency by defining:
 

--- a/docs/curate.md
+++ b/docs/curate.md
@@ -240,7 +240,7 @@ artifact.describe()
 This section covers the most frequent curation issues and their solutions.
 Use this as a reference when validation fails.
 
-### Feature validation issues
+### Feature validation errors
 
 <!-- #region -->
 
@@ -275,7 +275,7 @@ schema = ln.Schema(
 
 <!-- #endregion -->
 
-### Value validation issues
+### Value validation errors
 
 <!-- #region -->
 
@@ -317,7 +317,7 @@ objects = bt.CellType.from_values(["my_new_cell_type"]).save()
 
 <!-- #endregion -->
 
-### Data type issues
+### Data type errors
 
 <!-- #region -->
 
@@ -339,7 +339,7 @@ ln.Feature(name="cell_type", dtype=bt.CellType, coerce=True).save()
 
 <!-- #endregion -->
 
-### Organism-specific ontology issues
+### Organism-specific ontology errors
 
 <!-- #region -->
 

--- a/docs/curate.md
+++ b/docs/curate.md
@@ -16,16 +16,6 @@ Curating a dataset means three things:
 
 In other guides, we've mostly covered annotation. In this guide we'll curate common data structures focusing on validation and standardization.
 
-```python
-!lamin init --storage ./test-curate --modules bionty
-```
-
-```python
-import lamindb as ln
-
-ln.track()
-```
-
 <!-- #region -->
 
 ## Schema design patterns
@@ -36,12 +26,12 @@ Here is an [FAQ](/faq/pydantic-pandera) that compares LaminDB with `pydantic` an
 
 Schemas ensure data consistency by defining:
 
-- What {class}`~lamindb.Feature`s (dimensions) exist in your dataset
+- Which features exist in your dataset
 - What data types those features should have
 - What values are valid for categorical features
-- Which {class}`~lamindb.Feature`s are required vs optional
+- Which features are required vs optional
 
-An exemplary schema:
+An exemplary schema that leverages {class}`~lamindb.Feature` objects to define features:
 
 ```python
 schema = ln.Schema(
@@ -54,23 +44,22 @@ schema = ln.Schema(
 )
 ```
 
-For composite data structures using slots:
-
-```{dropdown} What are slots?
-
-For composite data structures, you need to specify which component contains which schema, for example, to validate both cell metadata in `.obs` and gene metadata in `.var` within the same schema.
-Each slot is a key like `"obs"` for AnnData observations,`"rna:var"` for MuData modalities, or `"attrs:nested:key"` for SpatialData annotations.
-```
+Or for a composite data structure, like an `AnnData`:
 
 ```python
-# AnnData with multiple "slots"
-adata_schema = ln.Schema(
+schema = ln.Schema(
     otype="AnnData",
     slots={
         "obs": cell_metadata_schema,     # cell annotations
         "var.T": gene_id_schema          # gene-derived features
     }
 )
+```
+
+```{dropdown} What are slots?
+
+For composite data structures, you need to specify which component contains which schema, for example, to validate both cell metadata in `.obs` and gene metadata in `.var` within the same schema.
+Each slot is a key like `"obs"` for AnnData observations,`"rna:var"` for MuData modalities, or `"attrs:nested:key"` for SpatialData annotations.
 ```
 
 Before diving into curation, let's understand the different schema approaches and when to use each one.
@@ -114,6 +103,20 @@ schema = ln.Schema(
 <!-- #endregion -->
 
 ## DataFrame
+
+If you're not connected to a database, create one:
+
+```python
+!lamin init --storage ./test-curate --modules bionty
+```
+
+Let's import `lamindb` and optionally track this run:
+
+```python
+import lamindb as ln
+
+ln.track()
+```
 
 ### Step 1: Load and examine your data
 

--- a/docs/curate.md
+++ b/docs/curate.md
@@ -118,10 +118,6 @@ import lamindb as ln
 ln.track()
 ```
 
-We'll not be walking through the steps of curating a dataset.
-
-### (1) Load and examine your dataset
-
 We'll be working with the mini immuno dataset:
 
 ```python
@@ -131,7 +127,9 @@ df = ln.examples.datasets.mini_immuno.get_dataset1(
 df
 ```
 
-### (2) Set up your registries
+We'll now be walking through a sequence of steps to curate it.
+
+### (1) Set up your registries
 
 Before creating a schema, ensure your registries have the right features and labels:
 
@@ -140,7 +138,7 @@ Before creating a schema, ensure your registries have the right features and lab
    :language: python
 ```
 
-### (3) Create your schema
+### (2) Create your schema
 
 Let's instantiate the flexible schema we discussed earlier (available in our examples module):
 
@@ -151,7 +149,7 @@ schema.describe()
 
 <!-- #region -->
 
-### (4) Validate the dataset
+### (3) Validate the dataset
 
 :::{admonition} Shortcut
 If you expect the validation to pass, you can directly ingest a validated artifact via:
@@ -175,7 +173,7 @@ except ln.errors.ValidationError as error:
     print(error)
 ```
 
-### (5) Fix validation errors
+### (4) Fix validation errors
 
 Check the non-validated terms:
 
@@ -228,7 +226,7 @@ For the `perturbation` feature, we need to register new perturbations:
 ln.Record.from_values(["DMSO", "IFNG"], create=True).save()
 ```
 
-### (6) Save a validated & annotated dataset
+### (5) Save the dataset
 
 ```python
 artifact = curator.save_artifact(key="examples/my_curated_dataset.parquet")

--- a/docs/curate.md
+++ b/docs/curate.md
@@ -211,19 +211,10 @@ df["cell_type_by_expert"] = df["cell_type_by_expert"].cat.rename_categories(
 )
 ```
 
-Re-run validation:
+Validation now passes:
 
 ```python
-try:
-    curator.validate()
-except ln.errors.ValidationError as error:
-    print(error)
-```
-
-For the `perturbation` feature, we need to register new perturbations:
-
-```python
-ln.Record.from_values(["DMSO", "IFNG"], create=True).save()
+curator.validate()
 ```
 
 ### (5) Save the dataset

--- a/docs/curate.md
+++ b/docs/curate.md
@@ -171,8 +171,9 @@ except ln.errors.ValidationError as error:
 
 ### Step 5: Fix validation issues
 
+Check the non-validated terms:
+
 ```python
-# check the non-validated terms
 curator.cat.non_validated
 ```
 
@@ -211,16 +212,19 @@ df["cell_type_by_expert"] = df["cell_type_by_expert"].cat.rename_categories(
 )
 ```
 
-For the `perturbation` feature, we want to add the new values: `"DMSO"`, `"IFNG"`
+Let's re-run validation:
+
+```python
+try:
+    curator.validate()
+except ln.errors.ValidationError as error:
+    print(error)
+```
+
+For the `perturbation` feature, we need to register new perturbations:
 
 ```python
 ln.Record.from_values(["DMSO", "IFNG"], create=True).save()
-```
-
-Validate again:
-
-```python
-curator.validate()
 ```
 
 ### Step 6: Save your curated dataset

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -33,7 +33,11 @@ from lamindb.models import (
     Schema,
     SQLRecord,
 )
-from lamindb.models._from_values import _format_values, _from_values
+from lamindb.models._from_values import (
+    _format_values,
+    _from_values,
+    build_create_records_hint,
+)
 from lamindb.models.artifact import (
     data_is_scversedatastructure,
     data_is_soma_experiment,
@@ -1715,13 +1719,9 @@ class CatVector:
         else:
             slot = None
         in_slot = f" in slot '{slot}'" if slot is not None else ""
-        slot_prefix = f".slots['{slot}']" if slot is not None else ""
-        non_validated_hint_print = (
-            f"curator{slot_prefix}.cat.add_new_from('{self._key}')"
-        )
         n_non_validated = len(non_validated)
         if n_non_validated == 0:
-            logger.success(
+            logger.debug(
                 f'"{self._key}" is validated against {colors.italic(model_field)}'
             )
             return [], {}
@@ -1747,11 +1747,24 @@ class CatVector:
                 ):
                     organism = self._filter_kwargs.get("organism", None)
                     check_organism = f"fix organism '{organism}', "
-                warning_message += f"    → {check_organism}fix typos, remove non-existent values, or save terms via: {colors.cyan(non_validated_hint_print)}"
+                registry_str = self._registry.__get_name_with_module__()
+                slot_context = f" for slot '{slot}'" if slot is not None else ""
+                create_hint = build_create_records_hint(
+                    {registry_str: (self._field_name, non_validated)},
+                    title=(
+                        "Here is how to create records for non-validated values"
+                        f"{slot_context}:"
+                    ),
+                )
+                warning_message += (
+                    f"    → {check_organism}fix typos, remove non-existent values, "
+                    "or create records via:\n\n"
+                    f"{colors.cyan(create_hint)}"
+                )
                 if self._subtype_query_set is not None and self._type_record:
                     warning_message += f"\n    → a valid label for subtype '{self._type_record.name}' has to be one of {self._subtype_query_set.to_list('name')}"
-            logger.info(f'mapping "{self._key}" on {colors.italic(model_field)}')
-            logger.warning(warning_message)
+            logger.debug(f'mapping "{self._key}" on {colors.italic(model_field)}')
+            logger.debug(warning_message)
             if self._cat_manager is not None:
                 self._cat_manager._validate_category_error_messages = strip_ansi_codes(
                     warning_message

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -1728,7 +1728,10 @@ class CatVector:
         else:
             s = "" if n_non_validated == 1 else "s"
             print_values = _format_values(non_validated)
-            warning_message = f"{colors.red(f'{n_non_validated} term{s}')} not validated in feature '{self._key}'{in_slot}: {colors.red(print_values)}\n"
+            key_label = (
+                "columns" if self._key == "columns" else f"feature '{self._key}'"
+            )
+            warning_message = f"{colors.red(f'{n_non_validated} term{s}')} not validated in {key_label}{in_slot}: {colors.red(print_values)}\n"
             # log synonyms if any
             if syn_mapper:
                 s = "" if len(syn_mapper) == 1 else "s"

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -1719,6 +1719,8 @@ class CatVector:
         else:
             slot = None
         in_slot = f" in slot '{slot}'" if slot is not None else ""
+        slot_prefix = f".slots['{slot}']" if slot is not None else ""
+        cat_prefix = f"curator{slot_prefix}.cat"
         n_non_validated = len(non_validated)
         if n_non_validated == 0:
             logger.debug(
@@ -1738,7 +1740,7 @@ class CatVector:
                 syn_mapper_print = _format_values(
                     [f'"{k}" → "{v}"' for k, v in syn_mapper.items()], sep=""
                 )
-                hint_msg = f'.standardize("{self._key}")'
+                hint_msg = f'{cat_prefix}.standardize("{self._key}")'
                 warning_message += f"    {colors.yellow(f'{len(syn_mapper)} synonym{s}')} found: {colors.yellow(syn_mapper_print)}\n    → curate synonyms via: {colors.cyan(hint_msg)}"
             if n_non_validated > len(syn_mapper):
                 if syn_mapper:

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -1748,17 +1748,13 @@ class CatVector:
                     organism = self._filter_kwargs.get("organism", None)
                     check_organism = f"fix organism '{organism}', "
                 registry_str = self._registry.__get_name_with_module__()
-                slot_context = f" for slot '{slot}'" if slot is not None else ""
                 create_hint = build_create_records_hint(
                     {registry_str: (self._field_name, non_validated)},
-                    title=(
-                        "Here is how to create records for non-validated values"
-                        f"{slot_context}:"
-                    ),
+                    title=None,
                 )
                 warning_message += (
                     f"    → {check_organism}fix typos, remove non-existent values, "
-                    "or create records via:\n\n"
+                    "or create objects via:\n\n"
                     f"{colors.cyan(create_hint)}"
                 )
                 if self._subtype_query_set is not None and self._type_record:

--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -22,7 +22,10 @@ from rich.text import Text
 from rich.tree import Tree
 
 from lamindb.errors import DoesNotExist, InvalidArgument, ValidationError
-from lamindb.models._from_values import _format_values
+from lamindb.models._from_values import (
+    _format_values,
+    build_not_validated_values_message,
+)
 from lamindb.models.feature import (
     serialize_pandas_dtype,
     suggest_categorical_for_str_iterable,
@@ -1338,15 +1341,7 @@ class FeatureManager:
     ) -> None:
         if not not_validated_values:
             return None
-        hint = ""
-        for key, (field, values_list) in not_validated_values.items():
-            key_str = "ln.Record" if key == "Record" else key
-            create_true = ", create=True" if "bionty." not in key else ""
-            hint += f"  records = {key_str}.from_values({values_list}, field='{field}'{create_true}).save()\n"
-        msg = (
-            f"These values could not be validated: {dict(not_validated_values)}\n"
-            f"Here is how to create records for them:\n\n{hint}"
-        )
+        msg = build_not_validated_values_message(not_validated_values)
         raise ValidationError(msg)
 
     def _collect_record_feature_writes(

--- a/lamindb/models/_from_values.py
+++ b/lamindb/models/_from_values.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 def build_create_records_hint(
     not_validated_values: dict[str, tuple[str, list[str]]],
     *,
-    title: str = "Here is how to create records for them:",
+    title: str | None = "Here is how to create objects for them:",
 ) -> str:
     """Build a creation hint for non-validated values grouped by registry."""
     hint = ""
@@ -27,6 +27,8 @@ def build_create_records_hint(
             f"  records = {key_str}.from_values({values_list},"
             f" field='{field}'{create_true}).save()\n"
         )
+    if title is None:
+        return hint
     return f"{title}\n\n{hint}"
 
 

--- a/lamindb/models/_from_values.py
+++ b/lamindb/models/_from_values.py
@@ -23,12 +23,15 @@ def build_create_records_hint(
     for key, (field, values_list) in not_validated_values.items():
         key_str = "ln.Record" if key == "Record" else key
         create_true = ", create=True" if "bionty." not in key else ""
+        normalized_values = [
+            value.item() if hasattr(value, "item") else value for value in values_list
+        ]
         hint += (
-            f"  records = {key_str}.from_values({values_list},"
+            f"  records = {key_str}.from_values({normalized_values},"
             f" field='{field}'{create_true}).save()\n"
         )
     if title is None:
-        return hint
+        return hint.rstrip("\n")
     return f"{title}\n\n{hint}"
 
 

--- a/lamindb/models/_from_values.py
+++ b/lamindb/models/_from_values.py
@@ -27,7 +27,7 @@ def build_create_records_hint(
             value.item() if hasattr(value, "item") else value for value in values_list
         ]
         hint += (
-            f"  records = {key_str}.from_values({normalized_values},"
+            f"  objects = {key_str}.from_values({normalized_values},"
             f" field='{field}'{create_true}).save()\n"
         )
     if title is None:

--- a/lamindb/models/_from_values.py
+++ b/lamindb/models/_from_values.py
@@ -13,6 +13,34 @@ if TYPE_CHECKING:
     from .sqlrecord import SQLRecord
 
 
+def build_create_records_hint(
+    not_validated_values: dict[str, tuple[str, list[str]]],
+    *,
+    title: str = "Here is how to create records for them:",
+) -> str:
+    """Build a creation hint for non-validated values grouped by registry."""
+    hint = ""
+    for key, (field, values_list) in not_validated_values.items():
+        key_str = "ln.Record" if key == "Record" else key
+        create_true = ", create=True" if "bionty." not in key else ""
+        hint += (
+            f"  records = {key_str}.from_values({values_list},"
+            f" field='{field}'{create_true}).save()\n"
+        )
+    return f"{title}\n\n{hint}"
+
+
+def build_not_validated_values_message(
+    not_validated_values: dict[str, tuple[str, list[str]]],
+) -> str:
+    """Build validation error message including record creation hints."""
+    create_hint = build_create_records_hint(not_validated_values)
+    return (
+        f"These values could not be validated: {dict(not_validated_values)}\n"
+        f"{create_hint}"
+    )
+
+
 # The base function for `from_values`
 def _from_values(
     iterable: ListLike,

--- a/tests/core/test_artifact_features_annotations.py
+++ b/tests/core/test_artifact_features_annotations.py
@@ -707,7 +707,7 @@ Here is how to create a feature:
             "lamindb.errors.ValidationError: These values could not be validated:"
             in error_msg
         )
-        assert "Here is how to create records for them:" in error_msg
+        assert "Here is how to create objects for them:" in error_msg
 
         expected_values = {
             "Record": ["project_1", "U0123", "Experiment 2"],

--- a/tests/core/test_curator_basics.py
+++ b/tests/core/test_curator_basics.py
@@ -696,7 +696,7 @@ def test_schema_maximal_set_var():
     with pytest.raises(ValidationError) as error:
         curator.validate()
     assert error.exconly() == (
-        "lamindb.errors.ValidationError: 1 term not validated in feature 'columns' in slot 'var.T': 'NOT_VALID_ENSEMBL'\n"
+        "lamindb.errors.ValidationError: 1 term not validated in columns in slot 'var.T': 'NOT_VALID_ENSEMBL'\n"
         "    → fix typos, remove non-existent values, or create objects via:\n"
         "\n"
         "  records = bionty.Gene.from_values(['NOT_VALID_ENSEMBL'], field='ensembl_gene_id').save()"

--- a/tests/core/test_curator_basics.py
+++ b/tests/core/test_curator_basics.py
@@ -697,9 +697,7 @@ def test_schema_maximal_set_var():
         curator.validate()
     assert error.exconly() == (
         "lamindb.errors.ValidationError: 1 term not validated in feature 'columns' in slot 'var.T': 'NOT_VALID_ENSEMBL'\n"
-        "    → fix typos, remove non-existent values, or create records via:\n"
-        "\n"
-        "Here is how to create records for non-validated values for slot 'var.T':\n"
+        "    → fix typos, remove non-existent values, or create objects via:\n"
         "\n"
         "  records = bionty.Gene.from_values(['NOT_VALID_ENSEMBL'], field='ensembl_gene_id').save()"
     )

--- a/tests/core/test_curator_basics.py
+++ b/tests/core/test_curator_basics.py
@@ -697,7 +697,11 @@ def test_schema_maximal_set_var():
         curator.validate()
     assert error.exconly() == (
         "lamindb.errors.ValidationError: 1 term not validated in feature 'columns' in slot 'var.T': 'NOT_VALID_ENSEMBL'\n"
-        "    → fix typos, remove non-existent values, or save terms via: curator.slots['var.T'].cat.add_new_from('columns')"
+        "    → fix typos, remove non-existent values, or create records via:\n"
+        "\n"
+        "Here is how to create records for non-validated values for slot 'var.T':\n"
+        "\n"
+        "  records = bionty.Gene.from_values(['NOT_VALID_ENSEMBL'], field='ensembl_gene_id').save()"
     )
 
     # clean up

--- a/tests/core/test_curator_basics.py
+++ b/tests/core/test_curator_basics.py
@@ -699,7 +699,7 @@ def test_schema_maximal_set_var():
         "lamindb.errors.ValidationError: 1 term not validated in columns in slot 'var.T': 'NOT_VALID_ENSEMBL'\n"
         "    → fix typos, remove non-existent values, or create objects via:\n"
         "\n"
-        "  records = bionty.Gene.from_values(['NOT_VALID_ENSEMBL'], field='ensembl_gene_id').save()"
+        "  objects = bionty.Gene.from_values(['NOT_VALID_ENSEMBL'], field='ensembl_gene_id').save()"
     )
 
     # clean up

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -236,11 +236,11 @@ def test_feature_manager_raise_not_validated_values():
     message = str(error.value)
     assert "These values could not be validated" in message
     assert (
-        "records = ln.Record.from_values(['missing-record'], field='name', create=True).save()"
+        "objects = ln.Record.from_values(['missing-record'], field='name', create=True).save()"
         in message
     )
     assert (
-        "records = bionty.Gene.from_values(['missing-gene'], field='symbol').save()"
+        "objects = bionty.Gene.from_values(['missing-gene'], field='symbol').save()"
         in message
     )
 

--- a/tests/curators/test_curators_examples.py
+++ b/tests/curators/test_curators_examples.py
@@ -671,7 +671,7 @@ def test_anndata_curator_varT_curation():
                     adata, key="examples/dataset1.h5ad", schema=anndata_schema
                 ).save()
             assert error.exconly() == (
-                f"lamindb.errors.ValidationError: 1 term not validated in feature 'columns' in slot '{slot}': 'GeneTypo'\n"
+                f"lamindb.errors.ValidationError: 1 term not validated in columns in slot '{slot}': 'GeneTypo'\n"
                 f"    → fix typos, remove non-existent values, or create objects via:\n"
                 "\n"
                 "  records = bionty.Gene.from_values(['GeneTypo'], field='ensembl_gene_id').save()"

--- a/tests/curators/test_curators_examples.py
+++ b/tests/curators/test_curators_examples.py
@@ -226,7 +226,7 @@ def test_dataframe_curator(mini_immuno_schema: ln.Schema):
         == """lamindb.errors.ValidationError: 1 term not validated in feature 'perturbation': 'ulabel_but_not_perturbation'
     → fix typos, remove non-existent values, or create objects via:
 
-  records = ULabel.from_values(['ulabel_but_not_perturbation'], field='name', create=True).save()
+  objects = ULabel.from_values(['ulabel_but_not_perturbation'], field='name', create=True).save()
     → a valid label for subtype 'Perturbation' has to be one of ['DMSO', 'IFNG']"""
     )
 
@@ -240,7 +240,7 @@ def test_dataframe_curator(mini_immuno_schema: ln.Schema):
         == """lamindb.errors.ValidationError: 1 term not validated in feature 'perturbation': 'IFNJ'
     → fix typos, remove non-existent values, or create objects via:
 
-  records = ULabel.from_values(['IFNJ'], field='name', create=True).save()
+  objects = ULabel.from_values(['IFNJ'], field='name', create=True).save()
     → a valid label for subtype 'Perturbation' has to be one of ['DMSO', 'IFNG']"""
     )
 
@@ -510,7 +510,7 @@ def test_schema_no_match_ensembl():
         == """lamindb.errors.ValidationError: 2 terms not validated in feature 'index': 'ENSG99999999998', 'ENSG99999999999'
     → fix typos, remove non-existent values, or create objects via:
 
-  records = bionty.Gene.from_values(['ENSG99999999998', 'ENSG99999999999'], field='ensembl_gene_id').save()"""
+  objects = bionty.Gene.from_values(['ENSG99999999998', 'ENSG99999999999'], field='ensembl_gene_id').save()"""
     )
 
     schema.delete(permanent=True)
@@ -674,7 +674,7 @@ def test_anndata_curator_varT_curation():
                 f"lamindb.errors.ValidationError: 1 term not validated in columns in slot '{slot}': 'GeneTypo'\n"
                 f"    → fix typos, remove non-existent values, or create objects via:\n"
                 "\n"
-                "  records = bionty.Gene.from_values(['GeneTypo'], field='ensembl_gene_id').save()"
+                "  objects = bionty.Gene.from_values(['GeneTypo'], field='ensembl_gene_id').save()"
             )
         else:
             for n_max_records in [2, 4]:
@@ -728,7 +728,7 @@ def test_anndata_curator_varT_curation_legacy(ccaplog):
                 f"lamindb.errors.ValidationError: 1 term not validated in feature 'var_index' in slot '{slot}': 'GeneTypo'\n"
                 f"    → fix typos, remove non-existent values, or create objects via:\n"
                 "\n"
-                "  records = bionty.Gene.from_values(['GeneTypo'], field='ensembl_gene_id').save()"
+                "  objects = bionty.Gene.from_values(['GeneTypo'], field='ensembl_gene_id').save()"
             )
         else:
             artifact = ln.Artifact.from_anndata(

--- a/tests/curators/test_curators_examples.py
+++ b/tests/curators/test_curators_examples.py
@@ -224,7 +224,11 @@ def test_dataframe_curator(mini_immuno_schema: ln.Schema):
     assert (
         error.exconly()
         == """lamindb.errors.ValidationError: 1 term not validated in feature 'perturbation': 'ulabel_but_not_perturbation'
-    → fix typos, remove non-existent values, or save terms via: curator.cat.add_new_from('perturbation')
+    → fix typos, remove non-existent values, or create records via:
+
+Here is how to create records for non-validated values:
+
+  records = ULabel.from_values(['ulabel_but_not_perturbation'], field='name', create=True).save()
     → a valid label for subtype 'Perturbation' has to be one of ['DMSO', 'IFNG']"""
     )
 
@@ -236,7 +240,11 @@ def test_dataframe_curator(mini_immuno_schema: ln.Schema):
     assert (
         error.exconly()
         == """lamindb.errors.ValidationError: 1 term not validated in feature 'perturbation': 'IFNJ'
-    → fix typos, remove non-existent values, or save terms via: curator.cat.add_new_from('perturbation')
+    → fix typos, remove non-existent values, or create records via:
+
+Here is how to create records for non-validated values:
+
+  records = ULabel.from_values(['IFNJ'], field='name', create=True).save()
     → a valid label for subtype 'Perturbation' has to be one of ['DMSO', 'IFNG']"""
     )
 
@@ -481,11 +489,6 @@ def test_schema_new_genes(ccaplog):
         "lamindb.errors.ValidationError: 2 terms not validated in feature 'index': 'ENSG00999000001', 'ENSG00999000002'"
     )
 
-    assert (
-        "2 terms not validated in feature 'index': 'ENSG00999000001', 'ENSG00999000002'"
-        in ccaplog.text
-    )
-
     schema.delete(permanent=True)
     feature.delete(permanent=True)
 
@@ -509,7 +512,11 @@ def test_schema_no_match_ensembl():
     assert (
         error.exconly()
         == """lamindb.errors.ValidationError: 2 terms not validated in feature 'index': 'ENSG99999999998', 'ENSG99999999999'
-    → fix typos, remove non-existent values, or save terms via: curator.cat.add_new_from('index')"""
+    → fix typos, remove non-existent values, or create records via:
+
+Here is how to create records for non-validated values:
+
+  records = bionty.Gene.from_values(['ENSG99999999998', 'ENSG99999999999'], field='ensembl_gene_id').save()"""
     )
 
     schema.delete(permanent=True)
@@ -543,8 +550,6 @@ def test_schema_mixed_ensembl_symbols(ccaplog):
     assert error.exconly().startswith(
         "lamindb.errors.ValidationError: 2 terms not validated in feature 'index': 'BRCA2', 'TP53'"
     )
-
-    assert "2 terms not validated in feature 'index': 'BRCA2', 'TP53'" in ccaplog.text
 
     schema.delete(permanent=True)
 
@@ -673,7 +678,11 @@ def test_anndata_curator_varT_curation():
                 ).save()
             assert error.exconly() == (
                 f"lamindb.errors.ValidationError: 1 term not validated in feature 'columns' in slot '{slot}': 'GeneTypo'\n"
-                f"    → fix typos, remove non-existent values, or save terms via: curator.slots['{slot}'].cat.add_new_from('columns')"
+                f"    → fix typos, remove non-existent values, or create records via:\n"
+                "\n"
+                f"Here is how to create records for non-validated values for slot '{slot}':\n"
+                "\n"
+                "  records = bionty.Gene.from_values(['GeneTypo'], field='ensembl_gene_id').save()"
             )
         else:
             for n_max_records in [2, 4]:
@@ -725,7 +734,11 @@ def test_anndata_curator_varT_curation_legacy(ccaplog):
                 ).save()
             assert error.exconly() == (
                 f"lamindb.errors.ValidationError: 1 term not validated in feature 'var_index' in slot '{slot}': 'GeneTypo'\n"
-                f"    → fix typos, remove non-existent values, or save terms via: curator.slots['{slot}'].cat.add_new_from('var_index')"
+                f"    → fix typos, remove non-existent values, or create records via:\n"
+                "\n"
+                f"Here is how to create records for non-validated values for slot '{slot}':\n"
+                "\n"
+                "  records = bionty.Gene.from_values(['GeneTypo'], field='ensembl_gene_id').save()"
             )
         else:
             artifact = ln.Artifact.from_anndata(

--- a/tests/curators/test_curators_examples.py
+++ b/tests/curators/test_curators_examples.py
@@ -224,9 +224,7 @@ def test_dataframe_curator(mini_immuno_schema: ln.Schema):
     assert (
         error.exconly()
         == """lamindb.errors.ValidationError: 1 term not validated in feature 'perturbation': 'ulabel_but_not_perturbation'
-    → fix typos, remove non-existent values, or create records via:
-
-Here is how to create records for non-validated values:
+    → fix typos, remove non-existent values, or create objects via:
 
   records = ULabel.from_values(['ulabel_but_not_perturbation'], field='name', create=True).save()
     → a valid label for subtype 'Perturbation' has to be one of ['DMSO', 'IFNG']"""
@@ -240,9 +238,7 @@ Here is how to create records for non-validated values:
     assert (
         error.exconly()
         == """lamindb.errors.ValidationError: 1 term not validated in feature 'perturbation': 'IFNJ'
-    → fix typos, remove non-existent values, or create records via:
-
-Here is how to create records for non-validated values:
+    → fix typos, remove non-existent values, or create objects via:
 
   records = ULabel.from_values(['IFNJ'], field='name', create=True).save()
     → a valid label for subtype 'Perturbation' has to be one of ['DMSO', 'IFNG']"""
@@ -512,9 +508,7 @@ def test_schema_no_match_ensembl():
     assert (
         error.exconly()
         == """lamindb.errors.ValidationError: 2 terms not validated in feature 'index': 'ENSG99999999998', 'ENSG99999999999'
-    → fix typos, remove non-existent values, or create records via:
-
-Here is how to create records for non-validated values:
+    → fix typos, remove non-existent values, or create objects via:
 
   records = bionty.Gene.from_values(['ENSG99999999998', 'ENSG99999999999'], field='ensembl_gene_id').save()"""
     )
@@ -678,9 +672,7 @@ def test_anndata_curator_varT_curation():
                 ).save()
             assert error.exconly() == (
                 f"lamindb.errors.ValidationError: 1 term not validated in feature 'columns' in slot '{slot}': 'GeneTypo'\n"
-                f"    → fix typos, remove non-existent values, or create records via:\n"
-                "\n"
-                f"Here is how to create records for non-validated values for slot '{slot}':\n"
+                f"    → fix typos, remove non-existent values, or create objects via:\n"
                 "\n"
                 "  records = bionty.Gene.from_values(['GeneTypo'], field='ensembl_gene_id').save()"
             )
@@ -734,9 +726,7 @@ def test_anndata_curator_varT_curation_legacy(ccaplog):
                 ).save()
             assert error.exconly() == (
                 f"lamindb.errors.ValidationError: 1 term not validated in feature 'var_index' in slot '{slot}': 'GeneTypo'\n"
-                f"    → fix typos, remove non-existent values, or create records via:\n"
-                "\n"
-                f"Here is how to create records for non-validated values for slot '{slot}':\n"
+                f"    → fix typos, remove non-existent values, or create objects via:\n"
                 "\n"
                 "  records = bionty.Gene.from_values(['GeneTypo'], field='ensembl_gene_id').save()"
             )


### PR DESCRIPTION
Before | After
--- | ---
<img width="816" height="421" alt="image" src="https://github.com/user-attachments/assets/8d3a597f-3ef9-4277-8512-2b3d21a51b96" /> | <img width="814" height="318" alt="image" src="https://github.com/user-attachments/assets/e1ca5013-af91-4c94-92ff-27feebba2098" />

The screenshot is from here: https://docs.lamin.ai/curate

Also in this PR: Fixed stylistic issues in the `curate.md` guide.
