### PR TITLE
🐛 Fix ambiguous Record match in `sheet.to_artifact()` for duplicate names

### DIFF
--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -181,7 +181,66 @@ def _resolve_record_categorical_from_sheet_export(
     cat_vector: CatVector,
     str_values: list[str],
 ) -> tuple[list[str], SQLRecordList, list[str]] | None:
-    """Resolve Record categoricals from existing DB links when sheet row uids are present."""
+    """Resolve linked ``Record`` categoricals during sheet export round-trips.
+
+    Background
+    ----------
+    Sheet rows can link to other :class:`~lamindb.Record` objects through features
+    with dtypes like ``cat[Record[BioSample].name]``. On export, only the linked
+    record's *display field* (usually ``name``) is written into the dataframe column
+    — not the linked record's uid.
+
+    When validating that export dataframe again (e.g. ``sheet.to_artifact()``), the
+    default categorical resolver looks up registry values **globally by name**. If two
+    different linked records share the same display name (e.g. two BioSamples both
+    named ``poolsample1``), that lookup is ambiguous and raises
+    :class:`~lamindb.errors.ValidationError`.
+
+    This helper avoids global name matching when the dataframe still carries enough
+    information to identify **which sheet row** each value came from. It resolves
+    linked records through existing :class:`~lamindb.models.record.RecordRecord` rows
+    in the database instead.
+
+    Row keys (two export shapes)
+    ----------------------------
+    Sheets **without** :attr:`~lamindb.Schema.index` include encoded metadata columns
+    on export::
+
+        sample,fastq_1,...,__lamindb_record_uid__
+        poolsample1,read_a,...,L2iXQt4UoivWTSut
+
+    Sheets **with** ``Schema.index`` omit ``__lamindb_record_*`` columns; the index
+    feature becomes ``df.index`` (values are stored on ``Record.name``)::
+
+        name,treatment,cell_line
+        Sample 1,treatment1,HEK293T
+
+    This function detects which shape applies and queries ``RecordRecord`` with the
+    matching row key:
+
+    - **No index**: ``record__uid__in`` from ``__lamindb_record_uid__``.
+    - **With index**: ``record__name__in`` from ``df.index`` (or the index column),
+      scoped to sheet types registered on the validating schema
+      (``Record.filter(is_type=True, schema_id=...)``). Index names are only unique
+      within a sheet, so the type filter is required.
+
+    What this does *not* do
+    -----------------------
+    - Does not add uid columns to exports; row keys come from the existing export
+      layout.
+    - Does not replace dtype-based validation — dtype still defines *what* to validate.
+    - Returns ``None`` for external dataframes without row keys, so normal global name
+      lookup proceeds unchanged.
+
+    Args:
+        cat_vector: Categorical being validated; must be a ``Record`` registry feature.
+        str_values: Distinct string values observed in the dataframe column.
+
+    Returns:
+        ``(validated_values, linked_records, non_validated_values)`` when row keys are
+        present and matching DB links exist; otherwise ``None`` (fall back to default
+        validation).
+    """
     if cat_vector.feature is None or cat_vector._cat_manager is None:
         return None
     if cat_vector._registry.__name__ != "Record":
