### PR TITLE
:zap: Speed up `Record.from_dataframe()` by a factor ~2 and fix casting of bool/int features with partially null entries

### DIFF
--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -2231,17 +2231,47 @@ def bulk_set_features_in_records(records: Iterable[Record]) -> None:
 
     assert batch_schema is not None  # noqa: S101
     schema_features = list(batch_schema.members.all())
-    dataframe = pd.DataFrame(prepared_rows)
+    from .feature import convert_to_pandas_dtype
     from .record import move_schema_index_column_to_dataframe_index
 
+    # Build the validation dataframe column-by-column with the dtype declared by
+    # each schema feature, instead of calling pd.DataFrame(prepared_rows) and
+    # letting pandas re-infer dtypes. The chopped per-row dicts drop null cells,
+    # so a naive pd.DataFrame would backfill NaN and widen partial-null columns
+    # (bool -> object, int -> float64), failing validation even for valid input.
+    # Supplying each column's declared pandas dtype up front propagates the type
+    # correctly through construction and removes the need for per-type casting.
+    feature_dtype_by_name = {
+        feature.name: convert_to_pandas_dtype(feature.dtype_as_str)
+        for feature in schema_features
+    }
+    # single pass to discover which columns actually appear across all rows
+    # (rows may differ once null cells are dropped)
+    present_columns: set[str] = set()
+    for row in prepared_rows:
+        present_columns.update(row)
+
+    # schema features first (stable, declared order), then any extra injected
+    # columns (e.g. the index/name), sorted for determinism
+    ordered_columns = [f.name for f in schema_features if f.name in present_columns]
+    ordered_columns += sorted(
+        column for column in present_columns if column not in feature_dtype_by_name
+    )
+
+    data: dict[str, pd.Series] = {}
+    for column in ordered_columns:
+        values = [row.get(column, pd.NA) for row in prepared_rows]
+        target_dtype = feature_dtype_by_name.get(column)
+        if target_dtype is not None:
+            data[column] = pd.Series(values, dtype=target_dtype)
+        else:
+            data[column] = pd.Series(values)
+    if data:
+        dataframe = pd.DataFrame(data)
+    else:
+        dataframe = pd.DataFrame(index=range(len(prepared_rows)))
+
     dataframe = move_schema_index_column_to_dataframe_index(dataframe, batch_schema)
-    for feature in schema_features:
-        if (
-            feature.name in dataframe
-            and feature.dtype_as_str.startswith("cat")
-            and not feature.dtype_as_str.startswith("list[cat")
-        ):
-            dataframe[feature.name] = dataframe[feature.name].astype("category")
     # Single-pass dataframe curation:
     # validate schema and resolve categoricals once for the entire batch.
     #

--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -2241,6 +2241,7 @@ def bulk_set_features_in_records(records: Iterable[Record]) -> None:
     # (bool -> object, int -> float64), failing validation even for valid input.
     # Supplying each column's declared pandas dtype up front propagates the type
     # correctly through construction and removes the need for per-type casting.
+    # Note: benchmark this when modifying, for reference -> https://lamin.ai/laminlabs/lamindata/transform/JuJZZEsit1KV
     feature_dtype_by_name = {
         feature.name: convert_to_pandas_dtype(feature.dtype_as_str)
         for feature in schema_features

--- a/tests/core/test_curator_basics.py
+++ b/tests/core/test_curator_basics.py
@@ -505,8 +505,14 @@ def test_curator_partial_null_bool_int():
             "cur-count": [1, None, 3],  # float64
         }
     )
-    with pytest.raises(ln.errors.ValidationError):
+    with pytest.raises(ln.errors.ValidationError) as excinfo:
         ln.curators.DataFrameCurator(df_degraded, schema).validate()
+    assert "Column 'cur-flag' failed dtype check for 'bool': got object" in str(
+        excinfo.value
+    )
+    assert "Column 'cur-count' failed dtype check for 'int': got float64" in str(
+        excinfo.value
+    )
 
     schema.delete(permanent=True)
     flag.delete(permanent=True)

--- a/tests/core/test_curator_basics.py
+++ b/tests/core/test_curator_basics.py
@@ -480,6 +480,39 @@ def test_nullable():
     disease.delete(permanent=True)
 
 
