### PR TITLE
♻️ Refactor the `Run` constructor, set run status upon start and completion of transfer and export functions

### DIFF
--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -774,13 +774,14 @@ class Context:
                 )
                 self._logging_message_track += f", re-started Run('{run.uid}'{entrypoint_str}) at {format_field_value(run.started_at)}"
 
-        if run is None:  # create new run
-            run = Run(transform=self._transform, plan=plan_record, status="started")
-            if entrypoint is not None:
-                run.entrypoint = entrypoint
-            if initiated_by_run_record is not None:
-                run.initiated_by_run = initiated_by_run_record
-            run.started_at = datetime.now(timezone.utc)
+        if run is None:  # create new run with auto-populated started_at timestamp
+            run = Run(
+                transform=self._transform,
+                status="started",
+                initiated_by_run=initiated_by_run_record,
+                entrypoint=entrypoint,
+                plan=plan_record,
+            )
             entrypoint_str = (
                 f", entrypoint='{entrypoint}'" if entrypoint is not None else ""
             )

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -775,13 +775,12 @@ class Context:
                 self._logging_message_track += f", re-started Run('{run.uid}'{entrypoint_str}) at {format_field_value(run.started_at)}"
 
         if run is None:  # create new run
-            run = Run(transform=self._transform, plan=plan_record)
+            run = Run(transform=self._transform, plan=plan_record, status="started")
             if entrypoint is not None:
                 run.entrypoint = entrypoint
             if initiated_by_run_record is not None:
                 run.initiated_by_run = initiated_by_run_record
             run.started_at = datetime.now(timezone.utc)
-            run._status_code = -1  # started
             entrypoint_str = (
                 f", entrypoint='{entrypoint}'" if entrypoint is not None else ""
             )

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -640,7 +640,11 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
                 transform.save()
             # Export is treated as a discrete user action, so always create a new
             # run. Transfer reuses runs to avoid repeated sync bookkeeping runs.
-            run = Run(transform=transform, initiated_by_run=initiated_by_run).save()  # type: ignore
+            run = Run(
+                transform=transform,
+                initiated_by_run=initiated_by_run,
+                status="started",
+            ).save()  # type: ignore
             run.initiated_by_run = initiated_by_run  # available in memory
         else:
             run = None
@@ -715,6 +719,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         self._set_export_run(is_run_input=is_run_input)
         self._export_run.input_records.add(self)
         self._export_run.finished_at = datetime.now(timezone.utc)
+        self._export_run._status_code = 0  # completed
         self._export_run.save()
         return df.sort_index()  # order by id
 

--- a/lamindb/models/run.py
+++ b/lamindb/models/run.py
@@ -188,13 +188,16 @@ class Run(SQLRecord, TracksUpdates):
     Args:
         transform: :class:`~lamindb.Transform` A data transformation object.
         name: `str | None = None` A name.
+        description: `str | None = None` An optional description.
+        entrypoint: `str | None = None` The entrypoint of the transform, e.g. a function name or CLI entry point.
         params: `dict | None = None` A dictionary of parameters.
-        initiated_by_run: `Run | None = None` The `run` that triggers this `run`.
         status: `Literal["scheduled", "started"] = "scheduled"` Run status at creation.
-            Note that the `started_at` timestamp is set via database default upon creation,
+            The `started_at` timestamp is set via database default upon creation,
             independent of status.
+        initiated_by_run: `Run | None = None` The `run` that triggers this `run`.
         reference: `str | None = None` For instance, an external ID or URL.
         reference_type: `str | None = None` For instance, `redun_id`, `nextflow_id` or `url`.
+        plan: `Artifact | None = None` The (agent) plan for this run.
 
     See Also:
         :func:`~lamindb.track`
@@ -385,9 +388,9 @@ class Run(SQLRecord, TracksUpdates):
         entrypoint: str | None = None,
         params: dict | None = None,
         status: Literal["scheduled", "started"] = "scheduled",
+        initiated_by_run: Run | None = None,
         reference: str | None = None,
         reference_type: str | None = None,
-        initiated_by_run: Run | None = None,
         plan: Artifact | None = None,
     ): ...
 