@@ -200,23 +259,49 @@ def _resolve_record_categorical_from_sheet_export(
     from lamindb.models.record import Record as RecordModel
     from lamindb.models.record import RecordRecord
 
+    row_record_filter: dict[str, Any] = {}
     uid_col = encode_lamindb_fields_as_columns(RecordModel, "uid")
-    if not isinstance(uid_col, str) or uid_col not in dataset.columns:
-        return None
+    if isinstance(uid_col, str) and uid_col in dataset.columns:
+        row_uids = dataset[uid_col].dropna().astype(str).unique().tolist()
+        if not row_uids:
+            return None
+        row_record_filter["record__uid__in"] = row_uids
+    else:
+        cat_manager = cat_vector._cat_manager
+        index_feature = cat_manager._index
+        schema = cat_manager._schema
+        if index_feature is None or schema is None or schema.id is None:
+            return None
 
-    row_uids = dataset[uid_col].dropna().astype(str).unique().tolist()
-    if not row_uids:
-        return None
+        index_name = index_feature.name
+        if dataset.index.name == index_name and not isinstance(
+            dataset.index, pd.RangeIndex
+        ):
+            index_values = dataset.index.dropna().astype(str).unique().tolist()
+        elif index_name in dataset.columns:
+            index_values = dataset[index_name].dropna().astype(str).unique().tolist()
+        else:
+            return None
+        if not index_values:
+            return None
+
+        sheet_type_ids = list(
+            RecordModel.objects.filter(is_type=True, schema_id=schema.id).values_list(
+                "id", flat=True
+            )
+        )
+        if not sheet_type_ids:
+            return None
+        row_record_filter["record__name__in"] = index_values
+        row_record_filter["record__type_id__in"] = sheet_type_ids
 
     branch_ids = get_default_branch_ids()
     links = RecordRecord.objects.filter(
-        record__uid__in=row_uids,
+        **row_record_filter,
         record__branch_id__in=branch_ids,
         feature_id=cat_vector.feature.id,
         value__branch_id__in=branch_ids,
     ).select_related("value", "value__type")
-    if cat_vector._type_uid:
-        links = links.filter(value__type__uid=cat_vector._type_uid)
     if cat_vector._filter_kwargs:
         value_filters = {}
         for key, val in cat_vector._filter_kwargs.items():
@@ -1926,6 +2011,7 @@ class DataFrameCatManager:
     ) -> None:
         self._non_validated = None
         self._index = index
+        self._schema = schema
         self._artifact: Artifact = None  # pass the dataset as an artifact
         self._dataset: Any = df  # pass the dataset as an AnyPathStr or data object
         if isinstance(self._dataset, Artifact):

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -177,6 +177,74 @@ Returns:
 LAMINDB_COLUMN_PREFIX_REGEX = r"^__lamindb_.*$"
 
 
