### PR TITLE
✨ Pull existing artifacts for `s3/gs` paths in `AUTO_KEY_PREFIX` when creating an artifact

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -15,7 +15,10 @@ from django.db.models import CASCADE, PROTECT, Q
 from django.db.models.functions import Length
 from lamin_utils import colors, logger
 from lamindb_setup import settings as setup_settings
-from lamindb_setup.core._hub_core import select_storage_or_parent
+from lamindb_setup.core._hub_core import (
+    get_instance_slug_by_uid,
+    select_storage_or_parent,
+)
 from lamindb_setup.core.hashing import HASH_LENGTH, hash_dir, hash_file
 from lamindb_setup.core.upath import (
     LocalPathClasses,
@@ -1677,10 +1680,42 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             raise ValueError(
                 f"Do not pass key that contains a managed storage path in `{_s().AUTO_KEY_PREFIX}`"
             )
-        # below is for internal calls that require defining the storage location
-        # ahead of constructing the Artifact
-        if isinstance(path, (str, Path, UPath)) and _s().AUTO_KEY_PREFIX in str(path):
-            if _is_internal_call:
+
+        if isinstance(path, (str, Path, UPath)) and _s().AUTO_KEY_PREFIX in (
+            path_str := path if isinstance(path, str) else path.as_posix()
+        ):
+            if not _is_internal_call:
+                # just check for 2 writable cloud protocols, maybe change in the future
+                if path_str.startswith(("s3://", "gs://")):
+                    storage_record = select_storage_or_parent(path_str)
+                    if storage_record is None:
+                        raise ValueError(
+                            f"Registered storage location for path '{path_str}' not found."
+                        )
+                    slug = get_instance_slug_by_uid(storage_record["instance_uid"])
+                    if slug is None:
+                        raise ValueError(
+                            f"Managing instance for storage location '{storage_record['root']}' not found."
+                        )
+                    try:
+                        # exclude trash?
+                        existing_artifact = Artifact.connect(slug).get(path=path_str)
+                    except Artifact.DoesNotExist as e:
+                        raise ValueError(
+                            f"Artifact for path '{path_str}' not found."
+                        ) from e
+
+                    from .sqlrecord import init_self_from_db
+
+                    init_self_from_db(self, existing_artifact)
+                    return None
+                else:
+                    raise ValueError(
+                        f"Do not pass path inside the `{_s().AUTO_KEY_PREFIX}` directory for non-s3/gs paths."
+                    )
+            # below is for internal calls that require defining the storage location
+            # ahead of constructing the Artifact
+            else:
                 if _key_is_virtual is False:
                     raise ValueError(
                         "Do not pass key_is_virtual=False with _is_internal_call=True."
@@ -1688,10 +1723,6 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                 is_automanaged_path = True
                 user_provided_key = key
                 key = None
-            else:
-                raise ValueError(
-                    f"Do not pass path inside the `{_s().AUTO_KEY_PREFIX}` directory."
-                )
         else:
             is_automanaged_path = False
 

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1707,7 +1707,9 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
 
                     from .sqlrecord import init_self_from_db
 
-                    init_self_from_db(self, existing_artifact, db=None)
+                    init_self_from_db(
+                        self, existing_artifact, db=existing_artifact._state.db
+                    )
                     return None
                 else:
                     raise ValueError(

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1687,6 +1687,22 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             if not _is_internal_call:
                 # just check for 2 writable cloud protocols, maybe change in the future
                 if path_str.startswith(("s3://", "gs://")):
+                    from .sqlrecord import init_self_from_db
+
+                    # might be in the current instance already
+                    # doing it here first because if the artifact was transferred already,
+                    # the query further will still search in the instance managing the storage of the artifact
+                    try:
+                        # exclude trash?
+                        existing_artifact = Artifact.get(path=path_str)
+                        logger.important(
+                            f"initializing from existing artifact with uid={existing_artifact.uid}"
+                        )
+                        init_self_from_db(self, existing_artifact)
+                        return None
+                    except Artifact.DoesNotExist:
+                        pass
+
                     storage_record = select_storage_or_parent(path_str)
                     if storage_record is None:
                         raise ValueError(
@@ -1705,8 +1721,9 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                             f"Artifact for path '{path_str}' not found."
                         ) from e
 
-                    from .sqlrecord import init_self_from_db
-
+                    logger.important(
+                        f"initializing from existing artifact with uid={existing_artifact.uid} on {slug}"
+                    )
                     init_self_from_db(
                         self, existing_artifact, db=existing_artifact._state.db
                     )

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1707,7 +1707,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
 
                     from .sqlrecord import init_self_from_db
 
-                    init_self_from_db(self, existing_artifact)
+                    init_self_from_db(self, existing_artifact, db=None)
                     return None
                 else:
                     raise ValueError(

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -327,7 +327,9 @@ def is_approx_pascal_case(s: str) -> bool:
     return last_component[:1].isupper() and "_" not in last_component
 
 
-def init_self_from_db(self: SQLRecord, existing_record: SQLRecord):
+def init_self_from_db(
+    self: SQLRecord, existing_record: SQLRecord, db: str | None = "default"
+):
     from .run import current_run
 
     new_args = [
@@ -335,7 +337,8 @@ def init_self_from_db(self: SQLRecord, existing_record: SQLRecord):
     ]
     super(self.__class__, self).__init__(*new_args)
     self._state.adding = False  # mimic from_db
-    self._state.db = "default"
+    if db is not None:
+        self._state.db = db
     # if run was not set on the existing record, set it to the current_run
     if hasattr(self, "run_id") and self.run_id is None and current_run() is not None:
         logger.warning(f"run was not set on {self}, setting to current run")

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -337,8 +337,7 @@ def init_self_from_db(
     ]
     super(self.__class__, self).__init__(*new_args)
     self._state.adding = False  # mimic from_db
-    if db is not None:
-        self._state.db = db
+    self._state.db = db
     # if run was not set on the existing record, set it to the current_run
     if hasattr(self, "run_id") and self.run_id is None and current_run() is not None:
         logger.warning(f"run was not set on {self}, setting to current run")

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -95,7 +95,7 @@ def test_basic_validation():
     )
 
 
-def test_cloud_autokey_path_missing_storage_raises(monkeypatch):
+def test_cloud_path_init_missing_storage_raises(monkeypatch):
     path = "s3://missing-storage/.lamindb/test_df.parquet"
     monkeypatch.setattr(
         "lamindb.models.artifact.select_storage_or_parent", lambda _: None
@@ -108,7 +108,7 @@ def test_cloud_autokey_path_missing_storage_raises(monkeypatch):
     )
 
 
-def test_cloud_autokey_path_missing_instance_slug_raises(monkeypatch):
+def test_cloud_path_init_missing_instance_slug_raises(monkeypatch):
     path = "s3://my-storage/.lamindb/test_df.parquet"
     storage_record = {"instance_uid": "missing-instance", "root": "s3://my-storage"}
     monkeypatch.setattr(
@@ -125,7 +125,7 @@ def test_cloud_autokey_path_missing_instance_slug_raises(monkeypatch):
     )
 
 
-def test_cloud_autokey_path_missing_artifact_raises(monkeypatch):
+def test_cloud_path_init_missing_artifact_raises(monkeypatch):
     path = "s3://my-storage/.lamindb/test_df.parquet"
     monkeypatch.setattr(
         "lamindb.models.artifact.select_storage_or_parent",
@@ -148,6 +148,29 @@ def test_cloud_autokey_path_missing_artifact_raises(monkeypatch):
     with pytest.raises(ValueError) as error:
         ln.Artifact(path, description="test")
     assert error.exconly() == f"ValueError: Artifact for path '{path}' not found."
+
+
+def test_path_init_existing_artifact():
+    # any artifact on s3 fits this test
+    artifact = (
+        ln.Artifact.connect("laminlabs/lamindata")
+        .filter(storage__root__startswith="s3://")
+        .first()
+    )
+    assert artifact is not None
+
+    artifact_transfer = ln.Artifact(artifact.path)
+    assert artifact_transfer.uid == artifact.uid
+    assert artifact_transfer._state.db == "laminlabs/lamindata"
+
+    artifact_transfer.save()
+    assert artifact_transfer._state.db == "default"
+    # repeated init pulls the transfered artifact from the current instance
+    artifact_transfer = ln.Artifact(artifact.path)
+    assert artifact_transfer.uid == artifact.uid
+    assert artifact_transfer._state.db == "default"
+
+    artifact_transfer.delete(permanent=True, storage=False)
 
 
 @pytest.mark.parametrize("key_is_virtual", [True, False])

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -91,7 +91,7 @@ def test_basic_validation():
         ln.Artifact(".lamindb/test_df.parquet", description="Test")
     assert (
         error.exconly()
-        == f"ValueError: Do not pass path inside the `{AUTO_KEY_PREFIX}` directory."
+        == f"ValueError: Do not pass path inside the `{AUTO_KEY_PREFIX}` directory for non-s3/gs paths."
     )
 
 

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -95,6 +95,61 @@ def test_basic_validation():
     )
 
 
+def test_cloud_autokey_path_missing_storage_raises(monkeypatch):
+    path = "s3://missing-storage/.lamindb/test_df.parquet"
+    monkeypatch.setattr(
+        "lamindb.models.artifact.select_storage_or_parent", lambda _: None
+    )
+    with pytest.raises(ValueError) as error:
+        ln.Artifact(path, description="test")
+    assert (
+        error.exconly()
+        == f"ValueError: Registered storage location for path '{path}' not found."
+    )
+
+
+def test_cloud_autokey_path_missing_instance_slug_raises(monkeypatch):
+    path = "s3://my-storage/.lamindb/test_df.parquet"
+    storage_record = {"instance_uid": "missing-instance", "root": "s3://my-storage"}
+    monkeypatch.setattr(
+        "lamindb.models.artifact.select_storage_or_parent", lambda _: storage_record
+    )
+    monkeypatch.setattr(
+        "lamindb.models.artifact.get_instance_slug_by_uid", lambda _: None
+    )
+    with pytest.raises(ValueError) as error:
+        ln.Artifact(path, description="test")
+    assert (
+        error.exconly()
+        == f"ValueError: Managing instance for storage location '{storage_record['root']}' not found."
+    )
+
+
+def test_cloud_autokey_path_missing_artifact_raises(monkeypatch):
+    path = "s3://my-storage/.lamindb/test_df.parquet"
+    monkeypatch.setattr(
+        "lamindb.models.artifact.select_storage_or_parent",
+        lambda _: {"instance_uid": "instance-uid", "root": "s3://my-storage"},
+    )
+    monkeypatch.setattr(
+        "lamindb.models.artifact.get_instance_slug_by_uid",
+        lambda _: "owner/instance",
+    )
+
+    class DummyConnection:
+        def get(self, **_kwargs):
+            raise ln.Artifact.DoesNotExist
+
+    monkeypatch.setattr(
+        ln.Artifact,
+        "connect",
+        classmethod(lambda cls, instance: DummyConnection()),
+    )
+    with pytest.raises(ValueError) as error:
+        ln.Artifact(path, description="test")
+    assert error.exconly() == f"ValueError: Artifact for path '{path}' not found."
+
+
 @pytest.mark.parametrize("key_is_virtual", [True, False])
 @pytest.mark.parametrize("key", [None, "my_new_dir/my_artifact.csv", "nosuffix"])
 @pytest.mark.parametrize("description", [None, "my description"])

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -171,6 +171,8 @@ def test_path_init_existing_artifact():
     assert artifact_transfer._state.db == "default"
 
     storage = artifact_transfer.storage
+    assert storage.instance_uid != ln.settings.instance_uid
+
     artifact_transfer.delete(permanent=True, storage=False)
     storage.delete()
 

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -170,7 +170,9 @@ def test_path_init_existing_artifact():
     assert artifact_transfer.uid == artifact.uid
     assert artifact_transfer._state.db == "default"
 
+    storage = artifact_transfer.storage
     artifact_transfer.delete(permanent=True, storage=False)
+    storage.delete()
 
 
 @pytest.mark.parametrize("key_is_virtual", [True, False])


### PR DESCRIPTION
`Artifact` can now be initialized directly from managed cloud paths inside `.lamindb/` on S3/GCS, instead of those paths being rejected.

This makes it easier to reference artifacts that already exist in managed storage, including artifacts managed by another instance.

## Example

```python
import lamindb as ln

path = "s3://my-bucket/.lamindb/ABCDEF1234567890.parquet"

# New: this resolves the existing artifact metadata
artifact = ln.Artifact(path) # assume exists in the current or another instance

print(artifact.uid)
artifact.save() # transfer if on another instance
```

## When it still errors

Clear `ValueError`s are raised when:

- the storage location for the path is not registered,
- no managing instance can be resolved for that storage,
- or no artifact exists at the specified managed path.

For non-cloud paths containing `.lamindb/`, validation still rejects them.