### PR TITLE
:memo: Refer to `SQLRecord` types as (dynamic) registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,32 +362,32 @@ ln.Artifact.to_dataframe(include="features")  # include the feature annotations
 
 ### Lake ♾️ LIMS ♾️ Sheets
 
-You can create records for the entities underlying your experiments: samples, perturbations, instruments, etc., for example:
+You can create records for entities underlying your experiments (samples, perturbations, instruments, etc.) and group them in dynamic registries (short: registries):
 
 ```python
-ln.Record(name="Sample 1", features={"gc_content": 0.5}).save()
+ln.Record(name="Sample 1", features={gc_content: 0.5}).save()
 ```
 
 You can create relationships of entities:
 
 ```python
-# create a flexible record type to track experiments
-experiment_type = ln.Record(name="Experiment", is_type=True).save()
+# create an experiments registry by defining a record type
+experiments_registry = ln.Record(name="Experiments", is_type=True).save()
 
-# create a record of type `Experiment` for your first experiment
-ln.Record(name="Experiment 1", type=experiment_type).save()
+# create a record inside the Experiments registry
+ln.Record(name="Experiment 1", type=experiments_registry).save()
 
-# create a feature to link experiments in records, dataframes, etc.
-ln.Feature(name="experiment", dtype=experiment_type).save()
+# create a feature that links experiments
+experiment = ln.Feature(name="experiment", dtype=experiments_registry).save()
 
 # create a sample record that links the sample to `Experiment 1` via the `experiment` feature
-ln.Record(name="Sample 2", features={"gc_content": 0.5, "experiment": "Experiment 1"}).save()
+ln.Record(name="Sample 2", features={gc_content: 0.5, experiment: "Experiment 1"}).save()
 ```
 
-You can convert any record type to dataframe/sheet:
+You can export any registry as a dataframe:
 
 ```python
-experiment_type.to_dataframe()
+experiments_registry.to_dataframe()
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -362,13 +362,13 @@ ln.Artifact.to_dataframe(include="features")  # include the feature annotations
 
 ### Lake ♾️ LIMS ♾️ Sheets
 
-You can create records for entities underlying your experiments (samples, perturbations, instruments, etc.) and group them in dynamic registries (short: registries):
+You can create records for entities underlying your experiments (samples, perturbations, instruments, etc.):
 
 ```python
 ln.Record(name="Sample 1", features={gc_content: 0.5}).save()
 ```
 
-You can create relationships of entities:
+You can dynamically create registries and relationships of entities:
 
 ```python
 # create an experiments registry by defining a record type
@@ -377,14 +377,14 @@ experiments_registry = ln.Record(name="Experiments", is_type=True).save()
 # create a record inside the Experiments registry
 ln.Record(name="Experiment 1", type=experiments_registry).save()
 
-# create a feature that links experiments
+# create a feature that links experiments, creating a relationship
 experiment = ln.Feature(name="experiment", dtype=experiments_registry).save()
 
 # create a sample record that links the sample to `Experiment 1` via the `experiment` feature
 ln.Record(name="Sample 2", features={gc_content: 0.5, experiment: "Experiment 1"}).save()
 ```
 
-You can export any registry as a dataframe:
+You can export a dynamic registry as a dataframe:
 
 ```python
 experiments_registry.to_dataframe()

--- a/docs/organize.md
+++ b/docs/organize.md
@@ -90,10 +90,10 @@ ulabel1 = ln.ULabel(name="raw_data").save()  # create a ulabel
 artifact1.ulabels.add(ulabel1)               # annotate artifact1
 ```
 
-And here is how to create a registry for samples and annotate the artifact with a sample:
+And here is how to create a samples registry and annotate the artifact with a sample:
 
 ```python