+def _resolve_record_categorical_from_sheet_export(
+    cat_vector: CatVector,
+    str_values: list[str],
+) -> tuple[list[str], SQLRecordList, list[str]] | None:
+    """Resolve Record categoricals from existing DB links when sheet row uids are present."""
+    if cat_vector.feature is None or cat_vector._cat_manager is None:
+        return None
+    if cat_vector._registry.__name__ != "Record":
+        return None
+    if cat_vector.feature.pk is None:
+        return None
+
+    dataset = cat_vector._cat_manager._dataset
+    if not isinstance(dataset, pd.DataFrame):
+        return None
+
+    from lamindb.models.query_set import (
+        encode_lamindb_fields_as_columns,
+        get_default_branch_ids,
+    )
+    from lamindb.models.record import Record as RecordModel
+    from lamindb.models.record import RecordRecord
+
+    uid_col = encode_lamindb_fields_as_columns(RecordModel, "uid")
+    if not isinstance(uid_col, str) or uid_col not in dataset.columns:
+        return None
+
+    row_uids = dataset[uid_col].dropna().astype(str).unique().tolist()
+    if not row_uids:
+        return None
+
+    branch_ids = get_default_branch_ids()
+    links = RecordRecord.objects.filter(
+        record__uid__in=row_uids,
+        record__branch_id__in=branch_ids,
+        feature_id=cat_vector.feature.id,
+        value__branch_id__in=branch_ids,
+    ).select_related("value", "value__type")
+    if cat_vector._type_uid:
+        links = links.filter(value__type__uid=cat_vector._type_uid)
+    if cat_vector._filter_kwargs:
+        value_filters = {}
+        for key, val in cat_vector._filter_kwargs.items():
+            if isinstance(val, SQLRecord):
+                value_filters[f"value__{key}_id"] = val.id
+            else:
+                value_filters[f"value__{key}"] = val
+        links = links.filter(**value_filters)
+
+    records_by_id: dict[int, SQLRecord] = {}
+    linked_field_values: set[str] = set()
+    field_name = cat_vector._field_name
+    for link in links:
+        record = link.value
+        records_by_id[record.id] = record
+        field_value = getattr(record, field_name, None)
+        if field_value is not None:
+            linked_field_values.add(field_value)
+
+    if not records_by_id:
+        return None
+
+    records = SQLRecordList(records_by_id.values())
+    validated_values = [v for v in str_values if v in linked_field_values]
+    non_validated_values = [v for v in str_values if v not in linked_field_values]
+    return validated_values, records, non_validated_values
+
+
 class Curator:
     """Curator base class.
 
@@ -1522,6 +1590,14 @@ class CatVector:
             validated_values = str_values  # type: ignore
             return validated_values, []
 
+        sheet_export_result = _resolve_record_categorical_from_sheet_export(
+            self, str_values
+        )
+        if sheet_export_result is not None:
+            validated_values, records, remaining_values = sheet_export_result
+            self.records = records
+            return validated_values, remaining_values
+
         # get all field specs for union types
         if self.feature:
             results = parse_dtype(self.feature._dtype_str)
@@ -1529,7 +1605,7 @@ class CatVector:
             results = [None]
 
         all_validated = []
-        all_records = []
+        all_records: list[SQLRecord] = []
         remaining_values = str_values
 
         for result in results:

--- a/tests/core/test_record_sheet_examples.py
+++ b/tests/core/test_record_sheet_examples.py
@@ -274,6 +274,50 @@ Sample_X,https://raw.githubusercontent.com/nf-core/test-datasets/scrnaseq/testda
         ],
     )
 
+    # Two linked BioSample records can share a display name; export resolves by row uid.
+    features = ln.Feature.lookup()
+    samples_sheet = ln.Record.get(name="Sample_X").type
+    sample_dup_a = ln.Record(name="poolsample1", type=samples_sheet).save()
+    sample_dup_b = ln.Record(type=samples_sheet).save()
+    sample_dup_b.name = "poolsample1"
+    sample_dup_b.save()
+    assert sample_dup_a.id != sample_dup_b.id
+
+    row_a = ln.Record(type=nextflow_sheet).save()
+    row_b = ln.Record(type=nextflow_sheet).save()
+    ln.models.RecordRecord(
+        record=row_a, feature=features.sample, value=sample_dup_a
+    ).save()
+    ln.models.RecordRecord(
+        record=row_b, feature=features.sample, value=sample_dup_b
+    ).save()
+    ln.models.RecordJson(record=row_a, feature=features.fastq_1, value="read_a").save()
+    ln.models.RecordJson(record=row_b, feature=features.fastq_1, value="read_b").save()
+    ln.models.RecordJson(
+        record=row_a, feature=features.expected_cells, value=5000
+    ).save()
+    ln.models.RecordJson(
+        record=row_b, feature=features.expected_cells, value=5000
+    ).save()
+
+    dup_rows = nextflow_sheet.to_dataframe()
+    dup_rows = dup_rows[dup_rows["sample"] == "poolsample1"]
+    assert len(dup_rows) == 2
+    assert set(dup_rows["__lamindb_record_uid__"]) == {row_a.uid, row_b.uid}
+
+    artifact_dup = nextflow_sheet.to_artifact()
+    linked_poolsample_uids = {
+        record.uid
+        for record in artifact_dup.records.all()
+        if record.name == "poolsample1"
+    }
+    assert linked_poolsample_uids == {sample_dup_a.uid, sample_dup_b.uid}
+    artifact_dup.delete(permanent=True)
+    row_a.delete(permanent=True)
+    row_b.delete(permanent=True)
+    sample_dup_a.delete(permanent=True)
+    sample_dup_b.delete(permanent=True)
+
     related_schemas = list(artifact.schemas.all())
     artifact.schemas.clear()
     for schema in related_schemas:
@@ -549,65 +593,3 @@ def test_record_export_populates_initiated_by_run(
     finally:
         ln.context._run = None
         artifact.delete(permanent=True)
-
-
-def test_to_artifact_with_duplicate_linked_record_names():
-    """Sheet export round-trip resolves Record links by row uid, not ambiguous names."""
-    pooled_sample_type = ln.Record(name="PooledSampleDupNameTest", is_type=True).save()
-    sample_a = ln.Record(name="poolsample1", type=pooled_sample_type).save()
-    sample_b = ln.Record(type=pooled_sample_type).save()
-    sample_b.name = "poolsample1"
-    sample_b.save()
-    assert sample_a.id != sample_b.id
-
-    sample_feature = ln.Feature(
-        name="dup_name_pooled_sample", dtype=pooled_sample_type
-    ).save()
-    fastq_feature = ln.Feature(name="dup_name_fastq_1", dtype=str).save()
-    schema = ln.Schema(
-        name="duplicate sample names schema",
-        features=[sample_feature, fastq_feature],
-    ).save()
-    sheet_type = ln.Record(name="DuplicateNameSheetType", is_type=True).save()
-    sheet = ln.Record(
-        name="duplicate name sheet",
-        is_type=True,
-        type=sheet_type,
-        schema=schema,
-    ).save()
-
-    row_a = ln.Record(type=sheet).save()
-    row_b = ln.Record(type=sheet).save()
-    ln.models.RecordRecord(record=row_a, feature=sample_feature, value=sample_a).save()
-    ln.models.RecordRecord(record=row_b, feature=sample_feature, value=sample_b).save()
-    ln.models.RecordJson(record=row_a, feature=fastq_feature, value="read_a").save()
-    ln.models.RecordJson(record=row_b, feature=fastq_feature, value="read_b").save()
-
-    df = sheet.to_dataframe()
-    assert df["dup_name_pooled_sample"].tolist() == ["poolsample1", "poolsample1"]
-    assert set(df["__lamindb_record_uid__"]) == {row_a.uid, row_b.uid}
-
-    artifact = sheet.to_artifact()
-    try:
-        assert artifact.schema is sheet.schema
-        linked_sample_uids = {
-            record.uid
-            for record in artifact.records.all()
-            if record.type_id == pooled_sample_type.id
-        }
-        assert linked_sample_uids == {sample_a.uid, sample_b.uid}
-    finally:
-        export_run = artifact.run
-        artifact.delete(permanent=True)
-        if export_run is not None:
-            export_run.delete(permanent=True)
-        row_a.delete(permanent=True)
-        row_b.delete(permanent=True)
-        sheet.delete(permanent=True)
-        sheet_type.delete(permanent=True)
-        schema.delete(permanent=True)
-        sample_feature.delete(permanent=True)
-        fastq_feature.delete(permanent=True)
-        sample_a.delete(permanent=True)
-        sample_b.delete(permanent=True)
-        pooled_sample_type.delete(permanent=True)

--- a/tests/core/test_record_sheet_examples.py
+++ b/tests/core/test_record_sheet_examples.py
@@ -1,5 +1,6 @@
 import re
 
+import bionty as bt
 import lamindb as ln
 import pandas as pd
 from lamindb.examples.fixtures.sheets import (
@@ -187,6 +188,58 @@ Sample 1,1,S1,treatment1,HEK293T,2025-06-01 05:00:00,Project 1""")
             ("uid", "str", None),
         ],
     )
