### PR TITLE
🐛 Fix edge cases in version handling

### DIFF
--- a/lamindb/core/storage/_tiledbsoma.py
+++ b/lamindb/core/storage/_tiledbsoma.py
@@ -221,7 +221,7 @@ def save_tiledbsoma_experiment(
     if appending:
         storepath = revises.path
     else:
-        uid, _ = create_uid(n_full_id=20)
+        uid = create_uid(n_full_id=20)
         storage_key = auto_storage_key_from_artifact_uid(
             uid, ".tiledbsoma", overwrite_versions=True
         )

--- a/lamindb/models/_is_versioned.py
+++ b/lamindb/models/_is_versioned.py
@@ -4,7 +4,6 @@ from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any, Iterable, Literal
 
 from django.db import models
-from django.db.models import Q
 from lamin_utils import logger
 from lamin_utils._base62 import decode as base62_to_int
 from lamin_utils._base62 import increment_base62
@@ -272,11 +271,13 @@ def process_revises(
 def _adjust_is_latest_when_deleting_is_versioned(
     objects: IsVersioned | Iterable[IsVersioned],
 ) -> list[int]:
-    """After deleting (soft or permanent) versioned records, promote new latest per version family.
+    """After deleting (soft or permanent) versioned records, promote a new latest head.
 
     Accepts a single IsVersioned instance, a QuerySet, or a list of IsVersioned.
-    Runs in 1 query (candidates + update) when objects are passed; no extra query for uids.
-    Returns the list of pks that were promoted to is_latest (for testing).
+    is_latest is per-branch, so for every deleted head we promote the most recently
+    created remaining version on its branch -- a global family max could leave that
+    branch headless (or flip the wrong branch's record). Non-branch-aware models keep a
+    single global head per family (branch is `None`). Returns the promoted pks.
     """
     if isinstance(objects, IsVersioned):
         objects = [objects]
@@ -285,42 +286,52 @@ def _adjust_is_latest_when_deleting_is_versioned(
     if not objects:
         return []
     id_list = [o.pk for o in objects]
-    stem_uids = list({o.uid[: o._len_stem_uid] for o in objects if o.is_latest})
-    if not stem_uids:
-        return []
-    registry = type(objects[0])
-    db = getattr(objects[0]._state, "db", None) or "default"
+
+    object_0 = objects[0]
+    registry = type(object_0)
+    db = getattr(object_0._state, "db", None) or "default"
+
     len_stem = registry._len_stem_uid
-    # All candidates: same family as any stem_uid, not in trash and not about to be deleted
-    q = Q()
-    for s in stem_uids:
-        q |= Q(uid__startswith=s)
-    qs = registry.objects.using(db).filter(q).exclude(pk__in=id_list)
+
     from .sqlrecord import SQLRecord
 
-    if issubclass(registry, SQLRecord):
-        qs = qs.exclude(branch_id=-1)
-    candidates = list(qs.values("pk", "uid", "created_at"))
-    # per stem_uid, pick candidate with max created_at
-    by_stem: dict[str, dict[str, Any]] = {}
-    for c in candidates:
-        stem = c["uid"][:len_stem]
-        if stem not in by_stem or c["created_at"] > by_stem[stem]["created_at"]:
-            by_stem[stem] = c
-    if not by_stem:
+    branch_aware = issubclass(registry, SQLRecord)
+    # (family, branch) heads that were just deleted and need a successor
+    groups = {
+        (o.uid[:len_stem], o.branch_id if branch_aware else None)
+        for o in objects
+        if o.is_latest
+    }
+    if not groups:
         return []
-    pks = [by_stem[s]["pk"] for s in by_stem]
+    # for each deleted head, let the db pick its successor: the newest remaining version
+    # in the same family on the same branch (LIMIT 1, no client-side scan of the family)
+    promoted: list[tuple[int, str]] = []
+    for stem, branch in groups:
+        candidates = (
+            registry.objects.using(db)
+            .filter(uid__startswith=stem)
+            .exclude(pk__in=id_list)
+        )
+        if branch_aware:
+            # a concrete branch id inherently excludes the trash (branch_id=-1)
+            candidates = candidates.filter(branch_id=branch)
+        new_head = candidates.order_by("-created_at", "-id").values("pk", "uid").first()
+        if new_head is not None:
+            promoted.append((new_head["pk"], new_head["uid"]))
+    if not promoted:
+        return []
+    pks = [pk for pk, _ in promoted]
     registry.objects.using(db).filter(pk__in=pks).update(is_latest=True)
-    if pks:
-        promoted_uids = [by_stem[s]["uid"] for s in by_stem]
-        if len(promoted_uids) == 1:
-            logger.important_hint(
-                f"new latest {registry.__name__} version is: {promoted_uids[0]}"
-            )
-        else:
-            logger.important_hint(
-                f"new latest {registry.__name__} versions: {promoted_uids}"
-            )
+    promoted_uids = [uid for _, uid in promoted]
+    if len(promoted_uids) == 1:
+        logger.important_hint(
+            f"new latest {registry.__name__} version is: {promoted_uids[0]}"
+        )
+    else:
+        logger.important_hint(
+            f"new latest {registry.__name__} versions: {promoted_uids}"
+        )
     return pks
 
 

--- a/lamindb/models/_is_versioned.py
+++ b/lamindb/models/_is_versioned.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Literal
 from django.db import models
 from django.db.models import Q
 from lamin_utils import logger
+from lamin_utils._base62 import decode as base62_to_int
 from lamin_utils._base62 import increment_base62
 
 from lamindb.base import uids
@@ -189,11 +190,24 @@ def create_uid(
     This is why it returns revises.
     """
     if revises is not None:
-        latest_in_family = (
-            revises.__class__.objects.filter(uid__startswith=revises.stem_uid)
-            .order_by("uid")
-            .last()
-        )
+        family_qs = revises.__class__.objects.filter(uid__startswith=revises.stem_uid)
+        # The canonical source of truth for the latest version is the `is_latest`
+        # flag. We do NOT order by `uid` in the database here: the version suffix is
+        # base62 (0-9 < A-Z < a-z), but locale-aware DB collations (e.g. Postgres
+        # `en_US.UTF-8`) sort letters case-insensitively, so e.g. `...000Z` wrongly
+        # sorts after `...000a` and the chain can't grow past the `Z -> a` boundary.
+        latest_in_family = family_qs.filter(is_latest=True).first()
+        if latest_in_family is None:
+            # Fallback when no record is flagged `is_latest=True`: pick the maximum
+            # version suffix using base62 ordering computed in Python (independent of
+            # the database collation), then load that one record.
+            latest_uid = max(
+                family_qs.values_list("uid", flat=True),
+                key=lambda uid: base62_to_int(uid[-4:]),
+                default=None,
+            )
+            if latest_uid is not None:
+                latest_in_family = family_qs.get(uid=latest_uid)
         if latest_in_family is not None and latest_in_family.uid != revises.uid:
             revises = latest_in_family
             logger.warning(

--- a/lamindb/models/_is_versioned.py
+++ b/lamindb/models/_is_versioned.py
@@ -101,7 +101,7 @@ class IsVersioned(models.Model):
             version_tag: semantic version tag of the record.
         """
         old_uid = self.uid  # type: ignore
-        new_uid, revises = create_uid(revises=revises, version_tag=version_tag)
+        new_uid = create_uid(revises=revises, version_tag=version_tag)
         if (
             self.__class__.__name__ == "Artifact"
             and self._real_key is None
@@ -208,54 +208,18 @@ def create_uid(
     version_tag: str | None = None,
     n_full_id: int = 20,
     revises: IsVersioned | None = None,
-    target_branch_id: int | None = None,
-) -> tuple[str, IsVersioned | None]:
-    """This also updates revises in case it's not the latest version.
+) -> str:
+    """Derive the uid for a new (possibly versioned) record.
 
-    This is why it returns revises.
-
-    The new version suffix is always derived from the family-wide max (collation-independent,
-    so it never collides with heads on other branches or trashed records). The record returned
-    in `revises` -- which decides the record demoted on save -- is the current head:
-
-    - if `target_branch_id` is given (the branch the new record will be created on), the
-      `is_latest` head *on that branch*. `is_latest` is per-branch, so the family-wide max may
-      live on a different branch and must not be chained from / demoted across branches.
-    - otherwise, the family-wide max record (branch-agnostic legacy behavior).
+    The new version suffix is derived from the family-wide max (computed in Python via base62
+    decoding, so it's independent of db collation and never collides with higher versions on
+    other branches or in the trash). `revises` is only read, never modified: choosing which
+    record a new version supersedes/demotes is `save`'s job, since only it knows the branch the
+    new record is created on (`is_latest` is per-branch).
     """
     if revises is not None:
-        # single query: pull the whole version family once, then derive everything in Python
-        # (most recent first so picking a branch head is deterministic).
-        family = sorted(
-            revises.__class__.objects.filter(uid__startswith=revises.stem_uid),
-            key=lambda record: record.created_at,
-            reverse=True,
-        )
-        # family-wide max version suffix -> the new uid, so it never collides (base62 decoded
-        # in Python, independent of db collation; includes other-branch and trashed versions).
-        max_uid = max(
-            (record.uid for record in family),
-            key=lambda uid: base62_to_int(uid[-4:]),
-            default=revises.uid,
-        )
-        if target_branch_id is not None:
-            head = next(
-                (
-                    record
-                    for record in family
-                    if record.is_latest
-                    and getattr(record, "branch_id", None) == target_branch_id
-                ),
-                None,
-            )
-        else:
-            head = next((record for record in family if record.uid == max_uid), None)
-        if head is not None and head.uid != revises.uid:
-            revises = head
-            logger.warning(
-                f"didn't pass the latest version in `revises`, retrieved it: {revises}"
-            )
         suid = revises.stem_uid
+        max_uid = max_version_uid_in_family(revises) or revises.uid
         vuid = increment_base62(max_uid[-4:])
     else:
         suid = uids.base62(n_full_id - 4)
@@ -270,7 +234,7 @@ def create_uid(
                 raise ValueError(
                     f"Please change the version tag or leave it `None`, '{revises.version_tag}' is already taken"
                 )
-    return suid + vuid, revises
+    return suid + vuid
 
 
 def process_revises(
@@ -279,22 +243,20 @@ def process_revises(
     key: str | None,
     description: str | None,
     type_: type[IsVersioned],
-    target_branch_id: int | None = None,
-) -> tuple[str, str, str, str, IsVersioned | None]:
+) -> tuple[str, str, str, str]:
     if revises is not None and not isinstance(revises, type_):
         raise TypeError(f"`revises` has to be of type `{type_.__name__}`")
-    uid, revises = create_uid(
+    uid = create_uid(
         revises=revises,
         version_tag=version_tag,
         n_full_id=type_._len_full_uid,
-        target_branch_id=target_branch_id,
     )
     if revises is not None:
         if description is None:
             description = getattr(revises, "description", None)
         if key is None:
             key = revises.key
-    return uid, version_tag, key, description, revises
+    return uid, version_tag, key, description
 
 
 def _adjust_is_latest_when_deleting_is_versioned(

--- a/lamindb/models/_is_versioned.py
+++ b/lamindb/models/_is_versioned.py
@@ -47,6 +47,12 @@ class IsVersioned(models.Model):
     ):
         self._revises = kwargs.pop("revises", None)
         self._refresh_revises_if_stale = kwargs.pop("_refresh_revises_if_stale", False)
+        # if `revises` is already a previous (non-latest) version at init, the user
+        # consciously passed an old version: revise from the live head, like the inferred
+        # case. This keeps the concurrent-demotion check (`revises` was the head at init
+        # but got demoted before save -> raise) intact for genuinely explicit heads.
+        if self._revises is not None and not self._revises.is_latest:
+            self._refresh_revises_if_stale = True
         super().__init__(*args, **kwargs)
 
     @property

--- a/lamindb/models/_is_versioned.py
+++ b/lamindb/models/_is_versioned.py
@@ -191,23 +191,20 @@ def create_uid(
     """
     if revises is not None:
         family_qs = revises.__class__.objects.filter(uid__startswith=revises.stem_uid)
-        # The canonical source of truth for the latest version is the `is_latest`
-        # flag. We do NOT order by `uid` in the database here: the version suffix is
-        # base62 (0-9 < A-Z < a-z), but locale-aware DB collations (e.g. Postgres
-        # `en_US.UTF-8`) sort letters case-insensitively, so e.g. `...000Z` wrongly
-        # sorts after `...000a` and the chain can't grow past the `Z -> a` boundary.
-        latest_in_family = family_qs.filter(is_latest=True).first()
-        if latest_in_family is None:
-            # Fallback when no record is flagged `is_latest=True`: pick the maximum
-            # version suffix using base62 ordering computed in Python (independent of
-            # the database collation), then load that one record.
-            latest_uid = max(
-                family_qs.values_list("uid", flat=True),
-                key=lambda uid: base62_to_int(uid[-4:]),
-                default=None,
-            )
-            if latest_uid is not None:
-                latest_in_family = family_qs.get(uid=latest_uid)
+        # Pick the maximum version suffix over the whole family. We compute the max
+        # via base62 decoding in Python rather than ordering by `uid` in the database:
+        # the version suffix is base62 (0-9 < A-Z < a-z), but locale-aware DB
+        # collations (e.g. Postgres `en_US.UTF-8`) sort letters case-insensitively, so
+        # e.g. `...000Z` wrongly sorts after `...000a` and the chain can't grow past
+        # the `Z -> a` boundary. Considering the whole family (not just `is_latest`,
+        # which is per-branch and thus not globally unique, and excludes trashed
+        # records) guarantees the new uid never collides with an existing one.
+        latest_uid = max(
+            family_qs.values_list("uid", flat=True),
+            key=lambda uid: base62_to_int(uid[-4:]),
+            default=None,
+        )
+        latest_in_family = None if latest_uid is None else family_qs.get(uid=latest_uid)
         if latest_in_family is not None and latest_in_family.uid != revises.uid:
             revises = latest_in_family
             logger.warning(

--- a/lamindb/models/_is_versioned.py
+++ b/lamindb/models/_is_versioned.py
@@ -26,6 +26,10 @@ class IsVersioned(models.Model):
         abstract = True
 
     _len_stem_uid: int
+    # `uid` is a concrete CharField on every subclass; declared here (annotation only,
+    # so Django does not create a clashing field on this abstract base) so that the
+    # `stem_uid`/`version` helpers and type-checkers can resolve its type.
+    uid: str
 
     version_tag: str | None = CharField(max_length=30, null=True, db_index=True)
     """Version tag (default `None`).
@@ -179,6 +183,26 @@ def set_version(version: str | None = None, previous_version: str | None = None)
     return version
 
 
+def max_version_uid_in_family(record: IsVersioned) -> str | None:
+    """Return the uid with the maximum base62 version suffix in the version family.
+
+    The max is computed in Python via base62 decoding rather than ordering by `uid`
+    in the database: the version suffix is base62 (0-9 < A-Z < a-z), but locale-aware
+    db collations (e.g. Postgres `en_US.UTF-8`) sort letters case-insensitively, so
+    e.g. `...000Z` wrongly sorts after `...000a` and the chain can't grow past the
+    `Z -> a` boundary. Considering the whole family (not just `is_latest`, which is
+    per-branch and thus not globally unique, and excludes trashed records) guarantees
+    a derived new uid never collides with an existing one.
+    """
+    return max(
+        record.__class__.objects.filter(uid__startswith=record.stem_uid).values_list(
+            "uid", flat=True
+        ),
+        key=lambda uid: base62_to_int(uid[-4:]),
+        default=None,
+    )
+
+
 def create_uid(
     *,
     version_tag: str | None = None,
@@ -190,21 +214,12 @@ def create_uid(
     This is why it returns revises.
     """
     if revises is not None:
-        family_qs = revises.__class__.objects.filter(uid__startswith=revises.stem_uid)
-        # Pick the maximum version suffix over the whole family. We compute the max
-        # via base62 decoding in Python rather than ordering by `uid` in the database:
-        # the version suffix is base62 (0-9 < A-Z < a-z), but locale-aware DB
-        # collations (e.g. Postgres `en_US.UTF-8`) sort letters case-insensitively, so
-        # e.g. `...000Z` wrongly sorts after `...000a` and the chain can't grow past
-        # the `Z -> a` boundary. Considering the whole family (not just `is_latest`,
-        # which is per-branch and thus not globally unique, and excludes trashed
-        # records) guarantees the new uid never collides with an existing one.
-        latest_uid = max(
-            family_qs.values_list("uid", flat=True),
-            key=lambda uid: base62_to_int(uid[-4:]),
-            default=None,
+        latest_uid = max_version_uid_in_family(revises)
+        latest_in_family = (
+            None
+            if latest_uid is None
+            else revises.__class__.objects.get(uid=latest_uid)
         )
-        latest_in_family = None if latest_uid is None else family_qs.get(uid=latest_uid)
         if latest_in_family is not None and latest_in_family.uid != revises.uid:
             revises = latest_in_family
             logger.warning(

--- a/lamindb/models/_is_versioned.py
+++ b/lamindb/models/_is_versioned.py
@@ -208,25 +208,55 @@ def create_uid(
     version_tag: str | None = None,
     n_full_id: int = 20,
     revises: IsVersioned | None = None,
+    target_branch_id: int | None = None,
 ) -> tuple[str, IsVersioned | None]:
     """This also updates revises in case it's not the latest version.
 
     This is why it returns revises.
+
+    The new version suffix is always derived from the family-wide max (collation-independent,
+    so it never collides with heads on other branches or trashed records). The record returned
+    in `revises` -- which decides the record demoted on save -- is the current head:
+
+    - if `target_branch_id` is given (the branch the new record will be created on), the
+      `is_latest` head *on that branch*. `is_latest` is per-branch, so the family-wide max may
+      live on a different branch and must not be chained from / demoted across branches.
+    - otherwise, the family-wide max record (branch-agnostic legacy behavior).
     """
     if revises is not None:
-        latest_uid = max_version_uid_in_family(revises)
-        latest_in_family = (
-            None
-            if latest_uid is None
-            else revises.__class__.objects.get(uid=latest_uid)
+        # single query: pull the whole version family once, then derive everything in Python
+        # (most recent first so picking a branch head is deterministic).
+        family = sorted(
+            revises.__class__.objects.filter(uid__startswith=revises.stem_uid),
+            key=lambda record: record.created_at,
+            reverse=True,
         )
-        if latest_in_family is not None and latest_in_family.uid != revises.uid:
-            revises = latest_in_family
+        # family-wide max version suffix -> the new uid, so it never collides (base62 decoded
+        # in Python, independent of db collation; includes other-branch and trashed versions).
+        max_uid = max(
+            (record.uid for record in family),
+            key=lambda uid: base62_to_int(uid[-4:]),
+            default=revises.uid,
+        )
+        if target_branch_id is not None:
+            head = next(
+                (
+                    record
+                    for record in family
+                    if record.is_latest
+                    and getattr(record, "branch_id", None) == target_branch_id
+                ),
+                None,
+            )
+        else:
+            head = next((record for record in family if record.uid == max_uid), None)
+        if head is not None and head.uid != revises.uid:
+            revises = head
             logger.warning(
                 f"didn't pass the latest version in `revises`, retrieved it: {revises}"
             )
         suid = revises.stem_uid
-        vuid = increment_base62(revises.uid[-4:])  # type: ignore
+        vuid = increment_base62(max_uid[-4:])
     else:
         suid = uids.base62(n_full_id - 4)
         vuid = "0000"
@@ -249,11 +279,15 @@ def process_revises(
     key: str | None,
     description: str | None,
     type: type[IsVersioned],
+    target_branch_id: int | None = None,
 ) -> tuple[str, str, str, str, IsVersioned | None]:
     if revises is not None and not isinstance(revises, type):
         raise TypeError(f"`revises` has to be of type `{type.__name__}`")
     uid, revises = create_uid(
-        revises=revises, version_tag=version_tag, n_full_id=type._len_full_uid
+        revises=revises,
+        version_tag=version_tag,
+        n_full_id=type._len_full_uid,
+        target_branch_id=target_branch_id,
     )
     if revises is not None:
         if description is None:

--- a/lamindb/models/_is_versioned.py
+++ b/lamindb/models/_is_versioned.py
@@ -278,15 +278,15 @@ def process_revises(
     version_tag: str | None,
     key: str | None,
     description: str | None,
-    type: type[IsVersioned],
+    type_: type[IsVersioned],
     target_branch_id: int | None = None,
 ) -> tuple[str, str, str, str, IsVersioned | None]:
-    if revises is not None and not isinstance(revises, type):
-        raise TypeError(f"`revises` has to be of type `{type.__name__}`")
+    if revises is not None and not isinstance(revises, type_):
+        raise TypeError(f"`revises` has to be of type `{type_.__name__}`")
     uid, revises = create_uid(
         revises=revises,
         version_tag=version_tag,
-        n_full_id=type._len_full_uid,
+        n_full_id=type_._len_full_uid,
         target_branch_id=target_branch_id,
     )
     if revises is not None:

--- a/lamindb/models/_is_versioned.py
+++ b/lamindb/models/_is_versioned.py
@@ -51,7 +51,11 @@ class IsVersioned(models.Model):
         # consciously passed an old version: revise from the live head, like the inferred
         # case. This keeps the concurrent-demotion check (`revises` was the head at init
         # but got demoted before save -> raise) intact for genuinely explicit heads.
-        if self._revises is not None and not self._revises.is_latest:
+        if (
+            not self._refresh_revises_if_stale
+            and self._revises is not None
+            and not self._revises.is_latest
+        ):
             self._refresh_revises_if_stale = True
         super().__init__(*args, **kwargs)
 

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -353,6 +353,7 @@ def get_stat_or_artifact(
     instance: str | None = None,
     skip_hash_lookup: bool = False,
     skip_key_revises_lookup: bool = False,
+    target_branch_id: int | None = None,
 ) -> Union[tuple[int, str | None, str | None, int | None, Artifact | None], Artifact]:
     """Retrieves file statistics or an existing artifact based on the path, hash, and key."""
     n_files = None
@@ -447,7 +448,16 @@ def get_stat_or_artifact(
             logger.important(
                 f"creating new artifact version for key '{key}' in storage '{storage.root}'"
             )
-            previous_artifact_version = queryset_same_key.first()
+            # prefer the latest version on the branch this artifact will be created
+            # on (is_latest is per-branch, so a family can have several heads); fall
+            # back to the most recent head across branches.
+            previous_artifact_version = None
+            if target_branch_id is not None:
+                previous_artifact_version = queryset_same_key.filter(
+                    branch_id=target_branch_id
+                ).first()
+            if previous_artifact_version is None:
+                previous_artifact_version = queryset_same_key.first()
     if artifact_with_same_hash_exists:
         artifact_with_same_hash = queryset_same_hash.first()
         logger.important(
@@ -510,6 +520,7 @@ def get_artifact_kwargs_from_data(
     to_disk_kwargs: dict[str, Any] | None = None,
     key_is_virtual: bool | None = None,
     skip_key_revises_lookup: bool = False,
+    target_branch_id: int | None = None,
 ):
     memory_rep, path, suffix, storage, use_existing_storage_key = process_data(
         provisional_uid,
@@ -552,6 +563,7 @@ def get_artifact_kwargs_from_data(
         is_replace=is_replace,
         skip_hash_lookup=effective_skip_hash_lookup,
         skip_key_revises_lookup=skip_key_revises_lookup,
+        target_branch_id=target_branch_id,
     )
     if not isinstance(path, LocalPathClasses):
         local_filepath = None
@@ -1896,6 +1908,8 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
 
         provisional_uid, revises = create_uid(revises=revises, version_tag=version_tag)
         run = get_run(run)
+        from .sqlrecord import get_branch_id_for_create
+
         kwargs_or_artifact, privates = get_artifact_kwargs_from_data(
             data=path,
             key=key,
@@ -1911,6 +1925,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             to_disk_kwargs=to_disk_kwargs,
             key_is_virtual=_key_is_virtual,
             skip_key_revises_lookup=revises is not None,
+            target_branch_id=get_branch_id_for_create(branch),
         )
 
         def set_private_attributes():

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -596,7 +596,11 @@ def get_artifact_kwargs_from_data(
 
     # update local path
     if revises is not None:  # update provisional_uid
-        provisional_uid, revises = create_uid(revises=revises, version_tag=version_tag)
+        provisional_uid, revises = create_uid(
+            revises=revises,
+            version_tag=version_tag,
+            target_branch_id=target_branch_id,
+        )
         if settings.cache_dir in path.parents:
             path = path.rename(path.with_name(f"{provisional_uid}{suffix}"))
             privates["local_filepath"] = path
@@ -1906,9 +1910,17 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         if revises is not None and key is not None and revises.key != key:
             logger.warning(f"renaming artifact from '{revises.key}' to {key}")
 
-        provisional_uid, revises = create_uid(revises=revises, version_tag=version_tag)
-        run = get_run(run)
         from .sqlrecord import get_branch_id_for_create
+
+        # the branch the new artifact will be created on; scopes which family head is
+        # demoted (is_latest is per-branch) when chaining a new version.
+        target_branch_id = get_branch_id_for_create(branch)
+        provisional_uid, revises = create_uid(
+            revises=revises,
+            version_tag=version_tag,
+            target_branch_id=target_branch_id,
+        )
+        run = get_run(run)
 
         kwargs_or_artifact, privates = get_artifact_kwargs_from_data(
             data=path,
@@ -1925,7 +1937,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             to_disk_kwargs=to_disk_kwargs,
             key_is_virtual=_key_is_virtual,
             skip_key_revises_lookup=revises is not None,
-            target_branch_id=get_branch_id_for_create(branch),
+            target_branch_id=target_branch_id,
         )
 
         def set_private_attributes():
@@ -2000,7 +2012,11 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                 if revises is None:
                     uid += "0000"
                 else:
-                    uid, revises = create_uid(revises=revises, version_tag=version_tag)
+                    uid, revises = create_uid(
+                        revises=revises,
+                        version_tag=version_tag,
+                        target_branch_id=target_branch_id,
+                    )
             kwargs["uid"] = uid
 
         # only set key now so that we don't perform a look-up on it in case revises is passed

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1827,8 +1827,16 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         run: Run | None | bool = _sqlrecord_or_id(
             Run, kwargs.pop("run", None), kwargs.pop("run_id", None), check_type=False
         )
-        branch: Branch | None = _sqlrecord_or_id(
-            Branch, kwargs.pop("branch", None), kwargs.pop("branch_id", None)
+        from .sqlrecord import get_current_branch
+
+        # resolve the creation branch once (defaulting to the current branch) so the
+        # inferred `revises` lookup and the record's actual branch_id can't diverge
+        # (is_latest is per-branch, so the demoted head must be on this exact branch).
+        branch: Branch = (
+            _sqlrecord_or_id(
+                Branch, kwargs.pop("branch", None), kwargs.pop("branch_id", None)
+            )
+            or get_current_branch()
         )
         space: Space | None = _sqlrecord_or_id(
             Space, kwargs.pop("space", None), kwargs.pop("space_id", None)
@@ -1906,14 +1914,8 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         if revises is not None and key is not None and revises.key != key:
             logger.warning(f"renaming artifact from '{revises.key}' to {key}")
 
-        from .sqlrecord import get_branch_id_for_create
-
-        # the branch the new artifact will be created on; used to scope the inferred
-        # `revises` lookup to this branch's head (is_latest is per-branch).
-        target_branch_id = get_branch_id_for_create(branch)
         provisional_uid = create_uid(revises=revises, version_tag=version_tag)
         run = get_run(run)
-
         kwargs_or_artifact, privates = get_artifact_kwargs_from_data(
             data=path,
             key=key,
@@ -1929,7 +1931,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             to_disk_kwargs=to_disk_kwargs,
             key_is_virtual=_key_is_virtual,
             skip_key_revises_lookup=revises is not None,
-            target_branch_id=target_branch_id,
+            target_branch_id=branch.id,
         )
 
         def set_private_attributes():

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -596,11 +596,7 @@ def get_artifact_kwargs_from_data(
 
     # update local path
     if revises is not None:  # update provisional_uid
-        provisional_uid, revises = create_uid(
-            revises=revises,
-            version_tag=version_tag,
-            target_branch_id=target_branch_id,
-        )
+        provisional_uid = create_uid(revises=revises, version_tag=version_tag)
         if settings.cache_dir in path.parents:
             path = path.rename(path.with_name(f"{provisional_uid}{suffix}"))
             privates["local_filepath"] = path
@@ -1131,7 +1127,7 @@ class LazyArtifact:
                 "The suffix argument and the suffix of key should be the same."
             )
 
-        uid, _ = create_uid(n_full_id=20)
+        uid = create_uid(n_full_id=20)
         storage_key = _s().auto_storage_key_from_artifact_uid(
             uid, suffix, overwrite_versions=overwrite_versions
         )
@@ -1912,14 +1908,10 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
 
         from .sqlrecord import get_branch_id_for_create
 
-        # the branch the new artifact will be created on; scopes which family head is
-        # demoted (is_latest is per-branch) when chaining a new version.
+        # the branch the new artifact will be created on; used to scope the inferred
+        # `revises` lookup to this branch's head (is_latest is per-branch).
         target_branch_id = get_branch_id_for_create(branch)
-        provisional_uid, revises = create_uid(
-            revises=revises,
-            version_tag=version_tag,
-            target_branch_id=target_branch_id,
-        )
+        provisional_uid = create_uid(revises=revises, version_tag=version_tag)
         run = get_run(run)
 
         kwargs_or_artifact, privates = get_artifact_kwargs_from_data(
@@ -2012,11 +2004,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                 if revises is None:
                     uid += "0000"
                 else:
-                    uid, revises = create_uid(
-                        revises=revises,
-                        version_tag=version_tag,
-                        target_branch_id=target_branch_id,
-                    )
+                    uid = create_uid(revises=revises, version_tag=version_tag)
             kwargs["uid"] = uid
 
         # only set key now so that we don't perform a look-up on it in case revises is passed

--- a/lamindb/models/block.py
+++ b/lamindb/models/block.py
@@ -102,7 +102,7 @@ def _init_versioned_attached_block(
             raise ValueError(
                 "revises is not allowed for kind='comment'; comments are not versioned"
             )
-        new_uid, _ = create_uid(
+        new_uid = create_uid(
             revises=None,
             version_tag=version_tag,
             n_full_id=cls._len_full_uid,
@@ -144,7 +144,7 @@ def _init_versioned_attached_block(
         init_self_from_db(self, revises)
         update_attributes(self, {})
         return None
-    new_uid, revises = create_uid(
+    new_uid = create_uid(
         revises=revises,
         version_tag=version_tag,
         n_full_id=cls._len_full_uid,
@@ -324,7 +324,7 @@ class Block(BaseBlock, SQLRecord):
             return None
         if revises is not None and key is not None and revises.key != key:
             logger.important(f"renaming block {revises.key} to {key}")
-        new_uid, version_tag, key, _, revises = process_revises(
+        new_uid, version_tag, key, _ = process_revises(
             revises, version_tag, key, None, Block
         )
         if uid is None:

--- a/lamindb/models/collection.py
+++ b/lamindb/models/collection.py
@@ -272,7 +272,7 @@ class Collection(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                 .order_by("-created_at")
                 .first()
             )
-        provisional_uid, version_tag, key, description, revises = process_revises(
+        provisional_uid, version_tag, key, description = process_revises(
             revises, version_tag, key, description, Collection
         )
         run = get_run(run)

--- a/lamindb/models/query_set.py
+++ b/lamindb/models/query_set.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Generic, NamedTuple, TypeVar, final
 
 import lamindb_setup as ln_setup
 from django.core.exceptions import FieldError
-from django.db import models
+from django.db import models, transaction
 from django.db.models import (
     F,
     FilteredRelation,
@@ -1338,8 +1338,11 @@ class BasicQuerySet(models.QuerySet):
                 _permanent_delete_transforms(self)
                 return
             if permanent is not True:
-                _adjust_is_latest_when_deleting_is_versioned(self)
-                self.update(branch_id=-1, is_latest=False)
+                # promote successors and trash the records atomically, so a failure can't
+                # leave both the successor and the (un-trashed) old head as is_latest
+                with transaction.atomic():
+                    _adjust_is_latest_when_deleting_is_versioned(self)
+                    self.update(branch_id=-1, is_latest=False)
                 return
         # Artifact, Collection: non-trivial delete behavior, handle in a loop
         if self.model in {Artifact, Collection}:

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1328,41 +1328,39 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                     has_branch_id = hasattr(revises, "branch_id") and hasattr(
                         self, "branch_id"
                     )
-                    refresh = getattr(self, "_refresh_revises_if_stale", False)
+                    # `revises` is refreshed when it was inferred or was already a previous
+                    # version at init (see `IsVersioned.__init__`); an explicit head that
+                    # gets demoted concurrently before save instead raises below.
+                    refresh = self._refresh_revises_if_stale
                     with transaction.atomic():
                         # A new version becomes the latest on its *creation* branch, so the
-                        # record it supersedes is the current head on that branch -- not
-                        # necessarily `revises`, which may live on another branch and only
-                        # carries lineage/metadata (is_latest is per-branch, so heads on other
-                        # branches stay intact). For non-branch-aware models, `revises` itself
-                        # is the head to demote.
+                        # record it supersedes is the current family head -- not necessarily
+                        # `revises`, which may be a previous version or live on another
+                        # branch and only carry lineage/metadata. For branch-aware models
+                        # is_latest is per-branch, so a family can have several heads and we
+                        # only demote the head on this record's creation branch.
+                        head_qs = self.__class__.objects.filter(
+                            uid__startswith=self.stem_uid, is_latest=True
+                        )
                         if has_branch_id:
-                            demote_target = (
-                                self.__class__.objects.filter(
-                                    uid__startswith=self.stem_uid,
-                                    is_latest=True,
-                                    branch_id=self.branch_id,
-                                )
-                                .order_by("-created_at", "-id")
-                                .first()
+                            head_qs = head_qs.filter(branch_id=self.branch_id)
+                        demote_target = head_qs.order_by("-created_at", "-id").first()
+                        head_advanced = (
+                            demote_target is not None
+                            and demote_target.uid != revises.uid
+                        )
+                        if refresh and head_advanced:
+                            # the live branch head differs from `revises` (a previous version
+                            # or a concurrently-created head): revise from it and re-derive a
+                            # collision-free uid from the current family max (independent of
+                            # db collation, never colliding with a concurrently-created head).
+                            self._revises = revises = demote_target
+                            self.uid = self.stem_uid + increment_base62(
+                                max_version_uid_in_family(demote_target)[-4:]
                             )
-                        else:
-                            demote_target = revises
-                        if has_branch_id and refresh:
-                            # inferred `revises`: the live branch head is authoritative. If it
-                            # advanced since init (concurrent write), re-point to it and
-                            # re-derive a collision-free uid from the current family max.
-                            if (
-                                demote_target is not None
-                                and demote_target.uid != revises.uid
-                            ):
-                                self._revises = demote_target
-                                self.uid = self.stem_uid + increment_base62(
-                                    max_version_uid_in_family(demote_target)[-4:]
-                                )
-                        else:
-                            # explicit `revises` (or non-branch-aware): it must still be a
-                            # current head, else the caller passed a stale (superseded) version.
+                        elif not refresh:
+                            # explicitly-passed `revises` that *was* a head at init: it must
+                            # still be one, else a newer revision was created concurrently.
                             revises.refresh_from_db(fields=["is_latest"])
                             if not revises.is_latest:
                                 raise LaminIntegrityError(
@@ -1373,10 +1371,10 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                                     "or an older record was selected for `revises`."
                                 )
                         if demote_target is not None:
-                            # if the head we demote is the very object the caller
-                            # passed as `revises`, demote that in-memory object so
-                            # the caller observes is_latest=False without a refresh
-                            if revises is not None and demote_target.pk == revises.pk:
+                            # if the head we demote is the very object the caller passed as
+                            # `revises`, demote that in-memory object so the caller observes
+                            # is_latest=False without a refresh
+                            if demote_target.pk == revises.pk:
                                 demote_target = revises
                             demote_target.is_latest = False
                             demote_target._revises = None  # avoid recursion

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -43,6 +43,7 @@ from django.db.models.fields.related import (
 )
 from django.db.models.functions import Lower
 from lamin_utils import colors, logger
+from lamin_utils._base62 import increment_base62
 from lamindb_setup import settings as setup_settings
 from lamindb_setup._connect_instance import (
     INSTANCE_NOT_FOUND_MESSAGE,
@@ -84,7 +85,11 @@ from ..errors import (
 from ..errors import (
     IntegrityError as LaminIntegrityError,
 )
-from ._is_versioned import IsVersioned, _adjust_is_latest_when_deleting_is_versioned
+from ._is_versioned import (
+    IsVersioned,
+    _adjust_is_latest_when_deleting_is_versioned,
+    max_version_uid_in_family,
+)
 from .query_manager import QueryManager, _lookup, _search
 
 if TYPE_CHECKING:
@@ -1332,10 +1337,27 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                         if should_demote:
                             revises.refresh_from_db(fields=["is_latest"])
                             if getattr(self, "_refresh_revises_if_stale", False):
-                                revises = _pull_latest_version_if_stale(
+                                refreshed = _pull_latest_version_if_stale(
                                     revises, self.branch_id if has_branch_id else None
                                 )
-                                self._revises = revises
+                                if refreshed is not revises:
+                                    # `revises` went stale: a newer version was
+                                    # created concurrently after this record was
+                                    # initialized. The demotion target changes to the
+                                    # current branch head, and the uid computed at
+                                    # init would now collide, so re-derive it from the
+                                    # current family max. We increment directly
+                                    # (base62, collation-independent) rather than via
+                                    # create_uid, which would emit a misleading
+                                    # warning when the head differs from the max-uid
+                                    # record. When `revises` is not stale, the uid set
+                                    # at init is already correct, so we leave it.
+                                    revises = refreshed
+                                    self._revises = revises
+                                    max_uid = max_version_uid_in_family(revises)
+                                    self.uid = revises.stem_uid + increment_base62(
+                                        max_uid[-4:]
+                                    )
                             if not revises.is_latest:
                                 raise LaminIntegrityError(
                                     "Cannot revise a non-latest record: "

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1363,6 +1363,10 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                                 self.uid = self.stem_uid + increment_base62(
                                     max_version_uid_in_family(demote_target)[-4:]
                                 )
+                                logger.warning(
+                                    "`revises` was not the latest version, "
+                                    f"updated it to the current head: {revises}"
+                                )
                         else:
                             # explicitly-passed `revises` that *was* a head at init: it must
                             # still be one, else a newer revision was created concurrently.

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -668,13 +668,16 @@ def delete_record(record: BaseSQLRecord, is_soft: bool = True):
         and record.is_latest
         and not getattr(record, "_overwrite_versions", False)
     ):
-        promoted = _adjust_is_latest_when_deleting_is_versioned(record)
-        if promoted:
-            if is_soft:
-                record.is_latest = False
-            with transaction.atomic():
-                result = delete()
-            return result
+        # promote a successor and delete the record atomically, so a failure can't leave
+        # both the successor and the (un-deleted) old head as is_latest
+        with transaction.atomic():
+            promoted = _adjust_is_latest_when_deleting_is_versioned(record)
+            if promoted:
+                if is_soft:
+                    record.is_latest = False
+                # evaluates, then returns, no exit from the transaction
+                return delete()
+        # nothing to promote (e.g. last remaining version): fall through to a plain delete
     # deal with all other cases of the nested if condition now
     return delete()
 

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -592,6 +592,35 @@ def pop_space_branch_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def get_current_branch() -> Branch:
+    """The branch a new record defaults to: run/context branch, else settings branch.
+
+    `setup_settings.branch` always resolves to a `Branch` (or a main-branch mock when
+    no instance is set up), so this never returns `None`.
+    """
+    from lamindb import context as run_context
+
+    if run_context.branch is not None:
+        return run_context.branch
+    return setup_settings.branch
+
+
+def get_branch_id_for_create(
+    branch: Branch | None = None, branch_id: int | None = None
+) -> int:
+    """Resolve the branch id a newly created record will be assigned.
+
+    Mirrors the branch defaulting in `SQLRecord.save`: an explicitly passed branch
+    wins, otherwise the current run/context branch, otherwise the settings branch.
+    Used to prefer the in-branch latest version when inferring `revises`.
+    """
+    if branch is not None:
+        return branch.id
+    if branch_id is not None:
+        return branch_id
+    return get_current_branch().id
+
+
 def suggest_records_with_similar_names(
     record: SQLRecord, name_field: str, kwargs
 ) -> SQLRecord | None:
@@ -1148,23 +1177,11 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                         elif kwargs.get("space") is None:
                             kwargs.pop("space", None)
                 if _is_branch_sensitive_model(self.__class__):
-                    from lamindb import context as run_context
-
-                    has_explicit_branch = resolve_fk_or_id("branch")
-                    if run_context.branch is not None:
-                        current_branch = run_context.branch
-                    elif setup_settings.branch is not None:
-                        current_branch = setup_settings.branch
-                    else:
-                        current_branch = None
-
-                    if not has_explicit_branch:
-                        if current_branch is not None:
-                            kwargs["branch"] = current_branch
-                        elif kwargs.get("branch") is None:
-                            kwargs.pop("branch", None)
-                    if "branch" in kwargs and kwargs["branch"] is not None:
-                        kwargs["created_on"] = kwargs["branch"]
+                    if not resolve_fk_or_id("branch"):
+                        kwargs["branch"] = get_current_branch()
+                    # `kwargs["branch"]` is now always a non-None Branch (explicit or
+                    # the current one), so the record is created on that branch.
+                    kwargs["created_on"] = kwargs["branch"]
             if skip_validation:
                 super().__init__(**kwargs)
             else:

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1332,33 +1332,38 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                     # version at init (see `IsVersioned.__init__`); an explicit head that
                     # gets demoted concurrently before save instead raises below.
                     refresh = self._refresh_revises_if_stale
+                    # the new version supersedes the current head on its *creation* branch.
+                    # That head is `revises` itself when it's an in-branch head; otherwise --
+                    # inferred / a previous version (`refresh`), or a head on another branch
+                    # (is_latest is per-branch) -- we look it up. Same-branch explicit heads
+                    # (the common case) thus skip this query.
+                    cross_branch = has_branch_id and revises.branch_id != self.branch_id
                     with transaction.atomic():
-                        # A new version becomes the latest on its *creation* branch, so the
-                        # record it supersedes is the current family head -- not necessarily
-                        # `revises`, which may be a previous version or live on another
-                        # branch and only carry lineage/metadata. For branch-aware models
-                        # is_latest is per-branch, so a family can have several heads and we
-                        # only demote the head on this record's creation branch.
-                        head_qs = self.__class__.objects.filter(
-                            uid__startswith=self.stem_uid, is_latest=True
-                        )
-                        if has_branch_id:
-                            head_qs = head_qs.filter(branch_id=self.branch_id)
-                        demote_target = head_qs.order_by("-created_at", "-id").first()
-                        head_advanced = (
-                            demote_target is not None
-                            and demote_target.uid != revises.uid
-                        )
-                        if refresh and head_advanced:
-                            # the live branch head differs from `revises` (a previous version
-                            # or a concurrently-created head): revise from it and re-derive a
-                            # collision-free uid from the current family max (independent of
-                            # db collation, never colliding with a concurrently-created head).
-                            self._revises = revises = demote_target
-                            self.uid = self.stem_uid + increment_base62(
-                                max_version_uid_in_family(demote_target)[-4:]
+                        if refresh or cross_branch:
+                            head_qs = self.__class__.objects.filter(
+                                uid__startswith=self.stem_uid, is_latest=True
                             )
-                        elif not refresh:
+                            if has_branch_id:
+                                head_qs = head_qs.filter(branch_id=self.branch_id)
+                            demote_target = head_qs.order_by(
+                                "-created_at", "-id"
+                            ).first()
+                        else:
+                            demote_target = revises
+                        if refresh:
+                            # revise from the live branch head; if it differs from `revises`
+                            # (a previous version, or a concurrently-created head) re-derive a
+                            # collision-free uid from the current family max (independent of db
+                            # collation, never colliding with a concurrently-created head).
+                            if (
+                                demote_target is not None
+                                and demote_target.uid != revises.uid
+                            ):
+                                self._revises = revises = demote_target
+                                self.uid = self.stem_uid + increment_base62(
+                                    max_version_uid_in_family(demote_target)[-4:]
+                                )
+                        else:
                             # explicitly-passed `revises` that *was* a head at init: it must
                             # still be one, else a newer revision was created concurrently.
                             revises.refresh_from_db(fields=["is_latest"])

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -148,22 +148,6 @@ def _format_versioned_record(record: IsVersioned) -> str:
     return f"{class_name}({', '.join(details)})"
 
 
-def _pull_latest_version_if_stale(
-    record: IsVersioned, branch_id: int | None = None
-) -> IsVersioned:
-    if not record.is_latest:
-        latest_version_qs = record.__class__.objects.filter(
-            uid__startswith=record.stem_uid,
-            is_latest=True,
-        )
-        if branch_id is not None:
-            latest_version_qs = latest_version_qs.filter(branch_id=branch_id)
-        latest_version = latest_version_qs.order_by("-created_at", "-id").first()
-        if latest_version is not None:
-            return latest_version
-    return record
-
-
 # -------------------------------------------------------------------------------------
 # A note on required fields at the SQLRecord level
 #
@@ -1341,40 +1325,45 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                 # save versioned record in presence of self._revises
                 if isinstance(self, IsVersioned) and self._revises is not None:
                     revises = self._revises
-                    # For branch-aware models (SQLRecord), keep source-branch latest
-                    # intact and only demote within the same branch. For other
-                    # versioned models (e.g. blocks), keep previous behavior.
-                    should_demote = True
                     has_branch_id = hasattr(revises, "branch_id") and hasattr(
                         self, "branch_id"
                     )
-                    if has_branch_id:
-                        should_demote = revises.branch_id == self.branch_id
+                    refresh = getattr(self, "_refresh_revises_if_stale", False)
                     with transaction.atomic():
-                        if should_demote:
-                            revises.refresh_from_db(fields=["is_latest"])
-                            if getattr(self, "_refresh_revises_if_stale", False):
-                                refreshed = _pull_latest_version_if_stale(
-                                    revises, self.branch_id if has_branch_id else None
+                        # A new version becomes the latest on its *creation* branch, so the
+                        # record it supersedes is the current head on that branch -- not
+                        # necessarily `revises`, which may live on another branch and only
+                        # carries lineage/metadata (is_latest is per-branch, so heads on other
+                        # branches stay intact). For non-branch-aware models, `revises` itself
+                        # is the head to demote.
+                        if has_branch_id:
+                            demote_target = (
+                                self.__class__.objects.filter(
+                                    uid__startswith=self.stem_uid,
+                                    is_latest=True,
+                                    branch_id=self.branch_id,
                                 )
-                                if refreshed is not revises:
-                                    # `revises` went stale: a newer version was
-                                    # created concurrently after this record was
-                                    # initialized. The demotion target changes to the
-                                    # current branch head, and the uid computed at
-                                    # init would now collide, so re-derive it from the
-                                    # current family max. We increment directly
-                                    # (base62, collation-independent) rather than via
-                                    # create_uid, which would emit a misleading
-                                    # warning when the head differs from the max-uid
-                                    # record. When `revises` is not stale, the uid set
-                                    # at init is already correct, so we leave it.
-                                    revises = refreshed
-                                    self._revises = revises
-                                    max_uid = max_version_uid_in_family(revises)
-                                    self.uid = revises.stem_uid + increment_base62(
-                                        max_uid[-4:]
-                                    )
+                                .order_by("-created_at", "-id")
+                                .first()
+                            )
+                        else:
+                            demote_target = revises
+                        if has_branch_id and refresh:
+                            # inferred `revises`: the live branch head is authoritative. If it
+                            # advanced since init (concurrent write), re-point to it and
+                            # re-derive a collision-free uid from the current family max.
+                            if (
+                                demote_target is not None
+                                and demote_target.uid != revises.uid
+                            ):
+                                self._revises = demote_target
+                                self.uid = self.stem_uid + increment_base62(
+                                    max_version_uid_in_family(demote_target)[-4:]
+                                )
+                        else:
+                            # explicit `revises` (or non-branch-aware): it must still be a
+                            # current head, else the caller passed a stale (superseded) version.
+                            revises.refresh_from_db(fields=["is_latest"])
                             if not revises.is_latest:
                                 raise LaminIntegrityError(
                                     "Cannot revise a non-latest record: "
@@ -1383,9 +1372,10 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                                     "This usually means a newer revision was created concurrently "
                                     "or an older record was selected for `revises`."
                                 )
-                            revises.is_latest = False
-                            revises._revises = None  # ensure we don't start a recursion
-                            revises.save()
+                        if demote_target is not None:
+                            demote_target.is_latest = False
+                            demote_target._revises = None  # avoid recursion
+                            demote_target.save()
                         super().save(*args, **kwargs)  # type: ignore
                     self._revises = None
                 # save unversioned record

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1373,6 +1373,11 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                                     "or an older record was selected for `revises`."
                                 )
                         if demote_target is not None:
+                            # if the head we demote is the very object the caller
+                            # passed as `revises`, demote that in-memory object so
+                            # the caller observes is_latest=False without a refresh
+                            if revises is not None and demote_target.pk == revises.pk:
+                                demote_target = revises
                             demote_target.is_latest = False
                             demote_target._revises = None  # avoid recursion
                             demote_target.save()

--- a/lamindb/models/transform.py
+++ b/lamindb/models/transform.py
@@ -286,6 +286,14 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
                 "Only key, description, version, kind, type, revises, reference, "
                 f"reference_type can be passed, but you passed: {kwargs}"
             )
+        from .sqlrecord import get_branch_id_for_create
+
+        # the branch the new transform will be created on; used both to infer `revises`
+        # and to scope which family head is demoted (is_latest is per-branch).
+        target_branch_id = get_branch_id_for_create(
+            space_branch_kwargs.get("branch"),
+            space_branch_kwargs.get("branch_id"),
+        )
         if revises is None:
             # need to check uid before checking key
             if uid is not None:
@@ -296,8 +304,6 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
                     .first()
                 )
             elif key is not None:
-                from .sqlrecord import get_branch_id_for_create
-
                 candidates_for_revises = (
                     Transform.objects.using(using_key)
                     .filter(~Q(branch_id=-1), key=key, is_latest=True)
@@ -306,10 +312,6 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
                 # prefer the latest version on the branch this transform will be
                 # created on (is_latest is per-branch, so a family can have several
                 # heads); fall back to the most recent head across branches.
-                target_branch_id = get_branch_id_for_create(
-                    space_branch_kwargs.get("branch"),
-                    space_branch_kwargs.get("branch_id"),
-                )
                 candidate_for_revises = (
                     candidates_for_revises.filter(branch_id=target_branch_id).first()
                     or candidates_for_revises.first()
@@ -331,7 +333,7 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
         if revises is not None and key is not None and revises.key != key:
             logger.important(f"renaming transform {revises.key} to {key}")
         new_uid, version_tag, key, description, revises = process_revises(
-            revises, version_tag, key, description, Transform
+            revises, version_tag, key, description, Transform, target_branch_id
         )
         # this is only because the user-facing constructor allows passing a uid
         # most others don't

--- a/lamindb/models/transform.py
+++ b/lamindb/models/transform.py
@@ -332,8 +332,8 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
             return None
         if revises is not None and key is not None and revises.key != key:
             logger.important(f"renaming transform {revises.key} to {key}")
-        new_uid, version_tag, key, description, revises = process_revises(
-            revises, version_tag, key, description, Transform, target_branch_id
+        new_uid, version_tag, key, description = process_revises(
+            revises, version_tag, key, description, Transform
         )
         # this is only because the user-facing constructor allows passing a uid
         # most others don't

--- a/lamindb/models/transform.py
+++ b/lamindb/models/transform.py
@@ -296,11 +296,23 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
                     .first()
                 )
             elif key is not None:
-                candidate_for_revises = (
+                from .sqlrecord import get_branch_id_for_create
+
+                candidates_for_revises = (
                     Transform.objects.using(using_key)
                     .filter(~Q(branch_id=-1), key=key, is_latest=True)
                     .order_by("-created_at")
-                    .first()
+                )
+                # prefer the latest version on the branch this transform will be
+                # created on (is_latest is per-branch, so a family can have several
+                # heads); fall back to the most recent head across branches.
+                target_branch_id = get_branch_id_for_create(
+                    space_branch_kwargs.get("branch"),
+                    space_branch_kwargs.get("branch_id"),
+                )
+                candidate_for_revises = (
+                    candidates_for_revises.filter(branch_id=target_branch_id).first()
+                    or candidates_for_revises.first()
                 )
                 if candidate_for_revises is not None:
                     revises = candidate_for_revises

--- a/lamindb/models/transform.py
+++ b/lamindb/models/transform.py
@@ -286,14 +286,16 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
                 "Only key, description, version, kind, type, revises, reference, "
                 f"reference_type can be passed, but you passed: {kwargs}"
             )
-        from .sqlrecord import get_branch_id_for_create
+        from .sqlrecord import get_branch_id_for_create, get_current_branch
 
-        # the branch the new transform will be created on; used both to infer `revises`
-        # and to scope which family head is demoted (is_latest is per-branch).
-        target_branch_id = get_branch_id_for_create(
-            space_branch_kwargs.get("branch"),
-            space_branch_kwargs.get("branch_id"),
-        )
+        # resolve the creation branch once and pin it into kwargs, so the inferred
+        # `revises` lookup and the record's actual branch_id can't diverge (is_latest
+        # is per-branch, so the demoted head must be on this exact branch).
+        branch = space_branch_kwargs.get("branch")
+        branch_id = space_branch_kwargs.get("branch_id")
+        if branch is None and branch_id is None:
+            space_branch_kwargs["branch"] = branch = get_current_branch()
+        target_branch_id = get_branch_id_for_create(branch, branch_id)
         if revises is None:
             # need to check uid before checking key
             if uid is not None:

--- a/tests/core/test_is_versioned.py
+++ b/tests/core/test_is_versioned.py
@@ -522,6 +522,74 @@ def test_inferred_revises_prefers_target_branch_head():
         branch.delete(permanent=True)
 
 
+def test_inferred_revises_prefers_target_branch_head_artifact():
+    main_branch = ln.Branch.get(name="main")
+    ln.setup.switch(main_branch.name)
+    branch = ln.Branch(name="test_inferred_revises_branch_artifact").save()
+    key = "inferred-revises-branch-aware-artifact.parquet"
+    artifact_main_v1 = ln.Artifact.from_dataframe(
+        pd.DataFrame({"inferred_feat": [20, 21]}),
+        key=key,
+        description="main-v1",
+    ).save()
+    # sanity check: `switch` must actually steer the creation branch, otherwise the
+    # rest of the test (which relies on heads living on distinct branches) is moot.
+    assert artifact_main_v1.branch_id == main_branch.id
+    try:
+        # create a *more recently* created head on another branch for the same key;
+        # with no explicit `revises` it infers the family head (here only main's) and
+        # joins the family on the contribution branch, leaving main's head intact.
+        ln.setup.switch(branch.name)
+        artifact_branch = ln.Artifact.from_dataframe(
+            pd.DataFrame({"inferred_feat": [22, 23]}),
+            key=key,
+            description="branch-v1",
+        ).save()
+        assert artifact_branch.branch_id == branch.id
+        assert artifact_branch.is_latest
+        assert artifact_branch.stem_uid == artifact_main_v1.stem_uid
+        artifact_main_v1.refresh_from_db()
+        # main head is preserved (cross-branch revision does not demote it)
+        assert artifact_main_v1.is_latest
+
+        # back on main, infer revises (no explicit `revises`). Even though the other
+        # branch's head was created more recently, the inferred revises must be the
+        # head on the *target* (main) branch.
+        ln.setup.switch(main_branch.name)
+        artifact_main_v2 = ln.Artifact.from_dataframe(
+            pd.DataFrame({"inferred_feat": [24, 25]}),
+            key=key,
+            description="main-v2",
+        )
+        # the record-to-be must target main, so the inferred revises is scoped to main
+        assert artifact_main_v2.branch_id == main_branch.id
+        assert artifact_main_v2._revises is not None
+        assert artifact_main_v2._revises.uid == artifact_main_v1.uid
+        artifact_main_v2.save()
+
+        artifact_main_v1.refresh_from_db()
+        artifact_branch.refresh_from_db()
+        assert artifact_main_v2.branch_id == main_branch.id
+        assert artifact_main_v2.is_latest
+        # the main head was demoted, the other branch's head is untouched
+        assert not artifact_main_v1.is_latest
+        assert artifact_branch.is_latest
+        # exactly one latest on main for this family (no double head)
+        main_latest = ln.Artifact.objects.filter(
+            uid__startswith=artifact_main_v2.stem_uid,
+            branch_id=main_branch.id,
+            is_latest=True,
+        )
+        assert main_latest.count() == 1
+    finally:
+        ln.setup.switch(main_branch.name)
+        for record in ln.Artifact.objects.filter(
+            uid__startswith=artifact_main_v1.stem_uid
+        ):
+            record.delete(permanent=True)
+        branch.delete(permanent=True)
+
+
 def test_path_rename():
     # this is related to renames inside _add_to_version_family
     with open("test_new_path.txt", "w") as f:

--- a/tests/core/test_is_versioned.py
+++ b/tests/core/test_is_versioned.py
@@ -590,6 +590,60 @@ def test_inferred_revises_prefers_target_branch_head_artifact():
         branch.delete(permanent=True)
 
 
+def test_soft_delete_promotes_within_branch():
+    main_branch = ln.Branch.get(name="main")
+    ln.setup.switch(main_branch.name)
+    branch = ln.Branch(name="test_soft_delete_within_branch").save()
+    key = "soft-delete-branch-aware.parquet"
+    # a version family with two versions on the contribution branch
+    ln.setup.switch(branch.name)
+    artifact_b1 = ln.Artifact.from_dataframe(
+        pd.DataFrame({"sd_feat": [1, 2]}), key=key, description="b1"
+    ).save()
+    artifact_b2 = ln.Artifact.from_dataframe(
+        pd.DataFrame({"sd_feat": [3, 4]}), revises=artifact_b1, description="b2"
+    ).save()
+    artifact_b1.refresh_from_db()
+    assert not artifact_b1.is_latest
+    assert artifact_b2.is_latest
+    try:
+        # a *more recently* created head on main for the same family
+        ln.setup.switch(main_branch.name)
+        artifact_main = ln.Artifact.from_dataframe(
+            pd.DataFrame({"sd_feat": [5, 6]}), revises=artifact_b1, description="main"
+        ).save()
+        assert artifact_main.branch_id == main_branch.id
+        assert artifact_main.is_latest
+        artifact_b2.refresh_from_db()
+        # cross-branch revise leaves the contribution branch's head intact
+        assert artifact_b2.is_latest
+
+        # soft-delete the branch head: the next version *on the branch* must be
+        # promoted, not main's (more recently created) head.
+        ln.setup.switch(branch.name)
+        artifact_b2.delete()
+        artifact_b1.refresh_from_db()
+        artifact_main.refresh_from_db()
+        assert artifact_b1.is_latest  # promoted within the branch
+        assert artifact_b1.branch_id == branch.id
+        assert artifact_main.is_latest  # main head untouched
+        # exactly one latest per branch for this family (no headless branch, no double head)
+        for branch_id in (branch.id, main_branch.id):
+            assert (
+                ln.Artifact.objects.filter(
+                    uid__startswith=artifact_b1.stem_uid,
+                    branch_id=branch_id,
+                    is_latest=True,
+                ).count()
+                == 1
+            )
+    finally:
+        ln.setup.switch(main_branch.name)
+        for record in ln.Artifact.objects.filter(uid__startswith=artifact_b1.stem_uid):
+            record.delete(permanent=True)
+        branch.delete(permanent=True)
+
+
 def test_path_rename():
     # this is related to renames inside _add_to_version_family
     with open("test_new_path.txt", "w") as f:

--- a/tests/core/test_is_versioned.py
+++ b/tests/core/test_is_versioned.py
@@ -5,6 +5,7 @@ from lamindb.errors import IntegrityError
 from lamindb.models._is_versioned import (
     _adjust_is_latest_when_deleting_is_versioned,
     bump_version,
+    max_version_uid_in_family,
     set_version,
 )
 
@@ -357,6 +358,56 @@ def test_inferred_revises_handles_concurrent_new_version():
         assert not transform_concurrent.is_latest
     finally:
         for record in ln.Transform.filter(uid__startswith=transform_v1.stem_uid):
+            record.delete(permanent=True)
+
+
+def test_version_chain_crosses_base62_case_boundary():
+    # base62 increments digits -> uppercase -> lowercase, so the version-suffix chain
+    # crosses ...000Z -> ...000a -> ...000b. This must hold regardless of the database
+    # collation: locale-aware collations (e.g. Postgres `en_US.UTF-8`) sort the letter
+    # `Z` after `a`, which previously made the chain stall at the Z -> a boundary
+    # (`...000Z` kept being selected as the latest, regenerating `...000a` forever).
+    transform_v1 = ln.Transform(
+        key="version-chain-z-to-a",
+        source_code="v1",
+        kind="pipeline",
+    ).save()
+    stem_uid = transform_v1.stem_uid
+    try:
+        # fast-forward the version suffix to ...000Z without creating 35 versions
+        ln.Transform.filter(id=transform_v1.id).update(uid=stem_uid + "000Z")
+        transform_v1 = ln.Transform.get(id=transform_v1.id)
+        assert transform_v1.uid.endswith("000Z")
+        assert transform_v1.is_latest
+
+        # crossing the Z -> a boundary
+        transform_v2 = ln.Transform(
+            key="version-chain-z-to-a",
+            revises=transform_v1,
+            source_code="v2",
+            kind="pipeline",
+        ).save()
+        assert transform_v2.uid.endswith("000a")
+
+        # the family now holds both ...000Z and ...000a; the max must be ...000a
+        # (base62), not ...000Z (locale collation) -- assert the selector directly.
+        assert max_version_uid_in_family(transform_v2).endswith("000a")
+
+        # so the next version is ...000b rather than colliding back on ...000a
+        transform_v3 = ln.Transform(
+            key="version-chain-z-to-a",
+            revises=transform_v2,
+            source_code="v3",
+            kind="pipeline",
+        ).save()
+        assert transform_v3.uid.endswith("000b")
+        assert transform_v3.is_latest
+        transform_v1.refresh_from_db()
+        transform_v2.refresh_from_db()
+        assert not transform_v1.is_latest
+        assert not transform_v2.is_latest
+    finally:
+        for record in ln.Transform.filter(uid__startswith=stem_uid):
             record.delete(permanent=True)
 
 

--- a/tests/core/test_is_versioned.py
+++ b/tests/core/test_is_versioned.py
@@ -420,6 +420,9 @@ def test_inferred_revises_prefers_target_branch_head():
         source_code="main-v1",
         kind="pipeline",
     ).save()
+    # sanity check: `switch` must actually steer the creation branch, otherwise the
+    # rest of the test (which relies on heads living on distinct branches) is moot.
+    assert transform_main_v1.branch_id == main_branch.id
     try:
         # create a *more recently* created head on another branch for the same key
         ln.setup.switch(branch.name)
@@ -428,6 +431,7 @@ def test_inferred_revises_prefers_target_branch_head():
             source_code="branch-v1",
             kind="pipeline",
         ).save()
+        assert transform_branch.branch_id == branch.id
         assert transform_branch.is_latest
         transform_main_v1.refresh_from_db()
         # main head is preserved (cross-branch revision does not demote it)
@@ -442,12 +446,15 @@ def test_inferred_revises_prefers_target_branch_head():
             source_code="main-v2",
             kind="pipeline",
         )
+        # the record-to-be must target main, so the inferred revises is scoped to main
+        assert transform_main_v2.branch_id == main_branch.id
         assert transform_main_v2._revises is not None
         assert transform_main_v2._revises.uid == transform_main_v1.uid
         transform_main_v2.save()
 
         transform_main_v1.refresh_from_db()
         transform_branch.refresh_from_db()
+        assert transform_main_v2.branch_id == main_branch.id
         assert transform_main_v2.is_latest
         # the main head was demoted, the other branch's head is untouched
         assert not transform_main_v1.is_latest

--- a/tests/core/test_is_versioned.py
+++ b/tests/core/test_is_versioned.py
@@ -411,6 +411,63 @@ def test_version_chain_crosses_base62_case_boundary():
             record.delete(permanent=True)
 
 
+def test_inferred_revises_prefers_target_branch_head():
+    main_branch = ln.Branch.get(name="main")
+    ln.setup.switch(main_branch.name)
+    branch = ln.Branch(name="test_inferred_revises_branch").save()
+    transform_main_v1 = ln.Transform(
+        key="inferred-revises-branch-aware",
+        source_code="main-v1",
+        kind="pipeline",
+    ).save()
+    try:
+        # create a *more recently* created head on another branch for the same key
+        ln.setup.switch(branch.name)
+        transform_branch = ln.Transform(
+            key="inferred-revises-branch-aware",
+            source_code="branch-v1",
+            kind="pipeline",
+        ).save()
+        assert transform_branch.is_latest
+        transform_main_v1.refresh_from_db()
+        # main head is preserved (cross-branch revision does not demote it)
+        assert transform_main_v1.is_latest
+
+        # back on main, infer revises (no explicit `revises`). Even though the other
+        # branch's head was created more recently, the inferred revises must be the
+        # head on the *target* (main) branch.
+        ln.setup.switch(main_branch.name)
+        transform_main_v2 = ln.Transform(
+            key="inferred-revises-branch-aware",
+            source_code="main-v2",
+            kind="pipeline",
+        )
+        assert transform_main_v2._revises is not None
+        assert transform_main_v2._revises.uid == transform_main_v1.uid
+        transform_main_v2.save()
+
+        transform_main_v1.refresh_from_db()
+        transform_branch.refresh_from_db()
+        assert transform_main_v2.is_latest
+        # the main head was demoted, the other branch's head is untouched
+        assert not transform_main_v1.is_latest
+        assert transform_branch.is_latest
+        # exactly one latest on main for this family (no double head)
+        main_latest = ln.Transform.objects.filter(
+            uid__startswith=transform_main_v2.stem_uid,
+            branch_id=main_branch.id,
+            is_latest=True,
+        )
+        assert main_latest.count() == 1
+    finally:
+        ln.setup.switch(main_branch.name)
+        for record in ln.Transform.objects.filter(
+            uid__startswith=transform_main_v1.stem_uid
+        ):
+            record.delete(permanent=True)
+        branch.delete(permanent=True)
+
+
 def test_path_rename():
     # this is related to renames inside _add_to_version_family
     with open("test_new_path.txt", "w") as f:

--- a/tests/core/test_is_versioned.py
+++ b/tests/core/test_is_versioned.py
@@ -233,7 +233,7 @@ def test_artifact_versioning_across_branches_preserves_main_latest():
     branch = ln.Branch(name="test_artifact_versioning_branch_latest").save()
     artifact_v1 = ln.Artifact.from_dataframe(
         pd.DataFrame({"branch_feat": [10, 11]}),
-        key="test-artifact-branch-aware-is-latest",
+        key="test-artifact-branch-aware-is-latest.parquet",
         description="main-v1",
     ).save()
     # sanity check: the artifact is created on the branch steered by `switch`.

--- a/tests/core/test_is_versioned.py
+++ b/tests/core/test_is_versioned.py
@@ -309,6 +309,57 @@ def test_inferred_revises_refreshes_and_requeries_latest():
             record.delete(permanent=True)
 
 
+def test_inferred_revises_handles_concurrent_new_version():
+    transform_v1 = ln.Transform(
+        key="stale-inferred-revises-concurrent",
+        source_code="v1",
+        kind="pipeline",
+    ).save()
+    transform_v2 = ln.Transform(
+        key="stale-inferred-revises-concurrent",
+        revises=transform_v1,
+        source_code="v2",
+        kind="pipeline",
+    ).save()
+    try:
+        # inferred revises picks the current latest (v2); uid is provisionally ...0002
+        transform_pending = ln.Transform(
+            key="stale-inferred-revises-concurrent",
+            source_code="v3",
+            kind="pipeline",
+        )
+        assert transform_pending._refresh_revises_if_stale
+        assert transform_pending._revises.uid == transform_v2.uid
+        assert transform_pending.uid.endswith("0002")
+
+        # Simulate a concurrent writer creating a genuinely new version (new uid)
+        # after `transform_pending` was initialized but before it is saved. This
+        # advances the family max uid to ...0002, which `transform_pending` would
+        # collide with if its uid were not recomputed at save time.
+        transform_concurrent = ln.Transform(
+            key="stale-inferred-revises-concurrent",
+            revises=transform_v2,
+            source_code="v-concurrent",
+            kind="pipeline",
+        ).save()
+        assert transform_concurrent.uid.endswith("0002")
+
+        # Saving must create the next version (...0003) from the new family head and
+        # keep this record's own content, not collide with / silently return the
+        # concurrently-created record.
+        transform_pending.save()
+        assert transform_pending.uid.endswith("0003")
+        assert transform_pending.source_code == "v3"
+        assert transform_pending.is_latest
+        transform_pending.refresh_from_db()
+        assert transform_pending.is_latest
+        transform_concurrent.refresh_from_db()
+        assert not transform_concurrent.is_latest
+    finally:
+        for record in ln.Transform.filter(uid__startswith=transform_v1.stem_uid):
+            record.delete(permanent=True)
+
+
 def test_path_rename():
     # this is related to renames inside _add_to_version_family
     with open("test_new_path.txt", "w") as f:

--- a/tests/core/test_is_versioned.py
+++ b/tests/core/test_is_versioned.py
@@ -227,6 +227,53 @@ def test_transform_versioning_across_branches_preserves_main_latest():
         branch.delete(permanent=True)
 
 
+def test_artifact_versioning_across_branches_preserves_main_latest():
+    main_branch = ln.Branch.get(name="main")
+    ln.setup.switch(main_branch.name)
+    branch = ln.Branch(name="test_artifact_versioning_branch_latest").save()
+    artifact_v1 = ln.Artifact.from_dataframe(
+        pd.DataFrame({"branch_feat": [10, 11]}),
+        key="test-artifact-branch-aware-is-latest",
+        description="main-v1",
+    ).save()
+    # sanity check: the artifact is created on the branch steered by `switch`.
+    assert artifact_v1.branch_id == main_branch.id
+    try:
+        ln.setup.switch(branch.name)
+        artifact_v2 = ln.Artifact.from_dataframe(
+            pd.DataFrame({"branch_feat": [12, 13]}),
+            revises=artifact_v1,
+            description="feature-v2",
+        ).save()
+        assert artifact_v2.branch_id == branch.id
+        artifact_v1.refresh_from_db()
+        # main's head stays latest; the contribution branch gets its own head.
+        assert artifact_v1.is_latest
+        assert artifact_v2.is_latest
+        assert artifact_v2.uid.endswith("0001")
+
+        # Passing an older `revises` still increments from the family max uid and only
+        # demotes the head on the *creation* branch, leaving main's head intact.
+        artifact_v3 = ln.Artifact.from_dataframe(
+            pd.DataFrame({"branch_feat": [14, 15]}),
+            revises=artifact_v1,
+            description="feature-v3",
+        ).save()
+        assert artifact_v3.branch_id == branch.id
+        artifact_v2.refresh_from_db()
+        artifact_v1.refresh_from_db()
+        assert artifact_v3.uid.endswith("0002")
+        assert artifact_v3.stem_uid == artifact_v1.stem_uid
+        assert not artifact_v2.is_latest
+        assert artifact_v3.is_latest
+        assert artifact_v1.is_latest
+    finally:
+        ln.setup.switch(main_branch.name)
+        for record in ln.Artifact.objects.filter(uid__startswith=artifact_v1.uid[:-4]):
+            record.delete(permanent=True)
+        branch.delete(permanent=True)
+
+
 def test_stale_revises_raises_integrity_error():
     transform_v1 = ln.Transform(
         key="stale-revises-validation-error",


### PR DESCRIPTION
### Bugs & Issues

1. **Version chains couldn't grow past `…000Z`.** (Reported in https://github.com/pfizer-collab/laminlabs/issues/988) When building up an artifact/transform version family, once the version suffix crossed from `…000Z` to `…000a`, LaminDB kept selecting `…000Z` as the latest version, regenerating `…000a` over and over instead of advancing the chain. Root cause: the "latest version in family" lookup relied on the database's string ordering of `uid`, which matches base62 order only under binary collation (e.g. SQLite). Under locale-aware collations (e.g. Postgres `en_US.UTF-8`), uppercase `Z` sorts after lowercase `a`, breaking the chain at the `Z → a` boundary. This is the user-reported bug.

2. **Stale-revision recovery could drop data on concurrent writes.** When a new version was inferred from `key` and another version was created concurrently before save, the record's id wasn't recomputed against the new family state. The save then collided on the unique id and silently returned the concurrently-created record, discarding the user's content.

3. **Initial inferred `revises` can select a head from the wrong branch.** When creating a new version by `key` without explicitly passing `revises`, LaminDB inferred the previous version by querying `is_latest=True` ordered by most-recently-created - but without scoping to the branch the new record was being created on. Because `is_latest` is tracked per branch, a single version family can have several heads (one per branch). The lookup therefore returned the globally most-recently-created head, which could belong to a *different* branch than the target one. Since demotion is branch-aware (a head is only demoted when it's on the same branch as the new record), revising from a foreign-branch head left the target branch's own head undemoted — resulting in two `is_latest=True` records on the target branch.

4. **Deleting a version head didn't promote a successor per branch.** When soft- or permanently deleting the latest version of a family, LaminDB promoted a new `is_latest` by picking the globally most-recently-created remaining version, ignoring the branch. Because `is_latest` is tracked per branch (a family can have one head per branch), deleting a branch's head could "promote" a record that lives on another branch — which was already `is_latest=True` there, so a no-op — and leave the deleted record's own branch with **no** `is_latest=True` version (a headless branch), or flip the wrong branch's record to latest. On top of that, promoting the successor and trashing/deleting the old head were not done in a single transaction, so a failure in between could leave both the successor and the old head marked `is_latest=True` (or neither).

### Fixes

1. Latest-version selection is now computed in a collation-independent way, so chains grow correctly across all boundaries (`9 → A`, `Z → a`) on any database backend.

2. On inferred revisions, the new version is re-derived from the current family state only when the previously chosen revision has gone stale, so concurrent writes produce a proper next version instead of a collision/silent-return.

3. The inferred lookup now prefers the latest version on the branch the record will actually be created on, and only falls back to the most recent head across branches when the target branch has no version of the key yet.

4. Promotion on delete is now branch-aware: for each deleted head, the successor is the most-recently-created remaining version of the same family **on the same branch**, so heads on other branches are left intact and the deleted record's branch always gets a new head (when one exists). The successor promotion and the delete/trash now run inside a single transaction on both the single-record and queryset delete paths, so they either both apply or neither does — no transient or persisted double/zero-head states.
