### PR TITLE
✨ Support timezone-ware datetimes as dtype

### DIFF
--- a/lamindb/base/types.py
+++ b/lamindb/base/types.py
@@ -115,6 +115,7 @@ DtypeStr = Literal[
     "str",  # string
     "bool",  # boolean
     "datetime",  # datetime
+    "datetime64[ns, UTC]",  # timezone-aware datetime
     "date",  # date
     "dict",  # dictionary
     "path",  # path, validated as str, but specially treated in the UI
@@ -132,6 +133,7 @@ float         `"float"`     `float64 | float32 | float16 | float8 | ...`
 string        `"str"`       `object`
 boolean       `"bool"`      `boolean | bool`
 datetime      `"datetime"`  `datetime`
+datetime (tz) `"datetime64[ns, UTC]"` `datetime64[ns, UTC]`
 date          `"date"`      `object` (pandera requires an ISO-format string, convert with `df["date"] = df["date"].dt.date`)
 dictionary    `"dict"`      `object`
 path          `"path"`      `str` (pandas does not have a dedicated path type, validated as `str`)

--- a/lamindb/base/types.py
+++ b/lamindb/base/types.py
@@ -124,21 +124,21 @@ DtypeStr = Literal[
 ]
 """String-serialized representations of common data types.
 
-============  ============  =================================================
-description   lamindb       pandas
-============  ============  =================================================
-numerical     `"num"`       `int | float`
-integer       `"int"`       `int64 | int32 | int16 | int8 | uint | ...`
-float         `"float"`     `float64 | float32 | float16 | float8 | ...`
-string        `"str"`       `object`
-boolean       `"bool"`      `boolean | bool`
-datetime (naive)     `"datetime"`  `datetime`
-datetime (tz) `"datetime64[ns, UTC]"` `datetime64[ns, UTC]`
-date          `"date"`      `object` (pandera requires an ISO-format string, convert with `df["date"] = df["date"].dt.date`)
-dictionary    `"dict"`      `object`
-path          `"path"`      `str` (pandas does not have a dedicated path type, validated as `str`)
-url           `"url"`       `str` (pandas does not have a dedicated url type, validated as `str`)
-============  ============  =================================================
+===============  ====================  =================================================
+description      lamindb (str)         pandas
+===============  ====================  =================================================
+numerical        `num`                 `int | float`
+integer          `int`                 `int64 | int32 | int16 | int8 | uint | ...`
+float            `float`               `float64 | float32 | float16 | float8 | ...`
+string           `str`                 `object`
+boolean          `bool`                `boolean | bool`
+datetime (naive) `datetime`            `datetime`
+datetime (tz)    `datetime64[ns, UTC]` `datetime64[ns, UTC]`
+date             `date`                `object` (pandera requires an ISO-format string, convert with `df["date"] = df["date"].dt.date`)
+dictionary       `dict`                `object`
+path             `path`                `str` (pandas does not have a dedicated path type, validated as `str`)
+url              `url`                 `str` (pandas does not have a dedicated url type, validated as `str`)
+===============  ====================  =================================================
 
 .. admonition:: Categorical and relational data types
 

--- a/lamindb/base/types.py
+++ b/lamindb/base/types.py
@@ -132,7 +132,7 @@ integer       `"int"`       `int64 | int32 | int16 | int8 | uint | ...`
 float         `"float"`     `float64 | float32 | float16 | float8 | ...`
 string        `"str"`       `object`
 boolean       `"bool"`      `boolean | bool`
-datetime      `"datetime"`  `datetime`
+datetime (naive)     `"datetime"`  `datetime`
 datetime (tz) `"datetime64[ns, UTC]"` `datetime64[ns, UTC]`
 date          `"date"`      `object` (pandera requires an ISO-format string, convert with `df["date"] = df["date"].dt.date`)
 dictionary    `"dict"`      `object`

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -23,6 +23,7 @@ from django.db.models import Q
 from lamin_utils import colors, logger
 from lamindb_setup.core._docs import doc_args
 from lamindb_setup.core.upath import LocalPathClasses
+from pandera.engines import pandas_engine
 
 from lamindb.base.dtypes import check_dtype
 from lamindb.base.types import FieldAttr  # noqa
@@ -584,9 +585,15 @@ class ComponentCurator(Curator):
                         ),
                     )
                 else:
-                    pandera_dtype = (
-                        dtype_str if not dtype_str.startswith("cat") else "category"
-                    )
+                    if dtype_str == "datetime64[ns, UTC]":
+                        pandera_dtype = pandas_engine.DateTime(
+                            time_zone_agnostic=True,
+                            tz="UTC" if feature.coerce else None,
+                        )
+                    else:
+                        pandera_dtype = (
+                            dtype_str if not dtype_str.startswith("cat") else "category"
+                        )
                     pandera_columns[feature.name] = pandera.Column(
                         pandera_dtype,
                         nullable=feature.nullable,

--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -414,7 +414,7 @@ def get_non_categoricals(
                     pass
 
             # Handle special datetime types
-            if feature_dtype == "datetime":
+            if feature_dtype in {"datetime", "datetime64[ns, UTC]"}:
                 values = {datetime.fromisoformat(value) for value in values}
             if feature_dtype == "date":
                 # date.fromisoformat() cannot handle cases like 2025-01-17T00:00:00.000Z
@@ -734,15 +734,28 @@ def infer_convert_dtype_key_value(
     elif isinstance(value, float):
         return "float", value, message
     elif isinstance(value, datetime):
-        return "datetime", value.isoformat(), message
+        return (
+            "datetime64[ns, UTC]" if value.tzinfo is not None else "datetime",
+            value.isoformat(),
+            message,
+        )
     elif isinstance(value, date):
         return "date", value.isoformat(), message
     elif isinstance(value, str):
-        if dtype_str in {None, "datetime", "date"} and (
-            datetime_str := is_valid_datetime_str(value)
-        ):
+        if dtype_str in {
+            None,
+            "datetime",
+            "datetime64[ns, UTC]",
+            "date",
+        } and (datetime_str := is_valid_datetime_str(value)):
             dt_type = (
-                "date" if len(value) == 10 else "datetime"
+                "date"
+                if len(value) == 10
+                else (
+                    "datetime64[ns, UTC]"
+                    if dtype_str == "datetime64[ns, UTC]"
+                    else "datetime"
+                )
             )  # YYYY-MM-DD is exactly 10 characters
             sanitized_value = datetime_str[:10] if dt_type == "date" else datetime_str  # type: ignore
             return dt_type, sanitized_value, message  # type: ignore
@@ -1129,7 +1142,7 @@ class FeatureManager:
                 for dtype, value in dtype_values:
                     if dtype == "date":
                         value = pd.to_datetime(value, format="ISO8601").date()
-                    elif dtype == "datetime":
+                    elif dtype in {"datetime", "datetime64[ns, UTC]"}:
                         value = datetime.fromisoformat(value)
                     feature_values_qs.append(value)
             else:

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -261,6 +261,10 @@ def dtype_as_object(dtype_str: str, old_format: bool = False) -> type | None:
             from datetime import datetime
 
             return datetime
+        elif dtype_str == "datetime64[ns, UTC]":
+            from datetime import datetime
+
+            return datetime
         elif dtype_str.startswith("dict"):
             return dict
         return None
@@ -674,12 +678,14 @@ def serialize_pandas_dtype(pandas_dtype: ExtensionDtype) -> str:
     # there are string-like categoricals and "pure" categoricals (pd.Categorical)
     elif isinstance(pandas_dtype, CategoricalDtype):
         dtype = "cat[ULabel]"
+    elif hasattr(pandas_dtype, "tz") and pandas_dtype.tz is not None:
+        dtype = "datetime64[ns, UTC]"
     else:
         # strip precision qualifiers
         dtype = "".join(dt for dt in pandas_dtype.name if not dt.isdigit())
         if dtype == "uint":
             dtype = "int"
-    if dtype.startswith("datetime"):
+    if dtype.startswith("datetime") and dtype != "datetime64[ns, UTC]":
         dtype = dtype.split("[")[0]
     if dtype != "cat[ULabel]":
         assert dtype in FEATURE_DTYPES  # noqa: S101
@@ -698,6 +704,7 @@ def convert_to_pandas_dtype(lamin_dtype: str) -> str | pd.CategoricalDtype:
         "float": "float64",
         "bool": "boolean",  # Nullable boolean
         "datetime": "datetime64[ns]",
+        "datetime64[ns, UTC]": "datetime64[ns, UTC]",
         "date": "object",  # preserve Date objects
         "dict": "object",  # dicts are stored as object dtype in pandas
     }
@@ -1251,25 +1258,25 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
                     f"cat_filters are incompatible with nested dtypes: '{dtype_str}'"
                 )
 
-            # Validate filter values and SQLRecord attributes
+            # Validate filter values and BaseSQLRecord attributes
             for filter_key, filter_value in cat_filters.items():
                 if not filter_value or (
                     isinstance(filter_value, str) and not filter_value.strip()
                 ):
                     raise ValidationError(f"Empty value in filter {filter_key}")
-                # Check SQLRecord attributes for relation lookups
-                if isinstance(filter_value, SQLRecord) and "__" in filter_key:
+                # Check record attributes for relation lookups
+                if isinstance(filter_value, BaseSQLRecord) and "__" in filter_key:
                     field_name = filter_key.split("__", 1)[1]
                     if not hasattr(filter_value, field_name):
                         raise ValidationError(
                             f"SQLRecord {filter_value.__class__.__name__} has no attribute '{field_name}' in filter {filter_key}"
                         )
 
-            # If a SQLRecord is passed, we access its uid to apply a standard filter
+            # If a BaseSQLRecord is passed, use uid-based filter serialization.
             cat_filters = {
                 f"{key}__uid"
                 if (
-                    is_sqlrecord := isinstance(filter, SQLRecord)
+                    is_sqlrecord := isinstance(filter, BaseSQLRecord)
                     and hasattr(filter, "uid")
                 )
                 else key: filter.uid if is_sqlrecord else filter

--- a/lamindb/models/query_set.py
+++ b/lamindb/models/query_set.py
@@ -948,6 +948,11 @@ def reshape_annotate_result(
                 result_encoded[feature.name] = pd.to_datetime(
                     result_encoded[feature.name], format="ISO8601", utc=True
                 ).dt.tz_localize(None)
+            if dtype_str == "datetime64[ns, UTC]":
+                # store timezone-aware datetimes normalized to UTC
+                result_encoded[feature.name] = pd.to_datetime(
+                    result_encoded[feature.name], format="ISO8601", utc=True
+                )
             if dtype_str == "date":
                 # see comments for datetime
                 result_encoded[feature.name] = (

--- a/tests/core/test_feature.py
+++ b/tests/core/test_feature.py
@@ -131,21 +131,6 @@ def test_cat_filters_invalid_field_name():
     source.delete(permanent=True)
 
 
-def test_cat_filters_artifact_schema_filter():
-    schema_feature = ln.Feature(name="schema_filter_column", dtype=str).save()
-    schema = ln.Schema(name="schema_filter_schema", features=[schema_feature]).save()
-    try:
-        feature = ln.Feature(
-            name="artifact_input",
-            dtype=ln.Artifact,
-            cat_filters={"schema": schema},
-        )
-        assert feature._dtype_str == f"cat[Artifact[schema__uid='{schema.uid}']]"
-    finally:
-        schema.delete(permanent=True)
-        schema_feature.delete(permanent=True)
-
-
 def test_feature_from_df():
     df = pd.DataFrame(
         {
@@ -260,3 +245,11 @@ def test_feature_query_by_dtype():
         # Clean up
         str_feat.delete(permanent=True)
         int_feat.delete(permanent=True)
+
+
+def test_serialize_pandas_datetime_dtypes():
+    datetime_series = pd.Series([pd.Timestamp("2024-01-01 12:00:00")])
+    datetime_tz_series = pd.Series([pd.Timestamp("2024-01-01 12:00:00+00:00")])
+
+    assert serialize_pandas_dtype(datetime_series.dtype) == "datetime"
+    assert serialize_pandas_dtype(datetime_tz_series.dtype) == "datetime64[ns, UTC]"

--- a/tests/core/test_feature_dtype.py
+++ b/tests/core/test_feature_dtype.py
@@ -354,7 +354,24 @@ def test_nested_cat_with_filter():
 # -----------------------------------------------------------------------------
 
 
-def test_feature_dtype():
+def test_cat_filters_artifact_schema_filter():
+    schema_feature = ln.Feature(name="schema_filter_column", dtype=str).save()
+    schema = ln.Schema(name="schema_filter_schema", features=[schema_feature]).save()
+    created_by = ln.User.get(ln.setup.settings.user.id)
+    feature = ln.Feature(
+        name="artifact_input",
+        dtype=ln.Artifact,
+        cat_filters={"schema": schema, "created_by": created_by},
+    )
+    assert (
+        feature._dtype_str
+        == f"cat[Artifact[schema__uid='{schema.uid}', created_by__uid='{created_by.uid}']]"
+    )
+    schema.delete(permanent=True)
+    schema_feature.delete(permanent=True)
+
+
+def test_cat_filters_bionty_disease_filter():
     feature = ln.Feature(
         name="disease",
         dtype=bt.Disease,
@@ -362,8 +379,8 @@ def test_feature_dtype():
             "source__uid": "4a3ejKuf"
         },  # uid corresponds to disease_ontology_old.uid
     ).save()
-
     result = parse_dtype(feature._dtype_str)
+    assert feature._dtype_str == "cat[bionty.Disease[source__uid='4a3ejKuf']]"
     assert len(result) == 1
     assert result[0] == {
         "registry_str": "bionty.Disease",
@@ -372,7 +389,6 @@ def test_feature_dtype():
         "registry": bt.Disease,
         "field": bt.Disease.name,
     }
-
     feature.delete(permanent=True)
 
 

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -1,6 +1,6 @@
 import os
 import re
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 
 import bionty as bt
 import lamindb as ln
@@ -842,6 +842,32 @@ def test_date_and_datetime_corruption():
     schema.delete(permanent=True)
     feature_datetime.delete(permanent=True)
     feature_date.delete(permanent=True)
+
+
+def test_timezone_aware_datetime_feature():
+    feature_datetime_tz = ln.Feature(
+        name="feature_datetime_tz", dtype="datetime64[ns, UTC]"
+    ).save()
+    schema = ln.Schema([feature_datetime_tz], name="test_schema_datetime_tz").save()
+    test_sheet = ln.Record(
+        name="TestSheetDatetimeTZ", is_type=True, schema=schema
+    ).save()
+    record = ln.Record(name="test_record_datetime_tz", type=test_sheet).save()
+    timestamp = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    record.features.add_values({"feature_datetime_tz": timestamp})
+    assert record.features.get_values() == {"feature_datetime_tz": timestamp}
+
+    df = test_sheet.to_dataframe()
+    assert str(df["feature_datetime_tz"].dtype) == "datetime64[ns, UTC]"
+    assert df.to_dict(orient="records")[0]["feature_datetime_tz"] == pd.Timestamp(
+        "2024-01-01 12:00:00+00:00"
+    )
+
+    record.delete(permanent=True)
+    test_sheet.delete(permanent=True)
+    schema.delete(permanent=True)
+    feature_datetime_tz.delete(permanent=True)
 
 
 def test_only_list_type_features_and_field_qualifiers():


### PR DESCRIPTION
To enforce timezone-aware timestamps, one can now use:

```python
ln.Feature(name="feature_datetime_tz", dtype="datetime64[ns, UTC]").save()
```

This builds on the mechanics of pandas and pandera and works for native Python timestamps, too. It can easily be extended to Python objects used in other libraries (`pyarrow`, ...).