### PR TITLE
🔥 Remove logic related to migrating old dtype format containing semantic type names

### DIFF
--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -1340,7 +1340,7 @@ class CatVector:
         feature: Feature | None = None,
         cat_manager: DataFrameCatManager | None = None,
         filter_str: str = "",
-        object_uid: str | None = None,
+        type_uid: str | None = None,
         maximal_set: bool = True,  # whether unvalidated categoricals cause validation failure.
         schema: Schema = None,
     ) -> None:
@@ -1352,7 +1352,7 @@ class CatVector:
         self._validated: None | list[str] = None
         self._non_validated: None | list[str] = None
         self._synonyms: None | dict[str, str] = None
-        self._object_uid = object_uid
+        self._type_uid = type_uid
         self._subtype_query_set = None
         self._cat_manager = cat_manager
         self.feature = feature
@@ -1383,11 +1383,11 @@ class CatVector:
             self._registry, self._filter_kwargs
         )
 
-        # get the dtype associated record based on the object_uid
-        if self._object_uid:
+        # get the dtype associated record based on the type_uid
+        if self._type_uid:
             self._type_record = get_record_type_from_uid(
                 self._registry,
-                self._object_uid,
+                self._type_uid,
             )
 
         if hasattr(self._registry, "_name_field"):
@@ -1899,7 +1899,7 @@ class DataFrameCatManager:
                     feature=feature,
                     cat_manager=self,
                     filter_str=result["filter_str"],
-                    object_uid=result.get("object_uid"),
+                    type_uid=result.get("type_uid"),
                 )
         if index is not None and index._dtype_str.startswith("cat"):
             result = parse_dtype(index._dtype_str)[0]
@@ -1914,7 +1914,7 @@ class DataFrameCatManager:
                 feature=index,
                 cat_manager=self,
                 filter_str=result["filter_str"],
-                object_uid=result.get("object_uid"),
+                type_uid=result.get("type_uid"),
             )
 
     @property

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -1340,7 +1340,7 @@ class CatVector:
         feature: Feature | None = None,
         cat_manager: DataFrameCatManager | None = None,
         filter_str: str = "",
-        record_uid: str | None = None,
+        object_uid: str | None = None,
         maximal_set: bool = True,  # whether unvalidated categoricals cause validation failure.
         schema: Schema = None,
     ) -> None:
@@ -1352,7 +1352,7 @@ class CatVector:
         self._validated: None | list[str] = None
         self._non_validated: None | list[str] = None
         self._synonyms: None | dict[str, str] = None
-        self._record_uid = record_uid
+        self._object_uid = object_uid
         self._subtype_query_set = None
         self._cat_manager = cat_manager
         self.feature = feature
@@ -1383,11 +1383,11 @@ class CatVector:
             self._registry, self._filter_kwargs
         )
 
-        # get the dtype associated record based on the record_uid
-        if self._record_uid:
+        # get the dtype associated record based on the object_uid
+        if self._object_uid:
             self._type_record = get_record_type_from_uid(
                 self._registry,
-                self._record_uid,
+                self._object_uid,
             )
 
         if hasattr(self._registry, "_name_field"):
@@ -1899,7 +1899,7 @@ class DataFrameCatManager:
                     feature=feature,
                     cat_manager=self,
                     filter_str=result["filter_str"],
-                    record_uid=result.get("record_uid"),
+                    object_uid=result.get("object_uid"),
                 )
         if index is not None and index._dtype_str.startswith("cat"):
             result = parse_dtype(index._dtype_str)[0]
@@ -1914,7 +1914,7 @@ class DataFrameCatManager:
                 feature=index,
                 cat_manager=self,
                 filter_str=result["filter_str"],
-                record_uid=result.get("record_uid"),
+                object_uid=result.get("object_uid"),
             )
 
     @property

--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -211,27 +211,27 @@ def format_dtype_for_display(dtype_str: str) -> str:
     if ("Record[" in dtype_str or "ULabel[" in dtype_str) and "]" in dtype_str:
         try:
             parsed = parse_dtype(dtype_str)
-            if parsed and parsed[0].get("record_uid"):
-                record_uid = parsed[0]["record_uid"]
+            if parsed and parsed[0].get("object_uid"):
+                object_uid = parsed[0]["object_uid"]
                 registry_str = parsed[0].get("registry_str", "")
                 try:
                     # Determine which registry to use
                     if registry_str == "Record":
-                        record_type = Record.get(uid=record_uid)
+                        record_type = Record.get(uid=object_uid)
                         # Replace Record[uid] with Record[TypeName]
                         dtype_str = dtype_str.replace(
-                            f"Record[{record_uid}]", f"Record[{record_type.name}]"
+                            f"Record[{object_uid}]", f"Record[{record_type.name}]"
                         )
                     elif registry_str == "ULabel":
-                        record_type = ULabel.get(uid=record_uid)
+                        record_type = ULabel.get(uid=object_uid)
                         # Replace ULabel[uid] with ULabel[TypeName]
                         dtype_str = dtype_str.replace(
-                            f"ULabel[{record_uid}]", f"ULabel[{record_type.name}]"
+                            f"ULabel[{object_uid}]", f"ULabel[{record_type.name}]"
                         )
                 except Exception as e:
                     # If we can't find the record, just return the original
                     logger.debug(
-                        f"Could not find {registry_str} with uid '{record_uid}' for display formatting: {e}"
+                        f"Could not find {registry_str} with uid '{object_uid}' for display formatting: {e}"
                     )
         except Exception as e:
             # If parsing fails, return the original

--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -211,27 +211,27 @@ def format_dtype_for_display(dtype_str: str) -> str:
     if ("Record[" in dtype_str or "ULabel[" in dtype_str) and "]" in dtype_str:
         try:
             parsed = parse_dtype(dtype_str)
-            if parsed and parsed[0].get("object_uid"):
-                object_uid = parsed[0]["object_uid"]
+            if parsed and parsed[0].get("type_uid"):
+                type_uid = parsed[0]["type_uid"]
                 registry_str = parsed[0].get("registry_str", "")
                 try:
                     # Determine which registry to use
                     if registry_str == "Record":
-                        record_type = Record.get(uid=object_uid)
+                        record_type = Record.get(uid=type_uid)
                         # Replace Record[uid] with Record[TypeName]
                         dtype_str = dtype_str.replace(
-                            f"Record[{object_uid}]", f"Record[{record_type.name}]"
+                            f"Record[{type_uid}]", f"Record[{record_type.name}]"
                         )
                     elif registry_str == "ULabel":