--- a/lamindb/models/run.py
+++ b/lamindb/models/run.py
@@ -430,7 +430,7 @@ class Run(SQLRecord, TracksUpdates):
             raise ValueError("Please save transform record before creating a run")
         if status not in {"scheduled", "started"}:
             raise ValueError(
-                f"status must be 'scheduled' or 'started', but you passed: {status!r}"
+                f"status must be 'scheduled' or 'started', but you passed: {status!r}."
             )
         if not len(kwargs) == 0:
             raise ValueError(

--- a/lamindb/models/run.py
+++ b/lamindb/models/run.py
@@ -192,8 +192,8 @@ class Run(SQLRecord, TracksUpdates):
         entrypoint: `str | None = None` The entrypoint of the transform, e.g. a function name or CLI entry point.
         params: `dict | None = None` A dictionary of parameters.
         status: `Literal["scheduled", "started"] = "scheduled"` Run status at creation.
-            The `started_at` timestamp is set via database default upon creation,
-            independent of status.
+            The `started_at` timestamp is populated via database default upon creation,
+            even if status is `"scheduled"`.
         initiated_by_run: `Run | None = None` The `run` that triggers this `run`.
         reference: `str | None = None` For instance, an external ID or URL.
         reference_type: `str | None = None` For instance, `redun_id`, `nextflow_id` or `url`.

--- a/lamindb/models/run.py
+++ b/lamindb/models/run.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING, Literal, overload
 
 from django.db import models
 from django.db.models import (
@@ -25,7 +25,7 @@ from lamindb.base.fields import (
 from lamindb.base.users import current_user_id
 from lamindb.base.utils import strict_classmethod
 
-from ..base.types import RUN_CODE_TO_STATUS
+from ..base.types import RUN_CODE_TO_STATUS, RUN_STATUS_TO_CODE
 from ..base.uids import base62_16
 from .can_curate import CanCurate
 from .query_set import BasicQuerySet, QuerySet
@@ -189,9 +189,12 @@ class Run(SQLRecord, TracksUpdates):
         transform: :class:`~lamindb.Transform` A data transformation object.
         name: `str | None = None` A name.
         params: `dict | None = None` A dictionary of parameters.
+        initiated_by_run: `Run | None = None` The `run` that triggers this `run`.
+        status: `Literal["scheduled", "started"] = "scheduled"` Run status at creation.
+            Note that the `started_at` timestamp is set via database default upon creation,
+            independent of status.
         reference: `str | None = None` For instance, an external ID or URL.
         reference_type: `str | None = None` For instance, `redun_id`, `nextflow_id` or `url`.
-        initiated_by_run: `Run | None = None` The `run` that triggers this `run`.
 
     See Also:
         :func:`~lamindb.track`
@@ -381,6 +384,7 @@ class Run(SQLRecord, TracksUpdates):
         description: str | None = None,
         entrypoint: str | None = None,
         params: dict | None = None,
+        status: Literal["scheduled", "started"] = "scheduled",
         reference: str | None = None,
         reference_type: str | None = None,
         initiated_by_run: Run | None = None,
@@ -416,14 +420,21 @@ class Run(SQLRecord, TracksUpdates):
         initiated_by_run: Run | None = kwargs.pop("initiated_by_run", None)
         report: Artifact | None = kwargs.pop("report", None)
         plan: Artifact | None = kwargs.pop("plan", None)
+        status: Literal["scheduled", "started"] = kwargs.pop("status", "scheduled")
         if transform is None:
             raise TypeError("Pass transform parameter")
         if transform._state.adding:
             raise ValueError("Please save transform record before creating a run")
+        if status not in {"scheduled", "started"}:
+            raise ValueError(
+                f"status must be 'scheduled' or 'started', but you passed: {status!r}"
+            )
         if not len(kwargs) == 0:
             raise ValueError(
-                f"Only transform, name, description, params, reference, reference_type, initiated_by_run, plan can be passed, but you passed: {kwargs}"
+                f"Only transform, name, description, params, reference, reference_type, initiated_by_run, plan, status can be passed, but you passed: {kwargs}"
             )
+        # started_at is set on insert by the database (db_default=Now()), independent
+        # of status. Mark completion with _status_code = 0 alongside finished_at.
         super().__init__(  # type: ignore
             transform=transform,
             name=name,
@@ -435,6 +446,7 @@ class Run(SQLRecord, TracksUpdates):
             initiated_by_run=initiated_by_run,
             report=report,
             plan=plan,
+            _status_code=RUN_STATUS_TO_CODE[status],
         )
 
     @property

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1329,6 +1329,7 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                 self.labels.add_from(self_on_db, transfer_logs=transfer_logs)
             if transfer_logs["run"] is not None:
                 transfer_logs["run"].finished_at = datetime.now(timezone.utc)  # type: ignore
+                transfer_logs["run"]._status_code = 0  # type: ignore[union-attr]
                 transfer_logs["run"].save()  # type: ignore
             for k, v in transfer_logs.items():
                 if k != "run" and len(v) > 0:
@@ -2222,7 +2223,11 @@ def get_transfer_run(record) -> Run:
     # it doesn't seem to make sense to create new runs for every transfer
     run = Run.filter(transform=transform, initiated_by_run=initiated_by_run).first()
     if run is None:
-        run = Run(transform=transform, initiated_by_run=initiated_by_run).save()  # type: ignore
+        run = Run(
+            transform=transform,
+            initiated_by_run=initiated_by_run,
+            status="started",
+        ).save()  # type: ignore
         run.initiated_by_run = initiated_by_run  # so that it's available in memory
     return run
 

--- a/tests/core/test_record_sheet_examples.py
+++ b/tests/core/test_record_sheet_examples.py
@@ -149,6 +149,9 @@ def test_record_example_compound_treatment(
     assert artifact.run.input_records.count() == 1
     assert artifact.transform.kind == "function"
     assert artifact.transform.key == "__lamindb_record_export__"
+    assert artifact.run.status == "completed"
+    assert artifact.run.started_at is not None
+    assert artifact.run.finished_at is not None
     # looks something like this:
     # id,uid,name,treatment,cell_line,preparation_date,__lamindb_record_uid__,__lamindb_record_name__
     # 1,S1,Sample 1,treatment1,HEK293T,2025-06-01 05:00:00,iCwgKgZELoLtIoGy,sample1
@@ -367,6 +370,8 @@ def test_record_export_reuses_legacy_transform_uid(
         assert artifact.transform.id == legacy_transform.id
         assert artifact.run is not None
         assert artifact.run.finished_at is not None
+        assert artifact.run.status == "completed"
+        assert artifact.run.started_at is not None
         assert legacy_transform_reloaded.uid == "v6KpQx9mRt2B0000"
         assert (
             ln.Transform.filter(

--- a/tests/core/test_run.py
+++ b/tests/core/test_run.py
@@ -19,6 +19,12 @@ def test_run():
         == "ValueError: Please save transform record before creating a run"
     )
     transform.save()
+    with pytest.raises(ValueError) as error:
+        ln.Run(transform, status="invalid")
+    assert (
+        error.exconly()
+        == "ValueError: status must be 'scheduled' or 'started', but you passed: 'invalid'."
+    )
     run = ln.Run(transform).save()
     assert run.status == "scheduled"
     started_run = ln.Run(transform, status="started").save()

--- a/tests/core/test_run.py
+++ b/tests/core/test_run.py
@@ -21,6 +21,8 @@ def test_run():
     transform.save()
     run = ln.Run(transform).save()
     assert run.status == "scheduled"
+    started_run = ln.Run(transform, status="started").save()
+    assert started_run.status == "started"
     assert run.reference is None
     assert run.reference_type is None
     run2 = ln.Run(transform, reference="test1", reference_type="test2").save()

--- a/tests/transfer/test_transfer.py
+++ b/tests/transfer/test_transfer.py
@@ -11,5 +11,7 @@ def test_transfer():
     assert artifact.key == "README.md"
     assert artifact.run is not None
     assert artifact.run.finished_at is not None
+    assert artifact.run.status == "completed"
+    assert artifact.run.started_at is not None
     assert ln.setup.settings.storage.root_as_str.endswith("testdb2")
     assert artifact.storage.root.endswith("testdb1")


### PR DESCRIPTION
More canonical usage of the run constructor in internal functions.