### PR TITLE
📝 Document the string serialization of `dtype` objects

### DIFF
--- a/lamindb/base/__init__.py
+++ b/lamindb/base/__init__.py
@@ -11,11 +11,13 @@ Modules
    uids
    types
    fields
-   dtypes
    utils
 
 """
 
+# we do not document dtypes right now because it's use is mostly internal
+# dtypes are documented on the lamindb.feature document and we do not
+# want to introduce another documentation page for it
 from . import dtypes, fields, types, uids, utils
 from .utils import deprecated, doc_args
 

--- a/lamindb/base/types.py
+++ b/lamindb/base/types.py
@@ -9,6 +9,8 @@ Central object types
 .. autoclass:: BranchStatus
 .. autoclass:: RunStatus
 .. autoclass:: SimpleDtype
+.. autoclass:: SimpleDtypeStr
+.. autoclass:: SimpleDvalue
 .. autoclass:: DtypeStr
 
 Basic types
@@ -107,7 +109,8 @@ BRANCH_CODE_TO_STATUS: dict[int, BranchStatus] = {
     code: status for status, code in BRANCH_STATUS_TO_CODE.items()
 }
 
-DtypeObject = int | float | str | bool | datetime.date | datetime.datetime | dict
+SimpleDvalue = int | float | str | bool | datetime.date | datetime.datetime | dict
+"""Values corresponding to :class:`~lamindb.base.types.SimpleDtype`."""
 
 SimpleDtype = (
     type[int]
@@ -118,13 +121,13 @@ SimpleDtype = (
     | type[datetime.datetime]
     | type[dict]
 )
-"""Native Python classes for LaminDB's simple scalar dtype categories.
+"""Python types for simple scalar dtypes.
 
 This alias represents the preferred constructor inputs for simple feature dtypes
 (`int`, `float`, `str`, `bool`, `datetime.date`, `datetime.datetime`, `dict`).
 """
 