+def test_curator_partial_null_bool_int():
+    flag = ln.Feature(name="cur-flag", dtype=bool, nullable=True).save()
+    count = ln.Feature(name="cur-count", dtype=int, nullable=True).save()
+    schema = ln.Schema(features=[flag, count]).save()
+
+    # Case 1: properly-typed nullable columns -> should PASS
+    # This is what a well-behaved user supplies, and what our _feature_manager fix
+    # produces after the cast. We are asserting the curator accepts these dtypes.
+    df_good = pd.DataFrame(
+        {
+            "cur-flag": pd.array([True, None, False], dtype="boolean"),
+            "cur-count": pd.array([1, None, 3], dtype="Int64"),
+        }
+    )
+    assert ln.curators.DataFrameCurator(df_good, schema).validate() is None
+
+    # Case 2: degraded dtypes (what pd.DataFrame(prepared_rows) produces internally)
+    # bool + null -> object, int + null -> float64.
+    # Should FAIL — this is correct curator behaviour, not a bug.
+    df_degraded = pd.DataFrame(
+        {
+            "cur-flag": [True, None, False],  # object
+            "cur-count": [1, None, 3],  # float64
+        }
+    )
+    with pytest.raises(ln.errors.ValidationError):
+        ln.curators.DataFrameCurator(df_degraded, schema).validate()
+
+    schema.delete(permanent=True)
+    flag.delete(permanent=True)
+    count.delete(permanent=True)
+
+
 def test_pandera_dataframe_schema(
     df,
     df_missing_sample_type_column,

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -129,16 +129,15 @@ def test_record_lazy_features_on_save():
     score_feature.delete(permanent=True)
 
 
-def test_record_from_dataframe_partial_null_bool_int_degradation():
-    """Reproduces internal dtype degradation in Record.from_dataframe().
+def test_record_from_dataframe_partial_null_bool_int():
+    """Partial-null bool/int features survive the from_dataframe save round-trip.
 
-    The user supplies correctly-typed nullable columns (boolean / Int64), but on
-    .save() the chop-reglue (_build_records drops the null cell, then
-    pd.DataFrame(prepared_rows) backfills NaN and re-infers) degrades them to
-    object / float64, so validation fails even though the input was valid.
-
-    Asserts the buggy failure for now; flip to a successful save + round-trip
-    once the fix lands.
+    The user supplies correctly-typed nullable columns (boolean / Int64). On
+    .save(), _build_records chops the frame into per-row dicts (dropping null
+    cells) and bulk_set_features_in_records rebuilds it. Building each column with
+    its declared dtype (via convert_to_pandas_dtype) instead of letting
+    pd.DataFrame re-infer keeps bool/int from degrading to object/float64, so
+    validation passes and the values round-trip.
     """
     flag = ln.Feature(name="from-df-flag", dtype=bool).save()
     count = ln.Feature(name="from-df-count", dtype=int).save()
@@ -159,16 +158,26 @@ def test_record_from_dataframe_partial_null_bool_int_degradation():
     assert df["from-df-flag"].dtype.name == "boolean"
     assert df["from-df-count"].dtype.name == "Int64"
 
-    with pytest.raises(ln.errors.ValidationError) as excinfo:
-        ln.Record.from_dataframe(df, type=sheet).save()
-    # the message proves lamindb degraded the dtypes internally: we passed
-    # boolean/Int64 but the curator reports object / float64
-    assert "Column 'from-df-flag' failed dtype check for 'bool': got object" in str(
-        excinfo.value
+    records = ln.Record.from_dataframe(df, type=sheet)
+    assert len(records) == 3
+    records.save()
+
+    # non-null values round-trip
+    assert ln.Record.get(name="from-df-a").features.get_values()["from-df-flag"] is True
+    assert ln.Record.get(name="from-df-a").features.get_values()["from-df-count"] == 1
+    # the None row drops the fragile keys entirely
+    assert "from-df-flag" not in ln.Record.get(name="from-df-b").features.get_values()
+    assert "from-df-count" not in ln.Record.get(name="from-df-b").features.get_values()
+    assert (
+        ln.Record.get(name="from-df-c").features.get_values()["from-df-flag"] is False
     )
-    assert "Column 'from-df-count' failed dtype check for 'int': got float64" in str(
-        excinfo.value
-    )
+    assert ln.Record.get(name="from-df-c").features.get_values()["from-df-count"] == 3
+
+    # dtypes survive the export round-trip: the columns come back as the nullable
+    # extension dtypes, not degraded object / float64
+    exported = sheet.to_dataframe()
+    assert exported["from-df-flag"].dtype.name == "boolean"
+    assert exported["from-df-count"].dtype.name == "Int64"
 
     ln.Record.filter(name__in=["from-df-a", "from-df-b", "from-df-c"]).delete(
         permanent=True

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -129,6 +129,57 @@ def test_record_lazy_features_on_save():
     score_feature.delete(permanent=True)
 
 
+def test_record_from_dataframe_partial_null_bool_int_degradation():
+    """Reproduces internal dtype degradation in Record.from_dataframe().
+
+    The user supplies correctly-typed nullable columns (boolean / Int64), but on
+    .save() the chop-reglue (_build_records drops the null cell, then
+    pd.DataFrame(prepared_rows) backfills NaN and re-infers) degrades them to
+    object / float64, so validation fails even though the input was valid.
+
+    Asserts the buggy failure for now; flip to a successful save + round-trip
+    once the fix lands.
+    """
+    flag = ln.Feature(name="from-df-flag", dtype=bool).save()
+    count = ln.Feature(name="from-df-count", dtype=int).save()
+    label = ln.Feature(name="from-df-label", dtype=str).save()
+    schema = ln.Schema([flag, count, label], name="from-df-bool-int-schema").save()
+    sheet = ln.Record(name="from-df-bool-int-sheet", is_type=True, schema=schema).save()
+
+    df = pd.DataFrame(
+        {
+            "__lamindb_record_name__": ["from-df-a", "from-df-b", "from-df-c"],
+            "from-df-flag": pd.array([True, None, False], dtype="boolean"),
+            "from-df-count": pd.array([1, None, 3], dtype="Int64"),
+            "from-df-label": ["a", "b", "c"],
+        }
+    )
+
+    # the supplied dtypes are genuinely correct/nullable
+    assert df["from-df-flag"].dtype.name == "boolean"
+    assert df["from-df-count"].dtype.name == "Int64"
+
+    with pytest.raises(ln.errors.ValidationError) as excinfo:
+        ln.Record.from_dataframe(df, type=sheet).save()
+    # the message proves lamindb degraded the dtypes internally: we passed
+    # boolean/Int64 but the curator reports object / float64
+    assert "Column 'from-df-flag' failed dtype check for 'bool': got object" in str(
+        excinfo.value
+    )
+    assert "Column 'from-df-count' failed dtype check for 'int': got float64" in str(
+        excinfo.value
+    )
+
+    ln.Record.filter(name__in=["from-df-a", "from-df-b", "from-df-c"]).delete(
+        permanent=True
+    )
+    ln.Record.filter(name="from-df-bool-int-sheet").delete(permanent=True)
+    schema.delete(permanent=True)
+    flag.delete(permanent=True)
+    count.delete(permanent=True)
+    label.delete(permanent=True)
+
+
 def test_record_from_dataframe_bulk_save_paths():
     score = ln.Feature(name="from-df-score", dtype=float).save()
     schema = ln.Schema([score], name="from-df-schema").save()


### PR DESCRIPTION
Fixes a ValidationError in `Record.from_dataframe(...).save()` when a `bool/int` feature has `None` on some rows but not others. 

Improves performance of the  `Record.from_dataframe()` by a factor of 2 for 10k records: 

Before | After
--- | ---
https://lamin.ai/laminlabs/lamindata/run/hnGNmdrq8PwS244w | https://lamin.ai/laminlabs/lamindata/run/ZCnnyAOejjnbIKVa
<img width="1252" height="523" alt="image" src="https://github.com/user-attachments/assets/fa19c0a2-0337-4541-a4ec-30def6bfdb41" /> | <img width="1048" height="636" alt="Screenshot 2026-06-24 at 10 09 23 AM" src="https://github.com/user-attachments/assets/e4def897-c8de-4157-8797-c448fe91c7af" />

## Materials

Previous PR:

- https://github.com/laminlabs/lamindb/pull/3649

Fixes:

- https://github.com/pfizer-collab/laminlabs/issues/1009

## Background

Internally the save path rebuilt the frame with `pd.DataFrame(prepared_rows)`, which let pandas re-infer and degrade those columns `(bool → object, int → float64)`, failing the `dtype` check even for correctly-typed nullable input. 

The frame is now built column-by-column using each feature's declared `dtype` (convert_to_pandas_dtype), so dtypes never degrade. Adds tests covering both the DataFrameCurator (accepts nullable boolean/Int64, rejects degraded object/float64) and the `from_dataframe()` save round-trip.