+
+    # Two linked Treatment records can share a display name; indexed export resolves
+    # by schema index (df.index), not __lamindb_record_uid__.
+    treatment_feature = ln.Feature.get(name="treatment")
+    cell_line_feature = ln.Feature.get(name="cell_line")
+    hek293t = bt.CellLine.filter(name="HEK293T").one()
+    treatment_dup_a = ln.Record(name="shared_treatment", type=treatments_sheet).save()
+    treatment_dup_b = ln.Record(type=treatments_sheet).save()
+    treatment_dup_b.name = "shared_treatment"
+    treatment_dup_b.save()
+    row_a = ln.Record(name="Sample 3", type=sample_sheet1).save()
+    row_b = ln.Record(name="Sample 4", type=sample_sheet1).save()
+    artifact_dup = None
+    try:
+        ln.models.RecordRecord(
+            record=row_a, feature=treatment_feature, value=treatment_dup_a
+        ).save()
+        ln.models.RecordRecord(
+            record=row_b, feature=treatment_feature, value=treatment_dup_b
+        ).save()
+        bt.models.RecordCellLine(
+            record=row_a, feature=cell_line_feature, value=hek293t
+        ).save()
+        bt.models.RecordCellLine(
+            record=row_b, feature=cell_line_feature, value=hek293t
+        ).save()
+
+        dup_rows = sample_sheet1.to_dataframe()
+        dup_rows = dup_rows[dup_rows["treatment"] == "shared_treatment"]
+        assert len(dup_rows) == 2
+        assert set(dup_rows.index) == {"Sample 3", "Sample 4"}
+        assert not any(col.startswith("__lamindb_record_") for col in dup_rows.columns)
+
+        artifact_dup = sample_sheet1.to_artifact()
+        linked_treatment_uids = {
+            record.uid
+            for record in artifact_dup.records.all()
+            if record.name == "shared_treatment"
+        }
+        assert linked_treatment_uids == {treatment_dup_a.uid, treatment_dup_b.uid}
+    finally:
+        if artifact_dup is not None:
+            export_run_dup = artifact_dup.run
+            artifact_dup.delete(permanent=True)
+            if export_run_dup is not None:
+                export_run_dup.delete(permanent=True)
+        row_a.delete(permanent=True)
+        row_b.delete(permanent=True)
+        treatment_dup_a.delete(permanent=True)
+        treatment_dup_b.delete(permanent=True)
+        assert sample_sheet1.records.count() == 2
+
     # re-run the export which triggers hash lookup
     artifact2 = sample_sheet1.to_artifact()
     # soft-delete a record in the sheet
