### PR TITLE
🚸 Print warnings on instance module mismatch with environment during `ln.connect()` and `ln.DB()`

### DIFF
--- a/lamindb/models/query_set.py
+++ b/lamindb/models/query_set.py
@@ -1738,7 +1738,7 @@ class DB:
             owner=owner, name=instance_name
         )
         self._modules = ["lamindb"] + list(instance_info.modules)
-        warning = import_module("lamindb_setup.core.django")._warn_module_mismatch(
+        warning = ln_setup.core.django._warn_module_mismatch(
             target_apps={"lamindb"} | instance_info.modules,
             # Read-only DB querying should only warn when instance modules are missing
             # from the local environment, not when local modules are additional.

--- a/lamindb/models/query_set.py
+++ b/lamindb/models/query_set.py
@@ -1738,6 +1738,14 @@ class DB:
             owner=owner, name=instance_name
         )
         self._modules = ["lamindb"] + list(instance_info.modules)
+        warning = import_module("lamindb_setup.core.django")._warn_module_mismatch(
+            target_apps={"lamindb"} | instance_info.modules,
+            # Read-only DB querying should only warn when instance modules are missing
+            # from the local environment, not when local modules are additional.
+            current_apps={"lamindb"} | (setup_settings.modules & instance_info.modules),
+        )
+        if warning is not None:
+            logger.warning(warning)
 
     def __getattr__(self, name: str) -> NonInstantiableQuerySet | BiontyDB | PertdbDB:
         """Access a registry class or schema namespace for this database instance.

--- a/tests/core/test_querydb.py
+++ b/tests/core/test_querydb.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import lamindb as ln
 import pytest
 
@@ -82,3 +84,53 @@ def test_DB_dir():
     assert "Collection" in dir_result
     assert "Gene" not in dir_result
     assert "bionty" in dir_result
+
+
+def test_DB_warns_for_missing_local_modules(monkeypatch):
+    warning_calls: list[str] = []
+    monkeypatch.setattr(
+        "lamindb.models.query_set.logger.warning",
+        lambda message: warning_calls.append(message),
+    )
+    monkeypatch.setattr(
+        "lamindb.models.query_set.ln_setup._connect_instance.get_owner_name_from_identifier",
+        lambda identifier: ("owner", "name"),
+    )
+    monkeypatch.setattr(
+        "lamindb.models.query_set.ln_setup._connect_instance._connect_instance",
+        lambda owner, name: SimpleNamespace(modules={"bionty", "pertdb"}),
+    )
+    monkeypatch.setattr(
+        "lamindb.models.query_set.setup_settings",
+        SimpleNamespace(modules={"bionty"}),
+    )
+
+    ln.DB("owner/name")
+
+    assert len(warning_calls) == 1
+    assert "non-configured modules: pertdb" in warning_calls[0]
+    assert "lamin settings modules set bionty,pertdb" in warning_calls[0]
+
+
+def test_DB_skips_warning_for_surplus_local_modules(monkeypatch):
+    warning_calls: list[str] = []
+    monkeypatch.setattr(
+        "lamindb.models.query_set.logger.warning",
+        lambda message: warning_calls.append(message),
+    )
+    monkeypatch.setattr(
+        "lamindb.models.query_set.ln_setup._connect_instance.get_owner_name_from_identifier",
+        lambda identifier: ("owner", "name"),
+    )
+    monkeypatch.setattr(
+        "lamindb.models.query_set.ln_setup._connect_instance._connect_instance",
+        lambda owner, name: SimpleNamespace(modules={"bionty"}),
+    )
+    monkeypatch.setattr(
+        "lamindb.models.query_set.setup_settings",
+        SimpleNamespace(modules={"bionty", "pertdb"}),
+    )
+
+    ln.DB("owner/name")
+
+    assert warning_calls == []


### PR DESCRIPTION
# Not enough modules

No modules configured in environment:

```bash
% lamin info
Instance: None
Settings:
 - modules: ""
 - cache: /Users/falexwolf/Library/Caches/lamindb
 - user settings: /Users/falexwolf/.lamin
 - system settings: /Library/Application Support/lamindb
```

Connecting to an instance with custom modules:

```python
>>> import lamindb as ln
>>> ln.connect("laminlabs/arc-virtual-cell-atlas")
→ connected lamindb: laminlabs/arc-virtual-cell-atlas
! the instance has non-configured modules: bionty,pertdb
you can only query entities (registries, fields) from modules that are configured in your environment
to configure your environment with the instance modules, call: lamin settings modules set bionty,pertdb
```

Connecting via `DB` object:

```python
>>> import lamindb as ln
>>> db = ln.DB("laminlabs/arc-virtual-cell-atlas")
! the instance has non-configured modules: bionty,pertdb
you can only query entities (registries, fields) from modules that are configured in your environment
to configure your environment with the instance modules, call: lamin settings modules set bionty,pertdb
```

# Too many modules

Several modules configured in environment:

```
% lamin info
Instance: None
Settings:
 - modules: bionty,pertdb
 - cache: /Users/falexwolf/Library/Caches/lamindb
 - user settings: /Users/falexwolf/.lamin
 - system settings: /Library/Application Support/lamindb
```

Connecting to an instance with no modules:

```python
>>> import lamindb as ln
>>> ln.connect("laminlabs/lamin-site-assets")
→ connected lamindb: laminlabs/lamin-site-assets
! the instance does not have some of your locally configured modules: bionty,pertdb
you will run into an error when trying to permanently delete objects that are related to objects in these modules
to configure your environment with the instance modules, call: lamin settings modules set ""
```

No warnings are printed upon connecting via the read-only `DB` object because no danger of delete.

Needs:

- https://github.com/laminlabs/lamindb-setup/pull/1346