-sample_type = ln.Record(                     # create a registry
+samples_registry = ln.Record(                     # create a registry
     name="Samples",
     is_type=True
 ).save()
@@ -103,7 +103,7 @@ gc_content = ln.Feature(                     # create a feature
 ).save()
 sample1 = ln.Record(                         # create a sample
     name="Sample 1",
-    type=sample_type,
+    type=samples_registry,
     features={gc_content: 0.5}
 ).save()
 artifact1.records.add(sample1)               # annotate artifact1
@@ -129,9 +129,9 @@ To annotate with non-categorical data types or to disambiguate categorical annot
 Here is how to define features and annotate an artifact with feature values:
 
 ```python
-experiment_registry = ln.Record.get(name="Experiments")  # retrieve the `Experiments` registry
+experiments_registry = ln.Record.get(name="Experiments")  # retrieve the `Experiments` registry
 gc_content = ln.Feature(name="gc_content", dtype=float).save()  # define a feature with dtype float
-experiment = ln.Feature(name="experiment", dtype=experiment_registry).save()  # define a feature with dtype `Experiments`
+experiment = ln.Feature(name="experiment", dtype=experiments_registry).save()  # define a feature with dtype `Experiments`
 artifact1.features.set_values({
     gc_content: 0.55,   # validated to be a float
     experiment: "Experiment 1",  # validated to exist in the `Experiments` registry

--- a/docs/query-search.md
+++ b/docs/query-search.md
@@ -135,6 +135,9 @@ The `SQLRecord` classes in LaminDB are Django Models and any [Django query](http
 
 The `Artifact`, `Record`, and `Run` registries can be queried by features, via an implicit lookup in the {class}`~lamindb.Feature` registry:
 
+<!-- region -->
+<!-- cannot run tabbed code on CI, see test_artifact_filter_by_multiple_features for tests -->
+
 ::::{tab-set}
 
 :::{tab-item} Via strings / kwargs
@@ -162,6 +165,8 @@ ln.Artifact.filter(    # note this is now an expression using the == syntax
 :::
 
 ::::
+
+<!-- endregion -->
 
 Just like for fields holding dictionary values, you can query for dictionary keys in features whose `dtype` is `dict`:
 

--- a/docs/query-search.md
+++ b/docs/query-search.md
@@ -135,7 +135,7 @@ The `SQLRecord` classes in LaminDB are Django Models and any [Django query](http
 
 The `Artifact`, `Record`, and `Run` registries can be queried by features, via an implicit lookup in the {class}`~lamindb.Feature` registry:
 
-<!-- region -->
+<!-- #region -->
 <!-- cannot run tabbed code on CI, see test_artifact_filter_by_multiple_features for tests -->
 
 ::::{tab-set}
@@ -166,7 +166,7 @@ ln.Artifact.filter(    # note this is now an expression using the == syntax
 
 ::::
 
-<!-- endregion -->
+<!-- #endregion -->
 
 Just like for fields holding dictionary values, you can query for dictionary keys in features whose `dtype` is `dict`:
 

--- a/docs/query-search.md
+++ b/docs/query-search.md
@@ -217,7 +217,7 @@ You can query for whether a dataset is annotated annotated by a feature:
 ln.Artifact.filter(perturbation__isnull=False).to_dataframe(include="features")
 ```
 
-## Filter operators
+## Cheat sheet: comparators
 
 You can qualify the type of comparison in a query by using a comparator.
 

--- a/docs/query-search.md
+++ b/docs/query-search.md
@@ -170,7 +170,11 @@ ln.Artifact.filter(schemas__genes__symbol="CD8A").to_dataframe()
 
 ### By features
 
-The `Artifact`, `Record`, and `Run` registries can be queried by features, via an implicit lookup in the {class}`~lamindb.Feature` registry:
+The {class}`~lamindb.Feature` registry indexes variables across datasets to enable querying by dimensions. Registry fields couldn't scale to the millions of dimensions biological datsets can have.
+
+<img width="800px" src="https://lamin-site-assets.s3.amazonaws.com/.lamindb/VFFgFdAlJnssyOdk0001.svg">
+
+The {class}`~lamindb.Artifact`, {class}`~lamindb.Record`, and {class}`~lamindb.Run` registries can be queried by features:
 
 <!-- #region -->
 <!-- cannot run tabbed code on CI, see test_artifact_filter_by_multiple_features for tests -->

--- a/docs/query-search.md
+++ b/docs/query-search.md
@@ -12,7 +12,6 @@ arrays
 ```
 
 This guide walks through different ways of querying & searching registries.
-In LaminDB, `Record` types such as `Samples` are dynamic registries (often just called registries).
 To understand the underlying cross-linking of objects in the SQL database, see {doc}`organize`.
 
 If you already have a set of artifacts and you'd like to stream their content, see {doc}`arrays`.

--- a/docs/query-search.md
+++ b/docs/query-search.md
@@ -88,7 +88,7 @@ import bionty as bt
 cell_types = bt.CellType.lookup()
 ```
 
-## Get one object
+## Get
 
 {meth}`~lamindb.models.BaseSQLRecord.get` errors if none or more than one matching objects are found.
 
@@ -97,7 +97,19 @@ ln.Record.get(experiment_1.uid)  # by uid
 ln.Record.get(name="Experiment 1")  # by field
 ```
 
-## Query objects by fields
+## Search
+
+You can search every registry via {meth}`~lamindb.models.BaseSQLRecord.search`. For example, the `Artifact` registry.
+
+```python
+ln.Artifact.search("iris").to_dataframe()
+```
+
+Here is more background on search and examples for searching the entire cell type ontology: {doc}`/faq/search`
+
+## Queries
+
+### By fields
 
 Use {meth}`~lamindb.models.BaseSQLRecord.filter` to query all artifacts by the `suffix` field:
 
@@ -131,7 +143,32 @@ qs.to_dataframe()
 
 The `SQLRecord` classes in LaminDB are Django Models and any [Django query](https://docs.djangoproject.com/en/stable/topics/db/queries/) works.
 
-## Query objects by features
+Django has a double-under-score syntax to filter based on related tables.
+This syntax enables you to traverse several layers of relations and comparators.
+
+```python
+ln.Artifact.filter(created_by__handle__startswith="testuse").to_dataframe()
+```
+
+The filter selects all artifacts based on the users who ran the generating notebook. Under the hood, in the SQL database, it's joining the artifact table with the user table.
+
+Another example would be querying all datasets that measure a particular feature. For instance, which datasets measures `"CD8A"`. Here is how:
+
+```python
+cd8a = bt.Gene.get(symbol="CD8A")
+# query for all feature sets that contain CD8A
+schemas_with_cd8a = ln.Schema.filter(genes=cd8a)
+# get all artifacts
+ln.Artifact.filter(schemas__in=schemas_with_cd8a).to_dataframe()
+```
+
+Instead of splitting this across three queries, the double-underscore syntax allows you to define a path for one query.
+
+```python
+ln.Artifact.filter(schemas__genes__symbol="CD8A").to_dataframe()
+```
+
+### By features
 
 The `Artifact`, `Record`, and `Run` registries can be queried by features, via an implicit lookup in the {class}`~lamindb.Feature` registry:
 
@@ -178,48 +215,6 @@ You can query for whether a dataset is annotated annotated by a feature:
 
 ```python
 ln.Artifact.filter(perturbation__isnull=False).to_dataframe(include="features")
-```
-
-## Query runs by parameters
-
-Here is an example for querying by parameters: {ref}`track-run-parameters`.
-
-## Search for objects
-
-You can search every registry via {meth}`~lamindb.models.BaseSQLRecord.search`. For example, the `Artifact` registry.
-
-```python
-ln.Artifact.search("iris").to_dataframe()
-```
-
-Here is more background on search and examples for searching the entire cell type ontology: {doc}`/faq/search`
-
-## Query related registries
-
-Django has a double-under-score syntax to filter based on related tables.
-
-This syntax enables you to traverse several layers of relations and leverage different comparators.
-
-```python
-ln.Artifact.filter(created_by__handle__startswith="testuse").to_dataframe()
-```
-
-The filter selects all artifacts based on the users who ran the generating notebook. Under the hood, in the SQL database, it's joining the artifact table with the user table.
-
-Another typical example is querying all datasets that measure a particular feature. For instance, which datasets measure `"CD8A"`. Here is how to do it:
-
-```python
-cd8a = bt.Gene.get(symbol="CD8A")
-# query for all feature sets that contain CD8A
-schemas_with_cd8a = ln.Schema.filter(genes=cd8a)
-# get all artifacts
-ln.Artifact.filter(schemas__in=schemas_with_cd8a).to_dataframe()
-```
-
-Instead of splitting this across three queries, the double-underscore syntax allows you to define a path for one query.
-
-```python
-ln.Artifact.filter(schemas__genes__symbol="CD8A").to_dataframe()
 ```
 
 ## Filter operators
@@ -297,3 +292,7 @@ ln.Artifact.filter(ln.Q(suffix=".jpg") | ln.Q(suffix=".fastq.gz")).to_dataframe(
 ```python
 ln.Artifact.filter(~ln.Q(suffix=".jpg")).to_dataframe()
 ```
+
+### JSON
+
+Here is an example for querying by parameters: {ref}`track-run-parameters`.

--- a/docs/query-search.md
+++ b/docs/query-search.md
@@ -32,7 +32,9 @@ ln.Artifact.from_dataframe(ln.examples.datasets.df_iris(), key="iris.parquet").s
 ln.examples.datasets.mini_immuno.save_mini_immuno_datasets()
 ```
 
-## Get an overview
+## Basics
+
+### Get an overview
 
 The easiest way to get an overview over all artifacts is by typing {meth}`~lamindb.Artifact.to_dataframe`, which returns the most recently created artifacts in the {class}`~lamindb.Artifact` registry.
 
@@ -65,7 +67,7 @@ You can also get an overview of the entire database.
 ln.view()
 ```
 
-## Auto-complete objects
+### Auto-complete
 
 For registries with less than 100k objects, auto-completing a `Lookup` object is the most convenient way of finding a record.
 
@@ -88,7 +90,7 @@ import bionty as bt
 cell_types = bt.CellType.lookup()
 ```
 
-## Get
+### Get one object
 
 {meth}`~lamindb.models.BaseSQLRecord.get` errors if none or more than one matching objects are found.
 
@@ -97,7 +99,7 @@ ln.Record.get(experiment_1.uid)  # by uid
 ln.Record.get(name="Experiment 1")  # by field
 ```
 
-## Search
+### Search
 
 You can search every registry via {meth}`~lamindb.models.BaseSQLRecord.search`. For example, the `Artifact` registry.
 
@@ -111,20 +113,21 @@ Here is more background on search and examples for searching the entire cell typ
 
 ### By fields
 
-Use {meth}`~lamindb.models.BaseSQLRecord.filter` to query all artifacts by the `suffix` field:
+Use {meth}`~lamindb.models.BaseSQLRecord.filter` to query artifacts by any field, e.g., the {attr}`~lamindb.Artifact.suffix` field:
 
 ```python
 qs = ln.Artifact.filter(suffix=".h5ad")
 qs
 ```
 
-This returns a {class}`~lamindb.models.QuerySet`, which lazily references the set of {class}`~lamindb.models.BaseSQLRecord` objects that matches the filter statement. You can iteratively filter a queryset:
+This returns a {class}`~lamindb.models.QuerySet`, which lazily references the set of {class}`~lamindb.models.BaseSQLRecord` objects that matches the filter. You can filter a queryset:
 
 ```python
 qs = qs.filter(records__name="Experiment 1")
+qs.to_dataframe()
 ```
 
-To access the results encoded in a queryset, call:
+To access the results encoded in a queryset, you can call one of:
 
 - {meth}`~lamindb.models.BasicQuerySet.to_dataframe`: A pandas `DataFrame` with each record in a row.
 - {meth}`~lamindb.models.BasicQuerySet.one`: Exactly one record. Will raise an error if there is none. Is equivalent to the `.get()` method shown above.
@@ -135,24 +138,17 @@ Alternatively,
 - use the `QuerySet` as an iterator
 - get individual objects via `qs[0]`, `qs[1]`
 
-For example:
-
-```python
-qs.to_dataframe()
-```
-
 The `SQLRecord` classes in LaminDB are Django Models and any [Django query](https://docs.djangoproject.com/en/stable/topics/db/queries/) works.
-
 Django has a double-under-score syntax to filter based on related tables.
 This syntax enables you to traverse several layers of relations and comparators.
+
+For example, the following filter selects artifacts based on the users who ran the generating notebook. Under the hood, in the SQL database, it's joining the artifact table with the user table.
 
 ```python
 ln.Artifact.filter(created_by__handle__startswith="testuse").to_dataframe()
 ```
 
-The filter selects all artifacts based on the users who ran the generating notebook. Under the hood, in the SQL database, it's joining the artifact table with the user table.
-
-Another example would be querying all datasets that measure a particular feature. For instance, which datasets measures `"CD8A"`. Here is how:
+Another example would be querying datasets that measure a particular feature. For instance, which datasets measures expression of `CD8A`:
 
 ```python
 cd8a = bt.Gene.get(symbol="CD8A")
@@ -162,7 +158,7 @@ schemas_with_cd8a = ln.Schema.filter(genes=cd8a)
 ln.Artifact.filter(schemas__in=schemas_with_cd8a).to_dataframe()
 ```
 
-Instead of splitting this across three queries, the double-underscore syntax allows you to define a path for one query.
+Instead of splitting this across three queries, the double-underscore syntax allows you to define a path for one query:
 
 ```python
 ln.Artifact.filter(schemas__genes__symbol="CD8A").to_dataframe()

--- a/docs/query-search.md
+++ b/docs/query-search.md
@@ -231,7 +231,7 @@ ln.Artifact.filter(suffix=".h5ad", records=experiment_1).to_dataframe()
 
 ### less than/ greater than
 
-Or subset to artifacts greater than 10kB. Here, we can't use keyword arguments, but need an explicit where statement.
+Subset to artifacts greater than 10kB.
 
 ```python
 ln.Artifact.filter(records=experiment_1, size__gt=1e4).to_dataframe()

--- a/docs/query-search.md
+++ b/docs/query-search.md
@@ -211,7 +211,7 @@ Just like for fields holding dictionary values, you can query for dictionary key
 ln.Artifact.filter(study_metadata__detail1="123").to_dataframe(include="features")
 ```
 
-You can query for whether a dataset is annotated annotated by a feature:
+You can query for whether a dataset is annotated by a feature:
 
 ```python
 ln.Artifact.filter(perturbation__isnull=False).to_dataframe(include="features")
@@ -220,8 +220,7 @@ ln.Artifact.filter(perturbation__isnull=False).to_dataframe(include="features")
 ## Cheat sheet: comparators
 
 You can qualify the type of comparison in a query by using a comparator.
-
-Below follows a list of the most import, but Django supports about [two dozen field comparators](https://docs.djangoproject.com/en/stable/ref/models/querysets/#field-lookups) `field__comparator=value`.
+Below follows a list of the most important, but Django supports about [two dozen field comparators](https://docs.djangoproject.com/en/stable/ref/models/querysets/#field-lookups) `field__comparator=value`.
 
 ### and
 
@@ -231,9 +230,8 @@ ln.Artifact.filter(suffix=".h5ad", records=experiment_1).to_dataframe()
 
 ### less than/ greater than
 
-Subset to artifacts greater than 10kB.
-
 ```python
+# artifacts greater than 10kB
 ln.Artifact.filter(records=experiment_1, size__gt=1e4).to_dataframe()
 ```
 

--- a/docs/query-search.md
+++ b/docs/query-search.md
@@ -40,12 +40,6 @@ The easiest way to get an overview over all artifacts is by typing {meth}`~lamin
 ln.Artifact.to_dataframe()
 ```
 
-You can include features.
-
-```python
-ln.Artifact.to_dataframe(include="features")
-```
-
 You can include fields from other registries.
 
 ```python
@@ -57,6 +51,12 @@ ln.Artifact.to_dataframe(
         "schemas__itype",
     ]
 )
