### PR TITLE
🎨 Export sheet artifacts to the sheet's space

### DIFF
--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -1111,7 +1111,9 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
                 transform=transform,
                 initiated_by_run=initiated_by_run,
                 status="started",
-            ).save()  # type: ignore
+            )
+            run.space = self.space
+            run.save()  # type: ignore
             run.initiated_by_run = initiated_by_run  # available in memory
         else:
             run = None

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -1331,6 +1331,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
                 "index": self.schema is not None and self.schema.index is not None
             },
             run=self._export_run,
+            space=self.space,
         ).save()
 
 

--- a/tests/core/test_record_sheet_examples.py
+++ b/tests/core/test_record_sheet_examples.py
@@ -357,6 +357,7 @@ def test_to_artifact_with_required_non_nullable_data_id_maximal_set_true():
 
     artifact = sheet.to_artifact()
     assert artifact.space_id == sheet.space_id
+    assert artifact.run.space_id == sheet.space_id
 
     df = artifact.load()
     assert "data_id" in df.columns

--- a/tests/core/test_record_sheet_examples.py
+++ b/tests/core/test_record_sheet_examples.py
@@ -356,6 +356,8 @@ def test_to_artifact_with_required_non_nullable_data_id_maximal_set_true():
     record.features.add_values({"data_id": "D1"})
 
     artifact = sheet.to_artifact()
+    assert artifact.space_id == sheet.space_id
+
     df = artifact.load()
     assert "data_id" in df.columns
     assert df["data_id"].to_list() == ["D1"]
@@ -363,9 +365,11 @@ def test_to_artifact_with_required_non_nullable_data_id_maximal_set_true():
     assert df["__lamindb_record_name__"].isna().all()
 
     # clean up
+    export_run = artifact.run
     record.delete(permanent=True)
     sheet.delete(permanent=True)
     artifact.delete(permanent=True)
+    export_run.delete(permanent=True)
     schema.delete(permanent=True)
     feature_data_id.delete(permanent=True)
 


### PR DESCRIPTION
## Summary

- Pass `space=self.space` in `Record.to_artifact()` so exported artifacts live in the same space as the sheet, rather than inheriting the run context or default settings space.
- Set `run.space = self.space` on the internal export run in `_set_export_run()` so the export run is tracked in the sheet's space as well.

## Test plan

- [x] `pytest tests/core/test_record_sheet_examples.py -k "to_artifact or export"`

Also needs https://github.com/laminlabs/lamindb/pull/3750