### PR TITLE
fix(feature): avoid IndexError when parsing a dtype with a trailing dot

### DIFF
--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -297,7 +297,7 @@ def parse_nested_brackets(dtype_str: str) -> dict[str, Any]:
         # No brackets - handle simple cases like "A" or "A.field"
         if "." in dtype_str:
             parts = dtype_str.split(".")
-            if len(parts) == 2 and parts[1][0].isupper():
+            if len(parts) == 2 and parts[1] != "" and parts[1][0].isupper():
                 # bionty.CellType
                 return {"registry": dtype_str, "filter_str": "", "field": ""}
             elif len(parts) == 3:

--- a/tests/core/test_feature_dtype.py
+++ b/tests/core/test_feature_dtype.py
@@ -9,6 +9,7 @@ from lamindb.errors import ValidationError
 from lamindb.models.feature import (
     parse_dtype,
     parse_filter_string,
+    parse_nested_brackets,
     resolve_relation_filters,
     serialize_dtype,
 )
@@ -121,6 +122,19 @@ def test_serialize_with_field_information():
 # -----------------------------------------------------------------------------
 # parsing serialized dtypes
 # -----------------------------------------------------------------------------
+
+
+def test_parse_nested_brackets_trailing_dot():
+    # a trailing dot used to raise `IndexError: string index out of range`
+    # because `parts[1][0]` was accessed on an empty second part
+    assert parse_nested_brackets("bionty.") == {
+        "registry": "bionty",
+        "filter_str": "",
+        "field": "",
+    }
+    # malformed dtype must surface as a clear ValidationError, not IndexError
+    with pytest.raises(ValidationError):
+        parse_dtype("cat[bionty.]")
 
 
 def test_simple_record_with_subtype_and_field():


### PR DESCRIPTION
## What's broken

`parse_nested_brackets` crashes with `IndexError: string index out of range` on any dtype segment ending in a dot, e.g. `"bionty."`. It's reachable from the public `parse_dtype` via a malformed categorical dtype:

```python
parse_dtype("cat[bionty.]")
```
```
  File ".../lamindb/models/feature.py", line 300, in parse_nested_brackets
    if len(parts) == 2 and parts[1][0].isupper():
IndexError: string index out of range
```

## Why it happens

After `dtype_str.split(".")`, the code checks `len(parts) == 2` but then reads `parts[1][0]` without checking that `parts[1]` is non-empty — a trailing dot makes it `""`.

## Fix

Guard `parts[1] != ""` before indexing. The malformed input now falls through to the bare-registry branch, so `parse_dtype("cat[bionty.]")` raises a clear `ValidationError` ("invalid dtype") instead of an opaque `IndexError`.

## Test

`test_parse_nested_brackets_trailing_dot` checks `"bionty."` no longer crashes and `parse_dtype("cat[bionty.]")` raises `ValidationError`.