@@ -285,44 +338,59 @@ Sample_X,https://raw.githubusercontent.com/nf-core/test-datasets/scrnaseq/testda
 
     row_a = ln.Record(type=nextflow_sheet).save()
     row_b = ln.Record(type=nextflow_sheet).save()
-    ln.models.RecordRecord(
-        record=row_a, feature=features.sample, value=sample_dup_a
-    ).save()
-    ln.models.RecordRecord(
-        record=row_b, feature=features.sample, value=sample_dup_b
-    ).save()
-    ln.models.RecordJson(record=row_a, feature=features.fastq_1, value="read_a").save()
-    ln.models.RecordJson(record=row_b, feature=features.fastq_1, value="read_b").save()
-    ln.models.RecordJson(
-        record=row_a, feature=features.expected_cells, value=5000
-    ).save()
-    ln.models.RecordJson(
-        record=row_b, feature=features.expected_cells, value=5000
-    ).save()
+    artifact_dup = None
+    try:
+        ln.models.RecordRecord(
+            record=row_a, feature=features.sample, value=sample_dup_a
+        ).save()
+        ln.models.RecordRecord(
+            record=row_b, feature=features.sample, value=sample_dup_b
+        ).save()
+        ln.models.RecordJson(
+            record=row_a, feature=features.fastq_1, value="read_a"
+        ).save()
+        ln.models.RecordJson(
+            record=row_b, feature=features.fastq_1, value="read_b"
+        ).save()
+        ln.models.RecordJson(
+            record=row_a, feature=features.expected_cells, value=5000
+        ).save()
+        ln.models.RecordJson(
+            record=row_b, feature=features.expected_cells, value=5000
+        ).save()
 
-    dup_rows = nextflow_sheet.to_dataframe()
-    dup_rows = dup_rows[dup_rows["sample"] == "poolsample1"]
-    assert len(dup_rows) == 2
-    assert set(dup_rows["__lamindb_record_uid__"]) == {row_a.uid, row_b.uid}
+        dup_rows = nextflow_sheet.to_dataframe()
+        dup_rows = dup_rows[dup_rows["sample"] == "poolsample1"]
+        assert len(dup_rows) == 2
+        assert set(dup_rows["__lamindb_record_uid__"]) == {row_a.uid, row_b.uid}
 
