### PR TITLE
🐛 Avoid duplication of `__lamindb_record_export__` under concurrency

### DIFF
--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -607,9 +607,36 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
             run = is_run_input
         elif is_run_input in {True, None}:
             if context.run is None:
-                transform, _ = Transform.objects.get_or_create(
-                    key="__lamindb_record_export__", kind="function"
-                )
+                # Compatibility path for older instances:
+                # historically, "__lamindb_record_export__" transforms could have
+                # arbitrary UIDs. We now standardize on a fixed UID to make creation
+                # idempotent under concurrency and to avoid duplicate internal
+                # transforms. This follows the fixed-UID pattern already used by
+                # "save_vitessce_config" (integrations/_vitessce.py) and
+                # "__lamindb_transfer__/{instance_uid}" (models/sqlrecord.py).
+                # After a few lamindb release cycles (once legacy UIDs are no
+                # longer expected), this normalization branch can be removed.
+                export_transform_uid = "v6KpQx9mRt2B0000"
+                transform = Transform.objects.filter(uid=export_transform_uid).first()
+                if transform is None:
+                    transform = (
+                        Transform.objects.filter(
+                            key="__lamindb_record_export__", kind="function"
+                        )
+                        .order_by("created_at")
+                        .first()
+                    )
+                if transform is None:
+                    transform, _ = Transform.objects.get_or_create(
+                        uid=export_transform_uid,
+                        defaults={
+                            "key": "__lamindb_record_export__",
+                            "kind": "function",
+                        },
+                    )
+                elif transform.uid != export_transform_uid:
+                    transform.uid = export_transform_uid
+                    transform.save()
                 run = Run(transform).save()
             else:
                 run = context.run

--- a/tests/core/test_record_sheet_examples.py
+++ b/tests/core/test_record_sheet_examples.py
@@ -347,3 +347,30 @@ def test_to_artifact_with_required_non_nullable_data_id_maximal_set_true():
     artifact.delete(permanent=True)
     schema.delete(permanent=True)
     feature_data_id.delete(permanent=True)
+
+
+def test_record_export_reuses_legacy_transform_uid(
+    populate_sheets_compound_treatment: tuple[ln.Record, ln.Record],  # noqa: F811
+):
+    _, sample_sheet = populate_sheets_compound_treatment
+    legacy_transform = ln.Transform(
+        key="__lamindb_record_export__",
+        kind="function",
+    )
+    legacy_transform.uid = "LeGaCyUid1230000"
+    legacy_transform = legacy_transform.save()
+
+    artifact = sample_sheet.to_artifact()
+    try:
+        legacy_transform_reloaded = ln.Transform.get(id=legacy_transform.id)
+        assert artifact.transform.uid == "v6KpQx9mRt2B0000"
+        assert artifact.transform.id == legacy_transform.id
+        assert legacy_transform_reloaded.uid == "v6KpQx9mRt2B0000"
+        assert (
+            ln.Transform.filter(
+                key="__lamindb_record_export__", kind="function"
+            ).count()
+            == 1
+        )
+    finally:
+        artifact.delete(permanent=True)


### PR DESCRIPTION
Make handling of concurrent creation of `__lamindb_record_export__` consistent with other internal transforms.

Addresses:

- https://github.com/pfizer-collab/laminlabs/issues/946