### PR TITLE
📝 Document and test features where the `dtype` is a sheet

### DIFF
--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1108,20 +1108,13 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             cat_filters={"schema": schema},
         ).save()
 
-        # restrict records to a specific Record type and schema
+        # restrict records to a specific sheet
         sample_type = ln.Record.get(name="Samples")
         sample_schema = ln.Schema.get(name="sampleschema")
         ln.Feature(
             name="samplesheet",
-            dtype=ln.Record,
-            cat_filters={"type": sample_type, "is_type": True, "schema": sample_schema},
-        ).save()
-
-        # equivalent shorthand: pass the type as dtype directly
-        ln.Feature(
-            name="samplesheet",
             dtype=sample_type,
-            cat_filters={"is_type": True, "schema": sample_schema},
+            cat_filters={"is_type": True, "schema": sample_schema},  # indicates sheet under sample_type
         ).save()
 
     A feature accepting multiple categorical types - a union type::

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1108,7 +1108,7 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             cat_filters={"schema": schema},
         ).save()
 
-        # restrict records to a specific sheet
+        # restrict records to sheet objects with a shared sample_schema
         sample_type = ln.Record.get(name="Samples")
         sample_schema = ln.Schema.get(name="sampleschema")
         ln.Feature(

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -498,9 +498,19 @@ def parse_nested_brackets(dtype_str: str, old_format: bool = False) -> dict[str,
                 # - a type uid, e.g. Record[Ab12Cd34Ef56Gh78]
                 # - relation filters injected from cat_filters, e.g.
                 #   Record[type__uid='...', is_type='True', schema__uid='...']
+                # - shorthand typed filters, e.g.
+                #   Record[Ab12Cd34Ef56Gh78, is_type='True', schema__uid='...']
                 # Distinguish them by presence of '=' in the bracket payload.
                 if "=" in bracket_content:
-                    filter_str = bracket_content
+                    first_item, sep, remaining_items = bracket_content.partition(",")
+                    first_item = first_item.strip()
+                    # Support shorthand typed filters by interpreting a leading bare
+                    # token as record uid and the remaining payload as filter string.
+                    if first_item and "=" not in first_item:
+                        record_uid = first_item
+                        filter_str = remaining_items.strip() if sep else ""
+                    else:
+                        filter_str = bracket_content
                 else:
                     record_uid = bracket_content
     else:
@@ -1107,6 +1117,13 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             cat_filters={"type": sample_type, "is_type": True, "schema": sample_schema},
         ).save()
 
+        # equivalent shorthand: pass the type as dtype directly
+        ln.Feature(
+            name="samplesheet",
+            dtype=sample_type,
+            cat_filters={"is_type": True, "schema": sample_schema},
+        ).save()
+
     A feature accepting multiple categorical types - a union type::
 
         ln.Feature(
@@ -1401,7 +1418,19 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
                 raise ValidationError(
                     f"cat_filters are incompatible with union dtypes: '{dtype_str}'"
                 )
-            if "]]" in dtype_str:
+            parsed_dtype = parse_dtype(dtype_str)
+            typed_registry: str | None = None
+            typed_record_uid: str | None = None
+            if (
+                len(parsed_dtype) == 1
+                and parsed_dtype[0].get("record_uid") is not None
+                and parsed_dtype[0].get("filter_str") == ""
+                and not parsed_dtype[0].get("list", False)
+            ):
+                typed_registry = parsed_dtype[0]["registry_str"]
+                typed_record_uid = parsed_dtype[0]["record_uid"]
+                dtype_str = f"cat[{typed_registry}]"
+            elif "]]" in dtype_str:
                 raise ValidationError(
                     f"cat_filters are incompatible with nested dtypes: '{dtype_str}'"
                 )
@@ -1431,10 +1460,45 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
                 for key, filter in cat_filters.items()
             }
 
+            # Normalize shorthand and explicit type selectors.
+            if "type" in cat_filters:
+                if "type__uid" in cat_filters and str(cat_filters["type"]) != str(
+                    cat_filters["type__uid"]
+                ):
+                    raise ValidationError(
+                        "Conflicting type selectors in cat_filters: 'type' and 'type__uid'"
+                    )
+                cat_filters["type__uid"] = cat_filters.pop("type")
+
+            if typed_record_uid is not None:
+                explicit_type_uid = cat_filters.get("type__uid")
+                if explicit_type_uid is not None and str(explicit_type_uid) != str(
+                    typed_record_uid
+                ):
+                    raise ValidationError(
+                        f"Conflicting typed dtype and cat_filters type selector: dtype uses uid '{typed_record_uid}', cat_filters uses uid '{explicit_type_uid}'"
+                    )
+                cat_filters["type__uid"] = typed_record_uid
+
+            shorthand_type_uid = None
+            if (
+                dtype_str in ("cat[Record]", "cat[ULabel]")
+                and "type__uid" in cat_filters
+            ):
+                shorthand_type_uid = str(cat_filters.pop("type__uid"))
+
             fill_in = ", ".join(
                 f"{key}='{value}'" for (key, value) in cat_filters.items()
             )
-            dtype_str = dtype_str.replace("]", f"[{fill_in}]]")
+            if shorthand_type_uid is not None:
+                bracket_payload = (
+                    shorthand_type_uid
+                    if fill_in == ""
+                    else f"{shorthand_type_uid}, {fill_in}"
+                )
+            else:
+                bracket_payload = fill_in
+            dtype_str = dtype_str.replace("]", f"[{bracket_payload}]]")
             self._dtype_str = dtype_str
         if not self._state.adding:
             if self._dtype_str != dtype_str:

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1058,14 +1058,14 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         feature = ln.Feature.get(name="my_ambig_name", type__name="my_feature_type")
         ln.Artifact.filter(feature == "hello")  # instead of my_ambig_name="hello"
 
-    A list dtype::
+    A list `dtype`::
 
         ln.Feature(
             name="cell_types",
             dtype=list[bt.CellType],  # or list[str] for a list of strings
         ).save()
 
-    A path feature::
+    A path `dtype`::
 
         ln.Feature(
             name="image_path",

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1090,6 +1090,15 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             cat_filters={"schema": schema},
         ).save()
 
+        # restrict records to a specific Record type and schema
+        sample_type = ln.Record.get(name="Samples")
+        sample_schema = ln.Schema.get(name="sampleschema")
+        ln.Feature(
+            name="samplesheet",
+            dtype=ln.Record,
+            cat_filters={"type": sample_type, "is_type": True, "schema": sample_schema},
+        ).save()
+
     A feature accepting multiple categorical types - a union type::
 
         ln.Feature(

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -494,7 +494,15 @@ def parse_nested_brackets(dtype_str: str, old_format: bool = False) -> dict[str,
                 subtypes_list = extracted["subtypes_list"]
                 filter_str = extracted["filter_str"]
             else:
-                record_uid = bracket_content
+                # In current format, Record/ULabel brackets can contain either:
+                # - a type uid, e.g. Record[Ab12Cd34Ef56Gh78]
+                # - relation filters injected from cat_filters, e.g.
+                #   Record[type__uid='...', is_type='True', schema__uid='...']
+                # Distinguish them by presence of '=' in the bracket payload.
+                if "=" in bracket_content:
+                    filter_str = bracket_content
+                else:
+                    record_uid = bracket_content
     else:
         # For other registries, bracket content is a filter
         filter_str = bracket_content if bracket_content else ""

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1113,8 +1113,8 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         sample_schema = ln.Schema.get(name="sampleschema")
         ln.Feature(
             name="samplesheet",
-            dtype=sample_type,
-            cat_filters={"is_type": True, "schema": sample_schema},  # indicates sheet under sample_type
+            dtype=sample_type,  # sheet needs to be under sample type
+            cat_filters={"is_type": True, "schema": sample_schema},  # indicates sheet
         ).save()
 
     A feature accepting multiple categorical types - a union type::

--- a/tests/core/test_curator_basics.py
+++ b/tests/core/test_curator_basics.py
@@ -881,7 +881,7 @@ def test_cat_filters_record_schema_validation():
     ).save()
     feature = ln.Feature(
         name="samplesheet",
-        dtype=ln.Record,
+        dtype=parent_type,
         cat_filters={"type": parent_type, "is_type": True, "schema": sampleschema},
     ).save()
     schema = ln.Schema([feature], name="samplesheet validation schema").save()
@@ -899,10 +899,10 @@ def test_cat_filters_record_schema_validation():
     curator = ln.curators.DataFrameCurator(df, schema)
     with pytest.raises(ln.errors.ValidationError) as error:
         curator.validate()
-    assert (
-        "2 terms not validated in feature 'samplesheet': 'samplesheet-wrong-parent', 'samplesheet-wrong-schema'"
-        in str(error.value)
-    )
+    error_message = str(error.value)
+    assert "2 terms not validated in feature 'samplesheet':" in error_message
+    assert "'samplesheet-wrong-schema'" in error_message
+    assert "'samplesheet-wrong-parent'" in error_message
 
     schema.delete(permanent=True)
     feature.delete(permanent=True)

--- a/tests/core/test_curator_basics.py
+++ b/tests/core/test_curator_basics.py
@@ -850,6 +850,71 @@ def test_cat_filters_multiple_relation_filters(df_disease, disease_ontology_old)
     feature.delete(permanent=True)
 
 
+def test_cat_filters_record_schema_validation():
+    parent_type = ln.Record(name="Samples", is_type=True).save()
+    other_parent_type = ln.Record(name="OtherSamples", is_type=True).save()
+    sampleschema = ln.Schema(
+        name="sampleschema",
+        features=[ln.Feature(name="sample_id", dtype=str).save()],
+    ).save()
+    otherschema = ln.Schema(
+        name="otherschema",
+        features=[ln.Feature(name="sample_label", dtype=str).save()],
+    ).save()
+    valid_sheet = ln.Record(
+        name="samplesheet-valid",
+        type=parent_type,
+        is_type=True,
+        schema=sampleschema,
+    ).save()
+    ln.Record(
+        name="samplesheet-wrong-schema",
+        type=parent_type,
+        is_type=True,
+        schema=otherschema,
+    ).save()
+    ln.Record(
+        name="samplesheet-wrong-parent",
+        type=other_parent_type,
+        is_type=True,
+        schema=sampleschema,
+    ).save()
+    feature = ln.Feature(
+        name="samplesheet",
+        dtype=ln.Record,
+        cat_filters={"type": parent_type, "is_type": True, "schema": sampleschema},
+    ).save()
+    schema = ln.Schema([feature], name="samplesheet validation schema").save()
+    df = pd.DataFrame(
+        {
+            "samplesheet": pd.Categorical(
+                [
+                    valid_sheet.name,
+                    "samplesheet-wrong-schema",
+                    "samplesheet-wrong-parent",
+                ]
+            )
+        }
+    )
+    curator = ln.curators.DataFrameCurator(df, schema)
+    with pytest.raises(ln.errors.ValidationError) as error:
+        curator.validate()
+    assert (
+        "2 terms not validated in feature 'samplesheet': 'samplesheet-wrong-parent', 'samplesheet-wrong-schema'"
+        in str(error.value)
+    )
+
+    schema.delete(permanent=True)
+    feature.delete(permanent=True)
+    ln.Record.filter(type=other_parent_type).delete(permanent=True)
+    other_parent_type.delete(permanent=True)
+    ln.Record.filter(type=parent_type).delete(permanent=True)
+    parent_type.delete(permanent=True)
+    sampleschema.delete(permanent=True)
+    otherschema.delete(permanent=True)
+    ln.Feature.filter(name__in=["sample_id", "sample_label"]).delete(permanent=True)
+
+
 def test_curate_columns(df):
     """Test that columns can be curated."""
     schema = ln.Schema(

--- a/tests/core/test_feature_dtype.py
+++ b/tests/core/test_feature_dtype.py
@@ -371,6 +371,26 @@ def test_cat_filters_artifact_schema_filter():
     schema_feature.delete(permanent=True)
 
 
+def test_cat_filters_record_type_is_type_and_schema_filters():
+    schema_feature = ln.Feature(name="record_schema_filter_column", dtype=str).save()
+    schema = ln.Schema(
+        name="record_schema_filter_schema", features=[schema_feature]
+    ).save()
+    sample_type = ln.Record(name="Samples", is_type=True).save()
+    feature = ln.Feature(
+        name="samplesheet",
+        dtype=ln.Record,
+        cat_filters={"type": sample_type, "is_type": True, "schema": schema},
+    )
+    assert (
+        feature._dtype_str
+        == f"cat[Record[type__uid='{sample_type.uid}', is_type='True', schema__uid='{schema.uid}']]"
+    )
+    schema.delete(permanent=True)
+    schema_feature.delete(permanent=True)
+    sample_type.delete(permanent=True)
+
+
 def test_cat_filters_bionty_disease_filter():
     feature = ln.Feature(
         name="disease",

--- a/tests/core/test_feature_dtype.py
+++ b/tests/core/test_feature_dtype.py
@@ -384,8 +384,11 @@ def test_cat_filters_record_type_is_type_and_schema_filters():
     )
     assert (
         feature._dtype_str
-        == f"cat[Record[type__uid='{sample_type.uid}', is_type='True', schema__uid='{schema.uid}']]"
+        == f"cat[Record[{sample_type.uid}, is_type='True', schema__uid='{schema.uid}']]"
     )
+    result = parse_dtype(feature._dtype_str)
+    assert result[0]["record_uid"] == sample_type.uid
+    assert result[0]["filter_str"] == f"is_type='True', schema__uid='{schema.uid}'"
     schema.delete(permanent=True)
     schema_feature.delete(permanent=True)
     sample_type.delete(permanent=True)
@@ -425,19 +428,31 @@ def test_cat_filters_incompatible_with_union_dtypes():
     )
 
 
-def test_cat_filters_incompatible_with_nested_dtypes():
+def test_cat_filters_supported_with_typed_dtype():
     record = ln.Record(name="Customer", is_type=True).save()
+    feature = ln.Feature(
+        name="test_feature",
+        dtype=record,
+        cat_filters={"is_type": True},
+    )
+    assert feature._dtype_str == f"cat[Record[{record.uid}, is_type='True']]"
+    record.delete(permanent=True)
+
+
+def test_cat_filters_conflicting_type_selectors():
+    first_record = ln.Record(name="Customer", is_type=True).save()
+    second_record = ln.Record(name="Supplier", is_type=True).save()
     with pytest.raises(ValidationError) as exc_info:
         ln.Feature(
             name="test_feature",
-            dtype=record,
-            cat_filters={"source": "test"},
+            dtype=first_record,
+            cat_filters={"type": second_record},
         )
-    assert (
-        f"cat_filters are incompatible with nested dtypes: 'cat[Record[{record.uid}]]'"
-        in str(exc_info.value)
+    assert "Conflicting typed dtype and cat_filters type selector" in str(
+        exc_info.value
     )
-    record.delete(permanent=True)
+    first_record.delete(permanent=True)
+    second_record.delete(permanent=True)
 
 
 def test_parse_filter_string_basic():


### PR DESCRIPTION
Added the following example to the tests and docstring:

```python
# restrict records to sheet objects with a shared sample_schema
sample_type = ln.Record.get(name="Samples")
sample_schema = ln.Schema.get(name="sampleschema")
ln.Feature(
    name="samplesheet",
    dtype=sample_type,  # sheet needs to be under sample type
    cat_filters={"is_type": True, "schema": sample_schema},  # indicates sheet
).save()
```

The user might pass the following equivalent specification instead:
```python
ln.Feature(
    name="samplesheet",
    dtype=ln.Record,
    cat_filters={"type": sample_type, "is_type": True, "schema": sample_schema},
).save()
```

Before saving in the database, this is internally canonicalized to: `f"cat[Record[{sample_type.uid}, is_type='True', schema__uid='{schema.uid}']]"`