### PR TITLE
🐛 Fix hashing for files and directories on GCS

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -365,7 +365,9 @@ def get_stat_or_artifact(
             # convert UPathStatResult to fsspec info dict
             stat = stat.as_info()
             if (store_type := stat["type"]) == "file":
-                size, hash, hash_type = get_stat_file_cloud(stat)
+                size, hash, hash_type = get_stat_file_cloud(
+                    stat, protocol=path.protocol
+                )
             elif store_type == "directory":
                 size, hash, hash_type, n_files = get_stat_dir_cloud(path)
         if hash is None:

--- a/tests/storage/test_artifact_storage.py
+++ b/tests/storage/test_artifact_storage.py
@@ -143,7 +143,7 @@ def test_gcp_paths():
     artifact_folder = ln.Artifact(
         "gs://rxrx1-europe-west4/images/test/HEPG2-08", description="Test GCP folder"
     ).save()
-    assert artifact_folder.hash == "6r5Hkce0UTy7X6gLeaqzBA"
+    assert artifact_folder.hash == "91wp4sNOCUyeK7kOEz3MiQ"
     assert artifact_folder.n_files == 14772
 
     artifact_file = ln.Artifact(
@@ -185,7 +185,7 @@ def test_http_paths():
 # there is also a test for GCP there
 def test_folder_like_artifact_s3():
     study0_data = ln.Artifact("s3://lamindata/iris_studies/study0_raw_images")
-    assert study0_data.hash == "IVKGMfNwi8zKvnpaD_gG7w"
+    assert study0_data.hash == "b4mOx8qRVGKmI2-4tw2WCw"
     assert study0_data._hash_type == "md5-d"
     assert study0_data.n_files == 51
     assert study0_data.size == 658465


### PR DESCRIPTION
Some files on GCS don't have md5 hash, now we use etag in this case.
Also hashes for files on GCS were saved in b64, it should be b64url. This PR fixes the problem.