### PR TITLE
🐛 Fix ambiguous Record match in `sheet.to_artifact()` for duplicate names

### DIFF
--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -177,6 +177,74 @@ Returns:
 LAMINDB_COLUMN_PREFIX_REGEX = r"^__lamindb_.*$"
 
 
+def _resolve_record_categorical_from_sheet_export(
+    cat_vector: CatVector,
+    str_values: list[str],
+) -> tuple[list[str], SQLRecordList, list[str]] | None:
+    """Resolve Record categoricals from existing DB links when sheet row uids are present."""
+    if cat_vector.feature is None or cat_vector._cat_manager is None:
+        return None
+    if cat_vector._registry.__name__ != "Record":
+        return None
+    if cat_vector.feature.pk is None:
+        return None
+
+    dataset = cat_vector._cat_manager._dataset
+    if not isinstance(dataset, pd.DataFrame):
+        return None
+
+    from lamindb.models.query_set import (
+        encode_lamindb_fields_as_columns,
+        get_default_branch_ids,
+    )
+    from lamindb.models.record import Record as RecordModel
+    from lamindb.models.record import RecordRecord
+
+    uid_col = encode_lamindb_fields_as_columns(RecordModel, "uid")
+    if not isinstance(uid_col, str) or uid_col not in dataset.columns:
+        return None
+
+    row_uids = dataset[uid_col].dropna().astype(str).unique().tolist()
+    if not row_uids:
+        return None
+
+    branch_ids = get_default_branch_ids()
+    links = RecordRecord.objects.filter(
+        record__uid__in=row_uids,
+        record__branch_id__in=branch_ids,
+        feature_id=cat_vector.feature.id,
+        value__branch_id__in=branch_ids,
+    ).select_related("value", "value__type")
+    if cat_vector._type_uid:
+        links = links.filter(value__type__uid=cat_vector._type_uid)
+    if cat_vector._filter_kwargs:
+        value_filters = {}
+        for key, val in cat_vector._filter_kwargs.items():
+            if isinstance(val, SQLRecord):
+                value_filters[f"value__{key}_id"] = val.id
+            else:
+                value_filters[f"value__{key}"] = val
+        links = links.filter(**value_filters)
+
+    records_by_id: dict[int, SQLRecord] = {}
+    linked_field_values: set[str] = set()
+    field_name = cat_vector._field_name
+    for link in links:
+        record = link.value
+        records_by_id[record.id] = record
+        field_value = getattr(record, field_name, None)
+        if field_value is not None:
+            linked_field_values.add(field_value)
+
+    if not records_by_id:
+        return None
+
+    records = SQLRecordList(records_by_id.values())
+    validated_values = [v for v in str_values if v in linked_field_values]
+    non_validated_values = [v for v in str_values if v not in linked_field_values]
+    return validated_values, records, non_validated_values
+
+
 class Curator:
     """Curator base class.
 
@@ -1522,6 +1590,14 @@ class CatVector:
             validated_values = str_values  # type: ignore
             return validated_values, []
 
+        sheet_export_result = _resolve_record_categorical_from_sheet_export(
+            self, str_values
+        )
+        if sheet_export_result is not None:
+            validated_values, records, remaining_values = sheet_export_result
+            self.records = records
+            return validated_values, remaining_values
+
         # get all field specs for union types
         if self.feature:
             results = parse_dtype(self.feature._dtype_str)
@@ -1529,7 +1605,7 @@ class CatVector:
             results = [None]
 
         all_validated = []
-        all_records = []
+        all_records: list[SQLRecord] = []
         remaining_values = str_values
 
         for result in results:

--- a/tests/core/test_record_sheet_examples.py
+++ b/tests/core/test_record_sheet_examples.py
@@ -549,3 +549,63 @@ def test_record_export_populates_initiated_by_run(
     finally:
         ln.context._run = None
         artifact.delete(permanent=True)
+
+
+def test_to_artifact_with_duplicate_linked_record_names():
+    """Sheet export round-trip resolves Record links by row uid, not ambiguous names."""
+    pooled_sample_type = ln.Record(name="PooledSample", is_type=True).save()
+    sample_a = ln.Record(name="poolsample1", type=pooled_sample_type).save()
+    sample_b = ln.Record(type=pooled_sample_type).save()
+    sample_b.name = "poolsample1"
+    sample_b.save()
+    assert sample_a.id != sample_b.id
+
+    sample_feature = ln.Feature(name="sample", dtype=pooled_sample_type).save()
+    fastq_feature = ln.Feature(name="fastq_1", dtype=str).save()
+    schema = ln.Schema(
+        name="duplicate sample names schema",
+        features=[sample_feature, fastq_feature],
+    ).save()
+    sheet_type = ln.Record(name="DuplicateNameSheetType", is_type=True).save()
+    sheet = ln.Record(
+        name="duplicate name sheet",
+        is_type=True,
+        type=sheet_type,
+        schema=schema,
+    ).save()
+
+    row_a = ln.Record(type=sheet).save()
+    row_b = ln.Record(type=sheet).save()
+    ln.models.RecordRecord(record=row_a, feature=sample_feature, value=sample_a).save()
+    ln.models.RecordRecord(record=row_b, feature=sample_feature, value=sample_b).save()
+    ln.models.RecordJson(record=row_a, feature=fastq_feature, value="read_a").save()
+    ln.models.RecordJson(record=row_b, feature=fastq_feature, value="read_b").save()
+
+    df = sheet.to_dataframe()
+    assert df["sample"].tolist() == ["poolsample1", "poolsample1"]
+    assert set(df["__lamindb_record_uid__"]) == {row_a.uid, row_b.uid}
+
+    artifact = sheet.to_artifact()
+    try:
+        assert artifact.schema is sheet.schema
+        linked_sample_uids = {
+            record.uid
+            for record in artifact.records.all()
+            if record.type_id == pooled_sample_type.id
+        }
+        assert linked_sample_uids == {sample_a.uid, sample_b.uid}
+    finally:
+        export_run = artifact.run
+        artifact.delete(permanent=True)
+        if export_run is not None:
+            export_run.delete(permanent=True)
+        row_a.delete(permanent=True)
+        row_b.delete(permanent=True)
+        sheet.delete(permanent=True)
+        sheet_type.delete(permanent=True)
+        schema.delete(permanent=True)
+        sample_feature.delete(permanent=True)
+        fastq_feature.delete(permanent=True)
+        sample_a.delete(permanent=True)
+        sample_b.delete(permanent=True)
+        pooled_sample_type.delete(permanent=True)

--- a/tests/core/test_record_sheet_examples.py
+++ b/tests/core/test_record_sheet_examples.py
@@ -553,15 +553,17 @@ def test_record_export_populates_initiated_by_run(
 
 def test_to_artifact_with_duplicate_linked_record_names():
     """Sheet export round-trip resolves Record links by row uid, not ambiguous names."""
-    pooled_sample_type = ln.Record(name="PooledSample", is_type=True).save()
+    pooled_sample_type = ln.Record(name="PooledSampleDupNameTest", is_type=True).save()
     sample_a = ln.Record(name="poolsample1", type=pooled_sample_type).save()
     sample_b = ln.Record(type=pooled_sample_type).save()
     sample_b.name = "poolsample1"
     sample_b.save()
     assert sample_a.id != sample_b.id
 
-    sample_feature = ln.Feature(name="sample", dtype=pooled_sample_type).save()
-    fastq_feature = ln.Feature(name="fastq_1", dtype=str).save()
+    sample_feature = ln.Feature(
+        name="dup_name_pooled_sample", dtype=pooled_sample_type
+    ).save()
+    fastq_feature = ln.Feature(name="dup_name_fastq_1", dtype=str).save()
     schema = ln.Schema(
         name="duplicate sample names schema",
         features=[sample_feature, fastq_feature],
@@ -582,7 +584,7 @@ def test_to_artifact_with_duplicate_linked_record_names():
     ln.models.RecordJson(record=row_b, feature=fastq_feature, value="read_b").save()
 
     df = sheet.to_dataframe()
-    assert df["sample"].tolist() == ["poolsample1", "poolsample1"]
+    assert df["dup_name_pooled_sample"].tolist() == ["poolsample1", "poolsample1"]
     assert set(df["__lamindb_record_uid__"]) == {row_a.uid, row_b.uid}
 
     artifact = sheet.to_artifact()


### PR DESCRIPTION
## Summary

- Fix `ValidationError: Ambiguous match for Record '...'` when calling `Record.to_artifact()` on a sheet whose Record-type features (e.g. `sample`) reference multiple records with the same display name.
- During curator validation, if the dataframe includes `__lamindb_record_uid__`, resolve linked Record categoricals from existing `RecordRecord` rows instead of re-matching by name.
- No change to exported CSV content — only the annotation/validation path is updated.

## Test plan

- [x] `pytest tests/core/test_record_sheet_examples.py::test_to_artifact_with_duplicate_linked_record_names`