+```
+
+You can include features.
+
+```python
+ln.Artifact.to_dataframe(include="features")
 ```
 
 You can also get an overview of the entire database.
@@ -170,7 +170,7 @@ ln.Artifact.filter(schemas__genes__symbol="CD8A").to_dataframe()
 
 ### By features
 
-The {class}`~lamindb.Feature` registry indexes variables across datasets to enable querying by dimensions. Registry fields couldn't scale to the millions of dimensions biological datsets can have.
+The {class}`~lamindb.Feature` registry indexes variables across datasets to enable querying by dimensions. Registry fields couldn't scale to millions of dimensions.
 
 <img width="800px" src="https://lamin-site-assets.s3.amazonaws.com/.lamindb/VFFgFdAlJnssyOdk0001.svg">
 

--- a/docs/query-search.md
+++ b/docs/query-search.md
@@ -12,6 +12,7 @@ arrays
 ```
 
 This guide walks through different ways of querying & searching registries.
+In LaminDB, `Record` types such as `Samples` are dynamic registries (often just called registries).
 To understand the underlying cross-linking of objects in the SQL database, see {doc}`organize`.
 
 If you already have a set of artifacts and you'd like to stream their content, see {doc}`arrays`.
@@ -135,26 +136,33 @@ The `SQLRecord` classes in LaminDB are Django Models and any [Django query](http
 
 The `Artifact`, `Record`, and `Run` registries can be queried by features, via an implicit lookup in the {class}`~lamindb.Feature` registry:
 
-:::::{tab-set}
+::::{tab-set}
 
-::::{tab-item} Via strings
+:::{tab-item} Via strings / kwargs
 
 ```python
-ln.Artifact.filter(perturbation="DMSO").to_dataframe(include="features")
+ln.Artifact.filter(
+    perturbation="DMSO",
+    temperature__gt=26,
+).to_dataframe(include="features")
 ```
 
-::::
+:::
 
-::::{tab-item} Via expressions
+:::{tab-item} Via objects / expressions
 
 ```python
 perturbation = ln.Feature.get(name="perturbation")  # can optionally pass a feature type to disambiguate
-ln.Artifact.filter(perturbation == "DMSO")  # note this is now an expression using the == syntax
+temperature = ln.Feature.get(name="temperature")
+ln.Artifact.filter(    # note this is now an expression using the == syntax
+    perturbation == "DMSO",
+    temperature > 21,
+).to_dataframe(include="features")
 ```
 
-::::
+:::
 
-:::::
+::::
 
 Just like for fields holding dictionary values, you can query for dictionary keys in features whose `dtype` is `dict`:
 

--- a/docs/track.md
+++ b/docs/track.md
@@ -380,7 +380,7 @@ In contrast to params, features are validated against the `Feature` registry and
 Let's first define labels & features.
 
 ```python
-experiment_type = ln.Record(name="Experiment", is_type=True).save()
+experiment_type = ln.Record(name="Experiments", is_type=True).save()
 experiment_label = ln.Record(name="Experiment1", type=experiment_type).save()
 ln.Feature(name="s3_folder", dtype=str).save()
 ln.Feature(name="experiment", dtype=experiment_type).save()

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -728,15 +728,15 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
 
         ln.Feature(name="sample", dtype=ln.ULabel).save()
 
-    Restrict a categorical feature to a specific `ULabel` type::
+    Restrict a categorical feature to a specific `ULabel` type, here a perturbations registry::
 
-        perturbation = ln.ULabel(name="Perturbation", is_type=True).save()
-        ln.Feature(name="perturbation", dtype=perturbation).save()
+        perturbation_registry = ln.ULabel(name="Perturbations", is_type=True).save()
+        ln.Feature(name="perturbation", dtype=perturbation_registry).save()
 
-    Restrict a categorical feature to a specific `Record` type::
+    Restrict a categorical feature to a `Record` type, here an experiments registry::
 
-        experiment = ln.Record(name="Experiment", is_type=True).save()
-        ln.Feature(name="experiment", dtype=experiment).save()
+        experiments_registry = ln.Record(name="Experiments", is_type=True).save()
+        ln.Feature(name="experiment", dtype=experiments_registry).save()
 
     Restrict a categorical feature to the `bt.CellType` registry::
 

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -123,11 +123,10 @@ class RecordBatch:
 
 
 class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates):
-    """Flexible records with sheets & markdown pages.
+    """Flexible records with markdown notes, dynamic registries, and sheets.
 
-    Useful for managing samples, donors, cells, compounds, sequences, and other custom entities with their features.
-
-    If you just want a simple label, use :class:`~lamindb.ULabel`.
+    Useful for managing notes, experiments, samples, donors, cells, compounds, sequences,
+    and other custom entities with their features.
 
     Args:
         name: `str | None = None` A name.
@@ -161,20 +160,20 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         # describe the record
         sample1.describe()
 
-    Group several records under a **record type**, optionally constrained with a :class:`~lamindb.Schema`::
+    Group several records in a registry by creating a record type, optionally constrained with a :class:`~lamindb.Schema`::
 
-        # create a flexible record type to track experiments
-        experiment_type = ln.Record(name="Experiment", is_type=True).save()
-        experiment1 = ln.Record(name="Experiment 1", type=experiment_type).save()
+        # create an experiments registry
+        experiments_registry = ln.Record(name="Experiments", is_type=True).save()
+        experiment1 = ln.Record(name="Experiment 1", type=experiments_registry).save()
 
         # create a feature to link experiments
-        experiment = ln.Feature(name="experiment", dtype=experiment_type).save()
+        experiment = ln.Feature(name="experiment", dtype=experiments_registry).save()
 
-        # create a record type to track samples -- constrain it with a schema
+        # constrain a samples registry with a schema, turning it into a sheet
         schema = ln.Schema([experiment, gc_content.with_config(optional=True)], name="sample_schema").save()
         sample_sheet = ln.Record(name="Sample Sheet", is_type=True, schema=schema).save()
 
-        # group the sample1 record under the sample sheet
+        # move the sample1 record into the sample sheet
         sample1.type = sample_sheet
         sample1.save()
 
@@ -186,7 +185,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
 
     Export all records under a type to a dataframe::
 
-        experiment_type.to_dataframe()
+        experiments_registry.to_dataframe()
         #> __lamindb_record_name__   ...
         #>            Experiment 1   ...
         #>            Experiment 2   ...

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -210,7 +210,7 @@ class HasType(models.Model):
 
     For instance, using the example of `ln.Record`::
 
-        experiment_type = ln.Record(name="Experiment", is_type=True).save()
+        experiment_type = ln.Record(name="Experiments", is_type=True).save()
         experiment1 = ln.Record(name="Experiment 1", type=experiment_type).save()
         experiment2 = ln.Record(name="Experiment 2", type=experiment_type).save()
     """

--- a/tests/core/test_artifact_features_annotations.py
+++ b/tests/core/test_artifact_features_annotations.py
@@ -437,6 +437,46 @@ def test_features_name_duplicates_across_equal_levels():
     lab_b_type.delete(permanent=True)
 
 
+@pytest.mark.parametrize("query_style", ["kwargs", "predicates"])
+def test_artifact_filter_by_multiple_features(query_style: str):
+    """Mirror docs/query-search.md multi-feature filtering examples."""
+    perturbation_type = ln.ULabel(name="Perturbation", is_type=True).save()
+    dmso = ln.ULabel(name="DMSO", type=perturbation_type).save()
+    ifng = ln.ULabel(name="IFNG", type=perturbation_type).save()
+    perturbation = ln.Feature(name="perturbation", dtype=perturbation_type).save()
+    temperature = ln.Feature(name="temperature", dtype=float).save()
+
+    matching_artifact = ln.Artifact(
+        ".gitignore",
+        key=f"multi-feature-match-{query_style}",
+    ).save()
+    non_matching_artifact = ln.Artifact(
+        "pyproject.toml",
+        key=f"multi-feature-non-match-{query_style}.toml",
+    ).save()
+    matching_artifact.features.set_values({perturbation: dmso, temperature: 22.6})
+    non_matching_artifact.features.set_values({perturbation: ifng, temperature: 20.0})
+
+    if query_style == "kwargs":
+        queryset = ln.Artifact.filter(perturbation="DMSO", temperature__gt=21)
+    else:
+        queryset = ln.Artifact.filter(perturbation == "DMSO", temperature > 21)
+
+    assert queryset.one() == matching_artifact
+    assert non_matching_artifact not in queryset
+    dataframe = queryset.to_dataframe(include="features")
+    assert "perturbation" in dataframe.columns
+    assert "temperature" in dataframe.columns
+
+    non_matching_artifact.delete(permanent=True)
+    matching_artifact.delete(permanent=True)
+    temperature.delete(permanent=True)
+    perturbation.delete(permanent=True)
+    ifng.delete(permanent=True)
+    dmso.delete(permanent=True)
+    perturbation_type.delete(permanent=True)
+
+
 def test_feature_predicate_queries_safe_hybrid():
     lab_a_type = ln.Feature(name="PredLabA", is_type=True).save()
     feature_a = ln.Feature(name="pred_name", dtype=str, type=lab_a_type).save()

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -16,38 +16,38 @@ def test_record_docstring_examples():
     gc_content = ln.Feature(name="gc_content", dtype=float).save()
 
     # create a record to track a sample
-    sample1 = ln.Record(name="Sample 1", features={"gc_content": 0.55}).save()
+    sample1 = ln.Record(name="Sample 1", features={"gc_content": 0.5}).save()
 
     # describe the record
     sample1.describe()
 
-    # create a dynamic registry to track experiments
-    experiment_type = ln.Record(name="Experiments", is_type=True).save()
-    experiment1 = ln.Record(name="Experiment 1", type=experiment_type).save()
+    # create an experiments registry
+    experiments_registry = ln.Record(name="Experiments", is_type=True).save()
+    experiment1 = ln.Record(name="Experiment 1", type=experiments_registry).save()
 
     # create a feature to link experiments
-    experiment = ln.Feature(name="experiment", dtype=experiment_type).save()
+    experiment = ln.Feature(name="experiment", dtype=experiments_registry).save()
 
-    # create a dynamic registry to track samples that's constrained with a schema
+    # constrain a samples registry with a schema, turning it into a sheet
     schema = ln.Schema(
         [experiment, gc_content.with_config(optional=True)], name="sample_schema"
     ).save()
     sample_sheet = ln.Record(name="Sample Sheet", is_type=True, schema=schema).save()
 
-    # group the sample1 record under the sample sheet
+    # move the sample1 record into the sample sheet
     sample1.type = sample_sheet
     sample1.save()
 
     # reset the feature values for the record including the experiment
     sample1.features.set_values(
         {
-            gc_content: 0.55,
+            gc_content: 0.5,
             experiment: "Experiment 1",  # automatically resolves by name, also accepts the experiment1 object
         }
     )
 
     # Export all records under a type to a dataframe
-    df = experiment_type.to_dataframe()
+    df = experiments_registry.to_dataframe()
     assert "Experiment 1" in df["__lamindb_record_name__"].values
 
     # Import records from a dataframe
@@ -63,8 +63,8 @@ def test_record_docstring_examples():
         sample2.features.set_values({"gc_content": 0.6})
 
     # Query records by features
-    assert ln.Record.filter(gc_content == 0.55).one() == sample1
-    assert ln.Record.filter(gc_content > 0.5).one() == sample1
+    assert ln.Record.filter(gc_content == 0.5).one() == sample1
+    assert ln.Record.filter(gc_content > 0.5).one_or_none() is None
     assert ln.Record.filter(type=sample_sheet).count() >= 1
 
     # Clean up
@@ -79,7 +79,7 @@ def test_record_docstring_examples():
     experiment1.delete(permanent=True)
     sample_sheet.delete(permanent=True)
     schema.delete(permanent=True)
-    experiment_type.delete(permanent=True)
+    experiments_registry.delete(permanent=True)
     gc_content.delete(permanent=True)
     experiment.delete(permanent=True)
 

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -21,14 +21,14 @@ def test_record_docstring_examples():
     # describe the record
     sample1.describe()
 
-    # create a flexible record type to track experiments
-    experiment_type = ln.Record(name="Experiment", is_type=True).save()
+    # create a dynamic registry to track experiments
+    experiment_type = ln.Record(name="Experiments", is_type=True).save()
     experiment1 = ln.Record(name="Experiment 1", type=experiment_type).save()
 
     # create a feature to link experiments
     experiment = ln.Feature(name="experiment", dtype=experiment_type).save()
 
-    # create a record type to track samples that's constrained with a schema
+    # create a dynamic registry to track samples that's constrained with a schema
     schema = ln.Schema(
         [experiment, gc_content.with_config(optional=True)], name="sample_schema"
     ).save()


### PR DESCRIPTION
Without introducing this language we're lacking a crucial term to refer to side bar of typed entities in the UI. 