### PR TITLE
🎨 Do not run `.save()` if feature_set is saved in curator

### DIFF
--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -2128,7 +2128,11 @@ def annotate_artifact(
             ArtifactSchema.objects.update_or_create(
                 artifact=artifact,
                 slot="columns",
-                defaults={"schema": feature_set.save()},
+                defaults={
+                    "schema": feature_set.save()
+                    if feature_set._state.adding
+                    else feature_set
+                },
             )
 
     else:
@@ -2176,7 +2180,13 @@ def annotate_artifact(
                 )
                 feature_set = Schema(itype=itype, n_members=len(features))
             ArtifactSchema.objects.update_or_create(
-                artifact=artifact, slot=slot, defaults={"schema": feature_set.save()}
+                artifact=artifact,
+                slot=slot,
+                defaults={
+                    "schema": feature_set.save()
+                    if feature_set._state.adding
+                    else feature_set
+                },
             )
 
     slug = ln_setup.settings.instance.slug

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -1102,24 +1102,16 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
                     .first()
                 )
             if transform is None:
-                transform = Transform(
-                    key="__lamindb_record_export__",
-                    kind="function",
-                    space=self.space,
+                transform, _ = Transform.objects.get_or_create(
+                    uid=export_transform_uid,
+                    defaults={
+                        "key": "__lamindb_record_export__",
+                        "kind": "function",
+                    },
                 )
+            elif transform.uid != export_transform_uid:
                 transform.uid = export_transform_uid
                 transform.save()
-            elif transform.uid != export_transform_uid:
-                from lamindb.errors import NoWriteAccess
-
-                previous_uid = transform.uid
-                transform.uid = export_transform_uid
-                try:
-                    transform.save()
-                except NoWriteAccess:
-                    # Legacy transforms may live in a space the caller cannot write.
-                    # Reuse them as-is; export runs still proceed in the sheet space.
-                    transform.uid = previous_uid
             # Export is treated as a discrete user action, so always create a new
             # run. Transfer reuses runs to avoid repeated sync bookkeeping runs.
             run = Run(

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -1102,16 +1102,24 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
                     .first()
                 )
             if transform is None:
-                transform, _ = Transform.objects.get_or_create(
-                    uid=export_transform_uid,
-                    defaults={
-                        "key": "__lamindb_record_export__",
-                        "kind": "function",
-                    },
+                transform = Transform(
+                    key="__lamindb_record_export__",
+                    kind="function",
+                    space=self.space,
                 )
-            elif transform.uid != export_transform_uid:
                 transform.uid = export_transform_uid
                 transform.save()
+            elif transform.uid != export_transform_uid:
+                from lamindb.errors import NoWriteAccess
+
+                previous_uid = transform.uid
+                transform.uid = export_transform_uid
+                try:
+                    transform.save()
+                except NoWriteAccess:
+                    # Legacy transforms may live in a space the caller cannot write.
+                    # Reuse them as-is; export runs still proceed in the sheet space.
+                    transform.uid = previous_uid
             # Export is treated as a discrete user action, so always create a new
             # run. Transfer reuses runs to avoid repeated sync bookkeeping runs.
             run = Run(


### PR DESCRIPTION
Fixes the bug if the user doesn't have space access to the existing feature set.