### PR TITLE
🚸 Upon exporting records, link each single record as an input rather than their type

### DIFF
--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -655,6 +655,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         cls_or_self,
         recurse: bool = False,
         is_run_input: bool | Run | None = None,
+        link_records_as_inputs: bool = True,
         **kwargs,
     ) -> pd.DataFrame:
         """Export to a pandas DataFrame.
@@ -670,6 +671,8 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         Args:
             recurse: Whether to include records of sub-types recursively.
             is_run_input: Whether to track the record as a run input.
+            link_records_as_inputs: Whether to link all exported records as
+                inputs of the export run. If `False`, only links the record type.
             **kwargs: Keyword arguments passed to :meth:`~lamindb.models.QuerySet.to_dataframe`.
         """
         import pandas as pd
@@ -717,9 +720,11 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
             desired_order.sort()
         df = reorder_subset_columns_in_df(df, desired_order, position=0)  # type: ignore
         self._set_export_run(is_run_input=is_run_input)
-        # Link all exported records as run inputs (not the record type itself).
-        input_record_ids = qs.values_list("id", flat=True)
-        self._export_run.input_records.add(*input_record_ids)
+        if link_records_as_inputs:
+            input_record_ids = qs.values_list("id", flat=True)
+            self._export_run.input_records.add(*input_record_ids)
+        else:
+            self._export_run.input_records.add(self)
         self._export_run.finished_at = datetime.now(timezone.utc)
         self._export_run._status_code = 0  # completed
         self._export_run.save()
@@ -730,6 +735,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         key: str | None = None,
         suffix: str | None = None,
         is_run_input: bool | Run | None = None,
+        link_records_as_inputs: bool = True,
         **kwargs,
     ) -> Artifact:
         """Calls `to_dataframe()` to create an artifact.
@@ -742,6 +748,8 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
             key: `str | None = None` The artifact key.
             suffix: `str | None = None` The suffix to append to the default key if no key is passed.
             is_run_input: Whether to track the record as a run input.
+            link_records_as_inputs: Whether to link all exported records as
+                inputs of the export run. If `False`, only links the record type.
             **kwargs: Keyword arguments passed to :meth:`~lamindb.models.Record.to_dataframe`.
         """
         assert self.is_type, "Only types can be exported as artifacts."
@@ -751,7 +759,11 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
             key = f"sheet_exports/{self.name}{suffix}"
         description = f": {self.description}" if self.description is not None else ""
         return Artifact.from_dataframe(
-            self.to_dataframe(is_run_input=is_run_input, **kwargs),
+            self.to_dataframe(
+                is_run_input=is_run_input,
+                link_records_as_inputs=link_records_as_inputs,
+                **kwargs,
+            ),
             key=key,
             description=f"Export of sheet {self.uid}{description}",
             schema=self.schema,

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -717,7 +717,9 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
             desired_order.sort()
         df = reorder_subset_columns_in_df(df, desired_order, position=0)  # type: ignore
         self._set_export_run(is_run_input=is_run_input)
-        self._export_run.input_records.add(self)
+        # Link all exported records as run inputs (not the record type itself).
+        input_record_ids = qs.values_list("id", flat=True)
+        self._export_run.input_records.add(*input_record_ids)
         self._export_run.finished_at = datetime.now(timezone.utc)
         self._export_run._status_code = 0  # completed
         self._export_run.save()

--- a/tests/core/test_record_sheet_examples.py
+++ b/tests/core/test_record_sheet_examples.py
@@ -386,6 +386,24 @@ def test_record_export_links_all_upstream_records():
         transform_b.delete(permanent=True)
 
 
+def test_record_export_links_record_type_when_link_records_false(
+    populate_sheets_compound_treatment: tuple[ln.Record, ln.Record],  # noqa: F811
+):
+    _, sample_sheet = populate_sheets_compound_treatment
+
+    sample_sheet.to_dataframe(link_records_as_inputs=False)
+    dataframe_export_run = sample_sheet.input_of_runs.get()
+    assert dataframe_export_run.input_records.count() == 1
+    assert dataframe_export_run.input_records.get().id == sample_sheet.id
+
+    artifact = sample_sheet.to_artifact(link_records_as_inputs=False)
+    try:
+        assert artifact.run.input_records.count() == 1
+        assert artifact.run.input_records.get().id == sample_sheet.id
+    finally:
+        artifact.delete(permanent=True)
+
+
 def test_record_export_reuses_legacy_transform_uid(
     populate_sheets_compound_treatment: tuple[ln.Record, ln.Record],  # noqa: F811
 ):

--- a/tests/core/test_record_sheet_examples.py
+++ b/tests/core/test_record_sheet_examples.py
@@ -101,7 +101,7 @@ def test_record_example_compound_treatment(
 
     assert sample_sheet1.input_of_runs.count() == 0
     df = sample_sheet1.to_dataframe()
-    assert sample_sheet1.input_of_runs.count() == 1
+    assert sample_sheet1.input_of_runs.count() == 0
     assert df.index.name == "__lamindb_record_id__"
     dictionary = df[
         [
@@ -146,7 +146,7 @@ def test_record_example_compound_treatment(
         "preparation_date",
         "project",
     ]
-    assert artifact.run.input_records.count() == 1
+    assert artifact.run.input_records.count() == 2
     assert artifact.transform.kind == "function"
     assert artifact.transform.key == "__lamindb_record_export__"
     assert artifact.run.status == "completed"
@@ -350,6 +350,40 @@ def test_to_artifact_with_required_non_nullable_data_id_maximal_set_true():
     artifact.delete(permanent=True)
     schema.delete(permanent=True)
     feature_data_id.delete(permanent=True)
+
+
+def test_record_export_links_all_upstream_records():
+    sheet = ln.Record(name="Run-linked sheet", is_type=True).save()
+    record_a = ln.Record(name="record_a", type=sheet).save()
+    record_b = ln.Record(name="record_b", type=sheet).save()
+    record_c = ln.Record(name="record_c", type=sheet).save()
+
+    transform_a = ln.Transform(key="record_export_upstream_a", kind="function").save()
+    transform_b = ln.Transform(key="record_export_upstream_b", kind="function").save()
+    run_a = ln.Run(transform=transform_a, status="started").save()
+    run_b = ln.Run(transform=transform_b, status="started").save()
+
+    record_a.run = run_a
+    record_a.save()
+    record_b.run = run_a
+    record_b.save()
+    record_c.run = run_b
+    record_c.save()
+
+    artifact = sheet.to_artifact()
+    try:
+        linked_record_ids = set(artifact.run.input_records.to_list("id"))
+        assert linked_record_ids == {record_a.id, record_b.id, record_c.id}
+        linked_run_ids = {record.run_id for record in artifact.run.input_records.all()}
+        assert linked_run_ids == {run_a.id, run_b.id}
+    finally:
+        artifact.delete(permanent=True)
+        record_a.delete(permanent=True)
+        record_b.delete(permanent=True)
+        record_c.delete(permanent=True)
+        sheet.delete(permanent=True)
+        transform_a.delete(permanent=True)
+        transform_b.delete(permanent=True)
 
 
 def test_record_export_reuses_legacy_transform_uid(


### PR DESCRIPTION
If one doesn't link the individual records, queries for which exact state of the registry was exported become difficult.

Hence, it seems sensible to track the additional information. If it ever becomes overwhelming, one can change it.