### PR TITLE
🚸 Enable pre-filtering records before export

### DIFF
--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -688,14 +688,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         import pandas as pd
 
         if isinstance(cls_or_self, type):
-            return type(cls_or_self).to_dataframe(
-                cls_or_self,
-                recurse=recurse,
-                filters=filters,
-                is_run_input=is_run_input,
-                link_records_as_inputs=link_records_as_inputs,
-                **kwargs,
-            )  # type: ignore
+            return type(cls_or_self).to_dataframe(cls_or_self, **kwargs)  # type: ignore
         if not cls_or_self.is_type:
             raise TypeError(
                 "to_dataframe() can only be called on the class or on record type instance."

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -697,20 +697,27 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         assert self.is_type, "Only types can be exported as dataframes"  # noqa: S101
 
         branch_ids = get_default_branch_ids()
-        qs = (
+        default_qs = (
             self.query_records()
             if recurse
-            else self.__class__.filter(type=self, branch_id__in=branch_ids)
+            else self.records.filter(branch_id__in=branch_ids)
         )
-        if filters is not None:
-            if isinstance(filters, dict):
-                qs = qs.filter(**filters)
-            elif isinstance(filters, Iterable) and not isinstance(
-                filters, (str, bytes)
-            ):
-                qs = qs.filter(*filters)
+        if filters is None:
+            qs = default_qs
+        elif isinstance(filters, dict):
+            # Keep kwargs behavior aligned with the historic `self.records.filter(...)`
+            # semantics where fields like `name` target record fields.
+            qs = default_qs.filter(**filters)
+        else:
+            expr_qs = (
+                self.query_records()
+                if recurse
+                else self.__class__.filter(type=self, branch_id__in=branch_ids)
+            )
+            if isinstance(filters, Iterable) and not isinstance(filters, (str, bytes)):
+                qs = expr_qs.filter(*filters)
             else:
-                qs = qs.filter(filters)
+                qs = expr_qs.filter(filters)
         logger.important(f"exporting {qs.count()} records of '{self.name}'")
         if "order_by" not in kwargs:
             kwargs["order_by"] = "id"

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -697,27 +697,26 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         assert self.is_type, "Only types can be exported as dataframes"  # noqa: S101
 
         branch_ids = get_default_branch_ids()
-        default_qs = (
+        qs = (
             self.query_records()
             if recurse
             else self.records.filter(branch_id__in=branch_ids)
         )
-        if filters is None:
-            qs = default_qs
-        elif isinstance(filters, dict):
+        if isinstance(filters, dict):
             # Keep kwargs behavior aligned with the historic `self.records.filter(...)`
             # semantics where fields like `name` target record fields.
-            qs = default_qs.filter(**filters)
-        else:
-            expr_qs = (
+            qs = qs.filter(**filters)
+        elif filters is not None:
+            # Feature predicates are only supported through Record.filter(...).
+            qs = (
                 self.query_records()
                 if recurse
                 else self.__class__.filter(type=self, branch_id__in=branch_ids)
             )
             if isinstance(filters, Iterable) and not isinstance(filters, (str, bytes)):
-                qs = expr_qs.filter(*filters)
+                qs = qs.filter(*filters)
             else:
-                qs = expr_qs.filter(filters)
+                qs = qs.filter(filters)
         logger.important(f"exporting {qs.count()} records of '{self.name}'")
         if "order_by" not in kwargs:
             kwargs["order_by"] = "id"

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -195,8 +195,8 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
 
     Query records by features::
 
-        ln.Record.filter(gc_content=0.55)     # exact match
-        ln.Record.filter(gc_content__gt=0.5)  # greater than
+        ln.Record.filter(gc_content == 0.55)  # exact match
+        ln.Record.filter(gc_content > 0.5)    # greater than
 
     Query records by field::
 

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -665,6 +665,16 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
 
         It will also track the record as an input to the current run.
 
+        Example:
+
+            Export all records on a sheet::
+
+                sample_sheet.to_dataframe()
+
+            Export only records with high GC content::
+
+                sample_sheet.to_dataframe(filters=gc_content > 0.55)
+
         Args:
             recurse: Whether to include records of sub-types recursively.
             filters: Filters applied before export. Supports filter kwargs via
@@ -760,6 +770,16 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         The format defaults to `.csv` unless the key specifies another format or suffix is passed.
 
         The `key` defaults to `sheet_exports/{self.name}{suffix}` unless a `key` is passed.
+
+        Example:
+
+            Export all records on a sheet to an artifact::
+
+                sample_sheet.to_artifact()
+
+            Export only records with high GC content::
+
+                sample_sheet.to_artifact(filters=gc_content > 0.55)
 
         Args:
             key: `str | None = None` The artifact key.

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -173,8 +173,8 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
 
         # reset the feature values for the record including the experiment
         sample1.features.set_values({
-            "gc_content": 0.5,
-            "experiment": "Experiment 1",  # automatically resolves by name, also accepts the experiment1 object
+            gc_content: 0.5,
+            experiment: "Experiment 1",  # automatically resolves by name, also accepts the experiment1 object
         })
 
     Export all records under a type to a dataframe::
@@ -191,21 +191,16 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
     If you try to set incomplete features in a record in a sheet, you'll get a validation error::
 
         sample2 = ln.Record(name="Sample 2", type=sample_sheet).save()
-        sample2.features.set_values({"gc_content": 0.6})  # raises ValidationError because experiment is missing
+        sample2.features.set_values({gc_content: 0.6})  # raises ValidationError because experiment is missing
 
     Query records by features::
 
         ln.Record.filter(gc_content=0.55)     # exact match
         ln.Record.filter(gc_content__gt=0.5)  # greater than
+
+    Query records by field::
+
         ln.Record.filter(type=sample_sheet)   # just the record on the sheet
-
-    If your feature names are ambiguous, you can use a `Feature` object to disambiguate::
-
-        # to set feature values
-        sample1.features.set_values({gc_content: 0.5})  # gc_content is the feature object
-
-        # to query by feature values
-        ln.Record.filter(gc_content == 0.5)  # instead of gc_content=0.5
 
     Notes
     -----

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, overload
 
@@ -654,6 +655,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
     def to_dataframe(
         cls_or_self,
         recurse: bool = False,
+        filters: Any | None = None,
         is_run_input: bool | Run | None = None,
         link_records_as_inputs: bool = True,
         **kwargs,
@@ -670,6 +672,9 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
 
         Args:
             recurse: Whether to include records of sub-types recursively.
+            filters: Filters applied before export. Supports filter kwargs via
+                a `dict`, Django `Q` expressions, and feature predicates
+                (e.g. `my_feature > 5`), including iterables of expressions.
             is_run_input: Whether to track the record as a run input.
             link_records_as_inputs: Whether to link all exported records as
                 inputs of the export run. If `False`, only links the record type.
@@ -678,7 +683,14 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         import pandas as pd
 
         if isinstance(cls_or_self, type):
-            return type(cls_or_self).to_dataframe(cls_or_self, **kwargs)  # type: ignore
+            return type(cls_or_self).to_dataframe(
+                cls_or_self,
+                recurse=recurse,
+                filters=filters,
+                is_run_input=is_run_input,
+                link_records_as_inputs=link_records_as_inputs,
+                **kwargs,
+            )  # type: ignore
         if not cls_or_self.is_type:
             raise TypeError(
                 "to_dataframe() can only be called on the class or on record type instance."
@@ -690,8 +702,17 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         qs = (
             self.query_records()
             if recurse
-            else self.records.filter(branch_id__in=branch_ids)
+            else self.__class__.filter(type=self, branch_id__in=branch_ids)
         )
+        if filters is not None:
+            if isinstance(filters, dict):
+                qs = qs.filter(**filters)
+            elif isinstance(filters, Iterable) and not isinstance(
+                filters, (str, bytes)
+            ):
+                qs = qs.filter(*filters)
+            else:
+                qs = qs.filter(filters)
         logger.important(f"exporting {qs.count()} records of '{self.name}'")
         if "order_by" not in kwargs:
             kwargs["order_by"] = "id"
@@ -734,6 +755,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         self,
         key: str | None = None,
         suffix: str | None = None,
+        filters: Any | None = None,
         is_run_input: bool | Run | None = None,
         link_records_as_inputs: bool = True,
         **kwargs,
@@ -747,6 +769,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         Args:
             key: `str | None = None` The artifact key.
             suffix: `str | None = None` The suffix to append to the default key if no key is passed.
+            filters: Filters applied before export.
             is_run_input: Whether to track the record as a run input.
             link_records_as_inputs: Whether to link all exported records as
                 inputs of the export run. If `False`, only links the record type.
@@ -760,6 +783,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         description = f": {self.description}" if self.description is not None else ""
         return Artifact.from_dataframe(
             self.to_dataframe(
+                filters=filters,
                 is_run_input=is_run_input,
                 link_records_as_inputs=link_records_as_inputs,
                 **kwargs,

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -16,7 +16,7 @@ def test_record_docstring_examples():
     gc_content = ln.Feature(name="gc_content", dtype=float).save()
 
     # create a record to track a sample
-    sample1 = ln.Record(name="Sample 1", features={"gc_content": 0.5}).save()
+    sample1 = ln.Record(name="Sample 1", features={"gc_content": 0.55}).save()
 
     # describe the record
     sample1.describe()
@@ -41,8 +41,8 @@ def test_record_docstring_examples():
     # reset the feature values for the record including the experiment
     sample1.features.set_values(
         {
-            "gc_content": 0.5,
-            "experiment": "Experiment 1",  # automatically resolves by name, also accepts the experiment1 object
+            gc_content: 0.55,
+            experiment: "Experiment 1",  # automatically resolves by name, also accepts the experiment1 object
         }
     )
 
@@ -50,17 +50,30 @@ def test_record_docstring_examples():
     df = experiment_type.to_dataframe()
     assert "Experiment 1" in df["__lamindb_record_name__"].values
 
+    # Import records from a dataframe
+    records = ln.Record.from_dataframe(
+        pd.DataFrame({"gc_content": [0.1, 0.2]}),
+        type="my_df",
+    ).save()
+    assert len(records) == 2
+
     # If you try to set incomplete features in a record in a sheet, you'll get a validation error
     sample2 = ln.Record(name="Sample 2", type=sample_sheet).save()
     with pytest.raises(ln.errors.ValidationError):
         sample2.features.set_values({"gc_content": 0.6})
 
     # Query records by features
-    assert ln.Record.filter(gc_content == 0.5).one() == sample1
-    assert ln.Record.filter(gc_content > 0.4).one() == sample1
+    assert ln.Record.filter(gc_content == 0.55).one() == sample1
+    assert ln.Record.filter(gc_content > 0.5).one() == sample1
     assert ln.Record.filter(type=sample_sheet).count() >= 1
 
     # Clean up
+    my_df_type = ln.Record.filter(name="my_df", is_type=True).one()
+    my_df_schema = my_df_type.schema
+    ln.Record.filter(type=my_df_type).delete(permanent=True)
+    my_df_type.delete(permanent=True)
+    if my_df_schema is not None:
+        my_df_schema.delete(permanent=True)
     sample1.delete(permanent=True)
     sample2.delete(permanent=True)
     experiment1.delete(permanent=True)

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -56,8 +56,8 @@ def test_record_docstring_examples():
         sample2.features.set_values({"gc_content": 0.6})
 
     # Query records by features
-    assert ln.Record.filter(gc_content=0.5).one() == sample1
-    assert ln.Record.filter(gc_content__gt=0.4).one() == sample1
+    assert ln.Record.filter(gc_content == 0.5).one() == sample1
+    assert ln.Record.filter(gc_content > 0.4).one() == sample1
     assert ln.Record.filter(type=sample_sheet).count() >= 1
 
     # Clean up

--- a/tests/core/test_record_sheet_examples.py
+++ b/tests/core/test_record_sheet_examples.py
@@ -404,12 +404,12 @@ def test_record_export_links_record_type_when_link_records_false(
         artifact.delete(permanent=True)
 
 
-def test_record_export_applies_filters(
-    populate_sheets_compound_treatment: tuple[ln.Record, ln.Record],  # noqa: F811
-):
-    _, sample_sheet = populate_sheets_compound_treatment
-    filtered_df = sample_sheet.to_dataframe(filters={"name": "sample1"})
+def test_record_export_applies_filters():
+    sample_sheet = ln.Record(name="FilterSheet", is_type=True).save()
+    sample1 = ln.Record(name="sample1", type=sample_sheet).save()
+    sample2 = ln.Record(name="sample2", type=sample_sheet).save()
 
+    filtered_df = sample_sheet.to_dataframe(filters={"name": "sample1"})
     assert len(filtered_df) == 1
     assert filtered_df["__lamindb_record_name__"].to_list() == ["sample1"]
 
@@ -426,6 +426,9 @@ def test_record_export_applies_filters(
         assert artifact.run.input_records.get().name == "sample1"
     finally:
         artifact.delete(permanent=True)
+        sample1.delete(permanent=True)
+        sample2.delete(permanent=True)
+        sample_sheet.delete(permanent=True)
 
 
 def test_record_export_applies_feature_predicate_filters():

--- a/tests/core/test_record_sheet_examples.py
+++ b/tests/core/test_record_sheet_examples.py
@@ -404,6 +404,61 @@ def test_record_export_links_record_type_when_link_records_false(
         artifact.delete(permanent=True)
 
 
+def test_record_export_applies_filters(
+    populate_sheets_compound_treatment: tuple[ln.Record, ln.Record],  # noqa: F811
+):
+    _, sample_sheet = populate_sheets_compound_treatment
+    filtered_df = sample_sheet.to_dataframe(filters={"name": "sample1"})
+
+    assert len(filtered_df) == 1
+    assert filtered_df["__lamindb_record_name__"].to_list() == ["sample1"]
+
+    dataframe_export_run = sample_sheet._export_run
+    assert dataframe_export_run is not None
+    assert dataframe_export_run.input_records.count() == 1
+    assert dataframe_export_run.input_records.get().name == "sample1"
+
+    artifact = sample_sheet.to_artifact(filters={"name": "sample1"})
+    try:
+        assert len(artifact.load()) == 1
+        assert artifact.run is not None
+        assert artifact.run.input_records.count() == 1
+        assert artifact.run.input_records.get().name == "sample1"
+    finally:
+        artifact.delete(permanent=True)
+
+
+def test_record_export_applies_feature_predicate_filters():
+    sample_sheet = ln.Record(name="PredicateFilterSheet", is_type=True).save()
+    sample1 = ln.Record(name="sample1", type=sample_sheet).save()
+    sample2 = ln.Record(name="sample2", type=sample_sheet).save()
+    export_filter_score = ln.Feature(name="export_filter_score", dtype=int).save()
+    sample1.features.add_values({"export_filter_score": 10})
+    sample2.features.add_values({"export_filter_score": 20})
+
+    filtered_df = sample_sheet.to_dataframe(filters=export_filter_score > 15)
+    assert len(filtered_df) == 1
+    assert filtered_df["__lamindb_record_name__"].to_list() == ["sample2"]
+
+    dataframe_export_run = sample_sheet._export_run
+    assert dataframe_export_run is not None
+    assert dataframe_export_run.input_records.count() == 1
+    assert dataframe_export_run.input_records.get().name == "sample2"
+
+    artifact = sample_sheet.to_artifact(filters=export_filter_score > 15)
+    try:
+        assert len(artifact.load()) == 1
+        assert artifact.run is not None
+        assert artifact.run.input_records.count() == 1
+        assert artifact.run.input_records.get().name == "sample2"
+    finally:
+        artifact.delete(permanent=True)
+        sample1.delete(permanent=True)
+        sample2.delete(permanent=True)
+        sample_sheet.delete(permanent=True)
+        export_filter_score.delete(permanent=True)
+
+
 def test_record_export_reuses_legacy_transform_uid(
     populate_sheets_compound_treatment: tuple[ln.Record, ln.Record],  # noqa: F811
 ):


### PR DESCRIPTION
This is useful for large sheets.

Also in this PR: Advocate using feature objects rather than feature name strings in the records docstring.