### PR TITLE
🚸 Expose notes as a `.notes` attribute

### DIFF
--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1267,6 +1267,12 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
         # TODO: refactor to use _TRACK_FIELDS
         track_current_name_value(self)
 
+    def _latest_readme_content(self) -> str | None:
+        latest_readme = self.ablocks.filter(kind="readme", is_latest=True).one_or_none()
+        if latest_readme is None:
+            return None
+        return latest_readme.content
+
     # used in __init__
     # populates the _original_values dictionary with the original values of the tracked fields
     def _populate_tracked_fields(self):
@@ -2020,6 +2026,17 @@ class Branch(BaseSQLRecord):
             )
         self._status_code = BRANCH_STATUS_TO_CODE[value]
 
+    @property
+    def notes(self) -> str | None:
+        """Notes.
+
+        Returns the latest content of an attached block of kind `readme`.
+
+        You can populate it via the UI or via `lamin annotate branch --readme README.md`.
+        """
+        # In the future, other block kinds (e.g. concatenated blocks) could contribute.
+        return self._latest_readme_content()
+
     @overload
     def __init__(
         self,
@@ -2097,6 +2114,17 @@ class SQLRecord(BaseSQLRecord, metaclass=Registry):
 
     class Meta:
         abstract = True
+
+    @property
+    def notes(self) -> str | None:
+        """Notes.
+
+        Returns the latest content of an attached block of kind `readme`.
+
+        You can populate it via the UI or via `lamin annotate ... --readme README.md`.
+        """
+        # In the future, other block kinds (e.g. concatenated blocks) could contribute.
+        return self._latest_readme_content()
 
     def restore(self) -> None:
         """Restore from trash onto the main branch.

--- a/tests/core/test_blocks.py
+++ b/tests/core/test_blocks.py
@@ -307,3 +307,51 @@ def test_record_block_filter_respects_default_branch_scope():
     contrib_record.delete(permanent=True)
     main_record.delete(permanent=True)
     contrib.delete(permanent=True)
+
+
+def test_sqlrecord_notes_returns_latest_readme_content():
+    record = ln.Record(name="record-notes-test").save()
+    assert record.notes is None
+
+    readme_v1 = ln.models.RecordBlock(
+        record=record, content="record notes v1", kind="readme"
+    ).save()
+    assert record.notes == "record notes v1"
+
+    ln.models.RecordBlock(
+        record=record, content="record notes v2", kind="readme"
+    ).save()
+    readme_v1.refresh_from_db()
+    assert not readme_v1.is_latest
+    assert record.notes == "record notes v2"
+
+    ln.models.RecordBlock(
+        record=record, content="just a comment", kind="comment"
+    ).save()
+    assert record.notes == "record notes v2"
+
+    record.delete(permanent=True)
+
+
+def test_branch_notes_returns_latest_readme_content():
+    branch = ln.Branch(name="branch-notes-test").save()
+    assert branch.notes is None
+
+    readme_v1 = ln.models.BranchBlock(
+        branch=branch, content="branch notes v1", kind="readme"
+    ).save()
+    assert branch.notes == "branch notes v1"
+
+    ln.models.BranchBlock(
+        branch=branch, content="branch notes v2", kind="readme"
+    ).save()
+    readme_v1.refresh_from_db()
+    assert not readme_v1.is_latest
+    assert branch.notes == "branch notes v2"
+
+    ln.models.BranchBlock(
+        branch=branch, content="branch comment", kind="comment"
+    ).save()
+    assert branch.notes == "branch notes v2"
+
+    branch.delete(permanent=True)


### PR DESCRIPTION
You can now access the notes for an object via:

```python
artifact.notes
branch.notes
...
```

Currently the only way to annotate objects with notes is via attached blocks of `kind = "readme"`. This is the documented behavior of the CLI and the mechanism behind the UI.