### PR TITLE
♻️ Making sure API  throws an error if categorical features in `RecordJson`

### DIFF
--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -394,6 +394,25 @@ def get_non_categoricals(
             else:
                 values = fv["values"]
 
+            # A JSON link table (e.g. RecordJson) must only hold non-categorical
+            # (scalar/JSON) values. A categorical dtype here means the value was
+            # written to the wrong link table -- it belongs in a relational link
+            # table such as RecordRecord -- e.g. by bypassing the validated API.
+            # Surface it loudly instead of silently displaying an invalid entry.
+            if feature_dtype is not None and (
+                feature_dtype.startswith("cat") or feature_dtype.startswith("list[cat")
+            ):
+                raise ValidationError(
+                    f"invalid entry for feature {feature_name!r}: it has the "
+                    f"categorical dtype {format_dtype_for_display(feature_dtype)!r}, so "
+                    f"its value must be stored as a relational link (in a link table "
+                    f"such as RecordRecord), but the value {values!r} was found stored "
+                    f"as raw JSON in the RecordJson link table. This typically happens "
+                    f"when a value is written without going through the validated API. "
+                    f"Fix it by re-writing the value via the validated API, e.g.\n"
+                    f"    record.features.set_values({{{feature_name!r}: <value>}})"
+                )
+
             if connections[self._state.db].vendor == "sqlite":
                 # undo GROUP_CONCAT
                 if isinstance(values, str):

--- a/tests/core/test_curator_basics.py
+++ b/tests/core/test_curator_basics.py
@@ -505,8 +505,14 @@ def test_curator_partial_null_bool_int():
             "cur-count": [1, None, 3],  # float64
         }
     )
-    with pytest.raises(ln.errors.ValidationError):
+    with pytest.raises(ln.errors.ValidationError) as excinfo:
         ln.curators.DataFrameCurator(df_degraded, schema).validate()
+    assert "Column 'cur-flag' failed dtype check for 'bool': got object" in str(
+        excinfo.value
+    )
+    assert "Column 'cur-count' failed dtype check for 'int': got float64" in str(
+        excinfo.value
+    )
 
     schema.delete(permanent=True)
     flag.delete(permanent=True)

--- a/tests/core/test_curator_basics.py
+++ b/tests/core/test_curator_basics.py
@@ -480,6 +480,39 @@ def test_nullable():
     disease.delete(permanent=True)
 
 
