### PR TITLE
🚸 Expose `Transform.from_path()`

### DIFF
--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -59,6 +59,7 @@ def detect_and_process_source_code_file(
     *,
     path: str | Path | None,
     transform_kind: TransformKind | None = None,
+    infer_reference: bool = True,
 ) -> tuple[Path, TransformKind, str, str, str | None]:
     """Track source code file and determine transform metadata.
 
@@ -115,7 +116,11 @@ def detect_and_process_source_code_file(
         transform_kind = "notebook" if path.suffix in {".Rmd", ".qmd"} else "script"
     reference = None
     reference_type = None
-    if settings.sync_git_repo is not None and path.suffix != ".ipynb":
+    if (
+        infer_reference
+        and settings.sync_git_repo is not None
+        and path.suffix != ".ipynb"
+    ):
         reference = get_transform_reference_from_git_repo(path)
         reference_type = "url"
     return path, transform_kind, reference, reference_type, key_from_module
@@ -684,8 +689,7 @@ class Context:
         cli_call = get_cli_call()
         if transform is None:
             description = None
-            transform_ref = None
-            transform_ref_type = None
+            file_transform: Transform | None = None
             if source_code is not None:
                 transform_kind = kind if kind is not None else "function"
                 assert key is not None, (
@@ -704,20 +708,36 @@ class Context:
                     (
                         self._path,
                         transform_kind,
-                        transform_ref,
-                        transform_ref_type,
+                        _,
+                        _,
                         key_from_module,
-                    ) = detect_and_process_source_code_file(path=path)
+                    ) = detect_and_process_source_code_file(
+                        path=path, infer_reference=False
+                    )
                     if key is None and key_from_module is not None:
                         key = key_from_module
+            if source_code is None and self._path is not None:
+                file_transform = Transform.from_file(
+                    path=self._path,
+                    key=key,
+                    kind=transform_kind,
+                )
+                key = file_transform.key
+                transform_kind = file_transform.kind
             if description is None:
                 description = self._description
             if description is None and cli_call is not None:
                 description = f"CLI: {cli_call[0]}"
             self._create_or_load_transform(
                 description=description,
-                transform_ref=transform_ref,
-                transform_ref_type=transform_ref_type,
+                transform_ref=file_transform.reference
+                if file_transform is not None
+                else None,
+                transform_ref_type=(
+                    file_transform.reference_type
+                    if file_transform is not None
+                    else None
+                ),
                 transform_kind=transform_kind,
                 key=key,
                 source_code=source_code,

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -12,25 +12,18 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, TextIO
 
 import lamindb_setup as ln_setup
-from django.db.models import Func, IntegerField, Q
+from django.db.models import Q
 from lamin_utils._logger import logger
 from lamindb_setup.core.django import _is_running_in_marimo
-from lamindb_setup.core.hashing import hash_file, hash_string
 
 from .._secret_redaction import (
     REDACTED_SECRET_VALUE,
     is_sensitive_param_key,
     is_sensitive_param_value,
-    redact_secrets_in_source_code,
 )
-from ..base.uids import base62_12
-from ..errors import InvalidArgument, TrackNotCalled, UpdateContext
+from ..errors import InvalidArgument, TrackNotCalled
 from ..models import Run, SQLRecord, Transform, format_field_value
 from ..models._feature_manager import infer_convert_dtype_key_value
-from ..models._is_versioned import bump_version as bump_version_function
-from ..models._is_versioned import (
-    increment_base62,
-)
 from ._settings import settings
 from ._sync_git import get_transform_reference_from_git_repo
 from ._track_environment import track_python_environment
@@ -689,7 +682,6 @@ class Context:
         cli_call = get_cli_call()
         if transform is None:
             description = None
-            file_transform: Transform | None = None
             if source_code is not None:
                 transform_kind = kind if kind is not None else "function"
                 assert key is not None, (
@@ -716,28 +708,12 @@ class Context:
                     )
                     if key is None and key_from_module is not None:
                         key = key_from_module
-            if source_code is None and self._path is not None:
-                file_transform = Transform.from_file(
-                    path=self._path,
-                    key=key,
-                    kind=transform_kind,
-                )
-                key = file_transform.key
-                transform_kind = file_transform.kind
             if description is None:
                 description = self._description
             if description is None and cli_call is not None:
                 description = f"CLI: {cli_call[0]}"
             self._create_or_load_transform(
                 description=description,
-                transform_ref=file_transform.reference
-                if file_transform is not None
-                else None,
-                transform_ref_type=(
-                    file_transform.reference_type
-                    if file_transform is not None
-                    else None
-                ),
                 transform_kind=transform_kind,
                 key=key,
                 source_code=source_code,
@@ -961,53 +937,6 @@ class Context:
                 pass
         return path, description
 
-    def _process_aux_transform(
-        self,
-        aux_transform: Transform,
-        transform_hash: str,
-    ) -> tuple[str, Transform | None, str]:
-        # first part of the if condition: no version bump, second part: version bump
-        message = ""
-        if (
-            # if a user hasn't yet saved the transform source code AND is the same user
-            (
-                aux_transform.source_code is None
-                and aux_transform.created_by_id == ln_setup.settings.user.id
-            )
-            # if the transform source code is unchanged
-            # if aux_transform.kind == "notebook", we anticipate the user makes changes to the notebook source code
-            # in an interactive session, hence we *pro-actively bump* the version number by setting `revises` / 'nbconvert' execution is NOT interactive
-            # in the second part of the if condition even though the source code is unchanged at point of running track()
-            or (
-                aux_transform.hash == transform_hash
-                and (
-                    aux_transform.kind != "notebook"
-                    or self._notebook_runner == "nbconvert"
-                )
-            )
-        ):
-            uid = aux_transform.uid
-            return uid, aux_transform, message
-        else:
-            uid = f"{aux_transform.uid[:-4]}{increment_base62(aux_transform.uid[-4:])}"
-            message = (
-                f"found {aux_transform.kind} {aux_transform.key}, making new version"
-            )
-            if (
-                aux_transform.hash == transform_hash
-                and aux_transform.kind == "notebook"
-            ):
-                message += " -- anticipating changes"
-            elif aux_transform.hash != transform_hash:
-                message += (
-                    ""  # could log "source code changed", but this seems too much
-                )
-            elif aux_transform.created_by_id != ln_setup.settings.user.id:
-                message += (
-                    f" -- {aux_transform.created_by.handle} already works on this draft"
-                )
-            return uid, None, message
-
     def _create_or_load_transform(
         self,
         *,
@@ -1018,252 +947,21 @@ class Context:
         key: str | None = None,
         source_code: str | None = None,
     ):
-        source_code_to_store = source_code
-        if source_code is not None:
-            source_code_to_store, redaction_count = redact_secrets_in_source_code(
-                source_code
-            )
-            if redaction_count > 0:
-                logger.warning(
-                    f"redacted {redaction_count} secret-looking assignment(s) before persisting transform source code"
-                )
-            transform_hash = hash_string(source_code)
-        else:
-            from .._finish import notebook_to_script
-
-            if not self._path.suffix == ".ipynb":
-                _, transform_hash, _ = hash_file(self._path)
-            else:
-                # need to convert to stripped py:percent format for hashing
-                source_code_path = (
-                    ln_setup.settings.cache_dir
-                    / self._path.name.replace(".ipynb", ".py")
-                )
-                if (
-                    self._path.exists()
-                ):  # notebook kernel might be running on a different machine
-                    notebook_to_script(description, self._path, source_code_path)
-                    _, transform_hash, _ = hash_file(source_code_path)
-                else:
-                    logger.debug(
-                        "skipping notebook hash comparison, notebook kernel running on a different machine"
-                    )
-                    transform_hash = None
-
-        # see whether we find a transform with the exact same hash
-        if transform_hash is not None:
-            aux_transform = Transform.filter(hash=transform_hash).first()
-        else:
-            aux_transform = None
-
-        # determine the transform key (only when path-based; key is required when source_code)
-        if key is None:
-            if ln_setup.settings.dev_dir is not None:
-                try:
-                    key = self._path.relative_to(ln_setup.settings.dev_dir).as_posix()
-                except ValueError as e:
-                    if "subpath" in str(e):
-                        logger.warning(
-                            f"path {self._path} is not within the configured dev directory "
-                            f"({ln_setup.settings.dev_dir}), falling back to using filename as transform key "
-                            f"('{self._path.name}')"
-                        )
-                        key = self._path.name
-                    else:
-                        raise
-            else:
-                key = self._path.name
-        # if the user did not pass a uid and there is no matching aux_transform
-        # need to search for the transform based on the key
-        if self.uid is None and aux_transform is None:
-
-            class SlashCount(Func):
-                template = "LENGTH(%(expressions)s) - LENGTH(REPLACE(%(expressions)s, '/', ''))"
-                output_field = IntegerField()
-
-            # we need to traverse from greater depth to shorter depth so that we match better matches first
-            transforms = (
-                Transform.filter(key__endswith=key, is_latest=True)
-                .annotate(slash_count=SlashCount("key"))
-                .order_by("-slash_count")
-            )
-            uid = f"{base62_12()}0000"
-            target_transform = None
-            if len(transforms) != 0:
-                message = ""
-                found_key = False
-                if self._path is not None:
-                    for aux_transform in transforms:
-                        # check whether the transform key is in the path
-                        # that's not going to be the case for keys that have "/" in them and don't match the folder
-                        if aux_transform.key in self._path.as_posix():
-                            key = aux_transform.key
-                            uid, target_transform, message = (
-                                self._process_aux_transform(
-                                    aux_transform, transform_hash
-                                )
-                            )
-                            found_key = True
-                            break
-                if not found_key:
-                    plural_s = "s" if len(transforms) > 1 else ""
-                    transforms_str = "\n".join(
-                        [
-                            f"    {transform.uid} → {transform.key}"
-                            for transform in transforms
-                        ]
-                    )
-                    message = f"ignoring transform{plural_s} with same filename in different folder:\n{transforms_str}"
-                if message != "":
-                    logger.important(message)
-            self.uid, transform = uid, target_transform
-        # the user did pass the uid
-        elif self.uid is not None and len(self.uid) == 16:
-            transform = Transform.filter(uid=self.uid).one_or_none()
-        else:
-            if self.uid is not None:
-                # the case with length 16 is covered above
-                if not len(self.uid) == 12:
-                    raise InvalidArgument(
-                        f'Please pass an auto-generated uid instead of "{self.uid}". Resolve by running: ln.track("{base62_12()}")'
-                    )
-                aux_transform = (
-                    Transform.filter(uid__startswith=self.uid)
-                    .order_by("-created_at")
-                    .first()
-                )
-            else:
-                # deal with a hash-based match
-                # the user might have a made a copy of the notebook or script
-                # and actually wants to create a new transform
-                if aux_transform is not None and not aux_transform.key.endswith(key):
-                    prompt = f"Found transform with same hash but different key: {aux_transform.key}. Did you rename your {transform_kind} to {key} (1) or intentionally made a copy (2)?"
-                    response = (
-                        "1" if os.getenv("LAMIN_TESTING") == "true" else input(prompt)
-                    )
-                    assert response in {"1", "2"}, (  # noqa: S101
-                        f"Please respond with either 1 or 2, not {response}"
-                    )
-                    if response == "2":
-                        aux_transform, transform_hash = (
-                            None,
-                            None,
-                        )  # make a new transform
-            if aux_transform is not None:
-                uid, target_transform, message = self._process_aux_transform(
-                    aux_transform, transform_hash
-                )
-                if message != "":
-                    logger.important(message)
-            else:
-                uid = f"{self.uid}0000" if self.uid is not None else None
-                target_transform = None
-            self.uid, transform = uid, target_transform
-        if self.version is not None:
-            # test inconsistent version passed
-            if (
-                transform is not None
-                and transform.version_tag is not None  # type: ignore
-                and self.version != transform.version_tag  # type: ignore
-            ):
-                raise ValueError(
-                    f"Transform is already tagged with version {transform.version_tag}, but you passed {self.version}\n"  # noqa: S608
-                    f"If you want to update the transform version, set it outside ln.track(): transform.version_tag = '{self.version}'; transform.save()"
-                )
-            # test whether version was already used for another member of the family
-            if self.uid is not None and len(self.uid) == 16:
-                suid, vuid = (self.uid[:-4], self.uid[-4:])
-                transform = Transform.filter(
-                    uid__startswith=suid, version_tag=self.version
-                ).one_or_none()
-                if transform is not None and vuid != transform.uid[-4:]:
-                    better_version = bump_version_function(self.version)
-                    raise SystemExit(
-                        f"✗ version '{self.version}' is already taken by Transform('{transform.uid}'); please set another version, e.g., ln.context.version = '{better_version}'"
-                    )
-        # make a new transform record
-        if transform is None:
-            assert key is not None  # noqa: S101
-            transform = Transform(  # type: ignore
-                uid=self.uid,
-                version_tag=self.version,
-                description=description,
-                key=key,
-                reference=transform_ref,
-                reference_type=transform_ref_type,
-                kind=transform_kind,
-                source_code=source_code_to_store,
-                skip_hash_lookup=source_code is not None,
-            )
-            if source_code is not None:
-                transform.hash = transform_hash
-            transform = transform.save()
-            self._logging_message_track += (
-                f"created Transform('{transform.uid}', key='{transform.key}')"
-            )
-        else:
-            uid = transform.uid
-            # transform was already saved via `finish()`
-            transform_was_saved = transform.source_code is not None
-            # check whether the transform.key is consistent
-            if transform.key != key:
-                self._logging_message_track += (
-                    f"renaming transform {transform.key} to {key}"
-                )
-                transform.key = key
-                transform.save()
-            elif transform.description != description and description is not None:
-                transform.description = description
-                transform.save()
-                self._logging_message_track += (
-                    "updated transform description, "  # white space on purpose
-                )
-            elif (
-                transform.created_by_id != ln_setup.settings.user.id
-                and not transform_was_saved
-            ):
-                raise UpdateContext(
-                    f'{transform.created_by.name} ({transform.created_by.handle}) already works on this draft {transform.kind}.\n\nPlease create a revision via `ln.track("{uid[:-4]}{increment_base62(uid[-4:])}")` or a new transform with a *different* key and `ln.track("{base62_12()}0000")`.'
-                )
-            if transform.reference != transform_ref:
-                transform.reference = transform_ref
-                transform.reference_type = transform_ref_type
-                transform.save()
-                self._logging_message_track += (
-                    "updated transform reference, "  # white space on purpose
-                )
-            # check whether transform source code was already saved
-            if transform_was_saved:
-                bump_revision = False
-                if (
-                    transform.kind == "notebook"
-                    and self._notebook_runner != "nbconvert"
-                ):
-                    # we anticipate the user makes changes to the notebook source code
-                    # in an interactive session, hence we pro-actively bump the version number
-                    bump_revision = True
-                else:
-                    if transform_hash != transform.hash:
-                        bump_revision = True
-                    else:
-                        self._logging_message_track += f"loaded Transform('{transform.uid}', key='{transform.key}')"
-                if bump_revision:
-                    change_type = (
-                        "re-running notebook with already-saved source code"
-                        if (
-                            transform.kind == "notebook"
-                            and self._notebook_runner != "nbconvert"
-                        )
-                        else "source code changed"
-                    )
-                    raise UpdateContext(
-                        f'✗ {change_type}, please update the `uid` argument in `track()` to "{uid[:-4]}{increment_base62(uid[-4:])}"'
-                    )
-            else:
-                self._logging_message_track += (
-                    f"loaded Transform('{transform.uid}', key='{transform.key}')"
-                )
+        transform, logging_message = Transform._create_or_load_from_source(
+            path=self._path,
+            description=description,
+            transform_ref=transform_ref,
+            transform_ref_type=transform_ref_type,
+            transform_kind=transform_kind,
+            key=key,
+            source_code=source_code,
+            uid=self.uid,
+            version=self.version,
+            notebook_runner=self._notebook_runner,
+        )
         self._transform = transform
+        self._uid = transform.uid
+        self._logging_message_track += logging_message
 
     def _finish(self, ignore_non_consecutive: None | bool = None) -> None:
         """Finish the run of a notebook or script.

