### PR TITLE
🩹 Fix edge cases for getting artifacts by path

### DIFF
--- a/lamindb/models/artifact_set.py
+++ b/lamindb/models/artifact_set.py
@@ -143,12 +143,14 @@ def artifacts_from_path(artifacts: ArtifactSet, path: AnyPathStr) -> ArtifactSet
 
     stem = upath.stem
     stem_len = len(stem)
+    suffix = upath.suffix
 
     if stem_len == 16:
         qs = artifacts.filter(
             Q(_key_is_virtual=True) | Q(key__isnull=True),
             _real_key__isnull=True,
             _overwrite_versions=True,
+            suffix=suffix,
             uid__startswith=stem,
         )
     elif stem_len == 20:
@@ -156,6 +158,7 @@ def artifacts_from_path(artifacts: ArtifactSet, path: AnyPathStr) -> ArtifactSet
             Q(_key_is_virtual=True) | Q(key__isnull=True),
             _real_key__isnull=True,
             _overwrite_versions=False,
+            suffix=suffix,
             uid=stem,
         )
     else:

--- a/lamindb/models/artifact_set.py
+++ b/lamindb/models/artifact_set.py
@@ -148,12 +148,14 @@ def artifacts_from_path(artifacts: ArtifactSet, path: AnyPathStr) -> ArtifactSet
         qs = artifacts.filter(
             Q(_key_is_virtual=True) | Q(key__isnull=True),
             _real_key__isnull=True,
+            _overwrite_versions=True,
             uid__startswith=stem,
         )
     elif stem_len == 20:
         qs = artifacts.filter(
             Q(_key_is_virtual=True) | Q(key__isnull=True),
             _real_key__isnull=True,
+            _overwrite_versions=False,
             uid=stem,
         )
     else:

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -1670,10 +1670,18 @@ def test_artifact_get_tracking(example_dataframe: pd.DataFrame):
 
 def test_get_by_path(example_dataframe: pd.DataFrame):
     artifact = ln.Artifact.from_dataframe(example_dataframe, key="df.parquet").save()
+    assert artifact._key_is_virtual
     artifact_path = artifact.path
 
     assert ln.Artifact.get(path=artifact_path) == artifact
     assert ln.Artifact.filter().get(path=artifact_path.as_posix()) == artifact
+    # only partial uid in the path
+    stem = artifact_path.stem
+    with pytest.raises(ln.errors.ObjectDoesNotExist):
+        ln.Artifact.get(path=artifact_path.with_name(stem[:-4]) + ".parquet")
+    # no suffix in the path
+    with pytest.raises(ln.errors.ObjectDoesNotExist):
+        ln.Artifact.get(path=artifact_path.with_name(stem))
 
     with pytest.raises(ln.errors.ObjectDoesNotExist):
         ln.Artifact.get(path="s3://bucket/folder/file.parquet")

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -1676,12 +1676,15 @@ def test_get_by_path(example_dataframe: pd.DataFrame):
     assert ln.Artifact.get(path=artifact_path) == artifact
     assert ln.Artifact.filter().get(path=artifact_path.as_posix()) == artifact
     # only partial uid in the path
-    stem = artifact_path.stem
     with pytest.raises(ln.errors.ObjectDoesNotExist):
-        ln.Artifact.get(path=artifact_path.with_name(stem[:-4]) + ".parquet")
+        ln.Artifact.get(
+            path=artifact_path.with_name(artifact_path.stem[:-4]).with_suffix(
+                ".parquet"
+            )
+        )
     # no suffix in the path
     with pytest.raises(ln.errors.ObjectDoesNotExist):
-        ln.Artifact.get(path=artifact_path.with_name(stem))
+        ln.Artifact.get(path=artifact_path.with_suffix(""))
 
     with pytest.raises(ln.errors.ObjectDoesNotExist):
         ln.Artifact.get(path="s3://bucket/folder/file.parquet")


### PR DESCRIPTION
Fix cases where artifacts were incorrectly given for paths with partial uids in names and with no suffixes.