### PR TITLE
:sparkles: Recognize `schema.index` in the `Record` API

### DIFF
--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -1631,13 +1631,11 @@ class FeatureManager:
             if self._get_external_schema():
                 raise ValueError("Cannot add values if artifact has external schema.")
         if schema is not None:
-            from .record import feature_is_schema_member_or_index
-
             member_ids = set(schema.members.values_list("id", flat=True))
             features_not_in_schema = [
                 feature.name
                 for feature in explicit_features
-                if not feature_is_schema_member_or_index(feature, schema, member_ids)
+                if feature.id not in member_ids
             ]
             if features_not_in_schema:
                 raise ValidationError(
@@ -1877,13 +1875,11 @@ class FeatureManager:
             schema = self._get_external_schema()
         if schema is not None:
             ExperimentalDictCurator(dictionary, schema).validate()
-            from .record import feature_is_schema_member_or_index
-
             member_ids = set(schema.members.values_list("id", flat=True))
             features_not_in_schema = [
                 feature.name
                 for feature in explicit_features
-                if not feature_is_schema_member_or_index(feature, schema, member_ids)
+                if feature.id not in member_ids
             ]
             if features_not_in_schema:
                 raise ValidationError(
@@ -2284,8 +2280,6 @@ def bulk_set_features_in_records(records: Iterable[Record]) -> None:
     feature_json_values: list[SQLRecord] = []
     links_by_model: dict[type[SQLRecord], list[SQLRecord]] = defaultdict(list)
     not_validated_values: dict[str, tuple[str, list[str]]] = {}
-    from .record import feature_is_schema_member_or_index
-
     for (
         record,
         manager,
@@ -2297,9 +2291,7 @@ def bulk_set_features_in_records(records: Iterable[Record]) -> None:
         features_not_in_schema = [
             feature.name
             for feature in explicit_features
-            if not feature_is_schema_member_or_index(
-                feature, batch_schema, schema_member_ids
-            )
+            if feature.id not in schema_member_ids
         ]
         if features_not_in_schema:
             raise ValidationError(

--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -1631,11 +1631,13 @@ class FeatureManager:
             if self._get_external_schema():
                 raise ValueError("Cannot add values if artifact has external schema.")
         if schema is not None:
+            from .record import feature_is_schema_member_or_index
+
             member_ids = set(schema.members.values_list("id", flat=True))
             features_not_in_schema = [
                 feature.name
                 for feature in explicit_features
-                if feature.id not in member_ids
+                if not feature_is_schema_member_or_index(feature, schema, member_ids)
             ]
             if features_not_in_schema:
                 raise ValidationError(
@@ -1875,11 +1877,13 @@ class FeatureManager:
             schema = self._get_external_schema()
         if schema is not None:
             ExperimentalDictCurator(dictionary, schema).validate()
+            from .record import feature_is_schema_member_or_index
+
             member_ids = set(schema.members.values_list("id", flat=True))
             features_not_in_schema = [
                 feature.name
                 for feature in explicit_features
-                if feature.id not in member_ids
+                if not feature_is_schema_member_or_index(feature, schema, member_ids)
             ]
             if features_not_in_schema:
                 raise ValidationError(
@@ -2280,6 +2284,8 @@ def bulk_set_features_in_records(records: Iterable[Record]) -> None:
     feature_json_values: list[SQLRecord] = []
     links_by_model: dict[type[SQLRecord], list[SQLRecord]] = defaultdict(list)
     not_validated_values: dict[str, tuple[str, list[str]]] = {}
+    from .record import feature_is_schema_member_or_index
+
     for (
         record,
         manager,
@@ -2291,7 +2297,9 @@ def bulk_set_features_in_records(records: Iterable[Record]) -> None:
         features_not_in_schema = [
             feature.name
             for feature in explicit_features
-            if feature.id not in schema_member_ids
+            if not feature_is_schema_member_or_index(
+                feature, batch_schema, schema_member_ids
+            )
         ]
         if features_not_in_schema:
             raise ValidationError(

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -281,6 +281,8 @@ def migrate_record_sheet_index_on_schema_save(
     ):
         return
 
+    from django.db import transaction
+
     from .save import bulk_create
 
     db = using or schema._state.db
@@ -298,62 +300,63 @@ def migrate_record_sheet_index_on_schema_save(
         .values_list("id", flat=True)
     )
 
-    if old_index_uid is not None:
-        old_feature = Feature.objects.using(db).get(uid=old_index_uid)
-        rows_with_name = (
-            Record.objects.using(db)
-            .filter(
-                id__in=row_ids,
-                name__isnull=False,
+    with transaction.atomic(using=db):
+        if old_index_uid is not None:
+            old_feature = Feature.objects.using(db).get(uid=old_index_uid)
+            rows_with_name = (
+                Record.objects.using(db)
+                .filter(
+                    id__in=row_ids,
+                    name__isnull=False,
+                )
+                .exclude(name="")
             )
-            .exclude(name="")
-        )
-        json_to_create = [
-            RecordJson(record_id=record_id, feature=old_feature, value=name)
-            for record_id, name in rows_with_name.values_list("id", "name")
-            if name
-        ]
-        if json_to_create:
-            bulk_create(json_to_create, ignore_conflicts=True)
-        rows_with_name.update(name=None)
+            json_to_create = [
+                RecordJson(record_id=record_id, feature=old_feature, value=name)
+                for record_id, name in rows_with_name.values_list("id", "name")
+                if name
+            ]
+            if json_to_create:
+                bulk_create(json_to_create, ignore_conflicts=True)
+            rows_with_name.update(name=None)
 
-    if new_index_uid is not None:
-        new_feature = Feature.objects.using(db).get(uid=new_index_uid)
-        validate_record_sheet_index_feature(new_feature)
-        json_links = (
-            RecordJson.objects.using(db)
-            .filter(
-                record_id__in=row_ids,
-                feature=new_feature,
+        if new_index_uid is not None:
+            new_feature = Feature.objects.using(db).get(uid=new_index_uid)
+            validate_record_sheet_index_feature(new_feature)
+            json_links = (
+                RecordJson.objects.using(db)
+                .filter(
+                    record_id__in=row_ids,
+                    feature=new_feature,
+                )
+                .values_list("id", "record_id", "value")
             )
-            .values_list("id", "record_id", "value")
-        )
-        if not json_links:
-            return
+            if not json_links:
+                return
 
-        records_by_id = {
-            record.id: record
-            for record in Record.objects.using(db).filter(
-                id__in={record_id for _, record_id, _ in json_links}
-            )
-        }
-        records_to_update: list[Record] = []
-        json_ids_to_delete: list[int] = []
-        for link_id, record_id, value in json_links:
-            record = records_by_id.get(record_id)
-            if record is None:
+            records_by_id = {
+                record.id: record
+                for record in Record.objects.using(db).filter(
+                    id__in={record_id for _, record_id, _ in json_links}
+                )
+            }
+            records_to_update: list[Record] = []
+            json_ids_to_delete: list[int] = []
+            for link_id, record_id, value in json_links:
+                record = records_by_id.get(record_id)
+                if record is None:
+                    json_ids_to_delete.append(link_id)
+                    continue
+                name = coerce_index_value_to_record_name(value, new_feature)
+                if name is not None and not record.name:
+                    record.name = name
+                    records_to_update.append(record)
                 json_ids_to_delete.append(link_id)
-                continue
-            name = coerce_index_value_to_record_name(value, new_feature)
-            if name is not None and not record.name:
-                record.name = name
-                records_to_update.append(record)
-            json_ids_to_delete.append(link_id)
 
-        if records_to_update:
-            Record.objects.using(db).bulk_update(records_to_update, ["name"])
-        if json_ids_to_delete:
-            RecordJson.objects.using(db).filter(id__in=json_ids_to_delete).delete()
+            if records_to_update:
+                Record.objects.using(db).bulk_update(records_to_update, ["name"])
+            if json_ids_to_delete:
+                RecordJson.objects.using(db).filter(id__in=json_ids_to_delete).delete()
 
 
 class RecordBatch:

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -265,6 +265,97 @@ def strip_index_for_record_persistence(
     return dictionary, feature_objects
 
 
+def migrate_record_sheet_index_on_schema_save(
+    schema: Schema,
+    *,
+    old_index_uid: str | None,
+    new_index_uid: str | None,
+    using: str | None = None,
+) -> None:
+    """Migrate sheet row keys when ``schema.index`` changes on save."""
+    if (
+        old_index_uid == new_index_uid
+        or schema.is_type
+        or schema.itype != "Feature"
+        or schema.otype == "Composite"
+    ):
+        return
+
+    from .save import bulk_create
+
+    db = using or schema._state.db
+    sheet_type_ids = (
+        Record.objects.using(db)
+        .filter(is_type=True, schema_id=schema.id)
+        .values_list("id", flat=True)
+    )
+    if not sheet_type_ids:
+        return
+
+    row_ids = (
+        Record.objects.using(db)
+        .filter(is_type=False, type_id__in=sheet_type_ids)
+        .values_list("id", flat=True)
+    )
+
+    if old_index_uid is not None:
+        old_feature = Feature.objects.using(db).get(uid=old_index_uid)
+        rows_with_name = (
+            Record.objects.using(db)
+            .filter(
+                id__in=row_ids,
+                name__isnull=False,
+            )
+            .exclude(name="")
+        )
+        json_to_create = [
+            RecordJson(record_id=record_id, feature=old_feature, value=name)
+            for record_id, name in rows_with_name.values_list("id", "name")
+            if name
+        ]
+        if json_to_create:
+            bulk_create(json_to_create, ignore_conflicts=True)
+        rows_with_name.update(name=None)
+
+    if new_index_uid is not None:
+        new_feature = Feature.objects.using(db).get(uid=new_index_uid)
+        validate_record_sheet_index_feature(new_feature)
+        json_links = (
+            RecordJson.objects.using(db)
+            .filter(
+                record_id__in=row_ids,
+                feature=new_feature,
+            )
+            .values_list("id", "record_id", "value")
+        )
+        if not json_links:
+            return
+
+        records_by_id = {
+            record.id: record
+            for record in Record.objects.using(db).filter(
+                id__in={record_id for _, record_id, _ in json_links}
+            )
+        }
+        records_to_update: list[Record] = []
+        json_ids_to_delete: list[int] = []
+        for link_id, record_id, value in json_links:
+            record = records_by_id.get(record_id)
+            if record is None:
+                json_ids_to_delete.append(link_id)
+                continue
+            name = coerce_index_value_to_record_name(value, new_feature)
+            if name is not None and not record.name:
+                record.name = name
+                records_to_update.append(record)
+            json_ids_to_delete.append(link_id)
+
+        if records_to_update:
+            Record.objects.using(db).bulk_update(records_to_update, ["name"])
+        if json_ids_to_delete:
+            RecordJson.objects.using(db).filter(id__in=json_ids_to_delete).delete()
+
+
 class RecordBatch:
     """DataFrame-backed batch created by :meth:`Record.from_dataframe`."""
 

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -78,12 +78,6 @@ def is_schema_index_feature(schema: Schema | None, feature: Feature) -> bool:
     return index_feature is not None and feature.uid == index_feature.uid
 
 
-def feature_is_schema_member_or_index(
-    feature: Feature, schema: Schema, member_ids: set[int]
-) -> bool:
-    return feature.id in member_ids or is_schema_index_feature(schema, feature)
-
-
 def validate_record_sheet_index_feature(index_feature: Feature) -> None:
     """Ensure a record-sheet index feature can be stored on `Record.name`."""
     if index_feature.dtype_as_str != "str":

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Iterable
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, overload
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 import pgtrigger
 from django.conf import settings as django_settings
@@ -75,6 +76,12 @@ def is_schema_index_feature(schema: Schema | None, feature: Feature) -> bool:
         return False
     index_feature = schema.index
     return index_feature is not None and feature.uid == index_feature.uid
+
+
+def feature_is_schema_member_or_index(
+    feature: Feature, schema: Schema, member_ids: set[int]
+) -> bool:
+    return feature.id in member_ids or is_schema_index_feature(schema, feature)
 
 
 def validate_record_sheet_index_feature(index_feature: Feature) -> None:
@@ -265,12 +272,77 @@ def strip_index_for_record_persistence(
     return dictionary, feature_objects
 
 
+IndexNameConflict = Literal["keep_name", "keep_feature"]
+
+
+def _record_sheet_label(record: Record) -> str:
+    if record.type_id is None:
+        return "unknown sheet"
+    sheet = record.type
+    if sheet is None:
+        return f"type_id={record.type_id}"
+    if sheet.name:
+        return f"{sheet.name} ({sheet.uid})"
+    return sheet.uid
+
+
+def _collect_promote_index_name_conflicts(
+    json_links: list[tuple[int, int, Any]],
+    records_by_id: dict[int, Record],
+    feature: Feature,
+) -> list[tuple[int, str, str, str]]:
+    conflicts: list[tuple[int, str, str, str]] = []
+    for _, record_id, value in json_links:
+        record = records_by_id.get(record_id)
+        if record is None:
+            continue
+        feature_name = coerce_index_value_to_record_name(value, feature)
+        if feature_name is not None and record.name and record.name != feature_name:
+            conflicts.append(
+                (record_id, _record_sheet_label(record), record.name, feature_name)
+            )
+    return conflicts
+
+
+def _resolve_index_name_conflict(
+    conflicts: list[tuple[int, str, str, str]],
+    feature: Feature,
+    resolution: IndexNameConflict | None,
+) -> IndexNameConflict:
+    if not conflicts:
+        return "keep_name"
+    if resolution is not None:
+        return resolution
+    if os.getenv("LAMIN_TESTING") == "true":
+        return "keep_name"
+
+    feature_name = feature.name
+    n = len(conflicts)
+    example_lines = "\n".join(
+        f"  sheet {sheet_label}, record {record_id}: Record.name={name!r}, {feature_name}={feature_value!r}"
+        for record_id, sheet_label, name, feature_value in conflicts[:3]
+    )
+    if n > 3:
+        example_lines += f"\n  ... and {n - 3} more"
+    response = input(
+        f"{n} sheet row(s) have both Record.name and '{feature_name}' values that differ.\n"
+        f"{example_lines}\n"
+        "Keep Record.name (y) or use feature values (n)? "
+    )
+    if response == "y":
+        return "keep_name"
+    if response == "n":
+        return "keep_feature"
+    raise ValueError("schema save cancelled: index name conflict not resolved")
+
+
 def migrate_record_sheet_index_on_schema_save(
     schema: Schema,
     *,
     old_index_uid: str | None,
     new_index_uid: str | None,
     using: str | None = None,
+    index_name_conflict: IndexNameConflict | None = None,
 ) -> None:
     """Migrate sheet row keys when ``schema.index`` changes on save."""
     if (
@@ -336,10 +408,16 @@ def migrate_record_sheet_index_on_schema_save(
 
             records_by_id = {
                 record.id: record
-                for record in Record.objects.using(db).filter(
-                    id__in={record_id for _, record_id, _ in json_links}
-                )
+                for record in Record.objects.using(db)
+                .filter(id__in={record_id for _, record_id, _ in json_links})
+                .select_related("type")
             }
+            conflicts = _collect_promote_index_name_conflicts(
+                list(json_links), records_by_id, new_feature
+            )
+            resolution = _resolve_index_name_conflict(
+                conflicts, new_feature, index_name_conflict
+            )
             records_to_update: list[Record] = []
             json_ids_to_delete: list[int] = []
             for link_id, record_id, value in json_links:
@@ -348,9 +426,13 @@ def migrate_record_sheet_index_on_schema_save(
                     json_ids_to_delete.append(link_id)
                     continue
                 name = coerce_index_value_to_record_name(value, new_feature)
-                if name is not None and not record.name:
-                    record.name = name
-                    records_to_update.append(record)
+                if name is not None:
+                    if not record.name:
+                        record.name = name
+                        records_to_update.append(record)
+                    elif record.name != name and resolution == "keep_feature":
+                        record.name = name
+                        records_to_update.append(record)
                 json_ids_to_delete.append(link_id)
 
             if records_to_update:

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -941,6 +941,17 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
 
         features_to_delete = []
         print_hash_mutation_warning = kwargs.pop("print_hash_mutation_warning", True)
+        using = kwargs.get("using") or self._state.db
+        old_index_uid = None
+        if self.pk is not None:
+            aux = (
+                Schema.objects.using(using)
+                .filter(pk=self.pk)
+                .values_list("_aux", flat=True)
+                .first()
+            )
+            if aux and isinstance(aux, dict) and "af" in aux and "3" in aux["af"]:
+                old_index_uid = aux["af"]["3"]
 
         if self.pk is not None:
             existing_features = self.members.to_list() if self.members.exists() else []
@@ -992,6 +1003,14 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
                         )
                 self.hash = validated_kwargs["hash"]
                 self.n_members = validated_kwargs["n_members"]
+            from .record import migrate_record_sheet_index_on_schema_save
+
+            migrate_record_sheet_index_on_schema_save(
+                self,
+                old_index_uid=old_index_uid,
+                new_index_uid=self._index_feature_uid,
+                using=using,
+            )
         super().save(*args, **kwargs)
         if hasattr(self, "_slots"):
             # analogous to save_schema_links in core._data.py
@@ -1008,7 +1027,6 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             delattr(self, "_slots")
         if hasattr(self, "_features"):
             assert self.n_members > 0  # noqa: S101
-            using: bool | None = kwargs.pop("using", None)
             related_name, records = self._features
 
             # self.related_name.set(features) does **not** preserve the order
@@ -1145,8 +1163,6 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     @index.setter
     def index(self, value: None | Feature) -> None:
         if value is None:
-            current_index = self.index
-            self.features.remove(current_index)
             self._index_feature_uid = value
         else:
             self.features.add(value)

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -206,7 +206,7 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         index: `Feature | None = None` Index feature for row keys. For `DataFrame` /
             `AnnData` curation, validates `df.index` or `obs` / `var` indices. On record
             sheets, stored on :attr:`~lamindb.Record.name` and must have `dtype=str`;
-            see :class:`~lamindb.Record`. Adds the feature to ``schema.features``.
+            see :class:`~lamindb.Record`. The index feature does not have to be a schema member.
         flexible: `bool | None = None` Whether to include any feature of the same `itype` during validation & annotation.
             If `features` is passed, defaults to `False` so that, e.g., additional columns of a `DataFrame` encountered during validation are disregarded.
             If `features` is not passed, defaults to `True`.
@@ -669,7 +669,6 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         if index is not None:
             if not isinstance(index, Feature):
                 raise TypeError("index must be a Feature")
-            features.insert(0, index)
         if features:
             features, configs = get_features_config(features)
             features_registry = validate_features(features)
@@ -679,9 +678,13 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             else:
                 itype = itype_compare
             if n_features is not None:
-                if n_features != len(features):
+                if n_features != len(features) and not (
+                    index is not None and n_features > len(features)
+                ):
                     logger.important(f"updating to n {len(features)} features")
-            n_features = len(features)
+                    n_features = len(features)
+            else:
+                n_features = len(features)
             if features_registry == Feature:
                 optional_features = [
                     config[0] for config in configs if config[1].get("optional")
@@ -944,6 +947,7 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
 
         features_to_delete = []
         print_hash_mutation_warning = kwargs.pop("print_hash_mutation_warning", True)
+        index_name_conflict = kwargs.pop("index_name_conflict", None)
         using = kwargs.get("using") or self._state.db
 
         if self.pk is not None:
@@ -958,6 +962,7 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
                 features = existing_features
             index_feature = self.index
             index_feature_id = None if index_feature is None else index_feature.id
+            n_member_count = len(features)
             _, validated_kwargs, _, _, _ = self._validate_kwargs_calculate_hash(
                 features=[  # type: ignore
                     f
@@ -978,7 +983,7 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
                 ordered_set=self.ordered_set,
                 maximal_set=self.maximal_set,
                 coerce=self.coerce,
-                n_features=self.n_members,
+                n_features=n_member_count,
                 optional_features_manual=self.optionals.get(),
             )
             if validated_kwargs["hash"] != self.hash:
@@ -1012,6 +1017,7 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
                     old_index_uid=old_index_uid,
                     new_index_uid=self._index_feature_uid,
                     using=using,
+                    index_name_conflict=index_name_conflict,
                 )
         super().save(*args, **kwargs)
         if hasattr(self, "_slots"):
@@ -1147,11 +1153,14 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     def index(self) -> None | Feature:
         """The index feature, if configured.
 
-        Set `schema.index = feature` to mark a schema member as the row key, or
-        `schema.index = None` to unset. Assignment does not add or remove features
-        from `schema.features`; add the feature first, or remove it after unsetting.
+        Set `schema.index = feature` to define the row key, or `schema.index = None`
+        to unset. The index feature does not have to be in `schema.features`.
+        Assignment does not add or remove schema members.
         On :meth:`~lamindb.Schema.save`, record sheets migrate row keys between
         :attr:`~lamindb.Record.name` and the link table when the index changes.
+        If both differ for a row, you are prompted to keep `Record.name` or the
+        feature values; pass `index_name_conflict="keep_name"` or
+        `"keep_feature"` to :meth:`~lamindb.Schema.save` to skip the prompt.
         """
         if self._index_feature_uid is None:
             return None
@@ -1162,7 +1171,9 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
                 if feature.uid == self._index_feature_uid:
                     return feature
 
-        return self.features.get(uid=self._index_feature_uid)
+        from .feature import Feature
+
+        return Feature.objects.using(self._state.db).get(uid=self._index_feature_uid)
 
     @index.setter
     def index(self, value: None | Feature) -> None:

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -945,16 +945,6 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         features_to_delete = []
         print_hash_mutation_warning = kwargs.pop("print_hash_mutation_warning", True)
         using = kwargs.get("using") or self._state.db
-        old_index_uid = None
-        if self.pk is not None:
-            aux = (
-                Schema.objects.using(using)
-                .filter(pk=self.pk)
-                .values_list("_aux", flat=True)
-                .first()
-            )
-            if aux and isinstance(aux, dict) and "af" in aux and "3" in aux["af"]:
-                old_index_uid = aux["af"]["3"]
 
         if self.pk is not None:
             existing_features = self.members.to_list() if self.members.exists() else []
@@ -1006,14 +996,23 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
                         )
                 self.hash = validated_kwargs["hash"]
                 self.n_members = validated_kwargs["n_members"]
-            from .record import migrate_record_sheet_index_on_schema_save
+                from .record import migrate_record_sheet_index_on_schema_save
 
-            migrate_record_sheet_index_on_schema_save(
-                self,
-                old_index_uid=old_index_uid,
-                new_index_uid=self._index_feature_uid,
-                using=using,
-            )
+                old_index_uid = None
+                aux = (
+                    Schema.objects.using(using)
+                    .filter(pk=self.pk)
+                    .values_list("_aux", flat=True)
+                    .first()
+                )
+                if aux and isinstance(aux, dict) and "af" in aux and "3" in aux["af"]:
+                    old_index_uid = aux["af"]["3"]
+                migrate_record_sheet_index_on_schema_save(
+                    self,
+                    old_index_uid=old_index_uid,
+                    new_index_uid=self._index_feature_uid,
+                    using=using,
+                )
         super().save(*args, **kwargs)
         if hasattr(self, "_slots"):
             # analogous to save_schema_links in core._data.py
@@ -1148,9 +1147,9 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     def index(self) -> None | Feature:
         """The index feature, if configured.
 
-        Set ``schema.index = feature`` to mark a schema member as the row key, or
-        ``schema.index = None`` to unset. Assignment does not add or remove features
-        from ``schema.features``; add the feature first, or remove it after unsetting.
+        Set `schema.index = feature` to mark a schema member as the row key, or
+        `schema.index = None` to unset. Assignment does not add or remove features
+        from `schema.features`; add the feature first, or remove it after unsetting.
         On :meth:`~lamindb.Schema.save`, record sheets migrate row keys between
         :attr:`~lamindb.Record.name` and the link table when the index changes.
         """

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -938,12 +938,12 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     def save(self, *args, **kwargs) -> Schema:
         """Save schema.
 
-        When the schema hash changes because ``schema.index`` was set or unset on a
+        When the schema hash changes because `schema.index` was set or unset on a
         record-sheet schema, row keys are migrated between :attr:`~lamindb.Record.name`
-        and the link table in bulk. If ``Record.name`` and the link-table index value
-        both exist and differ, you are prompted to keep ``Record.name`` (``y``) or use
-        the feature values (``n``); pass ``index_name_conflict="keep_name"`` or
-        ``"keep_feature"`` to skip the prompt.
+        and the link table in bulk. If `Record.name` and the link-table index value
+        both exist and differ, you are prompted to keep `Record.name` (`y`) or use
+        the feature values (`n`); pass `index_name_conflict="keep_name"` or
+        `"keep_feature"` to skip the prompt.
 
         UX example::
 
@@ -1161,60 +1161,20 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     def n(self, value: int | None) -> None:
         self.n_members = value
 
-    def _revalidate_unsaved_hash(self) -> None:
-        if not self._state.adding:
-            return
-        index_feature = self.index
-        index_feature_id = None if index_feature is None else index_feature.id
-        features = self._features[1] if hasattr(self, "_features") else []
-        (
-            features,
-            validated_kwargs,
-            _,
-            _,
-            _,
-        ) = self._validate_kwargs_calculate_hash(
-            features=[  # type: ignore
-                f
-                for f in features
-                if index_feature_id is None or f.id != index_feature_id
-            ],
-            index=index_feature,
-            slots=getattr(self, "_slots", {}),
-            name=self.name,
-            description=self.description,
-            itype=self.itype,
-            flexible=self.flexible,
-            type=self.type,
-            is_type=self.is_type,
-            otype=self.otype,
-            dtype=self.dtype,
-            minimal_set=self.minimal_set,
-            ordered_set=self.ordered_set,
-            maximal_set=self.maximal_set,
-            coerce=self.coerce,
-            n_features=None,
-        )
-        if hasattr(self, "_features"):
-            self._features = (self._features[0], features)
-        self.hash = validated_kwargs["hash"]
-        self.n_members = validated_kwargs["n_members"]
-        if validated_kwargs.get("_aux") is not None:
-            self._aux = validated_kwargs["_aux"]
-
     @property
     def index(self) -> None | Feature:
         """The feature configured to act as index.
 
         For `DataFrame` / `AnnData` schemas, validates row indices during curation.
         For record sheet schemas, the index feature must have `dtype=str`; see
-        :class:`~lamindb.Record`. Setting ``schema.index`` adds the feature to
-        ``schema.features`` if it is not already a member. To unset, set
-        ``schema.index`` to ``None``. On :meth:`~lamindb.Schema.save`, record sheets
-        migrate row keys between :attr:`~lamindb.Record.name` and the link table when
-        the index changes. If both differ for a row, you are prompted to keep
-        ``Record.name`` or the feature values; pass ``index_name_conflict="keep_name"``
-        or ``"keep_feature"`` to :meth:`~lamindb.Schema.save` to skip the prompt.
+        :class:`~lamindb.Record`. The schema must be saved before assigning
+        `schema.index` (pass `index` to the constructor for unsaved schemas).
+        Assignment only sets or clears the index marker; it does not add or remove
+        schema members. On :meth:`~lamindb.Schema.save`, record sheets migrate row
+        keys between :attr:`~lamindb.Record.name` and the link table when the index
+        changes. If both differ for a row, you are prompted to keep `Record.name` or
+        the feature values; pass `index_name_conflict="keep_name"` or
+        `"keep_feature"` to :meth:`~lamindb.Schema.save` to skip the prompt.
         """
         if self._index_feature_uid is None:
             return None
@@ -1225,28 +1185,25 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
                 if feature.uid == self._index_feature_uid:
                     return feature
 
-        return self.features.get(uid=self._index_feature_uid)
+        from .feature import Feature
+
+        if self._state.adding:
+            return Feature.objects.using(self._state.db).get(
+                uid=self._index_feature_uid
+            )
+        try:
+            return self.features.get(uid=self._index_feature_uid)
+        except Feature.DoesNotExist:
+            return Feature.objects.using(self._state.db).get(
+                uid=self._index_feature_uid
+            )
 
     @index.setter
     def index(self, value: None | Feature) -> None:
-        if value is None:
-            self._index_feature_uid = value
-            if self._state.adding:
-                self._revalidate_unsaved_hash()
-            return
-        if self._state.adding:
-            if hasattr(self, "_features"):
-                _, features = self._features
-                if not any(feature.id == value.id for feature in features):
-                    features.insert(0, value)
-            else:
-                related_name = _get_related_name(self) or "features"
-                self._features = (related_name, [value])
-        elif not self.members.filter(id=value.id).exists():
-            self.features.add(value)
-        self._index_feature_uid = value.uid
-        if self._state.adding:
-            self._revalidate_unsaved_hash()
+        assert self._state.adding is False, (
+            "Cannot set index on unsaved schema, pass index to constructor instead."
+        )
+        self._index_feature_uid = None if value is None else value.uid
 
     @property
     def _index_feature_uid(self) -> None | str:

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -203,7 +203,10 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             Is automatically set to the type of the passed `features`.
         type: `Schema | None = None` Define schema types like `ln.Schema(name="ProteinPanel", is_type=True)`.
         is_type: `bool = False` Whether the schema is a type.
-        index: `Feature | None = None` Index feature for row keys. For `DataFrame` / `AnnData` curation, validates `df.index` or `obs` / `var` indices. On record sheets, stored on :attr:`~lamindb.Record.name` and must have `dtype=str`; see :class:`~lamindb.Record`.
+        index: `Feature | None = None` Index feature for row keys. For `DataFrame` /
+            `AnnData` curation, validates `df.index` or `obs` / `var` indices. On record
+            sheets, stored on :attr:`~lamindb.Record.name` and must have `dtype=str`;
+            see :class:`~lamindb.Record`. Adds the feature to ``schema.features``.
         flexible: `bool | None = None` Whether to include any feature of the same `itype` during validation & annotation.
             If `features` is passed, defaults to `False` so that, e.g., additional columns of a `DataFrame` encountered during validation are disregarded.
             If `features` is not passed, defaults to `True`.
@@ -1143,11 +1146,13 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
 
     @property
     def index(self) -> None | Feature:
-        """The feature configured to act as index.
+        """The index feature, if configured.
 
-        For `DataFrame` / `AnnData` schemas, validates row indices during curation.
-        For record sheet schemas, the index feature must have `dtype=str`; see
-        :class:`~lamindb.Record`. To unset, set `schema.index` to `None`.
+        Set ``schema.index = feature`` to mark a schema member as the row key, or
+        ``schema.index = None`` to unset. Assignment does not add or remove features
+        from ``schema.features``; add the feature first, or remove it after unsetting.
+        On :meth:`~lamindb.Schema.save`, record sheets migrate row keys between
+        :attr:`~lamindb.Record.name` and the link table when the index changes.
         """
         if self._index_feature_uid is None:
             return None
@@ -1165,7 +1170,6 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         if value is None:
             self._index_feature_uid = value
         else:
-            self.features.add(value)
             self._index_feature_uid = value.uid
 
     @property

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -203,10 +203,7 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             Is automatically set to the type of the passed `features`.
         type: `Schema | None = None` Define schema types like `ln.Schema(name="ProteinPanel", is_type=True)`.
         is_type: `bool = False` Whether the schema is a type.
-        index: `Feature | None = None` Index feature for row keys. For `DataFrame` /
-            `AnnData` curation, validates `df.index` or `obs` / `var` indices. On record
-            sheets, stored on :attr:`~lamindb.Record.name` and must have `dtype=str`;
-            see :class:`~lamindb.Record`. The index feature does not have to be a schema member.
+        index: `Feature | None = None` Index feature for row keys. For `DataFrame` / `AnnData` curation, validates `df.index` or `obs` / `var` indices. On record sheets, stored on :attr:`~lamindb.Record.name` and must have `dtype=str`; see :class:`~lamindb.Record`.
         flexible: `bool | None = None` Whether to include any feature of the same `itype` during validation & annotation.
             If `features` is passed, defaults to `False` so that, e.g., additional columns of a `DataFrame` encountered during validation are disregarded.
             If `features` is not passed, defaults to `True`.
@@ -669,6 +666,7 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         if index is not None:
             if not isinstance(index, Feature):
                 raise TypeError("index must be a Feature")
+            features.insert(0, index)
         if features:
             features, configs = get_features_config(features)
             features_registry = validate_features(features)
@@ -678,13 +676,9 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             else:
                 itype = itype_compare
             if n_features is not None:
-                if n_features != len(features) and not (
-                    index is not None and n_features > len(features)
-                ):
+                if n_features != len(features):
                     logger.important(f"updating to n {len(features)} features")
-                    n_features = len(features)
-            else:
-                n_features = len(features)
+            n_features = len(features)
             if features_registry == Feature:
                 optional_features = [
                     config[0] for config in configs if config[1].get("optional")
@@ -942,7 +936,26 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         return cls.from_dataframe(df, field, name, mute, organism, source)
 
     def save(self, *args, **kwargs) -> Schema:
-        """Save schema."""
+        """Save schema.
+
+        When the schema hash changes because ``schema.index`` was set or unset on a
+        record-sheet schema, row keys are migrated between :attr:`~lamindb.Record.name`
+        and the link table in bulk. If ``Record.name`` and the link-table index value
+        both exist and differ, you are prompted to keep ``Record.name`` (``y``) or use
+        the feature values (``n``); pass ``index_name_conflict="keep_name"`` or
+        ``"keep_feature"`` to skip the prompt.
+
+        UX example::
+
+            >>> schema.save()
+            ! you updated the schema hash and might invalidate datasets...
+            1 sheet row(s) have both Record.name and 'name' values that differ.
+              sheet My samples 2025-05 (Kzpu3Xo8g7xy), record 21977: Record.name='schmidt22_perturbseq', name='sample-001'
+            Keep Record.name (y) or use feature values (n)? y
+
+        The prompt only appears when both values exist and differ; matching values
+        migrate silently.
+        """
         from .save import bulk_create
 
         features_to_delete = []
@@ -962,7 +975,6 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
                 features = existing_features
             index_feature = self.index
             index_feature_id = None if index_feature is None else index_feature.id
-            n_member_count = len(features)
             _, validated_kwargs, _, _, _ = self._validate_kwargs_calculate_hash(
                 features=[  # type: ignore
                     f
@@ -983,7 +995,7 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
                 ordered_set=self.ordered_set,
                 maximal_set=self.maximal_set,
                 coerce=self.coerce,
-                n_features=n_member_count,
+                n_features=self.n_members,
                 optional_features_manual=self.optionals.get(),
             )
             if validated_kwargs["hash"] != self.hash:
@@ -1149,18 +1161,60 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     def n(self, value: int | None) -> None:
         self.n_members = value
 
+    def _revalidate_unsaved_hash(self) -> None:
+        if not self._state.adding:
+            return
+        index_feature = self.index
+        index_feature_id = None if index_feature is None else index_feature.id
+        features = self._features[1] if hasattr(self, "_features") else []
+        (
+            features,
+            validated_kwargs,
+            _,
+            _,
+            _,
+        ) = self._validate_kwargs_calculate_hash(
+            features=[  # type: ignore
+                f
+                for f in features
+                if index_feature_id is None or f.id != index_feature_id
+            ],
+            index=index_feature,
+            slots=getattr(self, "_slots", {}),
+            name=self.name,
+            description=self.description,
+            itype=self.itype,
+            flexible=self.flexible,
+            type=self.type,
+            is_type=self.is_type,
+            otype=self.otype,
+            dtype=self.dtype,
+            minimal_set=self.minimal_set,
+            ordered_set=self.ordered_set,
+            maximal_set=self.maximal_set,
+            coerce=self.coerce,
+            n_features=None,
+        )
+        if hasattr(self, "_features"):
+            self._features = (self._features[0], features)
+        self.hash = validated_kwargs["hash"]
+        self.n_members = validated_kwargs["n_members"]
+        if validated_kwargs.get("_aux") is not None:
+            self._aux = validated_kwargs["_aux"]
+
     @property
     def index(self) -> None | Feature:
-        """The index feature, if configured.
+        """The feature configured to act as index.
 
-        Set `schema.index = feature` to define the row key, or `schema.index = None`
-        to unset. The index feature does not have to be in `schema.features`.
-        Assignment does not add or remove schema members.
-        On :meth:`~lamindb.Schema.save`, record sheets migrate row keys between
-        :attr:`~lamindb.Record.name` and the link table when the index changes.
-        If both differ for a row, you are prompted to keep `Record.name` or the
-        feature values; pass `index_name_conflict="keep_name"` or
-        `"keep_feature"` to :meth:`~lamindb.Schema.save` to skip the prompt.
+        For `DataFrame` / `AnnData` schemas, validates row indices during curation.
+        For record sheet schemas, the index feature must have `dtype=str`; see
+        :class:`~lamindb.Record`. Setting ``schema.index`` adds the feature to
+        ``schema.features`` if it is not already a member. To unset, set
+        ``schema.index`` to ``None``. On :meth:`~lamindb.Schema.save`, record sheets
+        migrate row keys between :attr:`~lamindb.Record.name` and the link table when
+        the index changes. If both differ for a row, you are prompted to keep
+        ``Record.name`` or the feature values; pass ``index_name_conflict="keep_name"``
+        or ``"keep_feature"`` to :meth:`~lamindb.Schema.save` to skip the prompt.
         """
         if self._index_feature_uid is None:
             return None
@@ -1171,16 +1225,28 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
                 if feature.uid == self._index_feature_uid:
                     return feature
 
-        from .feature import Feature
-
-        return Feature.objects.using(self._state.db).get(uid=self._index_feature_uid)
+        return self.features.get(uid=self._index_feature_uid)
 
     @index.setter
     def index(self, value: None | Feature) -> None:
         if value is None:
             self._index_feature_uid = value
-        else:
-            self._index_feature_uid = value.uid
+            if self._state.adding:
+                self._revalidate_unsaved_hash()
+            return
+        if self._state.adding:
+            if hasattr(self, "_features"):
+                _, features = self._features
+                if not any(feature.id == value.id for feature in features):
+                    features.insert(0, value)
+            else:
+                related_name = _get_related_name(self) or "features"
+                self._features = (related_name, [value])
+        elif not self.members.filter(id=value.id).exists():
+            self.features.add(value)
+        self._index_feature_uid = value.uid
+        if self._state.adding:
+            self._revalidate_unsaved_hash()
 
     @property
     def _index_feature_uid(self) -> None | str:

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -178,9 +178,9 @@ def test_record_schema_index_stored_on_name():
         index=sample_id,
         name="index-on-name-schema",
     ).save()
-    # Story 1: constructor sets schema.index without adding it to members
+    # Story 1: constructor with index adds it to schema members
     assert schema.index == sample_id
-    assert sample_id not in schema.features.all()
+    assert sample_id in schema.features.all()
     assert score in schema.features.all()
     sheet = ln.Record(name="index-sheet", is_type=True, schema=schema).save()
 
@@ -291,16 +291,18 @@ def test_record_schema_index_stored_on_name():
     int_schema.delete(permanent=True)
     row_id.delete(permanent=True)
 
-    # Story 1b: set index via setter without adding it to schema members
+    # Story 1b: set index via setter on unsaved then saved schema
     setter_index = ln.Feature(name="setter_index", dtype=str).save()
-    setter_schema = ln.Schema(features=[score], name="setter-index-schema").save()
+    setter_schema = ln.Schema(features=[score], name="setter-index-schema")
+    assert setter_schema._state.adding
+    setter_schema.index = setter_index
+    assert setter_index in setter_schema.members
+    setter_schema.save()
     setter_sheet = ln.Record(
         name="setter-index-sheet", is_type=True, schema=setter_schema
     ).save()
-    setter_schema.index = setter_index
-    setter_schema.save()
     assert setter_schema.index == setter_index
-    assert setter_index not in setter_schema.features.all()
+    assert setter_index in setter_schema.features.all()
     setter_record = ln.Record(
         type=setter_sheet,
         features={"setter_index": "S-setter", "score": 2.0},

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -1055,7 +1055,10 @@ def test_record_features_add_remove_values():
 
     record_entity1.restore()
     test_values["feature_type1"] = "entity1"
-    test_values["feature_type1s"] = ["entity1", "entity2"]
+    restored_values = test_record.features.get_values()
+    assert restored_values["feature_type1"] == "entity1"
+    assert set(restored_values["feature_type1s"]) == {"entity1", "entity2"}
+    test_values["feature_type1s"] = restored_values["feature_type1s"]
 
     # remove values
 

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -178,9 +178,10 @@ def test_record_schema_index_stored_on_name():
         index=sample_id,
         name="index-on-name-schema",
     ).save()
-    # Story 1: constructor adds index to features and sets schema.index
+    # Story 1: constructor sets schema.index without adding it to members
     assert schema.index == sample_id
-    assert sample_id in schema.features.all()
+    assert sample_id not in schema.features.all()
+    assert score in schema.features.all()
     sheet = ln.Record(name="index-sheet", is_type=True, schema=schema).save()
 
     # index helper functions
@@ -290,6 +291,31 @@ def test_record_schema_index_stored_on_name():
     int_schema.delete(permanent=True)
     row_id.delete(permanent=True)
 
+    # Story 1b: set index via setter without adding it to schema members
+    setter_index = ln.Feature(name="setter_index", dtype=str).save()
+    setter_schema = ln.Schema(features=[score], name="setter-index-schema").save()
+    setter_sheet = ln.Record(
+        name="setter-index-sheet", is_type=True, schema=setter_schema
+    ).save()
+    setter_schema.index = setter_index
+    setter_schema.save()
+    assert setter_schema.index == setter_index
+    assert setter_index not in setter_schema.features.all()
+    setter_record = ln.Record(
+        type=setter_sheet,
+        features={"setter_index": "S-setter", "score": 2.0},
+    ).save()
+    assert setter_record.name == "S-setter"
+    assert (
+        ln.models.RecordJson.filter(record=setter_record, feature=setter_index).count()
+        == 0
+    )
+
+    ln.Record.filter(type=setter_sheet).delete(permanent=True)
+    setter_sheet.delete(permanent=True)
+    setter_schema.delete(permanent=True)
+    setter_index.delete(permanent=True)
+
     # migration on save: set index when feature is already a schema member
     migration_sample_id = ln.Feature(name="migration_sample_id", dtype=str).save()
     migration_score = ln.Feature(name="migration_score", dtype=float).save()
@@ -345,6 +371,78 @@ def test_record_schema_index_stored_on_name():
     migration_schema.delete(permanent=True)
     migration_sample_id.delete(permanent=True)
     migration_score.delete(permanent=True)
+
+    ln.Record.filter(type=sheet).delete(permanent=True)
+    sheet.delete(permanent=True)
+    schema.delete(permanent=True)
+    sample_id.delete(permanent=True)
+    score.delete(permanent=True)
+
+
+def test_record_schema_index_name_conflict_resolution():
+    """When Record.name and index feature values differ, user can choose which to keep."""
+    sample_id = ln.Feature(name="conflict_sample_id", dtype=str).save()
+    score = ln.Feature(name="conflict_score", dtype=float).save()
+    schema = ln.Schema(
+        features=[sample_id, score],
+        name="conflict-schema",
+    ).save()
+    sheet = ln.Record(name="conflict-sheet", is_type=True, schema=schema).save()
+    record = ln.Record(
+        name="manual-name",
+        type=sheet,
+        features={"conflict_sample_id": "feature-value", "conflict_score": 1.0},
+    ).save()
+    assert (
+        ln.models.RecordJson.get(record=record, feature=sample_id).value
+        == "feature-value"
+    )
+
+    schema.index = sample_id
+    schema.save(index_name_conflict="keep_name")
+    record.refresh_from_db()
+    assert record.name == "manual-name"
+    assert ln.models.RecordJson.filter(record=record, feature=sample_id).count() == 0
+    assert record.features.get_values()["conflict_sample_id"] == "manual-name"
+
+    schema.index = None
+    schema.save()
+    record.refresh_from_db()
+    record.name = "manual-name"
+    record.save()
+    ln.models.RecordJson.filter(record=record, feature=sample_id).update(
+        value="feature-value"
+    )
+    schema.index = sample_id
+    schema.save(index_name_conflict="keep_feature")
+    record.refresh_from_db()
+    assert record.name == "feature-value"
+    assert ln.models.RecordJson.filter(record=record, feature=sample_id).count() == 0
+
+    schema.index = None
+    schema.save()
+    record.refresh_from_db()
+    record.name = "manual-name"
+    record.save()
+    ln.models.RecordJson.filter(record=record, feature=sample_id).update(
+        value="feature-value"
+    )
+    schema.index = sample_id
+    prompt_messages: list[str] = []
+
+    def capture_input(_: str) -> str:
+        return "n"
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "builtins.input",
+            lambda msg: prompt_messages.append(msg) or capture_input(msg),
+        )
+        monkeypatch.delenv("LAMIN_TESTING", raising=False)
+        schema.save()
+    assert "sheet conflict-sheet" in prompt_messages[0]
+    record.refresh_from_db()
+    assert record.name == "feature-value"
 
     ln.Record.filter(type=sheet).delete(permanent=True)
     sheet.delete(permanent=True)

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -287,6 +287,89 @@ def test_record_schema_index_stored_on_name():
     int_schema.delete(permanent=True)
     row_id.delete(permanent=True)
 
+    # migration on save: set index when feature is already a schema member
+    migration_sample_id = ln.Feature(name="migration_sample_id", dtype=str).save()
+    migration_score = ln.Feature(name="migration_score", dtype=float).save()
+    migration_schema = ln.Schema(
+        features=[migration_sample_id, migration_score],
+        name="migration-schema",
+    ).save()
+    migration_sheet = ln.Record(
+        name="migration-sheet", is_type=True, schema=migration_schema
+    ).save()
+    migration_record = ln.Record(
+        type=migration_sheet,
+        features={"migration_sample_id": "S-migrate", "migration_score": 3.0},
+    ).save()
+    assert migration_record.name is None
+    assert (
+        ln.models.RecordJson.filter(
+            record=migration_record, feature=migration_sample_id
+        ).count()
+        == 1
+    )
+
+    migration_schema.index = migration_sample_id
+    migration_record.refresh_from_db()
+    assert migration_record.name is None
+
+    migration_schema.save()
+    migration_record.refresh_from_db()
+    assert migration_record.name == "S-migrate"
+    assert (
+        ln.models.RecordJson.filter(
+            record=migration_record, feature=migration_sample_id
+        ).count()
+        == 0
+    )
+    migration_df = migration_sheet.to_dataframe()
+    assert migration_df.index.tolist() == ["S-migrate"]
+
+    migration_schema.index = None
+    migration_schema.save()
+    migration_record.refresh_from_db()
+    assert migration_record.name is None
+    assert (
+        ln.models.RecordJson.get(
+            record=migration_record, feature=migration_sample_id
+        ).value
+        == "S-migrate"
+    )
+    assert migration_sample_id in migration_schema.features.all()
+
+    # migration on save: set index when feature is not yet in the schema
+    new_index_feature = ln.Feature(name="migration_new_index", dtype=str).save()
+    migration_schema2 = ln.Schema(
+        features=[migration_score], name="migration-schema-2"
+    ).save()
+    migration_sheet2 = ln.Record(
+        name="migration-sheet-2", is_type=True, schema=migration_schema2
+    ).save()
+    migration_record2 = ln.Record(
+        type=migration_sheet2,
+        features={"migration_score": 4.0},
+    ).save()
+    ln.models.RecordJson(
+        record=migration_record2, feature=new_index_feature, value="S-new"
+    ).save()
+
+    migration_schema2.index = new_index_feature
+    migration_schema2.save()
+    migration_record2.refresh_from_db()
+    assert migration_record2.name == "S-new"
+    assert new_index_feature in migration_schema2.features.all()
+
+    ln.Record.filter(type__in=[migration_sheet, migration_sheet2]).delete(
+        permanent=True
+    )
+    migration_sheet.delete(permanent=True)
+    migration_sheet2.delete(permanent=True)
+    migration_schema.delete(permanent=True)
+    migration_schema2.delete(permanent=True)
+    migration_sample_id.delete(permanent=True)
+    migration_score.delete(permanent=True)
+    new_index_feature.delete(permanent=True)
+
     ln.Record.filter(type=sheet).delete(permanent=True)
     sheet.delete(permanent=True)
     schema.delete(permanent=True)

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -178,6 +178,9 @@ def test_record_schema_index_stored_on_name():
         index=sample_id,
         name="index-on-name-schema",
     ).save()
+    # Story 1: constructor adds index to features and sets schema.index
+    assert schema.index == sample_id
+    assert sample_id in schema.features.all()
     sheet = ln.Record(name="index-sheet", is_type=True, schema=schema).save()
 
     # index helper functions
@@ -337,38 +340,11 @@ def test_record_schema_index_stored_on_name():
     )
     assert migration_sample_id in migration_schema.features.all()
 
-    # migration on save: set index when feature is not yet in the schema
-    new_index_feature = ln.Feature(name="migration_new_index", dtype=str).save()
-    migration_schema2 = ln.Schema(
-        features=[migration_score], name="migration-schema-2"
-    ).save()
-    migration_sheet2 = ln.Record(
-        name="migration-sheet-2", is_type=True, schema=migration_schema2
-    ).save()
-    migration_record2 = ln.Record(
-        type=migration_sheet2,
-        features={"migration_score": 4.0},
-    ).save()
-    ln.models.RecordJson(
-        record=migration_record2, feature=new_index_feature, value="S-new"
-    ).save()
-
-    migration_schema2.index = new_index_feature
-    migration_schema2.save()
-    migration_record2.refresh_from_db()
-    assert migration_record2.name == "S-new"
-    assert new_index_feature in migration_schema2.features.all()
-
-    ln.Record.filter(type__in=[migration_sheet, migration_sheet2]).delete(
-        permanent=True
-    )
+    ln.Record.filter(type=migration_sheet).delete(permanent=True)
     migration_sheet.delete(permanent=True)
-    migration_sheet2.delete(permanent=True)
     migration_schema.delete(permanent=True)
-    migration_schema2.delete(permanent=True)
     migration_sample_id.delete(permanent=True)
     migration_score.delete(permanent=True)
-    new_index_feature.delete(permanent=True)
 
     ln.Record.filter(type=sheet).delete(permanent=True)
     sheet.delete(permanent=True)

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -291,12 +291,19 @@ def test_record_schema_index_stored_on_name():
     int_schema.delete(permanent=True)
     row_id.delete(permanent=True)
 
-    # Story 1b: set index via setter on unsaved then saved schema
+    # Story 1b: symmetric setter only marks index; add member separately
     setter_index = ln.Feature(name="setter_index", dtype=str).save()
-    setter_schema = ln.Schema(features=[score], name="setter-index-schema")
-    assert setter_schema._state.adding
+    setter_schema = ln.Schema(features=[score], name="setter-index-schema").save()
+    unsaved_score = ln.Feature(name="unsaved_score_for_index", dtype=float).save()
+    unsaved_schema = ln.Schema(features=[unsaved_score], name="unsaved-index-schema")
+    assert unsaved_schema._state.adding
+    with pytest.raises(
+        AssertionError,
+        match="Cannot set index on unsaved schema, pass index to constructor instead",
+    ):
+        unsaved_schema.index = setter_index
+    setter_schema.features.add(setter_index)
     setter_schema.index = setter_index
-    assert setter_index in setter_schema.members
     setter_schema.save()
     setter_sheet = ln.Record(
         name="setter-index-sheet", is_type=True, schema=setter_schema
@@ -317,6 +324,7 @@ def test_record_schema_index_stored_on_name():
     setter_sheet.delete(permanent=True)
     setter_schema.delete(permanent=True)
     setter_index.delete(permanent=True)
+    unsaved_score.delete(permanent=True)
 
     # migration on save: set index when feature is already a schema member
     migration_sample_id = ln.Feature(name="migration_sample_id", dtype=str).save()

--- a/tests/core/test_schema.py
+++ b/tests/core/test_schema.py
@@ -318,9 +318,15 @@ def test_schema_update(
     # remove the index
     mini_immuno_schema_flexible.index = None
     mini_immuno_schema_flexible.save()
+    assert mini_immuno_schema_flexible.n_members == 7
+    assert mini_immuno_schema_flexible.index is None
+    assert index_feature in mini_immuno_schema_flexible.features.all()
+    assert mini_immuno_schema_flexible.hash != orig_hash
+    assert ccaplog.text.count(warning_message) == 8
+    mini_immuno_schema_flexible.features.remove(index_feature)
+    mini_immuno_schema_flexible.save()
     assert mini_immuno_schema_flexible.n_members == 6
     assert mini_immuno_schema_flexible.hash == orig_hash
-    assert ccaplog.text.count(warning_message) == 8
     index_feature.delete(permanent=True)
 
     # make a feature optional --------------------------------
@@ -329,13 +335,13 @@ def test_schema_update(
     mini_immuno_schema_flexible.optionals.add(required_feature)
     mini_immuno_schema_flexible.save()
     assert mini_immuno_schema_flexible.hash != orig_hash
-    assert ccaplog.text.count(warning_message) == 9
+    assert ccaplog.text.count(warning_message) == 10
 
     # make it required again
     mini_immuno_schema_flexible.optionals.remove(required_feature)
     mini_immuno_schema_flexible.save()
     assert mini_immuno_schema_flexible.hash == orig_hash
-    assert ccaplog.text.count(warning_message) == 10
+    assert ccaplog.text.count(warning_message) == 11
 
     artifact.delete(permanent=True)
 

--- a/tests/core/test_schema.py
+++ b/tests/core/test_schema.py
@@ -324,11 +324,11 @@ def test_schema_update(
     assert mini_immuno_schema_flexible.hash == orig_hash
     assert ccaplog.text.count(warning_message) == 8
 
-    # Story 3: set index via setter on a new feature (adds it to members)
+    # Story 3: add a new feature, then mark it as index
 
     new_index_feature = ln.Feature(name="immuno_sample", dtype=str).save()
+    mini_immuno_schema_flexible.features.add(new_index_feature)
     mini_immuno_schema_flexible.index = new_index_feature
-    assert new_index_feature in mini_immuno_schema_flexible.features.all()
     mini_immuno_schema_flexible.save()
     assert mini_immuno_schema_flexible.index == new_index_feature
     assert new_index_feature in mini_immuno_schema_flexible.features.all()

--- a/tests/core/test_schema.py
+++ b/tests/core/test_schema.py
@@ -306,28 +306,51 @@ def test_schema_update(
     assert mini_immuno_schema_flexible.hash == orig_hash
     assert ccaplog.text.count(warning_message) == 6
 
-    # add an index --------------------------------
+    # add an index (Story 2: mark an existing member as index) -----------
 
-    index_feature = ln.Feature(name="immuno_sample", dtype=str).save()
+    index_feature = ln.Feature.get(name="perturbation")
     mini_immuno_schema_flexible.index = index_feature
     mini_immuno_schema_flexible.save()
     assert mini_immuno_schema_flexible.hash != orig_hash
-    assert mini_immuno_schema_flexible.n_members == 7
+    assert mini_immuno_schema_flexible.n_members == 6
     assert ccaplog.text.count(warning_message) == 7
 
     # remove the index
     mini_immuno_schema_flexible.index = None
     mini_immuno_schema_flexible.save()
-    assert mini_immuno_schema_flexible.n_members == 7
+    assert mini_immuno_schema_flexible.n_members == 6
     assert mini_immuno_schema_flexible.index is None
     assert index_feature in mini_immuno_schema_flexible.features.all()
-    assert mini_immuno_schema_flexible.hash != orig_hash
+    assert mini_immuno_schema_flexible.hash == orig_hash
     assert ccaplog.text.count(warning_message) == 8
-    mini_immuno_schema_flexible.features.remove(index_feature)
+
+    # Story 3: add a new feature, then mark it as index -----------------------
+
+    new_index_feature = ln.Feature(name="immuno_sample", dtype=str).save()
+    mini_immuno_schema_flexible.features.add(new_index_feature)
+    mini_immuno_schema_flexible.index = new_index_feature
     mini_immuno_schema_flexible.save()
+    assert mini_immuno_schema_flexible.index == new_index_feature
+    assert new_index_feature in mini_immuno_schema_flexible.features.all()
+    assert mini_immuno_schema_flexible.n_members == 7
+    assert mini_immuno_schema_flexible.hash != orig_hash
+    assert ccaplog.text.count(warning_message) == 9
+
+    # Story 4: unset index, then remove the feature from the schema ---------
+
+    mini_immuno_schema_flexible.index = None
+    mini_immuno_schema_flexible.save()
+    assert mini_immuno_schema_flexible.index is None
+    assert new_index_feature in mini_immuno_schema_flexible.features.all()
+    assert ccaplog.text.count(warning_message) == 10
+
+    mini_immuno_schema_flexible.features.remove(new_index_feature)
+    mini_immuno_schema_flexible.save()
+    assert new_index_feature not in mini_immuno_schema_flexible.features.all()
     assert mini_immuno_schema_flexible.n_members == 6
     assert mini_immuno_schema_flexible.hash == orig_hash
-    index_feature.delete(permanent=True)
+    assert ccaplog.text.count(warning_message) == 11
+    new_index_feature.delete(permanent=True)
 
     # make a feature optional --------------------------------
 
@@ -335,13 +358,13 @@ def test_schema_update(
     mini_immuno_schema_flexible.optionals.add(required_feature)
     mini_immuno_schema_flexible.save()
     assert mini_immuno_schema_flexible.hash != orig_hash
-    assert ccaplog.text.count(warning_message) == 10
+    assert ccaplog.text.count(warning_message) == 12
 
     # make it required again
     mini_immuno_schema_flexible.optionals.remove(required_feature)
     mini_immuno_schema_flexible.save()
     assert mini_immuno_schema_flexible.hash == orig_hash
-    assert ccaplog.text.count(warning_message) == 11
+    assert ccaplog.text.count(warning_message) == 13
 
     artifact.delete(permanent=True)
 

--- a/tests/core/test_schema.py
+++ b/tests/core/test_schema.py
@@ -324,11 +324,11 @@ def test_schema_update(
     assert mini_immuno_schema_flexible.hash == orig_hash
     assert ccaplog.text.count(warning_message) == 8
 
-    # Story 3: add a new feature, then mark it as index -----------------------
+    # Story 3: set index via setter on a new feature (adds it to members)
 
     new_index_feature = ln.Feature(name="immuno_sample", dtype=str).save()
-    mini_immuno_schema_flexible.features.add(new_index_feature)
     mini_immuno_schema_flexible.index = new_index_feature
+    assert new_index_feature in mini_immuno_schema_flexible.features.all()
     mini_immuno_schema_flexible.save()
     assert mini_immuno_schema_flexible.index == new_index_feature
     assert new_index_feature in mini_immuno_schema_flexible.features.all()


### PR DESCRIPTION
## Summary

- On `Schema.save()` for record-sheet schemas, when the schema hash changes because `schema.index` was set or unset, migrate row keys in bulk between `Record.name` and the `RecordJson` link table.
  - **Set index:** copy link-table values to `Record.name` and delete the link rows.
  - **Unset index:** copy `Record.name` to the link table and clear `Record.name`.
- Migration runs only when the hash changes. The previous index uid is read from persisted `_aux["af"]["3"]` inside that block.
- `schema.index` assignment is symmetric: it only sets or clears the index marker in `_aux` and does not add or remove schema members. Add features via `schema.features.add()` or `Schema(..., index=feature)` at construction. The setter requires a saved schema (`AssertionError` otherwise).
- If `Record.name` and the link-table index value both exist and differ, `schema.save()` prompts to keep `Record.name` or use feature values. Pass `index_name_conflict="keep_name"` or `"keep_feature"` to skip the prompt in scripts (`LAMIN_TESTING=true` defaults to `keep_name`).

## UX

```python
>>> schema.save()
! you updated the schema hash and might invalidate datasets that were previously validated with this schema:
                       uid                                                key                         description  ...
3264  b3BN3ADHGYtPhWkj0000  sheet_exports/input - My samples schema 2025-0...  Export of sheet O9oZfVX88ZaiEsn5:   ...
3233  GJ8FnqFCCLKMT2CM0000  sheet_exports/Uploads/Book2__2026-04-26T19-09-...  Export of sheet OgoulsHOA0mKma42:   ...

[8 rows x 22 columns]
1 sheet row(s) have both Record.name and 'name' values that differ.
  sheet My samples 2025-05 (Kzpu3Xo8g7xy), record 21977: Record.name='schmidt22_perturbseq', name='sample-001'
Keep Record.name (y) or use feature values (n)? y
```

The prompt only appears when both values exist and differ; matching values migrate silently.

## Test plan

- [x] `test_record_schema_index_stored_on_name` — constructor index; symmetric setter; `features.add` then index; migration on save; conflict resolution
- [x] `test_record_schema_index_name_conflict_resolution` — `index_name_conflict="keep_name"` / `"keep_feature"`
- [x] `test_schema_update` — mark existing member as index; add feature then index; unset keeps feature in members
- [x] `test_hash_index_feature` — schema hash unchanged for indexed schemas