### PR TITLE
📝 Update outdated code in `curate_mudata.py`

### DIFF
--- a/docs/scripts/curate_mudata.py
+++ b/docs/scripts/curate_mudata.py
@@ -17,8 +17,8 @@ ln.Record(name="rep3", type=replicate).save()
 obs_schema = ln.Schema(
     name="mudata_papalexi21_subset_obs_schema",
     features=[
-        ln.Feature(name="perturbation", dtype="cat[Record[Perturbation]]").save(),
-        ln.Feature(name="replicate", dtype="cat[Record[Replicate]]").save(),
+        ln.Feature(name="perturbation", dtype=perturbation).save(),
+        ln.Feature(name="replicate", dtype=replicate).save(),
     ],
 ).save()
 


### PR DESCRIPTION
## Summary

Fixes the MuData curation tutorial script (`docs/scripts/curate_mudata.py`) to pass `Record` type objects to `Feature(dtype=...)` instead of the removed string format `cat[Record[Perturbation]]`.

This is required since lamindb 2.5.0 dropped support for semantic type names in string-based dtypes ([changelog](https://docs.lamin.ai/changelog/2026#db-2-5-0)).

## Follow-up

CI did not catch this regression: `curate_mudata.py` is executed in the `tiledbsoma` job via `docs/curate.ipynb`, but the notebook cell uses `!python scripts/curate_mudata.py`. nbclient does not fail notebook execution when a shell subprocess exits non-zero, so script errors are silently ignored.

A follow-up should make doc script failures fail CI, e.g. by running `curate_mudata.py` (and similar scripts) directly in pytest, or by replacing `!python ...` shell cells with in-kernel execution (`%run` / inline Python).