-                        record_type = ULabel.get(uid=object_uid)
+                        record_type = ULabel.get(uid=type_uid)
                         # Replace ULabel[uid] with ULabel[TypeName]
                         dtype_str = dtype_str.replace(
-                            f"ULabel[{object_uid}]", f"ULabel[{record_type.name}]"
+                            f"ULabel[{type_uid}]", f"ULabel[{record_type.name}]"
                         )
                 except Exception as e:
                     # If we can't find the record, just return the original
                     logger.debug(
-                        f"Could not find {registry_str} with uid '{object_uid}' for display formatting: {e}"
+                        f"Could not find {registry_str} with uid '{type_uid}' for display formatting: {e}"
                     )
         except Exception as e:
             # If parsing fails, return the original

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -122,17 +122,17 @@ def parse_dtype(dtype_str: str, check_exists: bool = False) -> list[dict[str, An
 
 def get_record_type_from_uid(
     registry: Registry,
-    object_uid: str,
+    type_uid: str,
 ) -> SQLRecord:
-    type_record: SQLRecord = registry.get(object_uid)
+    type_record: SQLRecord = registry.get(type_uid)
 
     if type_record.branch_id == -1:
-        warning_msg = f"retrieving {registry.__name__} type '{type_record.name}' (uid='{object_uid}') from trash"
+        warning_msg = f"retrieving {registry.__name__} type '{type_record.name}' (uid='{type_uid}') from trash"
         logger.warning(warning_msg)
 
     if not type_record.is_type:
         raise InvalidArgument(
-            f"The resolved {type_record.__class__.__name__} '{type_record.name}' (uid='{object_uid}') is not a type: is_type is False."
+            f"The resolved {type_record.__class__.__name__} '{type_record.name}' (uid='{type_uid}') is not a type: is_type is False."
         )
     return type_record
 
@@ -172,14 +172,14 @@ def dtype_as_object(dtype_str: str) -> type | None:
     if len(parsed_dtypes) > 0:
         dtype_objects = []
         for parsed_dtype in parsed_dtypes:
-            if parsed_dtype.get("object_uid"):
-                # return the subtype record for dtypes with object_uid
+            if parsed_dtype.get("type_uid"):
+                # return the subtype record for dtypes with type_uid
                 dtype_object = get_record_type_from_uid(
                     parsed_dtype["registry"],
-                    parsed_dtype["object_uid"],
+                    parsed_dtype["type_uid"],
                 )
             else:
-                # return field for dtypes without object_uid, e.g. bt.CellType.ontology_id
+                # return field for dtypes without type_uid, e.g. bt.CellType.ontology_id
                 dtype_object = parsed_dtype["field"]
             # for list, returns list[SQLRecord]
             dtype_objects.append(
@@ -248,9 +248,9 @@ def parse_cat_dtype(
         field_str = registry._name_field if hasattr(registry, "_name_field") else "name"
     assert hasattr(registry, field_str), f"{registry} has no field {field_str}"
 
-    object_uid = parsed.get("object_uid")
-    if object_uid and check_exists:
-        get_record_type_from_uid(registry, object_uid)
+    type_uid = parsed.get("type_uid")
+    if type_uid and check_exists:
+        get_record_type_from_uid(registry, type_uid)
 
     if filter_str != "":
         # TODO: validate or process filter string
@@ -263,9 +263,9 @@ def parse_cat_dtype(
         "field": getattr(registry, field_str),
     }
 
-    # Add object_uid if it exists (new format)
-    if object_uid:
-        result["object_uid"] = object_uid
+    # Add type_uid if it exists (new format)
+    if type_uid:
+        result["type_uid"] = type_uid
 
     return result
 
@@ -276,8 +276,8 @@ def parse_nested_brackets(dtype_str: str) -> dict[str, Any]:
     Examples:
         "A" -> {"registry": "A", "filter_str": "", "field": ""}
         "A.field" -> {"registry": "A", "filter_str": "", "field": "field"}
-        "Record[abcdefg123456]" -> {"registry": "Record", "filter_str": "", "field": "", "object_uid": "abcdefg123456"}
-        "Record[abcdefg123456].name" -> {"registry": "Record", "filter_str": "", "field": "name", "object_uid": "abcdefg123456"}
+        "Record[abcdefg123456]" -> {"registry": "Record", "filter_str": "", "field": "", "type_uid": "abcdefg123456"}
+        "Record[abcdefg123456].name" -> {"registry": "Record", "filter_str": "", "field": "name", "type_uid": "abcdefg123456"}
         "bionty.Gene.ensembl_gene_id[source__id='abcd']" -> {"registry": "bionty.Gene", "filter_str": "source__id='abcd'", "field": "ensembl_gene_id"}
 
     Args:
@@ -353,9 +353,9 @@ def parse_nested_brackets(dtype_str: str) -> dict[str, Any]:
         field_part = pre_bracket_field
 
     # Extract UID or filter from bracket content
-    # For UID-based format: Record[uid] or ULabel[uid] -> object_uid
+    # For UID-based format: Record[uid] or ULabel[uid] -> type_uid
     # For filter format: registry.field[filter] -> filter_str
-    object_uid = None
+    type_uid = None
     filter_str = ""
 
     # If registry is Record or ULabel, bracket content could be UID or name(s)
@@ -372,14 +372,14 @@ def parse_nested_brackets(dtype_str: str) -> dict[str, Any]:
                 first_item, sep, remaining_items = bracket_content.partition(",")
                 first_item = first_item.strip()
                 # Support shorthand typed filters by interpreting a leading bare
-                # token as object uid and the remaining payload as filter string.
+                # token as type uid and the remaining payload as filter string.
                 if first_item and "=" not in first_item:
-                    object_uid = first_item
+                    type_uid = first_item
                     filter_str = remaining_items.strip() if sep else ""
                 else:
                     filter_str = bracket_content
             else:
-                object_uid = bracket_content
+                type_uid = bracket_content
     else:
         # For other registries, bracket content is a filter
         filter_str = bracket_content if bracket_content else ""
@@ -390,9 +390,9 @@ def parse_nested_brackets(dtype_str: str) -> dict[str, Any]:
         "field": field_part,
     }
 
-    # Add object_uid if it exists (new format)
-    if object_uid:
-        result["object_uid"] = object_uid
+    # Add type_uid if it exists (new format)
+    if type_uid:
+        result["type_uid"] = type_uid
 
     return result
 
@@ -1144,15 +1144,15 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
                 )
             parsed_dtype = parse_dtype(dtype_str)
             typed_registry: str | None = None
-            typed_object_uid: str | None = None
+            typed_type_uid: str | None = None
             if (
                 len(parsed_dtype) == 1
-                and parsed_dtype[0].get("object_uid") is not None
+                and parsed_dtype[0].get("type_uid") is not None
                 and parsed_dtype[0].get("filter_str") == ""
                 and not parsed_dtype[0].get("list", False)
             ):
                 typed_registry = parsed_dtype[0]["registry_str"]
-                typed_object_uid = parsed_dtype[0]["object_uid"]
+                typed_type_uid = parsed_dtype[0]["type_uid"]
                 dtype_str = f"cat[{typed_registry}]"
             elif "]]" in dtype_str:
                 raise ValidationError(
@@ -1194,15 +1194,15 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
                     )
                 cat_filters["type__uid"] = cat_filters.pop("type")
 
-            if typed_object_uid is not None:
+            if typed_type_uid is not None:
                 explicit_type_uid = cat_filters.get("type__uid")
                 if explicit_type_uid is not None and str(explicit_type_uid) != str(
-                    typed_object_uid
+                    typed_type_uid
                 ):
                     raise ValidationError(
-                        f"Conflicting typed dtype and cat_filters type selector: dtype uses uid '{typed_object_uid}', cat_filters uses uid '{explicit_type_uid}'"
+                        f"Conflicting typed dtype and cat_filters type selector: dtype uses uid '{typed_type_uid}', cat_filters uses uid '{explicit_type_uid}'"
                     )
-                cat_filters["type__uid"] = typed_object_uid
+                cat_filters["type__uid"] = typed_type_uid
 
             shorthand_type_uid = None
             if (

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, cast, get_args, overload
 import numpy as np
 import pgtrigger
 from django.conf import settings as django_settings
-from django.db import connection, models
+from django.db import models
 from django.db.models import CASCADE, PROTECT
 from django.db.models.query_utils import DeferredAttribute
 from django.db.utils import IntegrityError as DjangoIntegrityError
@@ -31,7 +31,6 @@ from lamindb.base.fields import (
 from lamindb.base.types import FieldAttr, SimpleDtype, SimpleDtypeStr
 from lamindb.errors import (
     FieldValidationError,
-    IntegrityError,
     InvalidArgument,
     ValidationError,
 )
@@ -80,9 +79,7 @@ class FeaturePredicate:
         )
 
 
-def parse_dtype(
-    dtype_str: str, check_exists: bool = False, old_format: bool = False
-) -> list[dict[str, Any]]:
+def parse_dtype(dtype_str: str, check_exists: bool = False) -> list[dict[str, Any]]:
     """Parses feature data type string into a structured list of components."""
     from .artifact import Artifact
 
@@ -92,7 +89,7 @@ def parse_dtype(
     if dtype_str.startswith("list[") and dtype_str.endswith("]"):
         inner_dtype_str = dtype_str[5:-1]  # Remove "list[" and "]"
         # Recursively parse the inner type
-        inner_result = parse_dtype(inner_dtype_str, old_format=old_format)
+        inner_result = parse_dtype(inner_dtype_str)
         # Add "list": True to each component
         for component in inner_result:
             if isinstance(component, dict):
@@ -114,7 +111,6 @@ def parse_dtype(
                     cat_single_dtype_str,
                     related_registries=related_registries,
                     check_exists=check_exists,
-                    old_format=old_format,
                 )
                 result.append(single_result)
     elif dtype_str not in allowed_dtypes:
@@ -141,107 +137,7 @@ def get_record_type_from_uid(
     return type_record
 
 
-def get_record_type_from_nested_subtypes(
-    registry: Registry, subtypes_list: list[str], field_str: str
-) -> SQLRecord:
-    """Get a record type by querying nested subtypes using raw SQL.
-
-    This function only works with Record or ULabel registries.
-    """
-    table_name = registry._meta.db_table
-    final_name = subtypes_list[-1]
-
-    # Build the SQL query with nested joins
-    # For subtypes_list = ["A", "B", "C"], we want:
-    # - Record with name="C"
-    # - Its type has name="B"
-    # - That type's type has name="A"
-
-    params: list[str | bool]
-    if len(subtypes_list) > 1:
-        # Build nested joins for parent types
-        parent_types = list(reversed(subtypes_list[:-1]))
-        joins = []
-        where_clauses = ["t0.name = %s"]  # Final record name
-        params = [final_name]
-
-        for i, parent_type_name in enumerate(parent_types):
-            alias = f"t{i + 1}"
-            prev_alias = f"t{i}"
-            joins.append(
-                f"INNER JOIN {table_name} {alias} ON {prev_alias}.type_id = {alias}.id"
-            )
-            where_clauses.append(f"{alias}.name = %s")
-            where_clauses.append(f"{alias}.is_type = %s")
-            params.extend([parent_type_name, True])
-
-        join_clause = " ".join(joins)
-        where_clause = " AND ".join(where_clauses)
-
-        query = f"""
-            SELECT t0.*
-            FROM {table_name} t0
-            {join_clause}
-            WHERE {where_clause}
-            LIMIT 1
-        """
-    else:
-        # Single type, no parent - type must be NULL
-        query = f"""
-            SELECT *
-            FROM {table_name}
-            WHERE name = %s AND type_id IS NULL
-            LIMIT 1
-        """
-        params = [final_name]
-
-    try:
-        with connection.cursor() as cursor:
-            cursor.execute(query, params)
-            columns = [col[0] for col in cursor.description]
-            rows = cursor.fetchall()
-
-            if not rows:
-                raise IntegrityError(
-                    f"No {registry.__name__} type found matching subtypes {subtypes_list} for field `.{field_str}`"
-                )
-
-            if len(rows) > 1:
-                raise IntegrityError(
-                    f"Multiple {registry.__name__} types found matching subtypes {subtypes_list} for field `.{field_str}`"
-                )
-
-            # Create a dictionary from the row data
-            row_dict = dict(zip(columns, rows[0]))
-
-            # Create a minimal mock object with only the fields we need
-            # This avoids querying the database which may not have all columns during migrations
-            # We create a simple object and set its class to the registry for proper error messages
-            type_record: SQLRecord = object.__new__(registry)
-            type_record.id = row_dict.get("id")
-            type_record.uid = row_dict.get("uid")
-            type_record.name = row_dict.get("name")
-            type_record.is_type = row_dict.get("is_type", False)
-            # Initialize _state attribute needed by Django models
-            # Create a minimal state object with the required attributes
-            state = type("ModelState", (), {"adding": False, "db": "default"})()
-            type_record._state = state
-
-    except IntegrityError:
-        raise
-    except Exception as e:
-        raise IntegrityError(
-            f"Error retrieving {registry.__name__} type with subtypes {subtypes_list} for field `.{field_str}`: {e}"
-        ) from e
-
-    if not type_record.is_type:
-        raise InvalidArgument(
-            f"The resolved {type_record.__class__.__name__} '{type_record.name}' for field `.{field_str}` is not a type: is_type is False."
-        )
-    return type_record
-
-
-def dtype_as_object(dtype_str: str, old_format: bool = False) -> type | None:
+def dtype_as_object(dtype_str: str) -> type | None:
     def _dtype_as_object_simple(dtype_str: str) -> type | None:
         if dtype_str == "str":
             return str
@@ -272,7 +168,7 @@ def dtype_as_object(dtype_str: str, old_format: bool = False) -> type | None:
     if dtype_str is None:
         return None
 
-    parsed_dtypes = parse_dtype(dtype_str, check_exists=True, old_format=old_format)
+    parsed_dtypes = parse_dtype(dtype_str, check_exists=True)
     if len(parsed_dtypes) > 0:
         dtype_objects = []
         for parsed_dtype in parsed_dtypes:
@@ -281,12 +177,6 @@ def dtype_as_object(dtype_str: str, old_format: bool = False) -> type | None:
                 dtype_object = get_record_type_from_uid(
                     parsed_dtype["registry"],
                     parsed_dtype["record_uid"],
-                )
-            elif parsed_dtype.get("subtypes_list"):
-                dtype_object = get_record_type_from_nested_subtypes(
-                    parsed_dtype["registry"],
-                    parsed_dtype["subtypes_list"],
-                    parsed_dtype["field"],
                 )
             else:
                 # return field for dtypes without record_uid, e.g. bt.CellType.ontology_id
@@ -315,7 +205,6 @@ def parse_cat_dtype(
     related_registries: dict[str, SQLRecord] | None = None,
     is_itype: bool = False,
     check_exists: bool = False,
-    old_format: bool = False,
 ) -> dict[str, Any]:
     """Parses a categorical dtype string into its components (registry, field, subtypes)."""
     from .artifact import Artifact
@@ -325,7 +214,7 @@ def parse_cat_dtype(
         related_registries = dict_module_name_to_model_name(Artifact)
 
     # Parse the string considering nested brackets
-    parsed = parse_nested_brackets(dtype_str, old_format=old_format)
+    parsed = parse_nested_brackets(dtype_str)
     registry_str = parsed["registry"]
     filter_str = parsed["filter_str"]
     field_str = parsed["field"]
@@ -360,17 +249,7 @@ def parse_cat_dtype(
     assert hasattr(registry, field_str), f"{registry} has no field {field_str}"
 
     record_uid = parsed.get("record_uid")
-    subtypes_list = parsed.get("subtypes_list")
-
-    # Handle old format (subtypes_list) or new format (record_uid)
-    if subtypes_list and check_exists:
-        # Old format: validate that the Record exists using nested subtypes
-        # subtypes_list is guaranteed to be list[str] when present
-        if isinstance(subtypes_list, list):
-            get_record_type_from_nested_subtypes(
-                registry, cast(list[str], subtypes_list), field_str
-            )
-    elif record_uid and check_exists:
+    if record_uid and check_exists:
         get_record_type_from_uid(registry, record_uid)
 
     if filter_str != "":
@@ -388,14 +267,10 @@ def parse_cat_dtype(
     if record_uid:
         result["record_uid"] = record_uid
 
-    # Add subtypes_list if it exists (old format)
-    if subtypes_list:
-        result["subtypes_list"] = subtypes_list
-
     return result
 
 
-def parse_nested_brackets(dtype_str: str, old_format: bool = False) -> dict[str, Any]:
+def parse_nested_brackets(dtype_str: str) -> dict[str, Any]:
     """Parse dtype string with potentially nested brackets.
 
     Examples:
@@ -477,42 +352,34 @@ def parse_nested_brackets(dtype_str: str, old_format: bool = False) -> dict[str,
     if not field_part and pre_bracket_field:
         field_part = pre_bracket_field
 
-    # Extract UID, subtypes_list, or filter from bracket content
+    # Extract UID or filter from bracket content
     # For UID-based format: Record[uid] or ULabel[uid] -> record_uid
-    # For old name-based format: Record[Name] or Record[Parent[Child]] -> subtypes_list
     # For filter format: registry.field[filter] -> filter_str
     record_uid = None
-    subtypes_list = None
     filter_str = ""
 
     # If registry is Record or ULabel, bracket content could be UID or name(s)
     if registry_part in ("Record", "ULabel"):
         if bracket_content:
-            if old_format:
-                # Old format with nested brackets like Record[Parent[Child]]
-                extracted = extract_subtypes_and_filter(bracket_content)
-                subtypes_list = extracted["subtypes_list"]
-                filter_str = extracted["filter_str"]
-            else:
-                # In current format, Record/ULabel brackets can contain either:
-                # - a type uid, e.g. Record[Ab12Cd34Ef56Gh78]
-                # - relation filters injected from cat_filters, e.g.
-                #   Record[type__uid='...', is_type='True', schema__uid='...']
-                # - shorthand typed filters, e.g.
-                #   Record[Ab12Cd34Ef56Gh78, is_type='True', schema__uid='...']
-                # Distinguish them by presence of '=' in the bracket payload.
-                if "=" in bracket_content:
-                    first_item, sep, remaining_items = bracket_content.partition(",")
-                    first_item = first_item.strip()
-                    # Support shorthand typed filters by interpreting a leading bare
-                    # token as record uid and the remaining payload as filter string.
-                    if first_item and "=" not in first_item:
-                        record_uid = first_item
-                        filter_str = remaining_items.strip() if sep else ""
-                    else:
-                        filter_str = bracket_content
+            # In current format, Record/ULabel brackets can contain either:
+            # - a type uid, e.g. Record[Ab12Cd34Ef56Gh78]
+            # - relation filters injected from cat_filters, e.g.
+            #   Record[type__uid='...', is_type='True', schema__uid='...']
+            # - shorthand typed filters, e.g.
+            #   Record[Ab12Cd34Ef56Gh78, is_type='True', schema__uid='...']
+            # Distinguish them by presence of '=' in the bracket payload.
+            if "=" in bracket_content:
+                first_item, sep, remaining_items = bracket_content.partition(",")
+                first_item = first_item.strip()
+                # Support shorthand typed filters by interpreting a leading bare
+                # token as record uid and the remaining payload as filter string.
+                if first_item and "=" not in first_item:
+                    record_uid = first_item
+                    filter_str = remaining_items.strip() if sep else ""
                 else:
-                    record_uid = bracket_content
+                    filter_str = bracket_content
+            else:
+                record_uid = bracket_content
     else:
         # For other registries, bracket content is a filter
         filter_str = bracket_content if bracket_content else ""
@@ -527,74 +394,7 @@ def parse_nested_brackets(dtype_str: str, old_format: bool = False) -> dict[str,
     if record_uid:
         result["record_uid"] = record_uid
 
-    # Add subtypes_list if it exists (old format)
-    if subtypes_list:
-        result["subtypes_list"] = subtypes_list
-
     return result
-
-
-def extract_subtypes_and_filter(subtype_str: str) -> dict[str, Any]:
-    """Extract nested subtypes and optional filter from a nested subtype string.
-
-    Examples:
-        "B" -> {"subtypes_list": ["B"], "filter_str": ""}
-        "B[C]" -> {"subtypes_list": ["B", "C"], "filter_str": ""}
-        "B[C[filter='<value>']]" -> {"subtypes_list": ["B", "C"], "filter_str": "filter='<value>'"}
-        "B[C[D]]" -> {"subtypes_list": ["B", "C", "D"], "filter_str": ""}
-        "B[C[D[E]]]" -> {"subtypes_list": ["B", "C", "D", "E"], "filter_str": ""}
-        "B[filter='value']" -> {"subtypes_list": ["B"], "filter_str": "filter='value'"}
-        "Customer[UScustomer[region='US']]" -> {"subtypes_list": ["Customer", "UScustomer"], "filter_str": "region='US'"}
-
-    Args:
-        subtype_str: The subtype string with potential nesting
-
-    Returns:
-        Dictionary with subtypes_list and filter_str
-    """
-    subtypes: list[str] = []
-    filter_str = ""
-    current = subtype_str
-
-    while current:
-        if "[" not in current:
-            # No more brackets
-            if current and "=" not in current:
-                # It's a subtype name
-                subtypes.append(current)
-            elif current and "=" in current:
-                # It's a filter
-                filter_str = current
-            break
-
-        # Find the first part before the bracket
-        bracket_pos = current.index("[")
-        part = current[:bracket_pos]
-
-        # Add the part (it's a subtype name)
-        if part:
-            subtypes.append(part)
-
-        # Find the matching closing bracket
-        bracket_count = 0
-        closing_pos = -1
-
-        for i in range(bracket_pos, len(current)):
-            if current[i] == "[":
-                bracket_count += 1
-            elif current[i] == "]":
-                bracket_count -= 1
-                if bracket_count == 0:
-                    closing_pos = i
-                    break
-
-        if closing_pos == -1:
-            break
-
-        # Move to the content inside the brackets
-        current = current[bracket_pos + 1 : closing_pos]
-
-    return {"subtypes_list": subtypes, "filter_str": filter_str}
 
 
 def serialize_dtype(
@@ -800,70 +600,6 @@ def resolve_relation_filters(
     return resolved
 
 
-def migrate_dtype_to_uid_format(connection, input_field: str = "_dtype_str") -> None:
-    """Update _dtype_str for nested Record/ULabel types to uid format.
-
-    Converts old format (name-based) dtype strings to new UID-based format.
-    This function is used in migrations to update existing feature records.
-
-    Args:
-        connection: Database connection (from schema_editor.connection)
-        input_field: Field name to read from ("_dtype_str" or "dtype")
-
-    Returns:
-        None. Updates are performed directly in the database.
-    """
-    # Patterns to look for old format (name-based)
-    patterns = [
-        "cat[Record[",
-        "cat[ULabel[",
-        "list[cat[Record[",
-        "list[cat[ULabel[",
-    ]
-
-    # Build SQL query to fetch features matching any pattern
-    # Using OR conditions for each pattern
-    pattern_conditions = " OR ".join(
-        [f"{input_field} LIKE '{pattern}%'" for pattern in patterns]
-    )
-
-    query = f"""
-        SELECT id, uid, name, {input_field}
-        FROM lamindb_feature
-        WHERE {pattern_conditions}
-    """
-
-    # Fetch matching features
-    with connection.cursor() as cursor:
-        cursor.execute(query)
-        columns = [col[0] for col in cursor.description]
-        features = [dict(zip(columns, row)) for row in cursor.fetchall()]
-
-    # Convert each feature
-    for feature in features:
-        try:
-            # Convert old format string to objects, then serialize to UID format
-            dtype_objects = dtype_as_object(feature[input_field], old_format=True)
-            new_dtype_str = serialize_dtype(dtype_objects)
-
-            if new_dtype_str != feature[input_field]:
-                # Update using raw SQL
-                update_query = """
-                    UPDATE lamindb_feature
-                    SET _dtype_str = %s
-                    WHERE id = %s
-                """
-                with connection.cursor() as cursor:
-                    cursor.execute(update_query, [new_dtype_str, feature["id"]])
-
-        except Exception as e:
-            # If conversion fails, keep the original value
-            print(
-                f"Warning: Could not convert dtype for feature {feature['name']} ({feature['uid']}) because of error: {e}"
-            )
-            continue
-
-
 def process_init_feature_param(args, kwargs):
     # now we proceed with the user-facing constructor
     if len(args) != 0:
@@ -906,12 +642,7 @@ def process_init_feature_param(args, kwargs):
                 f"rather than passing a string '{dtype}' to dtype, consider passing a Python object"
             )
             dtype_str = dtype
-            parse_dtype(dtype_str, check_exists=True, old_format=True)
-            if dtype_str.startswith(
-                ("cat[Record[", "cat[ULabel[", "list[cat[Record[", "list[cat[ULabel[")
-            ):
-                # need to convert from old semantic format to new uid-based format
-                dtype_str = serialize_dtype(dtype_as_object(dtype_str, old_format=True))
+            parse_dtype(dtype_str, check_exists=True)
         kwargs["_dtype_str"] = dtype_str
     return kwargs
 

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -122,17 +122,17 @@ def parse_dtype(dtype_str: str, check_exists: bool = False) -> list[dict[str, An
 
 def get_record_type_from_uid(
     registry: Registry,
-    record_uid: str,
+    object_uid: str,
 ) -> SQLRecord:
-    type_record: SQLRecord = registry.get(record_uid)
+    type_record: SQLRecord = registry.get(object_uid)
 
     if type_record.branch_id == -1:
-        warning_msg = f"retrieving {registry.__name__} type '{type_record.name}' (uid='{record_uid}') from trash"
+        warning_msg = f"retrieving {registry.__name__} type '{type_record.name}' (uid='{object_uid}') from trash"
         logger.warning(warning_msg)
 
     if not type_record.is_type:
         raise InvalidArgument(
-            f"The resolved {type_record.__class__.__name__} '{type_record.name}' (uid='{record_uid}') is not a type: is_type is False."
+            f"The resolved {type_record.__class__.__name__} '{type_record.name}' (uid='{object_uid}') is not a type: is_type is False."
         )
     return type_record
 
@@ -172,14 +172,14 @@ def dtype_as_object(dtype_str: str) -> type | None:
     if len(parsed_dtypes) > 0:
         dtype_objects = []
         for parsed_dtype in parsed_dtypes:
-            if parsed_dtype.get("record_uid"):
-                # return the subtype record for dtypes with record_uid
+            if parsed_dtype.get("object_uid"):
+                # return the subtype record for dtypes with object_uid
                 dtype_object = get_record_type_from_uid(
                     parsed_dtype["registry"],
-                    parsed_dtype["record_uid"],
+                    parsed_dtype["object_uid"],
                 )
             else:
-                # return field for dtypes without record_uid, e.g. bt.CellType.ontology_id
+                # return field for dtypes without object_uid, e.g. bt.CellType.ontology_id
                 dtype_object = parsed_dtype["field"]
             # for list, returns list[SQLRecord]
             dtype_objects.append(
@@ -248,9 +248,9 @@ def parse_cat_dtype(
         field_str = registry._name_field if hasattr(registry, "_name_field") else "name"
     assert hasattr(registry, field_str), f"{registry} has no field {field_str}"
 
-    record_uid = parsed.get("record_uid")
-    if record_uid and check_exists:
-        get_record_type_from_uid(registry, record_uid)
+    object_uid = parsed.get("object_uid")
+    if object_uid and check_exists:
+        get_record_type_from_uid(registry, object_uid)
 
     if filter_str != "":
         # TODO: validate or process filter string
@@ -263,9 +263,9 @@ def parse_cat_dtype(
         "field": getattr(registry, field_str),
     }
 
-    # Add record_uid if it exists (new format)
-    if record_uid:
-        result["record_uid"] = record_uid
+    # Add object_uid if it exists (new format)
+    if object_uid:
+        result["object_uid"] = object_uid
 
     return result
 
@@ -276,8 +276,8 @@ def parse_nested_brackets(dtype_str: str) -> dict[str, Any]:
     Examples:
         "A" -> {"registry": "A", "filter_str": "", "field": ""}
         "A.field" -> {"registry": "A", "filter_str": "", "field": "field"}
-        "Record[abcdefg123456]" -> {"registry": "Record", "filter_str": "", "field": "", "record_uid": "abcdefg123456"}
-        "Record[abcdefg123456].name" -> {"registry": "Record", "filter_str": "", "field": "name", "record_uid": "abcdefg123456"}
+        "Record[abcdefg123456]" -> {"registry": "Record", "filter_str": "", "field": "", "object_uid": "abcdefg123456"}
+        "Record[abcdefg123456].name" -> {"registry": "Record", "filter_str": "", "field": "name", "object_uid": "abcdefg123456"}
         "bionty.Gene.ensembl_gene_id[source__id='abcd']" -> {"registry": "bionty.Gene", "filter_str": "source__id='abcd'", "field": "ensembl_gene_id"}
 
     Args:
@@ -353,9 +353,9 @@ def parse_nested_brackets(dtype_str: str) -> dict[str, Any]:
         field_part = pre_bracket_field
 
     # Extract UID or filter from bracket content
-    # For UID-based format: Record[uid] or ULabel[uid] -> record_uid
+    # For UID-based format: Record[uid] or ULabel[uid] -> object_uid
     # For filter format: registry.field[filter] -> filter_str
-    record_uid = None
+    object_uid = None
     filter_str = ""
 
     # If registry is Record or ULabel, bracket content could be UID or name(s)
@@ -372,14 +372,14 @@ def parse_nested_brackets(dtype_str: str) -> dict[str, Any]:
                 first_item, sep, remaining_items = bracket_content.partition(",")
                 first_item = first_item.strip()
                 # Support shorthand typed filters by interpreting a leading bare
-                # token as record uid and the remaining payload as filter string.
+                # token as object uid and the remaining payload as filter string.
                 if first_item and "=" not in first_item:
-                    record_uid = first_item
+                    object_uid = first_item
                     filter_str = remaining_items.strip() if sep else ""
                 else:
                     filter_str = bracket_content
             else:
-                record_uid = bracket_content
+                object_uid = bracket_content
     else:
         # For other registries, bracket content is a filter
         filter_str = bracket_content if bracket_content else ""
@@ -390,9 +390,9 @@ def parse_nested_brackets(dtype_str: str) -> dict[str, Any]:
         "field": field_part,
     }
 
-    # Add record_uid if it exists (new format)
-    if record_uid:
-        result["record_uid"] = record_uid
+    # Add object_uid if it exists (new format)
+    if object_uid:
+        result["object_uid"] = object_uid
 
     return result
 
@@ -1144,15 +1144,15 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
                 )
             parsed_dtype = parse_dtype(dtype_str)
             typed_registry: str | None = None
-            typed_record_uid: str | None = None
+            typed_object_uid: str | None = None
             if (
                 len(parsed_dtype) == 1
-                and parsed_dtype[0].get("record_uid") is not None
+                and parsed_dtype[0].get("object_uid") is not None
                 and parsed_dtype[0].get("filter_str") == ""
                 and not parsed_dtype[0].get("list", False)
             ):
                 typed_registry = parsed_dtype[0]["registry_str"]
-                typed_record_uid = parsed_dtype[0]["record_uid"]
+                typed_object_uid = parsed_dtype[0]["object_uid"]
                 dtype_str = f"cat[{typed_registry}]"
             elif "]]" in dtype_str:
                 raise ValidationError(
@@ -1194,15 +1194,15 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
                     )
                 cat_filters["type__uid"] = cat_filters.pop("type")
 
-            if typed_record_uid is not None:
+            if typed_object_uid is not None:
                 explicit_type_uid = cat_filters.get("type__uid")
                 if explicit_type_uid is not None and str(explicit_type_uid) != str(
-                    typed_record_uid
+                    typed_object_uid
                 ):
                     raise ValidationError(
-                        f"Conflicting typed dtype and cat_filters type selector: dtype uses uid '{typed_record_uid}', cat_filters uses uid '{explicit_type_uid}'"
+                        f"Conflicting typed dtype and cat_filters type selector: dtype uses uid '{typed_object_uid}', cat_filters uses uid '{explicit_type_uid}'"
                     )
-                cat_filters["type__uid"] = typed_record_uid
+                cat_filters["type__uid"] = typed_object_uid
 
             shorthand_type_uid = None
             if (

--- a/tests/core/test_feature_dtype.py
+++ b/tests/core/test_feature_dtype.py
@@ -135,7 +135,7 @@ def test_simple_record_with_subtype_and_field():
         "field_str": "name",
         "registry": Record,
         "field": Record.name,
-        "object_uid": customer_type.uid,
+        "type_uid": customer_type.uid,
     }
     customer_type.delete(permanent=True)
 
@@ -155,7 +155,7 @@ def test_multiple_records_with_subtypes_and_fields():
         "field_str": "name",
         "registry": Record,
         "field": Record.name,
-        "object_uid": customer_type.uid,
+        "type_uid": customer_type.uid,
     }
     assert result[1] == {
         "registry_str": "Record",
@@ -163,7 +163,7 @@ def test_multiple_records_with_subtypes_and_fields():
         "field_str": "name",
         "registry": Record,
         "field": Record.name,
-        "object_uid": supplier_type.uid,
+        "type_uid": supplier_type.uid,
     }
     customer_type.delete(permanent=True)
     supplier_type.delete(permanent=True)
@@ -261,7 +261,7 @@ def test_registry_with_subtype_no_field():
         "field_str": "name",
         "registry": Record,
         "field": Record.name,
-        "object_uid": customer_type.uid,
+        "type_uid": customer_type.uid,
     }
     customer_type.delete(permanent=True)
 
@@ -278,7 +278,7 @@ def test_list_of_dtypes():
         "field_str": "name",
         "registry": Record,
         "field": Record.name,
-        "object_uid": customer_type.uid,
+        "type_uid": customer_type.uid,
         "list": True,
     }
     assert serialize_dtype(list[bt.CellLine]) == "list[cat[bionty.CellLine]]"
@@ -313,7 +313,7 @@ def test_nested_cat_dtypes():
         "field_str": "name",
         "registry": Record,
         "field": Record.name,
-        "object_uid": uscustomer_type.uid,
+        "type_uid": uscustomer_type.uid,
     }
     uscustomer_type.delete(permanent=True)
     customer_type.delete(permanent=True)
@@ -336,7 +336,7 @@ def test_nested_cat_with_filter():
         "field_str": "description",
         "registry": Record,
         "field": Record.description,
-        "object_uid": uscustomer_type.uid,
+        "type_uid": uscustomer_type.uid,
     }
     uscustomer_type.delete(permanent=True)
     customer_type.delete(permanent=True)
@@ -380,7 +380,7 @@ def test_cat_filters_record_type_is_type_and_schema_filters():
         == f"cat[Record[{sample_type.uid}, is_type='True', schema__uid='{schema.uid}']]"
     )
     result = parse_dtype(feature._dtype_str)
-    assert result[0]["object_uid"] == sample_type.uid
+    assert result[0]["type_uid"] == sample_type.uid
     assert result[0]["filter_str"] == f"is_type='True', schema__uid='{schema.uid}'"
     schema.delete(permanent=True)
     schema_feature.delete(permanent=True)

--- a/tests/core/test_feature_dtype.py
+++ b/tests/core/test_feature_dtype.py
@@ -7,7 +7,6 @@ import pytest
 from lamindb import Record
 from lamindb.errors import ValidationError
 from lamindb.models.feature import (
-    dtype_as_object,
     parse_dtype,
     parse_filter_string,
     resolve_relation_filters,
@@ -86,12 +85,6 @@ def test_serialize_record_objects():
     assert feature.dtype == "cat[Record[InstituteA[LabB[Sample]]]]"
     feature.delete(permanent=True)
     assert serialize_dtype(sample_type) == serialized_str
-    with pytest.raises(ln.errors.IntegrityError) as error:
-        parse_dtype("cat[Record[Sample]]", check_exists=True, old_format=True)
-    assert (
-        "No Record type found matching subtypes ['Sample'] for field `.name`"
-        in error.exconly()
-    )
     sample = ln.Record(name="sample").save()
     with pytest.raises(ln.errors.InvalidArgument) as error:
         parse_dtype(f"cat[Record[{sample.uid}]]", check_exists=True)
@@ -566,131 +559,6 @@ def test_resolve_relation_filter_duplicate():
         resolve_relation_filters(parsed, bt.Gene)
 
 
-# -----------------------------------------------------------------------------
-# backward compatibility for old format strings
-# -----------------------------------------------------------------------------
-
-
-def test_convert_old_format_ulabel_string():
-    """Test converting old format ULabel string to object."""
-    # Create a ULabel type
-    perturbation = ln.ULabel(name="Perturbation", is_type=True).save()
-
-    # Convert old format string
-    dtype_obj = dtype_as_object("cat[ULabel[Perturbation]]", old_format=True)
-
-    # Should return the ULabel object
-    assert dtype_obj == perturbation
-    assert hasattr(dtype_obj, "uid")
-
-    # Clean up
-    perturbation.delete(permanent=True)
-
-
-def test_convert_old_format_record_string():
-    """Test converting old format Record string to object."""
-    # Create a Record type
-    sample_type = ln.Record(name="Sample", is_type=True).save()
-
-    # Convert old format string
-    dtype_obj = dtype_as_object("cat[Record[Sample]]", old_format=True)
-
-    # Should return the Record object
-    assert dtype_obj == sample_type
-    assert hasattr(dtype_obj, "uid")
-
-    # Clean up
-    sample_type.delete(permanent=True)
-
-
-def test_convert_old_format_nested_record_string():
-    """Test converting old format nested Record string to object."""
-    # Create nested Record types
-    lab_type = ln.Record(name="LabA", is_type=True).save()
-    experiment_type = ln.Record(name="Experiment", type=lab_type, is_type=True).save()
-
-    # Convert old format string
-    dtype_obj = dtype_as_object("cat[Record[LabA[Experiment]]]", old_format=True)
-
-    # Should return the nested Record object
-    assert dtype_obj == experiment_type
-    assert hasattr(dtype_obj, "uid")
-
-    # Clean up
-    experiment_type.delete(permanent=True)
-    lab_type.delete(permanent=True)
-
-
-def test_convert_old_format_list_string():
-    """Test converting old format list string to object."""
-    # Create a ULabel type
-    perturbation = ln.ULabel(name="Perturbation", is_type=True).save()
-
-    # Convert old format string with list wrapper
-    dtype_obj = dtype_as_object("list[cat[ULabel[Perturbation]]]", old_format=True)
-
-    # Should return list[ULabel] type
-    assert hasattr(dtype_obj, "__origin__")
-    assert dtype_obj.__origin__ is list
-    # Get the inner type
-    from typing import get_args
-
-    inner_type = get_args(dtype_obj)[0]
-    assert inner_type == perturbation
-
-    # Clean up
-    perturbation.delete(permanent=True)
-
-
-def test_feature_constructor_with_old_format_string(ccaplog):
-    """Test Feature constructor with old format string raises deprecation warning."""
-    # Create a ULabel type
-    perturbation = ln.ULabel(name="Perturbation", is_type=True).save()
-
-    # Create feature with old format string
-    feature = ln.Feature(name="perturbation", dtype="cat[ULabel[Perturbation]]")
-    assert (
-        "rather than passing a string 'cat[ULabel[Perturbation]]' to dtype, consider passing a Python object"
-        in ccaplog.text
-    )
-
-    # Should have converted to UID format
-    assert feature._dtype_str is not None
-    assert "ULabel[" in feature._dtype_str
-    # Should contain UID, not name
-    assert "Perturbation" not in feature._dtype_str
-    assert perturbation.uid in feature._dtype_str
-
-    # Clean up
-    perturbation.delete(permanent=True)
-
-
-def test_feature_constructor_with_old_format_nested_string(ccaplog):
-    """Test Feature constructor with old format nested string."""
-    # Create nested Record types
-    lab_type = ln.Record(name="LabA", is_type=True).save()
-    experiment_type = ln.Record(name="Experiment", type=lab_type, is_type=True).save()
-
-    # Create feature with old format nested string
-    feature = ln.Feature(name="experiment", dtype="cat[Record[LabA[Experiment]]]")
-    assert (
-        "rather than passing a string 'cat[Record[LabA[Experiment]]]' to dtype, consider passing a Python object"
-        in ccaplog.text
-    )
-
-    # Should have converted to UID format
-    assert feature._dtype_str is not None
-    assert "Record[" in feature._dtype_str
-    # Should contain UID, not names
-    assert "LabA" not in feature._dtype_str
-    assert "Experiment" not in feature._dtype_str
-    assert experiment_type.uid in feature._dtype_str
-
-    # Clean up
-    experiment_type.delete(permanent=True)
-    lab_type.delete(permanent=True)
-
-
 def test_bare_cat_dtype_backward_compatibility():
     """Test that bare 'cat' dtype is accepted for backward compatibility."""
     # Test parse_dtype accepts "cat" and returns empty list
@@ -701,94 +569,3 @@ def test_bare_cat_dtype_backward_compatibility():
     with pytest.warns(DeprecationWarning, match="dtype `cat` is deprecated"):
         feature = ln.Feature(name="test_bare_cat", dtype="cat")
     assert feature._dtype_str == "cat"
-
-
-def test_migrate_dtype_to_uid_format():
-    """Test migrate_dtype_to_uid_format() function for migration."""
-    from django.db import connection
-    from lamindb.models.feature import migrate_dtype_to_uid_format
-
-    # Create Record types for testing
-    lab_type = ln.Record(name="LabA", is_type=True).save()
-    experiment_type = ln.Record(name="Experiment", type=lab_type, is_type=True).save()
-    perturbation = ln.ULabel(name="Perturbation", is_type=True).save()
-
-    # Create features with old format strings in _dtype_str
-    feature1 = ln.Feature(name="test_record_old_format", dtype="str").save()
-    feature2 = ln.Feature(name="test_ulabel_old_format", dtype="str").save()
-    feature3 = ln.Feature(name="test_list_record_old_format", dtype="str").save()
-    feature4 = ln.Feature(name="test_list_ulabel_old_format", dtype="str").save()
-
-    # Manually set old format strings using raw SQL
-    old_format_record = "cat[Record[LabA[Experiment]]]"
-    old_format_ulabel = "cat[ULabel[Perturbation]]"
-    old_format_list_record = "list[cat[Record[LabA[Experiment]]]]"
-    old_format_list_ulabel = "list[cat[ULabel[Perturbation]]]"
-
-    with connection.cursor() as cursor:
-        cursor.execute(
-            "UPDATE lamindb_feature SET _dtype_str = %s WHERE id = %s",
-            [old_format_record, feature1.id],
-        )
-        cursor.execute(
-            "UPDATE lamindb_feature SET _dtype_str = %s WHERE id = %s",
-            [old_format_ulabel, feature2.id],
-        )
-        cursor.execute(
-            "UPDATE lamindb_feature SET _dtype_str = %s WHERE id = %s",
-            [old_format_list_record, feature3.id],
-        )
-        cursor.execute(
-            "UPDATE lamindb_feature SET _dtype_str = %s WHERE id = %s",
-            [old_format_list_ulabel, feature4.id],
-        )
-
-    # Refresh features from database
-    feature1.refresh_from_db()
-    feature2.refresh_from_db()
-    feature3.refresh_from_db()
-    feature4.refresh_from_db()
-
-    # Verify old format is present
-    assert feature1._dtype_str == old_format_record
-    assert feature2._dtype_str == old_format_ulabel
-    assert feature3._dtype_str == old_format_list_record
-    assert feature4._dtype_str == old_format_list_ulabel
-
-    # Run migration function
-    migrate_dtype_to_uid_format(connection, input_field="_dtype_str")
-
-    # Refresh features from database
-    feature1.refresh_from_db()
-    feature2.refresh_from_db()
-    feature3.refresh_from_db()
-    feature4.refresh_from_db()
-
-    # Verify conversion to UID format
-    assert feature1._dtype_str == f"cat[Record[{experiment_type.uid}]]"
-    assert feature2._dtype_str == f"cat[ULabel[{perturbation.uid}]]"
-    assert feature3._dtype_str == f"list[cat[Record[{experiment_type.uid}]]]"
-    assert feature4._dtype_str == f"list[cat[ULabel[{perturbation.uid}]]]"
-
-    # Verify old names are not in the converted strings
-    assert "LabA" not in feature1._dtype_str
-    assert "Experiment" not in feature1._dtype_str
-    assert "Perturbation" not in feature2._dtype_str
-    assert "LabA" not in feature3._dtype_str
-    assert "Experiment" not in feature3._dtype_str
-    assert "Perturbation" not in feature4._dtype_str
-
-    # Verify UIDs are present
-    assert experiment_type.uid in feature1._dtype_str
-    assert perturbation.uid in feature2._dtype_str
-    assert experiment_type.uid in feature3._dtype_str
-    assert perturbation.uid in feature4._dtype_str
-
-    # Clean up
-    feature1.delete(permanent=True)
-    feature2.delete(permanent=True)
-    feature3.delete(permanent=True)
-    feature4.delete(permanent=True)
-    experiment_type.delete(permanent=True)
-    lab_type.delete(permanent=True)
-    perturbation.delete(permanent=True)

--- a/tests/core/test_feature_dtype.py
+++ b/tests/core/test_feature_dtype.py
@@ -135,7 +135,7 @@ def test_simple_record_with_subtype_and_field():
         "field_str": "name",
         "registry": Record,
         "field": Record.name,
-        "record_uid": customer_type.uid,
+        "object_uid": customer_type.uid,
     }
     customer_type.delete(permanent=True)
 
@@ -155,7 +155,7 @@ def test_multiple_records_with_subtypes_and_fields():
         "field_str": "name",
         "registry": Record,
         "field": Record.name,
-        "record_uid": customer_type.uid,
+        "object_uid": customer_type.uid,
     }
     assert result[1] == {
         "registry_str": "Record",
@@ -163,7 +163,7 @@ def test_multiple_records_with_subtypes_and_fields():
         "field_str": "name",
         "registry": Record,
         "field": Record.name,
-        "record_uid": supplier_type.uid,
+        "object_uid": supplier_type.uid,
     }
     customer_type.delete(permanent=True)
     supplier_type.delete(permanent=True)
@@ -261,7 +261,7 @@ def test_registry_with_subtype_no_field():
         "field_str": "name",
         "registry": Record,
         "field": Record.name,
-        "record_uid": customer_type.uid,
+        "object_uid": customer_type.uid,
     }
     customer_type.delete(permanent=True)
 
@@ -278,7 +278,7 @@ def test_list_of_dtypes():
         "field_str": "name",
         "registry": Record,
         "field": Record.name,
-        "record_uid": customer_type.uid,
+        "object_uid": customer_type.uid,
         "list": True,
     }
     assert serialize_dtype(list[bt.CellLine]) == "list[cat[bionty.CellLine]]"
@@ -313,7 +313,7 @@ def test_nested_cat_dtypes():
         "field_str": "name",
         "registry": Record,
         "field": Record.name,
-        "record_uid": uscustomer_type.uid,
+        "object_uid": uscustomer_type.uid,
     }
     uscustomer_type.delete(permanent=True)
     customer_type.delete(permanent=True)
@@ -336,7 +336,7 @@ def test_nested_cat_with_filter():
         "field_str": "description",
         "registry": Record,
         "field": Record.description,
-        "record_uid": uscustomer_type.uid,
+        "object_uid": uscustomer_type.uid,
     }
     uscustomer_type.delete(permanent=True)
     customer_type.delete(permanent=True)
@@ -380,7 +380,7 @@ def test_cat_filters_record_type_is_type_and_schema_filters():
         == f"cat[Record[{sample_type.uid}, is_type='True', schema__uid='{schema.uid}']]"
     )
     result = parse_dtype(feature._dtype_str)
-    assert result[0]["record_uid"] == sample_type.uid
+    assert result[0]["object_uid"] == sample_type.uid
     assert result[0]["filter_str"] == f"is_type='True', schema__uid='{schema.uid}'"
     schema.delete(permanent=True)
     schema_feature.delete(permanent=True)

--- a/tests/curators/test_dataframe_curation.py
+++ b/tests/curators/test_dataframe_curation.py
@@ -18,7 +18,7 @@ def transactions_schema():
     assert eur.type == currency_type
 
     # Features
-    currency = ln.Feature(name="currency_name", dtype="cat[ULabel[Currency]]").save()
+    currency = ln.Feature(name="currency_name", dtype=currency_type).save()
     date = ln.Feature(name="date", dtype="date").save()
     receipt_url = ln.Feature(name="receipt_url", dtype="url").save()
 


### PR DESCRIPTION
Removes the internal code that was relevant for the LaminDB v1 to v2 migration and to support for v1 dtype strings that contain semantic type names.