### PR TITLE
🚸 Reduce the default value for limit in `to_dataframe()` from 100 to 20

### DIFF
--- a/lamindb/models/query_manager.py
+++ b/lamindb/models/query_manager.py
@@ -30,14 +30,15 @@ from lamindb_setup.core._docs import doc_args
 if TYPE_CHECKING:
     from ..base.types import StrField
 
+SEARCH_QUERY_DEFAULT_LIMIT = 20
+
 
 def _search(
     cls,
     string: str,
     *,
     field: StrField | list[StrField] | None = None,
-    # TODO: factor into SEARCH_QUERY_DEFAULT_LIMIT in 2.6 once consistent.
-    limit: int | None = 20,
+    limit: int | None = SEARCH_QUERY_DEFAULT_LIMIT,
     case_sensitive: bool = False,
     truncate_string: bool = False,
 ) -> QuerySet:

--- a/lamindb/models/query_set.py
+++ b/lamindb/models/query_set.py
@@ -30,7 +30,7 @@ from ..base.types import BRANCH_STATUS_TO_CODE, RUN_STATUS_TO_CODE
 from ..errors import DoesNotExist, MultipleResultsFound
 from ._is_versioned import IsVersioned, _adjust_is_latest_when_deleting_is_versioned
 from .can_curate import CanCurate, _inspect, _standardize, _validate
-from .query_manager import _lookup, _search
+from .query_manager import SEARCH_QUERY_DEFAULT_LIMIT, _lookup, _search
 from .sqlrecord import Registry, SQLRecord
 
 if TYPE_CHECKING:
@@ -1156,8 +1156,7 @@ class BasicQuerySet(models.QuerySet):
         *,
         include: str | list[str] | None = None,
         features: str | list[str] | None = None,
-        # TODO: factor into SEARCH_QUERY_DEFAULT_LIMIT in 2.6 once consistent.
-        limit: int | None = 100,
+        limit: int | None = SEARCH_QUERY_DEFAULT_LIMIT,
         order_by: str | None = "-id",
         record_metadata: bool = True,
     ) -> pd.DataFrame:
@@ -1288,7 +1287,7 @@ class BasicQuerySet(models.QuerySet):
                         )
         if is_truncated:
             logger.warning(
-                f"truncated query result to limit={limit} {self.model.__name__} objects (will change to limit=20 in lamindb 2.7)"
+                f"truncated query result to limit={limit} {self.model.__name__} objects"
             )
         return df_reshaped
 

--- a/lamindb/models/query_set.py
+++ b/lamindb/models/query_set.py
@@ -1181,8 +1181,12 @@ class BasicQuerySet(models.QuerySet):
             subset = subset.order_by(order_by)
         is_truncated = False
         if limit is not None:
-            # Fetch one extra row as a sentinel to detect truncation without count().
-            subset = subset[: limit + 1]
+            # Determine truncation on base record ids before annotate fanout.
+            limited_ids = list(subset.values_list("id", flat=True)[: limit + 1])
+            is_truncated = len(limited_ids) > limit
+            if is_truncated:
+                limited_ids = limited_ids[:limit]
+            subset = subset.filter(id__in=limited_ids)
         if include is None:
             include_input = []
         elif isinstance(include, str):
@@ -1237,9 +1241,6 @@ class BasicQuerySet(models.QuerySet):
         # another refactoring effort
         # we have the correct ordering in `features.get_values()`, though
         df = pd.DataFrame(queryset.values(*field_names, *list(annotate_kwargs.keys())))
-        if limit is not None and len(df) > limit:
-            is_truncated = True
-            df = df.iloc[:limit].copy()
         if len(df) == 0:
             df = pd.DataFrame({}, columns=field_names)
             return df

--- a/lamindb/models/query_set.py
+++ b/lamindb/models/query_set.py
@@ -13,12 +13,15 @@ import lamindb_setup as ln_setup
 from django.core.exceptions import FieldError
 from django.db import models, transaction
 from django.db.models import (
+    Case,
     F,
     FilteredRelation,
     ForeignKey,
+    IntegerField,
     ManyToManyField,
     Q,
     Subquery,
+    When,
 )
 from django.db.models.fields.related import ForeignObjectRel
 from lamin_utils import logger
@@ -1186,7 +1189,18 @@ class BasicQuerySet(models.QuerySet):
             is_truncated = len(limited_ids) > limit
             if is_truncated:
                 limited_ids = limited_ids[:limit]