-    artifact_dup = nextflow_sheet.to_artifact()
-    linked_poolsample_uids = {
-        record.uid
-        for record in artifact_dup.records.all()
-        if record.name == "poolsample1"
-    }
-    assert linked_poolsample_uids == {sample_dup_a.uid, sample_dup_b.uid}
-    artifact_dup.delete(permanent=True)
-    row_a.delete(permanent=True)
-    row_b.delete(permanent=True)
-    sample_dup_a.delete(permanent=True)
-    sample_dup_b.delete(permanent=True)
+        artifact_dup = nextflow_sheet.to_artifact()
+        linked_poolsample_uids = {
+            record.uid
+            for record in artifact_dup.records.all()
+            if record.name == "poolsample1"
+        }
+        assert linked_poolsample_uids == {sample_dup_a.uid, sample_dup_b.uid}
+    finally:
+        if artifact_dup is not None:
+            export_run_dup = artifact_dup.run
+            artifact_dup.delete(permanent=True)
+            if export_run_dup is not None:
+                export_run_dup.delete(permanent=True)
+        row_a.delete(permanent=True)
+        row_b.delete(permanent=True)
+        sample_dup_a.delete(permanent=True)
+        sample_dup_b.delete(permanent=True)
+        assert nextflow_sheet.records.count() == 3
 
     related_schemas = list(artifact.schemas.all())
     artifact.schemas.clear()
     for schema in related_schemas:
         schema.delete(permanent=True)
+    export_run = artifact.run
     artifact.delete(permanent=True)
+    if export_run is not None:
+        export_run.delete(permanent=True)
 
 
 def test_record_soft_deleted_recreate():