-DtypeStr = Literal[
+SimpleDtypeStr = Literal[
     "num",  # numericals
     "int",  # integer / numpy.integer
     "float",  # float
@@ -167,7 +170,9 @@ url              `url`                 `str` (pandas does not have a dedicated u
     In LaminDB, categoricals define relationships with registries. See :class:`~lamindb.Feature` for more details.
 
 """
+DtypeStr = SimpleDtypeStr  # backward compat
 Dtype = DtypeStr  # backward compat
+DtypeObject = SimpleDvalue  # backward compat
 
 RegistryId = Literal[
     "__lamindb_artifact__",

--- a/lamindb/base/types.py
+++ b/lamindb/base/types.py
@@ -8,6 +8,7 @@ Central object types
 .. autoclass:: BlockKind
 .. autoclass:: BranchStatus
 .. autoclass:: RunStatus
+.. autoclass:: SimpleDtype
 .. autoclass:: DtypeStr
 
 Basic types
@@ -107,6 +108,21 @@ BRANCH_CODE_TO_STATUS: dict[int, BranchStatus] = {
 }
 
 DtypeObject = int | float | str | bool | datetime.date | datetime.datetime | dict
+
+SimpleDtype = (
+    type[int]
+    | type[float]
+    | type[str]
+    | type[bool]
+    | type[datetime.date]
+    | type[datetime.datetime]
+    | type[dict]
+)
+"""Native Python classes for LaminDB's simple scalar dtype categories.
+
+This alias represents the preferred constructor inputs for simple feature dtypes
+(`int`, `float`, `str`, `bool`, `datetime.date`, `datetime.datetime`, `dict`).
+"""
 
 DtypeStr = Literal[
     "num",  # numericals

--- a/lamindb/base/types.py
+++ b/lamindb/base/types.py
@@ -141,35 +141,7 @@ SimpleDtypeStr = Literal[
     "url",  # URL, validated as str, but specially treated in the UI
     "object",  # this is a pandas input dtype, we're only using it for complicated types, not for strings; consciously currently not documented
 ]
-"""String-serialized representations of common data types.
-
-===============  ====================  =================================================
-description      lamindb (str)         pandas
-===============  ====================  =================================================
-numerical        `num`                 `int | float`
-integer          `int`                 `int64 | int32 | int16 | int8 | uint | ...`
-float            `float`               `float64 | float32 | float16 | float8 | ...`
-string           `str`                 `object`
-boolean          `bool`                `boolean | bool`
-datetime (naive) `datetime`            `datetime`
-datetime (tz)    `datetime64[ns, UTC]` `datetime64[ns, UTC]`
-date             `date`                `object` (pandera requires an ISO-format string, convert with `df["date"] = df["date"].dt.date`)
-dictionary       `dict`                `object`
-path             `path`                `str` (pandas does not have a dedicated path type, validated as `str`)
-url              `url`                 `str` (pandas does not have a dedicated url type, validated as `str`)
-===============  ====================  =================================================
-
-.. admonition:: Categorical and relational data types
-
-    These are **not** contained in the `DTypeStr` `Literal`.
-
-    For any categorical, you can restrict the permissible values to the values defined in a registry.
-    When serializing this to a string, then `'cat[ULabel]'` or `'cat[bionty.CellType]'` indicate that permissible values are stored in the `name` field of the `ULabel` or `CellType` registry, respectively.
-    You can also restrict to sub-types defined in registries via the `type` field, e.g., `'cat[ULabel[123456ABCDEFG]]'` indicates that values must be of the type with `uid="123456ABCDEFG"` within the `ULabel` registry.
-
-    In LaminDB, categoricals define relationships with registries. See :class:`~lamindb.Feature` for more details.
-
-"""
+"""String-serialized representations of simple data types."""
 DtypeStr = SimpleDtypeStr  # backward compat
 Dtype = DtypeStr  # backward compat
 DtypeObject = SimpleDvalue  # backward compat

--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -67,7 +67,7 @@ if TYPE_CHECKING:
     )
     from lamindb.models.query_set import BasicQuerySet, SQLRecordList
 
-    from ..base.types import DtypeObject
+    from ..base.types import SimpleDvalue
     from .record import Record
     from .run import Run
 
@@ -1076,11 +1076,11 @@ class FeatureManager:
     def __getitem__(
         self, feature: str
     ) -> (
-        DtypeObject
+        SimpleDvalue
         | BasicQuerySet
         | SQLRecord
         | SQLRecordList
-        | dict[str, DtypeObject | BasicQuerySet | SQLRecord | SQLRecordList]
+        | dict[str, SimpleDvalue | BasicQuerySet | SQLRecord | SQLRecordList]
     ):
         """Get values by feature name.
 

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1097,9 +1097,11 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             dtype="cat[bionty.Tissue.ontology_id|bionty.CellType.ontology_id]"
         ).save()
 
-    ## Data types
+    Data types
+    ----------
 
-    ### Simple data types
+    Simple data types
+    ^^^^^^^^^^^^^^^^^
 
     The first column shows the object that can be passed to the `dtype` argument of `Feature()` or `Schema()`.
 
@@ -1119,7 +1121,8 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     `"url"`                 `"url"`               `str` (pandas does not have a dedicated url type, validated as `str`)
     ======================  ====================  =================================================
 
-    ### Categorical and relational data types
+    Categorical and relational data types
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     For any categorical, you can restrict the permissible values to the values defined in a registry.
     You can also restrict to sub-types defined in registries via the `type` field, e.g., `'cat[ULabel[123456ABCDEFG]]'` indicates that values must be of the type with `uid="123456ABCDEFG"` within the `ULabel` registry.
@@ -1153,8 +1156,8 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     `ln.Artifact`                    `{"schema": schema}`          `"cat[Artifact]"`            restricted artifacts by schema
     ===============================  ============================  ============================  ==========================================
 
-
-    ### List data types
+    List data types
+    ^^^^^^^^^^^^^^^
 
     ==================================================  ==================================================  ==========================================
     dtype                                               string serialization                                example in docstring
@@ -1162,7 +1165,8 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     `list[bt.CellType]`                                 `"list[cat[bionty.CellType]]"`                     list dtype of relational categories
     ==================================================  ==================================================  ==========================================
 
-    ### Union data types
+    Union data types
+    ^^^^^^^^^^^^^^^^
 
     ==================================================  ==================================================  ==========================================
     dtype                                               string serialization                                example in docstring

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1152,35 +1152,26 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
 
         * - dtype
           - string serialization
-          - example in docstring
         * - `ln.ULabel`
           - `"cat[ULabel]"`
-          - categorical feature managed in `ULabel`
         * - `bt.CellType`
           - `"cat[bionty.CellType]"`
-          - categorical feature in `bt.CellType`
         * - `bt.Disease`
           - `"cat[bionty.Disease]"`
-          - categorical feature with `cat_filters`
         * - `ln.Artifact`
           - `"cat[Artifact]"`
-          - relational feature with `cat_filters`
 
     You can restrict categoricals to types defined in registries via the `type` field.
-    For example, `"cat[ULabel[123456ABCDEFG]]"` indicates that values must be of the type with `uid="123456ABCDEFG"` within the `ULabel` registry.
 
     .. list-table::
         :header-rows: 1
 
         * - dtype
           - string serialization
-          - example in docstring
-        * - `perturbation` (a `ULabel` with `is_type=True`)
-          - `"cat[ULabel[<uid>]]"`
-          - restricted `ULabel` type
-        * - `experiment` (a `Record` with `is_type=True`)
-          - `"cat[Record[<uid>]]"`
-          - restricted `Record` type
+        * - `ulabel_type` (a `ULabel` with `is_type=True`)
+          - `"cat[ULabel[<uid_of_ulabel_type>]]"`
+        * - `record_type` (a `Record` with `is_type=True`)
+          - `"cat[Record[<uid_of_record_type>]]"`
 
     If you need even more control, you can arbitrarily restrict the permissible values to the values defined in a registry by filtering the categorical.
 

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1094,7 +1094,7 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
 
         ln.Feature(
             name="cell_types",
-            dtype="cat[bionty.Tissue.ontology_id|bionty.CellType.ontology_id]"
+            dtype=[bt.Tissue.ontology_id, bt.CellType.ontology_id]
         ).save()
 
     Data types
@@ -1110,9 +1110,6 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         * - dtype
           - string serialization
           - pandas
-        * - `"num"`
-          - `"num"`
-          - `int | float`
         * - `int`
           - `"int"`
           - `int64 | int32 | int16 | int8 | uint | ...`
@@ -1137,6 +1134,9 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         * - `dict`
           - `"dict"`
           - `object`
+        * - `"num"`
+          - `"num"`
+          - `int | float` ("num" is a convenience type for `int | float`)
         * - `"path"`
           - `"path"`
           - `str` (pandas does not have a dedicated path type, validated as `str`)
@@ -1207,7 +1207,7 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
 
         * - dtype
           - string serialization
-        * - `"cat[bionty.Tissue.ontology_id|bionty.CellType.ontology_id]"`
+        * - `[bt.Tissue.ontology_id, bt.CellType.ontology_id]`
           - `"cat[bionty.Tissue.ontology_id|bionty.CellType.ontology_id]"`
 
     """

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -991,7 +991,7 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         :meth:`~lamindb.Feature.from_dataframe`
             Create feature records from DataFrame.
         :attr:`~lamindb.Artifact.features`
-            Feature manager of an artifact or collection.
+            The `features` attribute of an artifact.
         :class:`~lamindb.ULabel`
             Universal labels.
         :class:`~lamindb.Schema`
@@ -1233,7 +1233,8 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     def __init__(
         self,
         name: str,
-        dtype: SimpleDtype  # one can also pass a SimpleDtypeStr
+        dtype: SimpleDtype
+        | SimpleDtypeStr
         | ULabel
         | Record
         | Registry

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1121,6 +1121,12 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
 
     ### Categorical and relational data types
 
+    For any categorical, you can restrict the permissible values to the values defined in a registry.
+    When serializing this to a string, then `'cat[ULabel]'` or `'cat[bionty.CellType]'` indicate that permissible values are stored in the `name` field of the `ULabel` or `CellType` registry, respectively.
+    You can also restrict to sub-types defined in registries via the `type` field, e.g., `'cat[ULabel[123456ABCDEFG]]'` indicates that values must be of the type with `uid="123456ABCDEFG"` within the `ULabel` registry.
+
+    In LaminDB, categoricals define relationships with registries. See :class:`~lamindb.Feature` for more details.
+
     ==================================================  ==================================================  ==========================================
     dtype                                               string serialization                                example in docstring
     ==================================================  ==================================================  ==========================================
@@ -1128,17 +1134,25 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     `perturbation` (`ln.ULabel` type instance)          `"cat[ULabel[<uid>]]"`                            restricted `ULabel` type
     `experiment` (`ln.Record` type instance)            `"cat[Record[<uid>]]"`                            restricted `Record` type
     `bt.CellType`                                       `"cat[bionty.CellType]"`                           categorical feature in `bt.CellType`
-    `list[bt.CellType]`                                 `"list[cat[bionty.CellType]]"`                     list dtype of relational categories
     `bt.Disease`                                        `"cat[bionty.Disease]"`                            categorical feature with `cat_filters`
     `ln.Artifact`                                       `"cat[Artifact]"`                                  relational feature with `cat_filters`
-    union categorical dtype string                       `"cat[bionty.Tissue.ontology_id|bionty.CellType.ontology_id]"` categorical union dtype
     ==================================================  ==================================================  ==========================================
 
-    For any categorical, you can restrict the permissible values to the values defined in a registry.
-    When serializing this to a string, then `'cat[ULabel]'` or `'cat[bionty.CellType]'` indicate that permissible values are stored in the `name` field of the `ULabel` or `CellType` registry, respectively.
-    You can also restrict to sub-types defined in registries via the `type` field, e.g., `'cat[ULabel[123456ABCDEFG]]'` indicates that values must be of the type with `uid="123456ABCDEFG"` within the `ULabel` registry.
+    ### List data types
 
-    In LaminDB, categoricals define relationships with registries. See :class:`~lamindb.Feature` for more details.
+    ==================================================  ==================================================  ==========================================
+    dtype                                               string serialization                                example in docstring
+    ==================================================  ==================================================  ==========================================
+    `list[bt.CellType]`                                 `"list[cat[bionty.CellType]]"`                     list dtype of relational categories
+    ==================================================  ==================================================  ==========================================
+
+    ### Union data types
+
+    ==================================================  ==================================================  ==========================================
+    dtype                                               string serialization                                example in docstring
+    ==================================================  ==================================================  ==========================================
+    `"cat[bionty.Tissue.ontology_id|bionty.CellType.ontology_id]"` `"cat[bionty.Tissue.ontology_id|bionty.CellType.ontology_id]"` categorical union dtype
+    ==================================================  ==================================================  ==========================================
 
     """
 

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1102,19 +1102,19 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     ### Simple data types
 
     ===============  ====================  =================================================
-    description      lamindb (str)         pandas
+    dtype            string serialization        pandas
     ===============  ====================  =================================================
-    numerical        `num`                 `int | float`
-    integer          `int`                 `int64 | int32 | int16 | int8 | uint | ...`
-    float            `float`               `float64 | float32 | float16 | float8 | ...`
-    string           `str`                 `object`
-    boolean          `bool`                `boolean | bool`
-    datetime (naive) `datetime`            `datetime`
-    datetime (tz)    `datetime64[ns, UTC]` `datetime64[ns, UTC]`
-    date             `date`                `object` (pandera requires an ISO-format string, convert with `df["date"] = df["date"].dt.date`)
-    dictionary       `dict`                `object`
-    path             `path`                `str` (pandas does not have a dedicated path type, validated as `str`)
-    url              `url`                 `str` (pandas does not have a dedicated url type, validated as `str`)
+    numerical        `'num'`               `int | float`
+    integer          `'int'`               `int64 | int32 | int16 | int8 | uint | ...`
+    float            `'float'`             `float64 | float32 | float16 | float8 | ...`
+    string           `'str'`               `object`
+    boolean          `'bool'`              `boolean | bool`
+    datetime (naive) `'datetime'`          `datetime`
+    datetime (tz)    `'datetime64[ns, UTC]'` `datetime64[ns, UTC]`
+    date             `'date'`              `object` (pandera requires an ISO-format string, convert with `df["date"] = df["date"].dt.date`)
+    dictionary       `'dict'`              `object`
+    path             `'path'`              `str` (pandas does not have a dedicated path type, validated as `str`)
+    url              `'url'`               `str` (pandas does not have a dedicated url type, validated as `str`)
     ===============  ====================  =================================================
 
     ### Categorical and relational data types

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -959,9 +959,8 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
 
     Note:
 
-        For more control, you can use :mod:`bionty` registries to manage simple
-        biological entities like genes, proteins & cell markers. Or you define
-        custom registries to manage high-level derived features like gene sets.
+        You can use :mod:`bionty` registries to manage leverage
+        biological entities like genes, proteins & cell markers as features.
 
     See Also:
         :meth:`~lamindb.Feature.from_dataframe`
@@ -973,104 +972,105 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         :class:`~lamindb.Schema`
             Sets of features.
 
-    Examples:
+    Examples
+    --------
 
-        Features with simple data types::
+    Features with simple data types::
 
-            ln.Feature(name="sample_note", dtype=str).save()
-            ln.Feature(name="temperature_in_celsius", dtype=float).save()
-            ln.Feature(name="read_count", dtype=int).save()
+        ln.Feature(name="sample_note", dtype=str).save()
+        ln.Feature(name="temperature_in_celsius", dtype=float).save()
+        ln.Feature(name="read_count", dtype=int).save()
 
-        A categorical feature measuring labels managed in the `ULabel` registry::
+    A categorical feature measuring labels managed in the `ULabel` registry::
 
-            ln.Feature(name="sample", dtype=ln.ULabel).save()
+        ln.Feature(name="sample", dtype=ln.ULabel).save()
 
-        Restrict a categorical feature to a specific `ULabel` type::
+    Restrict a categorical feature to a specific `ULabel` type::
 
-            perturbation = ln.ULabel(name="Perturbation", is_type=True).save()
-            ln.Feature(name="perturbation", dtype=perturbation).save()
+        perturbation = ln.ULabel(name="Perturbation", is_type=True).save()
+        ln.Feature(name="perturbation", dtype=perturbation).save()
 
-        Restrict a categorical feature to a specific `Record` type::
+    Restrict a categorical feature to a specific `Record` type::
 
-            experiment = ln.Record(name="Experiment", is_type=True).save()
-            ln.Feature(name="experiment", dtype=experiment).save()
+        experiment = ln.Record(name="Experiment", is_type=True).save()
+        ln.Feature(name="experiment", dtype=experiment).save()
 
-        Restrict a categorical feature to the `bt.CellType` registry::
+    Restrict a categorical feature to the `bt.CellType` registry::
 
-            ln.Feature(name="cell_type_by_expert", dtype=bt.CellType).save()  # expert annotation
-            ln.Feature(name="cell_type_by_model", dtype=bt.CellType).save()   # model annotation
+        ln.Feature(name="cell_type_by_expert", dtype=bt.CellType).save()  # expert annotation
+        ln.Feature(name="cell_type_by_model", dtype=bt.CellType).save()   # model annotation
 
-        .. admonition:: Categoricals define relationships.
+    .. admonition:: Categoricals define relationships.
 
-            In LaminDB, **categoricals** define **relationships**.
-            For example, with dtype set to a `ULabel` type, setting a feature value relates the object to a `ULabel` of that type.
+        In LaminDB, **categoricals** define **relationships**.
+        For example, with dtype set to a `ULabel` type, setting a feature value relates the object to a `ULabel` of that type.
 
-        Scope a feature with a **feature type** to distinguish the same feature name across different contexts::
+    Scope a feature with a **feature type** to distinguish the same feature name across different contexts::
 
-            abc_feature_type = ln.Feature(name="ABC", is_type=True).save()  # ABC could reference a schema, a project, a team, etc.
-            ln.Feature(name="concentration_nM", dtype=float, type=abc_feature_type).save()
+        abc_feature_type = ln.Feature(name="ABC", is_type=True).save()  # ABC could reference a schema, a project, a team, etc.
+        ln.Feature(name="concentration_nM", dtype=float, type=abc_feature_type).save()
 
-            xyz_feature_type = ln.Feature(name="XYZ", is_type=True).save()  # XYZ could reference a schema, a project, a team, etc.
-            ln.Feature(name="concentration_nM", dtype=float, type=xyz_feature_type).save()
+        xyz_feature_type = ln.Feature(name="XYZ", is_type=True).save()  # XYZ could reference a schema, a project, a team, etc.
+        ln.Feature(name="concentration_nM", dtype=float, type=xyz_feature_type).save()
 
-            # calling .save() again with the same name and type returns the existing feature
-            ln.Feature(name="concentration_nM", dtype=float, type=xyz_feature_type).save()
+        # calling .save() again with the same name and type returns the existing feature
+        ln.Feature(name="concentration_nM", dtype=float, type=xyz_feature_type).save()
 
-        Annotate an artifact with features (works identically for records and runs)::
+    Annotate an artifact with features (works identically for records and runs)::
 
-            artifact.features.set_values({
-                "temperature_in_celsius": 37.5,
-                "sample_note": "Control sample",
-            })
+        artifact.features.set_values({
+            "temperature_in_celsius": 37.5,
+            "sample_note": "Control sample",
+        })
 
-        Query artifacts/records/runs by features::
+    Query artifacts/records/runs by features::
 
-            ln.Artifact.filter(features__name="temperature_in_celsius")  # artifacts with this feature
-            ln.Artifact.filter(temperature_in_celsius__gt=37)            # artifacts where temperature > 37
+        ln.Artifact.filter(features__name="temperature_in_celsius")  # artifacts with this feature
+        ln.Artifact.filter(temperature_in_celsius__gt=37)            # artifacts where temperature > 37
 
-        Disambiguate duplicate feature names by querying with a `Feature` object::
+    Disambiguate duplicate feature names by querying with a `Feature` object::
 
-            feature = ln.Feature.get(name="my_ambig_name", type__name="my_feature_type")
-            ln.Artifact.filter(feature == "hello")  # instead of my_ambig_name="hello"
+        feature = ln.Feature.get(name="my_ambig_name", type__name="my_feature_type")
+        ln.Artifact.filter(feature == "hello")  # instead of my_ambig_name="hello"
 
-        A list dtype::
+    A list dtype::
 
-            ln.Feature(
-                name="cell_types",
-                dtype=list[bt.CellType],  # or list[str] for a list of strings
-            ).save()
+        ln.Feature(
+            name="cell_types",
+            dtype=list[bt.CellType],  # or list[str] for a list of strings
+        ).save()
 
-        A path feature::
+    A path feature::
 
-            ln.Feature(
-                name="image_path",
-                dtype="path",   # will be validated as `str`
-            ).save()
+        ln.Feature(
+            name="image_path",
+            dtype="path",   # will be validated as `str`
+        ).save()
 
-        Restrict categories via filters::
+    Restrict categories via filters::
 
-            # restrict diseases to those matching a specific ontology version
-            source = bt.Source.get(name="My ontology")  # a registry for ontology versions
-            ln.Feature(
-                name="disease",
-                dtype=bt.Disease,
-                cat_filters={"source": source},
-            ).save()
+        # restrict diseases to those matching a specific ontology version
+        source = bt.Source.get(name="My ontology")  # a registry for ontology versions
+        ln.Feature(
+            name="disease",
+            dtype=bt.Disease,
+            cat_filters={"source": source},
+        ).save()
 
-            # restrict artifacts to those matching a specific schema
-            schema = ln.Schema.get(name="my-schema")
-            ln.Feature(
-                name="valid_artifact",
-                dtype=ln.Artifact,
-                cat_filters={"schema": schema},
-            ).save()
+        # restrict artifacts to those matching a specific schema
+        schema = ln.Schema.get(name="my-schema")
+        ln.Feature(
+            name="valid_artifact",
+            dtype=ln.Artifact,
+            cat_filters={"schema": schema},
+        ).save()
 
-        A feature accepting multiple categorical types - a union type::
+    A feature accepting multiple categorical types - a union type::
 
-            ln.Feature(
-                name="cell_types",
-                dtype="cat[bionty.Tissue.ontology_id|bionty.CellType.ontology_id]"
-            ).save()
+        ln.Feature(
+            name="cell_types",
+            dtype="cat[bionty.Tissue.ontology_id|bionty.CellType.ontology_id]"
+        ).save()
 
     .. dropdown:: What is the difference between features and labels?
 

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1100,10 +1100,9 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     Data types
     ----------
 
-    Simple data types
-    ^^^^^^^^^^^^^^^^^
-
-    The first column shows the object that can be passed to the `dtype` argument of `Feature()` or `Schema()`.
+    **Simple data types.** In  the table below, the first column shows the object that
+    can be passed to the `dtype` argument of `Feature()` or `Schema()` and the second the string serialization
+    that's used in the `_dtype_str` field of the `lamindb_feature` table in the database.
 
     ======================  ====================  =================================================
     dtype                   string serialization  pandas
@@ -1121,13 +1120,8 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     `"url"`                 `"url"`               `str` (pandas does not have a dedicated url type, validated as `str`)
     ======================  ====================  =================================================
 
-    Categorical and relational data types
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-    For any categorical, you can restrict the permissible values to the values defined in a registry.
-    You can also restrict to sub-types defined in registries via the `type` field, e.g., `'cat[ULabel[123456ABCDEFG]]'` indicates that values must be of the type with `uid="123456ABCDEFG"` within the `ULabel` registry.
-
-    In LaminDB, categoricals define relationships with registries.
+    **Categorical and relational data types.** For any categorical, you can restrict permissible
+    values to the values defined in a registry. This establishes a relationship.
 
     ==================================================  ==================================================  ==========================================
     dtype                                               string serialization                                example in docstring
@@ -1138,13 +1132,14 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     `ln.Artifact`                                       `"cat[Artifact]"`                                  relational feature with `cat_filters`
     ==================================================  ==================================================  ==========================================
 
-    You can restrict to types defined in registries via the `type` field. For the examples above, this looks like this.
+    You can restrict categoricals to types defined in registries via the `type` field.
+    For example, `"cat[ULabel[123456ABCDEFG]]"` indicates that values must be of the type with `uid="123456ABCDEFG"` within the `ULabel` registry.
 
     ==================================================  ==================================================  ==========================================
     dtype                                               string serialization                                example in docstring
     ==================================================  ==================================================  ==========================================
-    `perturbation` (`ln.ULabel` type instance)          `"cat[ULabel[<uid>]]"`                            restricted `ULabel` type
-    `experiment` (`ln.Record` type instance)            `"cat[Record[<uid>]]"`                            restricted `Record` type
+    `perturbation` (a `ULabel` with `is_type=True`)     `"cat[ULabel[<uid>]]"`                            restricted `ULabel` type
+    `experiment` (a `Record` with `is_type=True`)       `"cat[Record[<uid>]]"`                            restricted `Record` type
     ==================================================  ==================================================  ==========================================
 
     If you need even more control, you can arbitrarily restrict the permissible values to the values defined in a registry by filtering the categorical.
@@ -1156,8 +1151,7 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     `ln.Artifact`                    `{"schema": schema}`          `"cat[Artifact]"`            restricted artifacts by schema
     ===============================  ============================  ============================  ==========================================
 
-    List data types
-    ^^^^^^^^^^^^^^^
+    **List data types.**
 
     ==================================================  ==================================================  ==========================================
     dtype                                               string serialization                                example in docstring
@@ -1165,8 +1159,7 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     `list[bt.CellType]`                                 `"list[cat[bionty.CellType]]"`                     list dtype of relational categories
     ==================================================  ==================================================  ==========================================
 
-    Union data types
-    ^^^^^^^^^^^^^^^^
+    **Union data types.**
 
     ==================================================  ==================================================  ==========================================
     dtype                                               string serialization                                example in docstring

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1101,8 +1101,10 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
 
     ### Simple data types
 
+    The first column shows the object that can be passed to the `dtype` argument of `Feature()` or `Schema()`.
+
     ===============  ====================  =================================================
-    dtype            string serialization        pandas
+    dtype            string serialization  pandas
     ===============  ====================  =================================================
     numerical        `'num'`               `int | float`
     integer          `'int'`               `int64 | int32 | int16 | int8 | uint | ...`

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -936,13 +936,13 @@ END;
 
 
 class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
-    """Measurable properties such as dataframe columns.
+    """Measurable properties of datasets such as dataframe columns.
 
     Features represent the variables or dimensions along which observed values in a dataset are measured.
     You can query datasets by features similar to how you query registries by fields.
     Features also define the validation constraints for individual dataset dimensions.
 
-    .. dropdown:: What if my dataset has 40k or many more dimensions, e.g., as in gene expression datasets?
+    .. dropdown:: What if my dataset has 40k or more dimensions as in a gene expression dataset?
 
         You don't bother defining an individual feature for each dimension but instead
         define a common `dtype` for a set of features along with a constraint for the feature identifier type.

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1173,7 +1173,7 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         * - `record_type` (a `Record` with `is_type=True`)
           - `"cat[Record[<uid_of_record_type>]]"`
 
-    You can restrict permissible values to by filtering the categorical on fields of its registry.
+    You can restrict permissible values by filtering the categorical on fields of its registry.
 
     .. list-table::
         :header-rows: 1

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -938,8 +938,9 @@ END;
 class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     """Measurable properties such as dataframe columns.
 
-    Features represent *what* is measured in a dataset — the variables or dimensions along which observed values are organized.
-    You can query datasets and records by features similar to how you query registries by fields.
+    Features represent the variables or dimensions along which observed values in a dataset are measured.
+    You can query datasets by features similar to how you query registries by fields.
+    Features also define the validation constraints for individual dataset dimensions.
 
     .. dropdown:: What if my dataset has 40k or many more dimensions, e.g., as in gene expression datasets?
 

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1197,6 +1197,8 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
           - string serialization
         * - `list[bt.CellType]`
           - `"list[cat[bionty.CellType]]"`
+        * - `list[float]`
+          - `"list[float]"`
 
     **Union data types.**
 

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1138,6 +1138,10 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     `ln.Artifact`                                       `"cat[Artifact]"`                                  relational feature with `cat_filters`
     ==================================================  ==================================================  ==========================================
 
+    You can arbitrarily restrict the permissible values to the values defined in a registry by filtering the categorical.
+
+
+
     ### List data types
 
     ==================================================  ==================================================  ==========================================

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -28,7 +28,7 @@ from lamindb.base.fields import (
     JSONField,
     TextField,
 )
-from lamindb.base.types import DtypeStr, FieldAttr
+from lamindb.base.types import DtypeStr, FieldAttr, SimpleDtype
 from lamindb.errors import (
     FieldValidationError,
     IntegrityError,
@@ -851,7 +851,7 @@ def process_init_feature_param(args, kwargs):
     if len(args) != 0:
         raise ValueError("Only keyword args allowed")
     name: str = kwargs.pop("name", None)
-    dtype: type | str | None = kwargs.pop("dtype", None)
+    dtype: SimpleDtype | type | str | None = kwargs.pop("dtype", None)
     is_type: bool = kwargs.pop("is_type", False)
     type_: Feature | str | None = kwargs.pop("type", None)
     description: str | None = kwargs.pop("description", None)
@@ -943,7 +943,7 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
 
     Args:
         name: `str` Name of the feature, typically a column name.
-        dtype: `type | ULabel | Record | DtypeStr | Registry | list[Registry] | FieldAttr`
+        dtype: `SimpleDtype | ULabel | Record | DtypeStr | Registry | list[Registry] | FieldAttr`
             Types or `ULabel` or `Record` objects representing types.
             See :class:`~lamindb.base.types.DtypeStr`.
         type: `Feature | None = None` A feature type, see :attr:`~lamindb.Feature.type`.
@@ -1193,7 +1193,13 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     def __init__(
         self,
         name: str,
-        dtype: DtypeStr | ULabel | Record | Registry | list[Registry] | FieldAttr,
+        dtype: SimpleDtype
+        | DtypeStr
+        | ULabel
+        | Record
+        | Registry
+        | list[Registry]
+        | FieldAttr,
         type: Feature | None = None,
         is_type: bool = False,
         unit: str | None = None,

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1190,15 +1190,12 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         * - dtype
           - cat_filters
           - string serialization
-          - example in docstring
         * - `bt.Disease`
           - `{"source": source}`
           - `"cat[bionty.Disease]"`
-          - restricted diseases by ontology source
         * - `ln.Artifact`
           - `{"schema": schema}`
           - `"cat[Artifact]"`
-          - restricted artifacts by schema
 
     **List data types.**
 
@@ -1207,10 +1204,8 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
 
         * - dtype
           - string serialization
-          - example in docstring
         * - `list[bt.CellType]`
           - `"list[cat[bionty.CellType]]"`
-          - list dtype of relational categories
 
     **Union data types.**
 
@@ -1219,10 +1214,8 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
 
         * - dtype
           - string serialization
-          - example in docstring
         * - `"cat[bionty.Tissue.ontology_id|bionty.CellType.ontology_id]"`
           - `"cat[bionty.Tissue.ontology_id|bionty.CellType.ontology_id]"`
-          - categorical union dtype
 
     """
 

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1106,17 +1106,17 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     ===============  ====================  =================================================
     dtype            string serialization  pandas
     ===============  ====================  =================================================
-    numerical        `'num'`               `int | float`
-    integer          `'int'`               `int64 | int32 | int16 | int8 | uint | ...`
-    float            `'float'`             `float64 | float32 | float16 | float8 | ...`
-    string           `'str'`               `object`
-    boolean          `'bool'`              `boolean | bool`
-    datetime (naive) `'datetime'`          `datetime`
+    `"num"`          `"num"`               `int | float`
+    `int`          `'int'`               `int64 | int32 | int16 | int8 | uint | ...`
+    `float`            `'float'`             `float64 | float32 | float16 | float8 | ...`
+    `str`           `'str'`               `object`
+    `bool`          `'bool'`              `boolean | bool`
+    `datetime`       `'datetime'`          `datetime`
     datetime (tz)    `'datetime64[ns, UTC]'` `datetime64[ns, UTC]`
-    date             `'date'`              `object` (pandera requires an ISO-format string, convert with `df["date"] = df["date"].dt.date`)
-    dictionary       `'dict'`              `object`
-    path             `'path'`              `str` (pandas does not have a dedicated path type, validated as `str`)
-    url              `'url'`               `str` (pandas does not have a dedicated url type, validated as `str`)
+    `date`             `'date'`              `object` (pandera requires an ISO-format string, convert with `df["date"] = df["date"].dt.date`)
+    `dict`       `'dict'`              `object`
+    `"path"`             `'path'`              `str` (pandas does not have a dedicated path type, validated as `str`)
+    `"url"`              `'url'`               `str` (pandas does not have a dedicated url type, validated as `str`)
     ===============  ====================  =================================================
 
     ### Categorical and relational data types

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1147,10 +1147,10 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     If you need even more control, you can arbitrarily restrict the permissible values to the values defined in a registry by filtering the categorical.
 
     ===============================  ============================  ============================  ==========================================
-    dtype                            string serialization          cat_filters                   example in docstring
+    dtype                            cat_filters                   string serialization          example in docstring
     ===============================  ============================  ============================  ==========================================
-    `bt.Disease`                     `"cat[bionty.Disease]"`      `{"source": source}`          restricted diseases by ontology source
-    `ln.Artifact`                    `"cat[Artifact]"`            `{"schema": schema}`          restricted artifacts by schema
+    `bt.Disease`                     `{"source": source}`          `"cat[bionty.Disease]"`      restricted diseases by ontology source
+    `ln.Artifact`                    `{"schema": schema}`          `"cat[Artifact]"`            restricted artifacts by schema
     ===============================  ============================  ============================  ==========================================
 
 

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1027,8 +1027,8 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
 
     .. admonition:: Categoricals define relationships.
 
-        In LaminDB, **categoricals** define **relationships**.
-        For example, with dtype set to a `ULabel` type, setting a feature value relates the object to a `ULabel` of that type.
+        For example, when passing `ULabel` to `dtype` in `Feature()`,
+        one relates the new feature to the `ULabel` registry.
 
     Scope a feature with a **feature type** to distinguish the same feature name across different contexts::
 

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1099,6 +1099,8 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
 
     ## Data types
 
+    ### Simple data types
+
     ===============  ====================  =================================================
     description      lamindb (str)         pandas
     ===============  ====================  =================================================
@@ -1115,15 +1117,13 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     url              `url`                 `str` (pandas does not have a dedicated url type, validated as `str`)
     ===============  ====================  =================================================
 
-    .. admonition:: Categorical and relational data types
+    ### Categorical and relational data types
 
-        These are **not** contained in the `DTypeStr` `Literal`.
+    For any categorical, you can restrict the permissible values to the values defined in a registry.
+    When serializing this to a string, then `'cat[ULabel]'` or `'cat[bionty.CellType]'` indicate that permissible values are stored in the `name` field of the `ULabel` or `CellType` registry, respectively.
+    You can also restrict to sub-types defined in registries via the `type` field, e.g., `'cat[ULabel[123456ABCDEFG]]'` indicates that values must be of the type with `uid="123456ABCDEFG"` within the `ULabel` registry.
 
-        For any categorical, you can restrict the permissible values to the values defined in a registry.
-        When serializing this to a string, then `'cat[ULabel]'` or `'cat[bionty.CellType]'` indicate that permissible values are stored in the `name` field of the `ULabel` or `CellType` registry, respectively.
-        You can also restrict to sub-types defined in registries via the `type` field, e.g., `'cat[ULabel[123456ABCDEFG]]'` indicates that values must be of the type with `uid="123456ABCDEFG"` within the `ULabel` registry.
-
-        In LaminDB, categoricals define relationships with registries. See :class:`~lamindb.Feature` for more details.
+    In LaminDB, categoricals define relationships with registries. See :class:`~lamindb.Feature` for more details.
 
     """
 

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -28,7 +28,7 @@ from lamindb.base.fields import (
     JSONField,
     TextField,
 )
-from lamindb.base.types import DtypeStr, FieldAttr, SimpleDtype
+from lamindb.base.types import FieldAttr, SimpleDtype, SimpleDtypeStr
 from lamindb.errors import (
     FieldValidationError,
     IntegrityError,
@@ -62,7 +62,7 @@ if TYPE_CHECKING:
     from .schema import Schema
     from .ulabel import ULabel
 
-FEATURE_DTYPES = set(get_args(DtypeStr))
+FEATURE_DTYPES = set(get_args(SimpleDtypeStr))
 
 
 @dataclass(frozen=True)
@@ -943,9 +943,9 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
 
     Args:
         name: `str` Name of the feature, typically a column name.
-        dtype: `SimpleDtype | ULabel | Record | DtypeStr | Registry | list[Registry] | FieldAttr`
+        dtype: `SimpleDtype | ULabel | Record | Registry | list[Registry] | FieldAttr`
             Types or `ULabel` or `Record` objects representing types.
-            See :class:`~lamindb.base.types.DtypeStr`.
+            See :class:`~lamindb.base.types.SimpleDtypeStr`.
         type: `Feature | None = None` A feature type, see :attr:`~lamindb.Feature.type`.
         is_type: `bool = False` Whether this feature is a type, see :attr:`~lamindb.Feature.is_type`.
         unit: `str | None = None` Unit of measure, ideally SI (`"m"`, `"s"`, `"kg"`, etc.) or `"normalized"` etc.
@@ -1124,8 +1124,8 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     """Universal id, valid across DB instances."""
     name: str = CharField(max_length=150, db_index=True)
     """Name of feature."""
-    _dtype_str: DtypeStr | str | None = CharField(db_index=True, null=True)
-    """The string-serialized data type (:class:`~lamindb.base.types.DtypeStr`).
+    _dtype_str: SimpleDtypeStr | str | None = CharField(db_index=True, null=True)
+    """The string-serialized data type (:class:`~lamindb.base.types.SimpleDtypeStr`).
 
     Note that mutating this field currently does not trigger re-validation of existing values.
     """
@@ -1193,8 +1193,7 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     def __init__(
         self,
         name: str,
-        dtype: SimpleDtype
-        | DtypeStr
+        dtype: SimpleDtype  # one can also pass a SimpleDtypeStr
         | ULabel
         | Record
         | Registry
@@ -1474,7 +1473,7 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             return self._dtype_str
 
     @property
-    def dtype_as_str(self) -> DtypeStr | str | None:
+    def dtype_as_str(self) -> SimpleDtypeStr | str | None:
         """The `dtype` as a string.
 
         You can query by this property as if it was a string field. The query is delegated to the private `_dtype_str` field.

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1122,24 +1122,36 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     ### Categorical and relational data types
 
     For any categorical, you can restrict the permissible values to the values defined in a registry.
-    When serializing this to a string, then `'cat[ULabel]'` or `'cat[bionty.CellType]'` indicate that permissible values are stored in the `name` field of the `ULabel` or `CellType` registry, respectively.
     You can also restrict to sub-types defined in registries via the `type` field, e.g., `'cat[ULabel[123456ABCDEFG]]'` indicates that values must be of the type with `uid="123456ABCDEFG"` within the `ULabel` registry.
 
-    In LaminDB, categoricals define relationships with registries. See :class:`~lamindb.Feature` for more details.
+    In LaminDB, categoricals define relationships with registries.
 
     ==================================================  ==================================================  ==========================================
     dtype                                               string serialization                                example in docstring
     ==================================================  ==================================================  ==========================================
     `ln.ULabel`                                         `"cat[ULabel]"`                                    categorical feature managed in `ULabel`
-    `perturbation` (`ln.ULabel` type instance)          `"cat[ULabel[<uid>]]"`                            restricted `ULabel` type
-    `experiment` (`ln.Record` type instance)            `"cat[Record[<uid>]]"`                            restricted `Record` type
     `bt.CellType`                                       `"cat[bionty.CellType]"`                           categorical feature in `bt.CellType`
     `bt.Disease`                                        `"cat[bionty.Disease]"`                            categorical feature with `cat_filters`
     `ln.Artifact`                                       `"cat[Artifact]"`                                  relational feature with `cat_filters`
     ==================================================  ==================================================  ==========================================
 
-    You can arbitrarily restrict the permissible values to the values defined in a registry by filtering the categorical.
+    You can restrict to types defined in registries via the `type` field. For the examples above, this looks like this.
 
+    ==================================================  ==================================================  ==========================================
+    dtype                                               string serialization                                example in docstring
+    ==================================================  ==================================================  ==========================================
+    `perturbation` (`ln.ULabel` type instance)          `"cat[ULabel[<uid>]]"`                            restricted `ULabel` type
+    `experiment` (`ln.Record` type instance)            `"cat[Record[<uid>]]"`                            restricted `Record` type
+    ==================================================  ==================================================  ==========================================
+
+    If you need even more control, you can arbitrarily restrict the permissible values to the values defined in a registry by filtering the categorical.
+
+    ==================================================  ==================================================  ==========================================
+    dtype                                               string serialization                                example in docstring
+    ==================================================  ==================================================  ==========================================
+    `perturbation` (`ln.ULabel` type instance)          `"cat[ULabel[<uid>]]"`                            restricted `ULabel` type
+    `experiment` (`ln.Record` type instance)            `"cat[Record[<uid>]]"`                            restricted `Record` type
+    ==================================================  ==================================================  ==========================================
 
 
     ### List data types

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1121,6 +1121,19 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
 
     ### Categorical and relational data types
 
+    ==================================================  ==================================================  ==========================================
+    dtype                                               string serialization                                example in docstring
+    ==================================================  ==================================================  ==========================================
+    `ln.ULabel`                                         `"cat[ULabel]"`                                    categorical feature managed in `ULabel`
+    `perturbation` (`ln.ULabel` type instance)          `"cat[ULabel[<uid>]]"`                            restricted `ULabel` type
+    `experiment` (`ln.Record` type instance)            `"cat[Record[<uid>]]"`                            restricted `Record` type
+    `bt.CellType`                                       `"cat[bionty.CellType]"`                           categorical feature in `bt.CellType`
+    `list[bt.CellType]`                                 `"list[cat[bionty.CellType]]"`                     list dtype of relational categories
+    `bt.Disease`                                        `"cat[bionty.Disease]"`                            categorical feature with `cat_filters`
+    `ln.Artifact`                                       `"cat[Artifact]"`                                  relational feature with `cat_filters`
+    union categorical dtype string                       `"cat[bionty.Tissue.ontology_id|bionty.CellType.ontology_id]"` categorical union dtype
+    ==================================================  ==================================================  ==========================================
+
     For any categorical, you can restrict the permissible values to the values defined in a registry.
     When serializing this to a string, then `'cat[ULabel]'` or `'cat[bionty.CellType]'` indicate that permissible values are stored in the `name` field of the `ULabel` or `CellType` registry, respectively.
     You can also restrict to sub-types defined in registries via the `type` field, e.g., `'cat[ULabel[123456ABCDEFG]]'` indicates that values must be of the type with `uid="123456ABCDEFG"` within the `ULabel` registry.

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -851,7 +851,7 @@ def process_init_feature_param(args, kwargs):
     if len(args) != 0:
         raise ValueError("Only keyword args allowed")
     name: str = kwargs.pop("name", None)
-    dtype: SimpleDtype | type | str | None = kwargs.pop("dtype", None)
+    dtype: SimpleDtype | SimpleDtypeStr | str | None = kwargs.pop("dtype", None)
     is_type: bool = kwargs.pop("is_type", False)
     type_: Feature | str | None = kwargs.pop("type", None)
     description: str | None = kwargs.pop("description", None)

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1261,7 +1261,7 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
 
     Allows to group features by type, e.g., all read outs, all metrics, etc.
     """
-    features: Feature
+    features: RelatedManager[Feature]
     """Features of this type (can only be non-empty if `is_type` is `True`)."""
     unit: str | None = CharField(max_length=30, db_index=True, null=True)
     """Unit of measure, ideally SI (`m`, `s`, `kg`, etc.) or 'normalized' etc. (optional)."""

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1103,21 +1103,21 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
 
     The first column shows the object that can be passed to the `dtype` argument of `Feature()` or `Schema()`.
 
-    ===============  ====================  =================================================
-    dtype            string serialization  pandas
-    ===============  ====================  =================================================
-    `"num"`          `"num"`               `int | float`
-    `int`          `'int'`               `int64 | int32 | int16 | int8 | uint | ...`
-    `float`            `'float'`             `float64 | float32 | float16 | float8 | ...`
-    `str`           `'str'`               `object`
-    `bool`          `'bool'`              `boolean | bool`
-    `datetime`       `'datetime'`          `datetime`
-    datetime (tz)    `'datetime64[ns, UTC]'` `datetime64[ns, UTC]`
-    `date`             `'date'`              `object` (pandera requires an ISO-format string, convert with `df["date"] = df["date"].dt.date`)
-    `dict`       `'dict'`              `object`
-    `"path"`             `'path'`              `str` (pandas does not have a dedicated path type, validated as `str`)
-    `"url"`              `'url'`               `str` (pandas does not have a dedicated url type, validated as `str`)
-    ===============  ====================  =================================================
+    ======================  ====================  =================================================
+    dtype                   string serialization  pandas
+    ======================  ====================  =================================================
+    `"num"`                 `"num"`               `int | float`
+    `int`                   `"int"`               `int64 | int32 | int16 | int8 | uint | ...`
+    `float`                 `"float"`             `float64 | float32 | float16 | float8 | ...`
+    `str`                   `"str"`               `object`
+    `bool`                  `"bool"`              `boolean | bool`
+    `datetime`              `"datetime"`          `datetime`
+    `"datetime64[ns, UTC]"` `"datetime64[ns, UTC]"` `datetime64[ns, UTC]`
+    `date`                  `"date"`              `object` (pandera requires an ISO-format string, convert with `df["date"] = df["date"].dt.date`)
+    `dict`                  `"dict"`              `object`
+    `"path"`                `"path"`              `str` (pandas does not have a dedicated path type, validated as `str`)
+    `"url"`                 `"url"`               `str` (pandas does not have a dedicated url type, validated as `str`)
+    ======================  ====================  =================================================
 
     ### Categorical and relational data types
 

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1102,7 +1102,7 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
 
     **Simple data types.** In  the table below, the first column shows the object that
     can be passed to the `dtype` argument of `Feature()` or `Schema()` and the second the string serialization
-    that's used in the `_dtype_str` field of the `lamindb_feature` table in the database.
+    that's used in the database.
 
     .. list-table::
         :header-rows: 1
@@ -1161,7 +1161,7 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         * - `ln.Artifact`
           - `"cat[Artifact]"`
 
-    You can restrict categoricals to types defined in registries via the `type` field.
+    You can restrict permissible values to instances of `ULabel` or `Record` types.
 
     .. list-table::
         :header-rows: 1
@@ -1173,7 +1173,7 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         * - `record_type` (a `Record` with `is_type=True`)
           - `"cat[Record[<uid_of_record_type>]]"`
 
-    If you need even more control, you can arbitrarily restrict the permissible values to the values defined in a registry by filtering the categorical.
+    You can restrict permissible values to by filtering the categorical on fields of its registry.
 
     .. list-table::
         :header-rows: 1

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1104,68 +1104,125 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     can be passed to the `dtype` argument of `Feature()` or `Schema()` and the second the string serialization
     that's used in the `_dtype_str` field of the `lamindb_feature` table in the database.
 
-    ======================  ====================  =================================================
-    dtype                   string serialization  pandas
-    ======================  ====================  =================================================
-    `"num"`                 `"num"`               `int | float`
-    `int`                   `"int"`               `int64 | int32 | int16 | int8 | uint | ...`
-    `float`                 `"float"`             `float64 | float32 | float16 | float8 | ...`
-    `str`                   `"str"`               `object`
-    `bool`                  `"bool"`              `boolean | bool`
-    `datetime`              `"datetime"`          `datetime`
-    `"datetime64[ns, UTC]"` `"datetime64[ns, UTC]"` `datetime64[ns, UTC]`
-    `date`                  `"date"`              `object` (pandera requires an ISO-format string, convert with `df["date"] = df["date"].dt.date`)
-    `dict`                  `"dict"`              `object`
-    `"path"`                `"path"`              `str` (pandas does not have a dedicated path type, validated as `str`)
-    `"url"`                 `"url"`               `str` (pandas does not have a dedicated url type, validated as `str`)
-    ======================  ====================  =================================================
+    .. list-table::
+        :header-rows: 1
+
+        * - dtype
+          - string serialization
+          - pandas
+        * - `"num"`
+          - `"num"`
+          - `int | float`
+        * - `int`
+          - `"int"`
+          - `int64 | int32 | int16 | int8 | uint | ...`
+        * - `float`
+          - `"float"`
+          - `float64 | float32 | float16 | float8 | ...`
+        * - `str`
+          - `"str"`
+          - `object`
+        * - `bool`
+          - `"bool"`
+          - `boolean | bool`
+        * - `datetime`
+          - `"datetime"`
+          - `datetime`
+        * - `"datetime64[ns, UTC]"`
+          - `"datetime64[ns, UTC]"`
+          - `datetime64[ns, UTC]`
+        * - `date`
+          - `"date"`
+          - `object` (pandera requires an ISO-format string, convert with `df["date"] = df["date"].dt.date`)
+        * - `dict`
+          - `"dict"`
+          - `object`
+        * - `"path"`
+          - `"path"`
+          - `str` (pandas does not have a dedicated path type, validated as `str`)
+        * - `"url"`
+          - `"url"`
+          - `str` (pandas does not have a dedicated url type, validated as `str`)
 
     **Categorical and relational data types.** For any categorical, you can restrict permissible
     values to the values defined in a registry. This establishes a relationship.
 
-    ==================================================  ==================================================  ==========================================
-    dtype                                               string serialization                                example in docstring
-    ==================================================  ==================================================  ==========================================
-    `ln.ULabel`                                         `"cat[ULabel]"`                                    categorical feature managed in `ULabel`
-    `bt.CellType`                                       `"cat[bionty.CellType]"`                           categorical feature in `bt.CellType`
-    `bt.Disease`                                        `"cat[bionty.Disease]"`                            categorical feature with `cat_filters`
-    `ln.Artifact`                                       `"cat[Artifact]"`                                  relational feature with `cat_filters`
-    ==================================================  ==================================================  ==========================================
+    .. list-table::
+        :header-rows: 1
+
+        * - dtype
+          - string serialization
+          - example in docstring
+        * - `ln.ULabel`
+          - `"cat[ULabel]"`
+          - categorical feature managed in `ULabel`
+        * - `bt.CellType`
+          - `"cat[bionty.CellType]"`
+          - categorical feature in `bt.CellType`
+        * - `bt.Disease`
+          - `"cat[bionty.Disease]"`
+          - categorical feature with `cat_filters`
+        * - `ln.Artifact`
+          - `"cat[Artifact]"`
+          - relational feature with `cat_filters`
 
     You can restrict categoricals to types defined in registries via the `type` field.
     For example, `"cat[ULabel[123456ABCDEFG]]"` indicates that values must be of the type with `uid="123456ABCDEFG"` within the `ULabel` registry.
 
-    ==================================================  ==================================================  ==========================================
-    dtype                                               string serialization                                example in docstring
-    ==================================================  ==================================================  ==========================================
-    `perturbation` (a `ULabel` with `is_type=True`)     `"cat[ULabel[<uid>]]"`                            restricted `ULabel` type
-    `experiment` (a `Record` with `is_type=True`)       `"cat[Record[<uid>]]"`                            restricted `Record` type
-    ==================================================  ==================================================  ==========================================
+    .. list-table::
+        :header-rows: 1
+
+        * - dtype
+          - string serialization
+          - example in docstring
+        * - `perturbation` (a `ULabel` with `is_type=True`)
+          - `"cat[ULabel[<uid>]]"`
+          - restricted `ULabel` type
+        * - `experiment` (a `Record` with `is_type=True`)
+          - `"cat[Record[<uid>]]"`
+          - restricted `Record` type
 
     If you need even more control, you can arbitrarily restrict the permissible values to the values defined in a registry by filtering the categorical.
 
-    ===============================  ============================  ============================  ==========================================
-    dtype                            cat_filters                   string serialization          example in docstring
-    ===============================  ============================  ============================  ==========================================
-    `bt.Disease`                     `{"source": source}`          `"cat[bionty.Disease]"`      restricted diseases by ontology source
-    `ln.Artifact`                    `{"schema": schema}`          `"cat[Artifact]"`            restricted artifacts by schema
-    ===============================  ============================  ============================  ==========================================
+    .. list-table::
+        :header-rows: 1
+
+        * - dtype
+          - cat_filters
+          - string serialization
+          - example in docstring
+        * - `bt.Disease`
+          - `{"source": source}`
+          - `"cat[bionty.Disease]"`
+          - restricted diseases by ontology source
+        * - `ln.Artifact`
+          - `{"schema": schema}`
+          - `"cat[Artifact]"`
+          - restricted artifacts by schema
 
     **List data types.**
 
-    ==================================================  ==================================================  ==========================================
-    dtype                                               string serialization                                example in docstring
-    ==================================================  ==================================================  ==========================================
-    `list[bt.CellType]`                                 `"list[cat[bionty.CellType]]"`                     list dtype of relational categories
-    ==================================================  ==================================================  ==========================================
+    .. list-table::
+        :header-rows: 1
+
+        * - dtype
+          - string serialization
+          - example in docstring
+        * - `list[bt.CellType]`
+          - `"list[cat[bionty.CellType]]"`
+          - list dtype of relational categories
 
     **Union data types.**
 
-    ==================================================  ==================================================  ==========================================
-    dtype                                               string serialization                                example in docstring
-    ==================================================  ==================================================  ==========================================
-    `"cat[bionty.Tissue.ontology_id|bionty.CellType.ontology_id]"` `"cat[bionty.Tissue.ontology_id|bionty.CellType.ontology_id]"` categorical union dtype
-    ==================================================  ==================================================  ==========================================
+    .. list-table::
+        :header-rows: 1
+
+        * - dtype
+          - string serialization
+          - example in docstring
+        * - `"cat[bionty.Tissue.ontology_id|bionty.CellType.ontology_id]"`
+          - `"cat[bionty.Tissue.ontology_id|bionty.CellType.ontology_id]"`
+          - categorical union dtype
 
     """
 

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1146,12 +1146,12 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
 
     If you need even more control, you can arbitrarily restrict the permissible values to the values defined in a registry by filtering the categorical.
 
-    ==================================================  ==================================================  ==========================================
-    dtype                                               string serialization                                example in docstring
-    ==================================================  ==================================================  ==========================================
-    `perturbation` (`ln.ULabel` type instance)          `"cat[ULabel[<uid>]]"`                            restricted `ULabel` type
-    `experiment` (`ln.Record` type instance)            `"cat[Record[<uid>]]"`                            restricted `Record` type
-    ==================================================  ==================================================  ==========================================
+    ===============================  ============================  ============================  ==========================================
+    dtype                            string serialization          cat_filters                   example in docstring
+    ===============================  ============================  ============================  ==========================================
+    `bt.Disease`                     `"cat[bionty.Disease]"`      `{"source": source}`          restricted diseases by ontology source
+    `ln.Artifact`                    `"cat[Artifact]"`            `{"schema": schema}`          restricted artifacts by schema
+    ===============================  ============================  ============================  ==========================================
 
 
     ### List data types

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -936,10 +936,39 @@ END;
 
 
 class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
-    """Measurable properties such as dataframe columns or record fields.
+    """Measurable properties such as dataframe columns.
 
-    Features represent *what* is measured in a dataset—the variables or dimensions along which data is organized.
-    They enable you to query datasets based on their structure and corresponding label annotations.
+    Features represent *what* is measured in a dataset — the variables or dimensions along which observed values are organized.
+    You can query datasets and records by features similar to how you query registries by fields.
+
+    .. dropdown:: What if my dataset has 40k or many more dimensions, e.g., as in gene expression datasets?
+
+        You don't bother defining an individual feature for each dimension but instead
+        define a common `dtype` for a set of features along with a constraint for the feature identifier type.
+
+        For example::
+
+            ln.Schema(itype=ln.Feature, dtype=float).save()  # use Feature.name as feature identifier type
+            ln.Schema(itype=bt.Gene.ensembl_gene_id, dtype=int).save()  # use Gene.ensembl_gene_id as feature identifier type
+            ln.Schema(itype=bt.Protein.uniprot_id, dtype=float).save()  # use Protein.uniprot_id as feature identifier type
+            ln.Schema(itype=bt.CellMarker, dtype=float).save()  # use CellMarker.name as feature identifier type
+
+        In these examples, :mod:`bionty` registries are used to leverage biological entities as feature identifiers.
+        If you pass a dataset for validation with this schema, feature identifiers will be validated accordingly.
+
+    .. dropdown:: What is the difference between features and labels?
+
+        1. A feature qualifies what is measured, i.e., a numerical or categorical random variable
+        2. A label *is* a measured value of a categorical variable, i.e., a category
+
+        Example: When annotating a dataset that measures expression of 30k genes,
+        the gene identifiers serve as feature identifiers, and the features are expression measurements for these genes.
+        When annotating a dataset whose experiment knocked out 3 specific genes, those genes serve as labels of the dataset.
+
+        Re-shaping data can introduce ambiguity among features & labels. If this
+        happened, ask yourself what the joint measurement was: a feature
+        qualifies variables in a joint measurement. The canonical data matrix
+        lists jointly measured variables in the columns.
 
     Args:
         name: `str` Name of the feature, typically a column name.
@@ -956,11 +985,6 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         coerce: `bool | None = None` When `True`, attempts to coerce values to the specified dtype during validation, see :attr:`~lamindb.Feature.coerce`.
             Defaults to `False` unless `is_type` is `True`.
         cat_filters: `dict[str, str | SQLRecord] | None = None` Subset a registry by additional filters to define valid categories.
-
-    Note:
-
-        You can use :mod:`bionty` registries to manage leverage
-        biological entities like genes, proteins & cell markers as features.
 
     See Also:
         :meth:`~lamindb.Feature.from_dataframe`
@@ -1072,19 +1096,34 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             dtype="cat[bionty.Tissue.ontology_id|bionty.CellType.ontology_id]"
         ).save()
 
-    .. dropdown:: What is the difference between features and labels?
+    ## Data types
 
-        1. A feature qualifies what is measured, i.e., a numerical or categorical random variable
-        2. A label *is* a measured value of a categorical variable, i.e., a category
+    ===============  ====================  =================================================
+    description      lamindb (str)         pandas
+    ===============  ====================  =================================================
+    numerical        `num`                 `int | float`
+    integer          `int`                 `int64 | int32 | int16 | int8 | uint | ...`
+    float            `float`               `float64 | float32 | float16 | float8 | ...`
+    string           `str`                 `object`
+    boolean          `bool`                `boolean | bool`
+    datetime (naive) `datetime`            `datetime`
+    datetime (tz)    `datetime64[ns, UTC]` `datetime64[ns, UTC]`
+    date             `date`                `object` (pandera requires an ISO-format string, convert with `df["date"] = df["date"].dt.date`)
+    dictionary       `dict`                `object`
+    path             `path`                `str` (pandas does not have a dedicated path type, validated as `str`)
+    url              `url`                 `str` (pandas does not have a dedicated url type, validated as `str`)
+    ===============  ====================  =================================================
 
-        Example: When annotating a dataset that measures expression of 30k genes,
-        the gene identifiers serve as feature identifiers, and the features are expression measurements for these genes.
-        When annotating a dataset whose experiment knocked out 3 specific genes, those genes serve as labels of the dataset.
+    .. admonition:: Categorical and relational data types
 
-        Re-shaping data can introduce ambiguity among features & labels. If this
-        happened, ask yourself what the joint measurement was: a feature
-        qualifies variables in a joint measurement. The canonical data matrix
-        lists jointly measured variables in the columns.
+        These are **not** contained in the `DTypeStr` `Literal`.
+
+        For any categorical, you can restrict the permissible values to the values defined in a registry.
+        When serializing this to a string, then `'cat[ULabel]'` or `'cat[bionty.CellType]'` indicate that permissible values are stored in the `name` field of the `ULabel` or `CellType` registry, respectively.
+        You can also restrict to sub-types defined in registries via the `type` field, e.g., `'cat[ULabel[123456ABCDEFG]]'` indicates that values must be of the type with `uid="123456ABCDEFG"` within the `ULabel` registry.
+
+        In LaminDB, categoricals define relationships with registries. See :class:`~lamindb.Feature` for more details.
+
     """
 
     class Meta(SQLRecord.Meta, TracksRun.Meta, TracksUpdates.Meta):

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -973,7 +973,7 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         :class:`~lamindb.Schema`
             Sets of features.
 
-    Example:
+    Examples:
 
         Features with simple data types::
 

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -2020,10 +2020,20 @@ def _get_record_kwargs(record_class) -> list[tuple[str, str]]:
         if "*db_args" in params_block:
             continue
 
-        params = []
+        params: list[tuple[str, str]] = []
         for line in params_block.split("\n"):
             line = line.strip()
             if not line or "self" in line:
+                continue
+
+            # Handle multiline union annotations formatted as:
+            #   dtype: A
+            #       | B
+            #       | C,
+            if line.startswith("|") and params:
+                prev_name, prev_type = params[-1]
+                continuation = line.rstrip(",").strip()
+                params[-1] = (prev_name, f"{prev_type} {continuation}")
                 continue
 
             # Extract name and type annotation

--- a/tests/core/test_feature.py
+++ b/tests/core/test_feature.py
@@ -67,6 +67,15 @@ def test_feature_init():
     feature = ln.Feature(name="feat1", dtype=[ln.Record, bt.Gene])
     assert feature._dtype_str == "cat[Record|bionty.Gene]"
 
+    # categorical dtype with union of registry fields using objects must be valid
+    feature = ln.Feature(
+        name="feat1", dtype=[bt.Tissue.ontology_id, bt.CellType.ontology_id]
+    )
+    assert (
+        feature._dtype_str
+        == "cat[bionty.Tissue.ontology_id|bionty.CellType.ontology_id]"
+    )
+
     # dtype with field name before bracket filters must be valid
     feature = ln.Feature(
         name="gene_feature", dtype="cat[bionty.Gene.ensembl_gene_id[organism='human']]"

--- a/tests/core/test_sqlrecord.py
+++ b/tests/core/test_sqlrecord.py
@@ -354,7 +354,10 @@ def test_using():
 def test_get_record_kwargs():
     assert _get_record_kwargs(ln.Feature) == [
         ("name", "str"),
-        ("dtype", "DtypeStr | ULabel | Record | Registry | list[Registry] | FieldAttr"),
+        (
+            "dtype",
+            "SimpleDtype | SimpleDtypeStr | ULabel | Record | Registry | list[Registry] | FieldAttr",
+        ),
         ("type", "Feature | None"),
         ("is_type", "bool"),
         ("unit", "str | None"),


### PR DESCRIPTION
Added this new section to the `lamindb.feature` document.

Before | After
--- | ---
documented under `lamindb.base.types`  | <img width="780" height="844" alt="image" src="https://github.com/user-attachments/assets/aa23d78f-d6df-428d-81e7-eb072d7ada6b" />
/ | <img width="779" height="928" alt="image" src="https://github.com/user-attachments/assets/eddbe894-0110-4d12-8658-d077edd07ecc" />