### PR TITLE
🐛 Reorder schema features on update from `features` input

### DIFF
--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -1064,12 +1064,20 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             else:
                 related_field = related_model_split[1].lower()
             related_field_id = f"{related_field}_id"
-            links = [
-                through_model(**{"schema_id": self.id, related_field_id: record.id})
-                for record in records
-            ]
-            through_model.objects.using(using).bulk_create(links, ignore_conflicts=True)
-            getattr(self, related_name).remove(*features_to_delete)
+            new_member_ids = [record.id for record in records]
+            existing_member_ids = list(
+                through_model.objects.using(using)
+                .filter(schema_id=self.id)
+                .order_by("id")
+                .values_list(related_field_id, flat=True)
+            )
+            if new_member_ids != existing_member_ids:
+                through_model.objects.using(using).filter(schema_id=self.id).delete()
+                links = [
+                    through_model(**{"schema_id": self.id, related_field_id: record.id})
+                    for record in records
+                ]
+                through_model.objects.using(using).bulk_create(links)
             delattr(self, "_features")
 
         return self

--- a/tests/core/test_schema.py
+++ b/tests/core/test_schema.py
@@ -246,6 +246,39 @@ def test_schema_update_implicit_through_name_equality(
     assert schema.hash == orig_hash  # restored original hash
 
 
+def test_schema_update_reorders_features():
+    """Features keep the order from the `features` input when updating a schema."""
+    feature_i = ln.Feature(name="feature_i", dtype=str).save()
+    feature_m = ln.Feature(name="feature_m", dtype=str).save()
+    feature_n = ln.Feature(name="feature_n", dtype=str).save()
+
+    schema = ln.Schema(
+        name="TestSchemaA",
+        features=[feature_i, feature_n],
+        ordered_set=True,
+    ).save()
+    assert schema.members.to_list("name") == ["feature_i", "feature_n"]
+
+    schema = ln.Schema(
+        name="TestSchemaA",
+        features=[feature_i, feature_m, feature_n],
+        ordered_set=True,
+    ).save()
+    assert schema.members.to_list("name") == ["feature_i", "feature_m", "feature_n"]
+
+    schema = ln.Schema(
+        name="TestSchemaA",
+        features=[feature_n, feature_i, feature_m],
+        ordered_set=True,
+    ).save()
+    assert schema.members.to_list("name") == ["feature_n", "feature_i", "feature_m"]
+
+    schema.delete(permanent=True)
+    feature_i.delete(permanent=True)
+    feature_m.delete(permanent=True)
+    feature_n.delete(permanent=True)
+
+
 def test_schema_update(
     mini_immuno_schema_flexible: ln.Schema,
     ccaplog,


### PR DESCRIPTION
## Summary

Fixes schema feature ordering when updating an existing schema via the `features` argument (e.g. by name). New or reordered features were previously appended to the end because `Schema.save()` used `bulk_create(..., ignore_conflicts=True)`, which only inserts missing links and leaves existing through-table rows in place.

Now, when the desired member order differs from what is stored, all feature links for the schema are replaced in the order given by `features`.

## Test plan

- [x] `test_schema_update_reorders_features` — insert a feature in the middle and fully reorder members
- [x] `test_schema_update_implicit_through_name_equality` — existing name-based schema update flow still passes