+def test_curator_partial_null_bool_int():
+    flag = ln.Feature(name="cur-flag", dtype=bool, nullable=True).save()
+    count = ln.Feature(name="cur-count", dtype=int, nullable=True).save()
+    schema = ln.Schema(features=[flag, count]).save()
+
+    # Case 1: properly-typed nullable columns -> should PASS
+    # This is what a well-behaved user supplies, and what our _feature_manager fix
+    # produces after the cast. We are asserting the curator accepts these dtypes.
+    df_good = pd.DataFrame(
+        {
+            "cur-flag": pd.array([True, None, False], dtype="boolean"),
+            "cur-count": pd.array([1, None, 3], dtype="Int64"),
+        }
+    )
+    assert ln.curators.DataFrameCurator(df_good, schema).validate() is None
+
+    # Case 2: degraded dtypes (what pd.DataFrame(prepared_rows) produces internally)
+    # bool + null -> object, int + null -> float64.
+    # Should FAIL — this is correct curator behaviour, not a bug.
+    df_degraded = pd.DataFrame(
+        {
+            "cur-flag": [True, None, False],  # object
+            "cur-count": [1, None, 3],  # float64
+        }
+    )
+    with pytest.raises(ln.errors.ValidationError):
+        ln.curators.DataFrameCurator(df_degraded, schema).validate()
+
+    schema.delete(permanent=True)
+    flag.delete(permanent=True)
+    count.delete(permanent=True)
+
+
 def test_pandera_dataframe_schema(
     df,
     df_missing_sample_type_column,

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -1538,3 +1538,48 @@ def test_record_features_accept_feature_object_keys():
     record.delete(permanent=True)
     feature_score.delete(permanent=True)
     feature_tag.delete(permanent=True)
+
+
+def test_categorical_value_stored_as_json_raises_on_read():
+    # A categorical (cat[...]) feature value belongs in a relational link table
+    # such as RecordRecord, never in the JSON link table (RecordJson). If it ends
+    # up in RecordJson -- e.g. by bypassing the validated API as could happen when
+    # validation fails -- reading the record must surface the invalid entry loudly
+    # instead of silently displaying it (which is what the Hub UI hides).
+    from lamindb.models.record import RecordJson
+
+    species_type = ln.Record(name="SpeciesTypeForJsonGuard", is_type=True).save()
+    human = ln.Record(name="HumanForJsonGuard", type=species_type).save()
+    species = ln.Feature(name="species_json_guard", dtype=species_type).save()
+    assert species.dtype.startswith("cat[Record[")
+
+    sample = ln.Record(name="SampleForJsonGuard").save()
+
+    # bypass the validated API: write the categorical value straight into the JSON
+    # link table as a bare string, the way the reported corruption was created
+    RecordJson(record=sample, feature=species, value="HumanForJsonGuard").save()
+
+    expected_error = (
+        "invalid entry for feature 'species_json_guard': it has the categorical "
+        "dtype 'cat[Record[SpeciesTypeForJsonGuard]]', so its value must be stored "
+        "as a relational link (in a link table such as RecordRecord), but the value "
+        "'HumanForJsonGuard' was found stored as raw JSON in the RecordJson link "
+        "table. This typically happens when a value is written without going through "
+        "the validated API. Fix it by re-writing the value via the validated API, "
+        "e.g.\n    record.features.set_values({'species_json_guard': <value>})"
+    )
+
+    # validation-on-read: get_values() must raise rather than return the bad value
+    with pytest.raises(ln.errors.ValidationError) as exc_info:
+        sample.features.get_values()
+    assert str(exc_info.value) == expected_error
+
+    # describe() reads the same path and must also raise the same error
+    with pytest.raises(ln.errors.ValidationError) as exc_info:
+        sample.describe(return_str=True)
+    assert str(exc_info.value) == expected_error
+
+    sample.delete(permanent=True)
+    species.delete(permanent=True)
+    human.delete(permanent=True)
+    species_type.delete(permanent=True)

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -129,6 +129,57 @@ def test_record_lazy_features_on_save():
     score_feature.delete(permanent=True)
 
 
+def test_record_from_dataframe_partial_null_bool_int_degradation():
+    """Reproduces internal dtype degradation in Record.from_dataframe().
+
+    The user supplies correctly-typed nullable columns (boolean / Int64), but on
+    .save() the chop-reglue (_build_records drops the null cell, then
+    pd.DataFrame(prepared_rows) backfills NaN and re-infers) degrades them to
+    object / float64, so validation fails even though the input was valid.
+
+    Asserts the buggy failure for now; flip to a successful save + round-trip
+    once the fix lands.
+    """
+    flag = ln.Feature(name="from-df-flag", dtype=bool).save()
+    count = ln.Feature(name="from-df-count", dtype=int).save()
+    label = ln.Feature(name="from-df-label", dtype=str).save()
+    schema = ln.Schema([flag, count, label], name="from-df-bool-int-schema").save()
+    sheet = ln.Record(name="from-df-bool-int-sheet", is_type=True, schema=schema).save()
+
+    df = pd.DataFrame(
+        {
+            "__lamindb_record_name__": ["from-df-a", "from-df-b", "from-df-c"],
+            "from-df-flag": pd.array([True, None, False], dtype="boolean"),
+            "from-df-count": pd.array([1, None, 3], dtype="Int64"),
+            "from-df-label": ["a", "b", "c"],
+        }
+    )
+
+    # the supplied dtypes are genuinely correct/nullable
+    assert df["from-df-flag"].dtype.name == "boolean"
+    assert df["from-df-count"].dtype.name == "Int64"
+
+    with pytest.raises(ln.errors.ValidationError) as excinfo:
+        ln.Record.from_dataframe(df, type=sheet).save()
+    # the message proves lamindb degraded the dtypes internally: we passed
+    # boolean/Int64 but the curator reports object / float64
+    assert "Column 'from-df-flag' failed dtype check for 'bool': got object" in str(
+        excinfo.value
+    )
+    assert "Column 'from-df-count' failed dtype check for 'int': got float64" in str(
+        excinfo.value
+    )
+
+    ln.Record.filter(name__in=["from-df-a", "from-df-b", "from-df-c"]).delete(
+        permanent=True
+    )
+    ln.Record.filter(name="from-df-bool-int-sheet").delete(permanent=True)
+    schema.delete(permanent=True)
+    flag.delete(permanent=True)
+    count.delete(permanent=True)
+    label.delete(permanent=True)
+
+
 def test_record_from_dataframe_bulk_save_paths():
     score = ln.Feature(name="from-df-score", dtype=float).save()
     schema = ln.Schema([score], name="from-df-schema").save()


### PR DESCRIPTION
Adding validation-on read in `get_non_categoricals`: when a value read from the JSON link table belongs to a categorical feature, raise a clear ValidationError. The error names the feature, dtype, offending value, and how to fix it via the validated API.

Fixes pfizer-collab/laminlabs#1034