--- a/tests/core/test_record_sheet_examples.py
+++ b/tests/core/test_record_sheet_examples.py
@@ -549,3 +549,63 @@ def test_record_export_populates_initiated_by_run(
     finally:
         ln.context._run = None
         artifact.delete(permanent=True)
+
+
+def test_to_artifact_with_duplicate_linked_record_names():
+    """Sheet export round-trip resolves Record links by row uid, not ambiguous names."""
+    pooled_sample_type = ln.Record(name="PooledSample", is_type=True).save()
+    sample_a = ln.Record(name="poolsample1", type=pooled_sample_type).save()
+    sample_b = ln.Record(type=pooled_sample_type).save()
+    sample_b.name = "poolsample1"
+    sample_b.save()
+    assert sample_a.id != sample_b.id
+
+    sample_feature = ln.Feature(name="sample", dtype=pooled_sample_type).save()
+    fastq_feature = ln.Feature(name="fastq_1", dtype=str).save()
+    schema = ln.Schema(
+        name="duplicate sample names schema",
+        features=[sample_feature, fastq_feature],
+    ).save()
+    sheet_type = ln.Record(name="DuplicateNameSheetType", is_type=True).save()
+    sheet = ln.Record(
+        name="duplicate name sheet",
+        is_type=True,
+        type=sheet_type,
+        schema=schema,
+    ).save()
+
+    row_a = ln.Record(type=sheet).save()
+    row_b = ln.Record(type=sheet).save()
+    ln.models.RecordRecord(record=row_a, feature=sample_feature, value=sample_a).save()
+    ln.models.RecordRecord(record=row_b, feature=sample_feature, value=sample_b).save()
+    ln.models.RecordJson(record=row_a, feature=fastq_feature, value="read_a").save()
+    ln.models.RecordJson(record=row_b, feature=fastq_feature, value="read_b").save()
+
+    df = sheet.to_dataframe()
+    assert df["sample"].tolist() == ["poolsample1", "poolsample1"]
+    assert set(df["__lamindb_record_uid__"]) == {row_a.uid, row_b.uid}
+
+    artifact = sheet.to_artifact()
+    try:
+        assert artifact.schema is sheet.schema
+        linked_sample_uids = {
+            record.uid
+            for record in artifact.records.all()
+            if record.type_id == pooled_sample_type.id
+        }
+        assert linked_sample_uids == {sample_a.uid, sample_b.uid}
+    finally:
+        export_run = artifact.run
+        artifact.delete(permanent=True)
+        if export_run is not None:
+            export_run.delete(permanent=True)
+        row_a.delete(permanent=True)
+        row_b.delete(permanent=True)
+        sheet.delete(permanent=True)
+        sheet_type.delete(permanent=True)
+        schema.delete(permanent=True)
+        sample_feature.delete(permanent=True)
+        fastq_feature.delete(permanent=True)
+        sample_a.delete(permanent=True)
+        sample_b.delete(permanent=True)
+        pooled_sample_type.delete(permanent=True)

--- a/tests/core/test_record_sheet_examples.py
+++ b/tests/core/test_record_sheet_examples.py
@@ -553,15 +553,17 @@ def test_record_export_populates_initiated_by_run(
 
 def test_to_artifact_with_duplicate_linked_record_names():
     """Sheet export round-trip resolves Record links by row uid, not ambiguous names."""
-    pooled_sample_type = ln.Record(name="PooledSample", is_type=True).save()
+    pooled_sample_type = ln.Record(name="PooledSampleDupNameTest", is_type=True).save()
     sample_a = ln.Record(name="poolsample1", type=pooled_sample_type).save()
     sample_b = ln.Record(type=pooled_sample_type).save()
     sample_b.name = "poolsample1"
     sample_b.save()
     assert sample_a.id != sample_b.id
 
-    sample_feature = ln.Feature(name="sample", dtype=pooled_sample_type).save()
-    fastq_feature = ln.Feature(name="fastq_1", dtype=str).save()
+    sample_feature = ln.Feature(
+        name="dup_name_pooled_sample", dtype=pooled_sample_type
+    ).save()
+    fastq_feature = ln.Feature(name="dup_name_fastq_1", dtype=str).save()
     schema = ln.Schema(
         name="duplicate sample names schema",
         features=[sample_feature, fastq_feature],
@@ -582,7 +584,7 @@ def test_to_artifact_with_duplicate_linked_record_names():
     ln.models.RecordJson(record=row_b, feature=fastq_feature, value="read_b").save()
 
     df = sheet.to_dataframe()
-    assert df["sample"].tolist() == ["poolsample1", "poolsample1"]
+    assert df["dup_name_pooled_sample"].tolist() == ["poolsample1", "poolsample1"]
     assert set(df["__lamindb_record_uid__"]) == {row_a.uid, row_b.uid}
 
     artifact = sheet.to_artifact()


### PR DESCRIPTION
## Summary

Fixes `ValidationError: Ambiguous match for Record '...'` when calling `Record.to_artifact()` on sheets whose Record-type features (e.g. `sample`, `treatment`) link to multiple records with the same display name.

### Problem

`to_artifact()` exports a dataframe and re-validates it. Record-type feature columns only contain the linked record's **display name** (e.g. `poolsample1`), not its uid. The default curator path resolves those values by **global name lookup**, which fails when two different linked records share a name.

### Solution

Add `_resolve_record_categorical_from_sheet_export()` in `lamindb/curators/core.py`. When the dataframe still identifies **which sheet row** each value came from, resolve linked records via existing `RecordRecord` DB links instead of global name matching.

Two export shapes are supported:

| Sheet type | Row key in dataframe | DB lookup |
|---|---|---|
| No `Schema.index` (e.g. nf-core samplesheet) | `__lamindb_record_uid__` column | `record__uid__in=...` |
| With `Schema.index` (e.g. compound-treatment sheet) | `df.index` (schema index feature) | `record__name__in=...`, scoped to sheet type |

- **No change to exported CSV content** — only the annotation/validation path is updated.
- External dataframes without row keys fall back to the existing global name lookup unchanged.
- Includes an extensive docstring on the helper explaining background, both export shapes, and scope.

### Performance

Negligible for typical sheets: a targeted `RecordRecord` query per Record-type feature column on `to_artifact()` round-trips only (replaces, not stacks on, the old global name lookup). No extra DB work for non-Record categoricals or dataframes without sheet row keys.

## Test plan

- [x] `pytest tests/core/test_record_sheet_examples.py`
  - `test_record_example_compound_treatment` — indexed sheet: two Treatments named `shared_treatment`, `to_artifact()` resolves via `df.index`
  - `test_nextflow_sheet_with_samples` — no-index sheet: two BioSamples named `poolsample1`, `to_artifact()` resolves via `__lamindb_record_uid__`

Replaces https://github.com/laminlabs/lamindb/pull/3753