--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -712,12 +712,21 @@ class Context:
                 description = self._description
             if description is None and cli_call is not None:
                 description = f"CLI: {cli_call[0]}"
-            self._create_or_load_transform(
+            transform_record, logging_message = Transform._create_or_load_from_source(
+                path=self._path,
                 description=description,
+                transform_ref=None,
+                transform_ref_type=None,
                 transform_kind=transform_kind,
                 key=key,
                 source_code=source_code,
+                uid=self.uid,
+                version=self.version,
+                notebook_runner=self._notebook_runner,
             )
+            self._transform = transform_record
+            self._uid = transform_record.uid
+            self._logging_message_track += logging_message
         else:
             if transform.kind in {"notebook", "script"}:
                 raise ValueError(
@@ -936,32 +945,6 @@ class Context:
                 logger.debug("reading the notebook file failed")
                 pass
         return path, description
-
-    def _create_or_load_transform(
-        self,
-        *,
-        description: str | None = None,
-        transform_ref: str | None = None,
-        transform_ref_type: str | None = None,
-        transform_kind: TransformKind = None,
-        key: str | None = None,
-        source_code: str | None = None,
-    ):
-        transform, logging_message = Transform._create_or_load_from_source(
-            path=self._path,
-            description=description,
-            transform_ref=transform_ref,
-            transform_ref_type=transform_ref_type,
-            transform_kind=transform_kind,
-            key=key,
-            source_code=source_code,
-            uid=self.uid,
-            version=self.version,
-            notebook_runner=self._notebook_runner,
-        )
-        self._transform = transform
-        self._uid = transform.uid
-        self._logging_message_track += logging_message
 
     def _finish(self, ignore_non_consecutive: None | bool = None) -> None:
         """Finish the run of a notebook or script.

--- a/lamindb/models/transform.py
+++ b/lamindb/models/transform.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import os
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, overload
 
+import lamindb_setup as ln_setup
 from django.db import models
-from django.db.models import CASCADE, PROTECT, Q
+from django.db.models import CASCADE, PROTECT, Func, IntegerField, Q
 from lamin_utils import logger
 from lamindb_setup.core.hashing import HASH_LENGTH, hash_file, hash_string
 
@@ -19,8 +21,15 @@ from lamindb.base.fields import (
 from lamindb.base.users import current_user_id
 
 from .._secret_redaction import redact_secrets_in_source_code
+from ..base.uids import base62_12
+from ..errors import InvalidArgument, UpdateContext
 from ..models._is_versioned import process_revises
-from ._is_versioned import IsVersioned, _adjust_is_latest_when_deleting_is_versioned
+from ._is_versioned import (
+    IsVersioned,
+    _adjust_is_latest_when_deleting_is_versioned,
+    increment_base62,
+)
+from ._is_versioned import bump_version as bump_version_function
 from .run import Run, TracksRun, User
 from .sqlrecord import (
     BaseSQLRecord,
@@ -383,34 +392,295 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
         )
 
     @classmethod
-    def from_file(
+    def _process_aux_transform_for_source(
         cls,
-        path: str | Path,
+        aux_transform: Transform,
+        transform_hash: str | None,
+        notebook_runner: str | None = None,
+    ) -> tuple[str, Transform | None, str]:
+        message = ""
+        if (
+            aux_transform.source_code is None
+            and aux_transform.created_by_id == ln_setup.settings.user.id
+        ) or (
+            aux_transform.hash == transform_hash
+            and (aux_transform.kind != "notebook" or notebook_runner == "nbconvert")
+        ):
+            uid = aux_transform.uid
+            return uid, aux_transform, message
+        uid = f"{aux_transform.uid[:-4]}{increment_base62(aux_transform.uid[-4:])}"
+        message = f"found {aux_transform.kind} {aux_transform.key}, making new version"
+        if aux_transform.hash == transform_hash and aux_transform.kind == "notebook":
+            message += " -- anticipating changes"
+        elif aux_transform.created_by_id != ln_setup.settings.user.id:
+            message += (
+                f" -- {aux_transform.created_by.handle} already works on this draft"
+            )
+        return uid, None, message
+
+    @classmethod
+    def _create_or_load_from_source(
+        cls,
+        *,
+        path: Path | None = None,
+        description: str | None = None,
+        transform_ref: str | None = None,
+        transform_ref_type: str | None = None,
+        transform_kind: TransformKind | None = None,
+        key: str | None = None,
+        source_code: str | None = None,
+        uid: str | None = None,
+        version: str | None = None,
+        notebook_runner: str | None = None,
+    ) -> tuple[Transform, str]:
+        from .._finish import notebook_to_script
+        from ..core._settings import settings
+
+        source_code_to_store = source_code
+        if source_code is not None:
+            source_code_to_store, redaction_count = redact_secrets_in_source_code(
+                source_code
+            )
+            if redaction_count > 0:
+                logger.warning(
+                    f"redacted {redaction_count} secret-looking assignment(s) before persisting transform source code"
+                )
+            transform_hash = hash_string(source_code)
+        else:
+            assert path is not None  # noqa: S101
+            if path.suffix != ".ipynb":
+                _, transform_hash, _ = hash_file(path)
+            else:
+                source_code_path = ln_setup.settings.cache_dir / path.name.replace(
+                    ".ipynb", ".py"
+                )
+                if path.exists():
+                    notebook_to_script(description, path, source_code_path)
+                    _, transform_hash, _ = hash_file(source_code_path)
+                else:
+                    logger.debug(
+                        "skipping notebook hash comparison, notebook kernel running on a different machine"
+                    )
+                    transform_hash = None
+
+        aux_transform = (
+            cls.filter(hash=transform_hash).first()
+            if transform_hash is not None
+            else None
+        )
+
+        if key is None:
+            assert path is not None  # noqa: S101
+            if ln_setup.settings.dev_dir is not None:
+                try:
+                    key = path.relative_to(ln_setup.settings.dev_dir).as_posix()
+                except ValueError as e:
+                    if "subpath" in str(e):
+                        logger.warning(
+                            f"path {path} is not within the configured dev directory "
+                            f"({ln_setup.settings.dev_dir}), falling back to using filename as transform key "
+                            f"('{path.name}')"
+                        )
+                        key = path.name
+                    else:
+                        raise
+            else:
+                key = path.name
+
+        if (
+            path is not None
+            and transform_ref is None
+            and transform_ref_type is None
+            and settings.sync_git_repo is not None
+            and path.suffix != ".ipynb"
+        ):
+            from ..core._sync_git import get_transform_reference_from_git_repo
+
+            transform_ref = get_transform_reference_from_git_repo(path)
+            transform_ref_type = "url"
+
+        if uid is None and aux_transform is None:
+
+            class SlashCount(Func):
+                template = "LENGTH(%(expressions)s) - LENGTH(REPLACE(%(expressions)s, '/', ''))"
+                output_field = IntegerField()
+
+            transforms = (
+                cls.filter(key__endswith=key, is_latest=True)
+                .annotate(slash_count=SlashCount("key"))
+                .order_by("-slash_count")
+            )
+            resolved_uid = f"{base62_12()}0000"
+            target_transform = None
+            if len(transforms) != 0:
+                message = ""
+                found_key = False
+                if path is not None:
+                    for candidate in transforms:
+                        if candidate.key in path.as_posix():
+                            key = candidate.key
+                            resolved_uid, target_transform, message = (
+                                cls._process_aux_transform_for_source(
+                                    candidate, transform_hash, notebook_runner
+                                )
+                            )
+                            found_key = True
+                            break
+                if not found_key:
+                    plural_s = "s" if len(transforms) > 1 else ""
+                    transforms_str = "\n".join(
+                        [
+                            f"    {transform.uid} → {transform.key}"
+                            for transform in transforms
+                        ]
+                    )
+                    message = f"ignoring transform{plural_s} with same filename in different folder:\n{transforms_str}"
+                if message != "":
+                    logger.important(message)
+            resolved_uid, transform = resolved_uid, target_transform
+        elif uid is not None and len(uid) == 16:
+            resolved_uid = uid
+            transform = cls.filter(uid=uid).one_or_none()
+        else:
+            if uid is not None:
+                if len(uid) != 12:
+                    raise InvalidArgument(
+                        f'Please pass an auto-generated uid instead of "{uid}". Resolve by running: ln.track("{base62_12()}")'
+                    )
+                aux_transform = (
+                    cls.filter(uid__startswith=uid).order_by("-created_at").first()
+                )
+            else:
+                if aux_transform is not None and not aux_transform.key.endswith(key):
+                    prompt = f"Found transform with same hash but different key: {aux_transform.key}. Did you rename your {transform_kind} to {key} (1) or intentionally made a copy (2)?"
+                    response = (
+                        "1" if os.getenv("LAMIN_TESTING") == "true" else input(prompt)
+                    )
+                    assert response in {"1", "2"}, (  # noqa: S101
+                        f"Please respond with either 1 or 2, not {response}"
+                    )
+                    if response == "2":
+                        aux_transform, transform_hash = None, None
+            if aux_transform is not None:
+                resolved_uid, target_transform, message = (
+                    cls._process_aux_transform_for_source(
+                        aux_transform, transform_hash, notebook_runner
+                    )
+                )
+                if message != "":
+                    logger.important(message)
+            else:
+                resolved_uid = f"{uid}0000" if uid is not None else None
+                target_transform = None
+            transform = target_transform
+
+        if version is not None:
+            if (
+                transform is not None
+                and transform.version_tag is not None
+                and version != transform.version_tag
+            ):
+                raise ValueError(
+                    f"Transform is already tagged with version {transform.version_tag}, but you passed {version}\n"
+                    f"If you want to update the transform version, set it outside ln.track(): transform.version_tag = '{version}'; transform.save()"
+                )
+            if resolved_uid is not None and len(resolved_uid) == 16:
+                suid, vuid = (resolved_uid[:-4], resolved_uid[-4:])
+                versioned_transform = cls.filter(
+                    uid__startswith=suid, version_tag=version
+                ).one_or_none()
+                if (
+                    versioned_transform is not None
+                    and vuid != versioned_transform.uid[-4:]
+                ):
+                    better_version = bump_version_function(version)
+                    raise SystemExit(
+                        f"✗ version '{version}' is already taken by Transform('{versioned_transform.uid}'); please set another version, e.g., ln.context.version = '{better_version}'"
+                    )
+
+        if transform is None:
+            assert key is not None  # noqa: S101
+            transform = cls(  # type: ignore
+                uid=resolved_uid,
+                version_tag=version,
+                description=description,
+                key=key,
+                reference=transform_ref,
+                reference_type=transform_ref_type,
+                kind=transform_kind,
+                source_code=source_code_to_store,
+                skip_hash_lookup=source_code is not None,
+            )
+            if source_code is not None:
+                transform.hash = transform_hash
+            transform = transform.save()
+            logging_message = (
+                f"created Transform('{transform.uid}', key='{transform.key}')"
+            )
+        else:
+            uid_for_error = transform.uid
+            transform_was_saved = transform.source_code is not None
+            if transform.key != key:
+                logging_message = f"renaming transform {transform.key} to {key}"
+                transform.key = key
+                transform.save()
+            elif transform.description != description and description is not None:
+                transform.description = description
+                transform.save()
+                logging_message = "updated transform description, "
+            elif (
+                transform.created_by_id != ln_setup.settings.user.id
+                and not transform_was_saved
+            ):
+                raise UpdateContext(
+                    f'{transform.created_by.name} ({transform.created_by.handle}) already works on this draft {transform.kind}.\n\nPlease create a revision via `ln.track("{uid_for_error[:-4]}{increment_base62(uid_for_error[-4:])}")` or a new transform with a *different* key and `ln.track("{base62_12()}0000")`.'
+                )
+            else:
+                logging_message = ""
+            if transform.reference != transform_ref:
+                transform.reference = transform_ref
+                transform.reference_type = transform_ref_type
+                transform.save()
+                logging_message += "updated transform reference, "
+            if transform_was_saved:
+                bump_revision = False
+                if transform.kind == "notebook" and notebook_runner != "nbconvert":
+                    bump_revision = True
+                else:
+                    if transform_hash != transform.hash:
+                        bump_revision = True
+                    else:
+                        logging_message += f"loaded Transform('{transform.uid}', key='{transform.key}')"
+                if bump_revision:
+                    change_type = (
+                        "re-running notebook with already-saved source code"
+                        if (
+                            transform.kind == "notebook"
+                            and notebook_runner != "nbconvert"
+                        )
+                        else "source code changed"
+                    )
+                    raise UpdateContext(
+                        f'✗ {change_type}, please update the `uid` argument in `track()` to "{uid_for_error[:-4]}{increment_base62(uid_for_error[-4:])}"'
+                    )
+            else:
+                logging_message += (
+                    f"loaded Transform('{transform.uid}', key='{transform.key}')"
+                )
+        return transform, logging_message
+
+    @classmethod
+    def _infer_from_file_metadata(
+        cls,
+        *,
+        path: Path,
         key: str | None = None,
         kind: TransformKind | None = None,
-        version: str | None = None,
-        description: str | None = None,
-        skip_hash_lookup: bool = False,
-    ) -> Transform:
-        """Create a transform from a local file path.
-
-        Args:
-            path: Path to a local script or notebook file.
-            key: Optional key for the transform.
-            kind: Optional kind override. If omitted, inferred from file suffix.
-            version: Optional version tag.
-            description: Optional description for the transform.
-            skip_hash_lookup: Skip hash-based lookup.
-
-        Notes:
-            Kind inference defaults to `"script"` and uses `"notebook"` for
-            `.ipynb`, `.Rmd`, and `.qmd` files.
-        """
+    ) -> tuple[str, TransformKind, str | None, str | None]:
         import lamindb_setup as ln_setup
 
         from ..core._settings import settings
 
-        path = Path(path)
         if kind is None:
             kind = "notebook" if path.suffix in {".ipynb", ".Rmd", ".qmd"} else "script"
         if key is None:
@@ -436,15 +706,52 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
 
             reference = get_transform_reference_from_git_repo(path)
             reference_type = "url"
-        return cls(
-            key=key,
-            kind=kind,
-            version=version,
-            description=description,
-            reference=reference,
-            reference_type=reference_type,
-            skip_hash_lookup=skip_hash_lookup,
+        return key, kind, reference, reference_type
+
+    @classmethod
+    def from_file(
+        cls,
+        path: str | Path,
+        key: str | None = None,
+        kind: TransformKind | None = None,
+        version: str | None = None,
+        description: str | None = None,
+        skip_hash_lookup: bool = False,
+    ) -> Transform:
+        """Create a transform from a local file path.
+
+        Args:
+            path: Path to a local script or notebook file.
+            key: Optional key for the transform.
+            kind: Optional kind override. If omitted, inferred from file suffix.
+            version: Optional version tag.
+            description: Optional description for the transform.
+            skip_hash_lookup: Skip hash-based lookup.
+
+        Notes:
+            Kind inference defaults to `"script"` and uses `"notebook"` for
+            `.ipynb`, `.Rmd`, and `.qmd` files.
+        """
+        path = Path(path)
+        inferred_key, inferred_kind, reference, reference_type = (
+            cls._infer_from_file_metadata(
+                path=path,
+                key=key,
+                kind=kind,
+            )
         )
+        transform, logging_message = cls._create_or_load_from_source(
+            path=path,
+            description=description,
+            transform_ref=reference,
+            transform_ref_type=reference_type,
+            transform_kind=inferred_kind,
+            key=inferred_key,
+            version=version,
+        )
+        if logging_message:
+            logger.important(logging_message)
+        return transform
 
     @classmethod
     def from_git(

--- a/lamindb/models/transform.py
+++ b/lamindb/models/transform.py
@@ -105,6 +105,17 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
         def my_step():
             print("One step!")
 
+    Create a transform from a local script or notebook path::
+
+        transform = ln.Transform.from_path("scripts/my_workflow.py").save()
+
+    Create a transform from a file in a git repository::
+
+        transform = ln.Transform.from_git(
+            url="https://github.com/openproblems-bio/task_batch_integration",
+            path="main.nf",
+        ).save()
+
     Create a transform for a pipeline::
 
         transform = ln.Transform(key="Cell Ranger", version="7.2.0", kind="pipeline").save()
@@ -709,7 +720,7 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
         return key, kind, reference, reference_type
 
     @classmethod
-    def from_file(
+    def from_path(
         cls,
         path: str | Path,
         key: str | None = None,

--- a/lamindb/models/transform.py
+++ b/lamindb/models/transform.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from pathlib import Path
 from typing import TYPE_CHECKING, overload
 
 from django.db import models
@@ -34,7 +35,6 @@ from .sqlrecord import (
 
 if TYPE_CHECKING:
     from datetime import datetime
-    from pathlib import Path
 
     from lamindb.base.types import TransformKind
 
@@ -380,6 +380,70 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
             revises=revises,
             _refresh_revises_if_stale=refresh_revises_if_stale,
             **space_branch_kwargs,
+        )
+
+    @classmethod
+    def from_file(
+        cls,
+        path: str | Path,
+        key: str | None = None,
+        kind: TransformKind | None = None,
+        version: str | None = None,
+        description: str | None = None,
+        skip_hash_lookup: bool = False,
+    ) -> Transform:
+        """Create a transform from a local file path.
+
+        Args:
+            path: Path to a local script or notebook file.
+            key: Optional key for the transform.
+            kind: Optional kind override. If omitted, inferred from file suffix.
+            version: Optional version tag.
+            description: Optional description for the transform.
+            skip_hash_lookup: Skip hash-based lookup.
+
+        Notes:
+            Kind inference defaults to `"script"` and uses `"notebook"` for
+            `.ipynb`, `.Rmd`, and `.qmd` files.
+        """
+        import lamindb_setup as ln_setup
+
+        from ..core._settings import settings
+
+        path = Path(path)
+        if kind is None:
+            kind = "notebook" if path.suffix in {".ipynb", ".Rmd", ".qmd"} else "script"
+        if key is None:
+            if ln_setup.settings.dev_dir is not None:
+                try:
+                    key = path.relative_to(ln_setup.settings.dev_dir).as_posix()
+                except ValueError as e:
+                    if "subpath" in str(e):
+                        logger.warning(
+                            f"path {path} is not within the configured dev directory "
+                            f"({ln_setup.settings.dev_dir}), falling back to using filename as transform key "
+                            f"('{path.name}')"
+                        )
+                        key = path.name
+                    else:
+                        raise
+            else:
+                key = path.name
+        reference = None
+        reference_type = None
+        if settings.sync_git_repo is not None and path.suffix != ".ipynb":
+            from ..core._sync_git import get_transform_reference_from_git_repo
+
+            reference = get_transform_reference_from_git_repo(path)
+            reference_type = "url"
+        return cls(
+            key=key,
+            kind=kind,
+            version=version,
+            description=description,
+            reference=reference,
+            reference_type=reference_type,
+            skip_hash_lookup=skip_hash_lookup,
         )
 
     @classmethod

--- a/tests/core/test_track_script_or_notebook.py
+++ b/tests/core/test_track_script_or_notebook.py
@@ -467,27 +467,36 @@ def test_create_or_load_transform():
     context.version = version
     context._path = Path("my-test-transform-create-or-load.py")
     context._path.touch(exist_ok=True)
-    context._create_or_load_transform(
+    transform, _ = ln.Transform._create_or_load_from_source(
+        path=context._path,
         description=title,
         transform_kind="notebook",
+        uid=context.uid,
+        version=context.version,
     )
-    assert context._transform.uid == uid
-    assert context._transform.version_tag == version
-    assert context._transform.description == title
-    context._create_or_load_transform(
+    assert transform.uid == uid
+    assert transform.version_tag == version
+    assert transform.description == title
+    transform, _ = ln.Transform._create_or_load_from_source(
+        path=context._path,
         description=title,
+        uid=context.uid,
+        version=context.version,
     )
-    assert context._transform.uid == uid
-    assert context._transform.version_tag == version
-    assert context._transform.description == title
+    assert transform.uid == uid
+    assert transform.version_tag == version
+    assert transform.description == title
 
     # now, test an updated transform name
-    context._create_or_load_transform(
+    transform, _ = ln.Transform._create_or_load_from_source(
+        path=context._path,
         description="updated title",
+        uid=context.uid,
+        version=context.version,
     )
-    assert context._transform.uid == uid
-    assert context._transform.version_tag == version
-    assert context._transform.description == "updated title"
+    assert transform.uid == uid
+    assert transform.version_tag == version
+    assert transform.description == "updated title"
 
     # unset to remove side effects
     ln.context._uid = None
@@ -510,8 +519,10 @@ def test_create_or_load_transform_warns_when_outside_dev_dir(
         ln_setup.settings.dev_dir.mkdir(exist_ok=True)
         ccaplog.clear()
         context._path = path_outside_dev_dir
-        context._create_or_load_transform(description="outside dev dir warning test")
-        transform = context._transform
+        transform, _ = ln.Transform._create_or_load_from_source(
+            path=context._path,
+            description="outside dev dir warning test",
+        )
         assert "falling back to using filename as transform key" in ccaplog.text
         assert transform.key == expected_key
     finally:

--- a/tests/core/test_transform.py
+++ b/tests/core/test_transform.py
@@ -11,7 +11,9 @@ def test_transform_from_file_infers_kind_and_key(tmp_path):
     script_path = tmp_path / f"workflow-{time.time_ns()}.py"
     script_path.write_text("print('hello')\n")
     notebook_path = tmp_path / f"analysis-{time.time_ns()}.ipynb"
-    notebook_path.write_text("{}\n")
+    notebook_path.write_text(
+        '{"cells":[],"metadata":{},"nbformat":4,"nbformat_minor":5}\n'
+    )
 
     script_transform = ln.Transform.from_file(script_path)
     notebook_transform = ln.Transform.from_file(notebook_path)

--- a/tests/core/test_transform.py
+++ b/tests/core/test_transform.py
@@ -7,7 +7,7 @@ import lamindb_setup as ln_setup
 import pytest
 
 
-def test_transform_from_file_infers_kind_and_key(tmp_path):
+def test_transform_from_path_infers_kind_and_key(tmp_path):
     script_path = tmp_path / f"workflow-{time.time_ns()}.py"
     script_path.write_text("print('hello')\n")
     notebook_path = tmp_path / f"analysis-{time.time_ns()}.ipynb"
@@ -15,8 +15,8 @@ def test_transform_from_file_infers_kind_and_key(tmp_path):
         '{"cells":[],"metadata":{},"nbformat":4,"nbformat_minor":5}\n'
     )
 
-    script_transform = ln.Transform.from_file(script_path)
-    notebook_transform = ln.Transform.from_file(notebook_path)
+    script_transform = ln.Transform.from_path(script_path)
+    notebook_transform = ln.Transform.from_path(notebook_path)
 
     assert script_transform.kind == "script"
     assert script_transform.key == script_path.name
@@ -24,14 +24,14 @@ def test_transform_from_file_infers_kind_and_key(tmp_path):
     assert notebook_transform.key == notebook_path.name
 
 
-def test_transform_from_file_uses_dev_dir_relative_key(tmp_path):
+def test_transform_from_path_uses_dev_dir_relative_key(tmp_path):
     previous_dev_dir = ln_setup.settings.dev_dir
     path_in_dev_dir = tmp_path / "pipelines" / f"wf-{time.time_ns()}.py"
     path_in_dev_dir.parent.mkdir(parents=True, exist_ok=True)
     path_in_dev_dir.write_text("print('hello')\n")
     try:
         ln_setup.settings.dev_dir = tmp_path
-        transform = ln.Transform.from_file(path_in_dev_dir)
+        transform = ln.Transform.from_path(path_in_dev_dir)
         assert transform.key == f"pipelines/{path_in_dev_dir.name}"
     finally:
         ln_setup.settings.dev_dir = previous_dev_dir

--- a/tests/core/test_transform.py
+++ b/tests/core/test_transform.py
@@ -1,8 +1,38 @@
+import time
 from pathlib import Path
 from unittest.mock import patch
 
 import lamindb as ln
+import lamindb_setup as ln_setup
 import pytest
+
+
+def test_transform_from_file_infers_kind_and_key(tmp_path):
+    script_path = tmp_path / f"workflow-{time.time_ns()}.py"
+    script_path.write_text("print('hello')\n")
+    notebook_path = tmp_path / f"analysis-{time.time_ns()}.ipynb"
+    notebook_path.write_text("{}\n")
+
+    script_transform = ln.Transform.from_file(script_path)
+    notebook_transform = ln.Transform.from_file(notebook_path)
+
+    assert script_transform.kind == "script"
+    assert script_transform.key == script_path.name
+    assert notebook_transform.kind == "notebook"
+    assert notebook_transform.key == notebook_path.name
+
+
+def test_transform_from_file_uses_dev_dir_relative_key(tmp_path):
+    previous_dev_dir = ln_setup.settings.dev_dir
+    path_in_dev_dir = tmp_path / "pipelines" / f"wf-{time.time_ns()}.py"
+    path_in_dev_dir.parent.mkdir(parents=True, exist_ok=True)
+    path_in_dev_dir.write_text("print('hello')\n")
+    try:
+        ln_setup.settings.dev_dir = tmp_path
+        transform = ln.Transform.from_file(path_in_dev_dir)
+        assert transform.key == f"pipelines/{path_in_dev_dir.name}"
+    finally:
+        ln_setup.settings.dev_dir = previous_dev_dir
 
 
 def test_transform_recovery_based_on_hash():


### PR DESCRIPTION
Expose an easy way to make transforms from scripts and notebooks through the `Transform()` registry. Previously this was internally used within `ln.track()` and `ln.flow()`.