-            subset = subset.filter(id__in=limited_ids)
+            # `subset` can already be sliced (e.g. from `.search()`), and Django
+            # disallows filtering sliced querysets. Rebuild from selected ids.
+            if not limited_ids:
+                subset = subset.model.objects.using(subset.db).none()
+            else:
+                preserved_order = Case(
+                    *[When(id=pk, then=pos) for pos, pk in enumerate(limited_ids)],
+                    output_field=IntegerField(),
+                )
+                subset = (
+                    subset.model.objects.using(subset.db).filter(id__in=limited_ids)
+                ).order_by(preserved_order)
         if include is None:
             include_input = []
         elif isinstance(include, str):

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -87,7 +87,7 @@ from ._is_versioned import (
     _adjust_is_latest_when_deleting_is_versioned,
     max_version_uid_in_family,
 )
-from .query_manager import QueryManager, _lookup, _search
+from .query_manager import SEARCH_QUERY_DEFAULT_LIMIT, QueryManager, _lookup, _search
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -838,13 +838,12 @@ class Registry(ModelBase):
         *,
         include: str | list[str] | None = None,
         features: str | list[str] | None = None,
-        # TODO: factor into SEARCH_QUERY_DEFAULT_LIMIT in 2.6 once consistent.
-        limit: int | None = 100,
+        limit: int | None = SEARCH_QUERY_DEFAULT_LIMIT,
         order_by: str | None = "-id",
     ) -> pd.DataFrame:
         """Evaluate and convert to `pd.DataFrame`.
 
-        By default, this returns up to 100 rows for a fast overview.
+        By default, this returns up to 20 rows for a fast overview.
         Pass `limit=None` to fetch all matching records.
 
         By default, maps simple fields and foreign keys onto `DataFrame` columns.
@@ -860,7 +859,7 @@ class Registry(ModelBase):
             features: Configure the features to include. Can be a feature name or a list of such names.
                 If `"queryset"`, infers the features used within the current queryset.
                 Only available for `Artifact`, `Record`, and `Run`.
-            limit: Maximum number of rows to display. Defaults to 100. If `None`,
+            limit: Maximum number of rows to display. Defaults to 20. If `None`,
                 includes all results.
             order_by: Field name to order the records by. Prefix with '-' for descending order.
                 Defaults to '-id' to get the most recent records. This argument is ignored
@@ -890,7 +889,7 @@ class Registry(ModelBase):
         *,
         include: str | list[str] | None = None,
         features: str | list[str] | None = None,
-        limit: int | None = 100,
+        limit: int | None = SEARCH_QUERY_DEFAULT_LIMIT,
         order_by: str | None = "-id",
     ) -> pd.DataFrame:
         return cls.to_dataframe(
@@ -903,8 +902,7 @@ class Registry(ModelBase):
         string: str,
         *,
         field: StrField | None = None,
-        # TODO: factor into SEARCH_QUERY_DEFAULT_LIMIT in 2.6 once consistent.
-        limit: int | None = 20,
+        limit: int | None = SEARCH_QUERY_DEFAULT_LIMIT,
         case_sensitive: bool = False,
     ) -> QuerySet:
         """{}"""  # noqa: D415

--- a/tests/core/test_artifact_describe_to_dataframe.py
+++ b/tests/core/test_artifact_describe_to_dataframe.py
@@ -117,6 +117,32 @@ def test_describe_to_dataframe_example_dataset():
     expected_df = pd.DataFrame(expected_data)
     _check_df_equality(df, expected_df)
 
+    # Regression: limiting should apply to base artifacts, not to expanded annotation rows.
+    # We should still get complete feature values for the selected artifact.
+    df_limited = (
+        ln.Artifact.filter(
+            key__startswith="examples/dataset",
+            suffix=".h5ad",
+            records__name="IFNG",
+        )
+        .order_by("-key")
+        .to_dataframe(
+            features=[
+                "cell_type_by_expert",
+                "cell_type_by_model",
+                "experiment",
+                "perturbation",
+                "temperature",
+                "study_note",
+                "date_of_study",
+            ],
+            limit=1,
+        )
+    )
+    assert len(df_limited) == 1
+    assert df_limited.iloc[0]["key"] == "examples/dataset2.h5ad"
+    assert df_limited.iloc[0]["study_metadata"] == {"detail1": "456", "detail2": 2}
+
     # Test filtering artifacts by schemas__in (alternative approach)
     # Query artifacts that measure CD8A gene by filtering schemas first
     cd8a = bt.Gene.get(symbol="CD8A")


### PR DESCRIPTION
Now `.filter()` and `.search()` are consistent.

We had warned that this would be coming since here:

- https://github.com/laminlabs/lamindb/pull/3505