### PR TITLE
🔥 Remove backward compat for `ln.Param` call pattern

### DIFF
--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -152,13 +152,6 @@ Developer API
 # denote a release candidate for 0.1.0 with 0.1rc1, 0.1a1, 0.1b1, etc.
 __version__ = "2.6.1"
 
-import warnings as _warnings
-
-# through SpatialData
-_warnings.filterwarnings(
-    "ignore", message="The legacy Dask DataFrame implementation is deprecated"
-)
-
 from lamindb_setup._check_setup import _check_instance_setup
 from lamindb_setup._connect_instance import connect
 from lamindb_setup.core.upath import UPath
@@ -200,8 +193,6 @@ settings.__doc__ = """Global live settings (:class:`~lamindb.core.Settings`)."""
 context.__doc__ = """Global run context (:class:`~lamindb.core.Context`)."""
 
 from django.db.models import Q
-
-Param = Feature  # backward compat
 
 __all__ = [
     # data lineage


### PR DESCRIPTION
This had been deprecated since `2025-06-01 db 1.6.0 | bionty 1.4.0`:

https://docs.lamin.ai/changelog/2025#db-1-6-0-bionty-1-4-0

It should have been removed with lamindb 2.