### PR TITLE
:zap: Speed up `Record.from_dataframe()` in presence of indexes

### DIFF
--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -1392,6 +1392,7 @@ class FeatureManager:
         not_validated_values: dict[str, tuple[str, list[str]]],
         resolved_records_by_feature_id: dict[int, dict[Any, list[SQLRecord]]]
         | None = None,
+        index_feature: Feature | None = None,
     ) -> None:
         from ..base.dtypes import is_iterable_of_sqlrecord
         from .can_curate import CanCurate
@@ -1401,7 +1402,8 @@ class FeatureManager:
             get_type_schema_index,
         )
 
-        index_feature = get_type_schema_index(record.type)  # type: ignore
+        if index_feature is None:
+            index_feature = get_type_schema_index(record.type)  # type: ignore
 
         for feature in feature_objects:
             if index_feature is not None and feature.uid == index_feature.uid:
@@ -2196,6 +2198,7 @@ def bulk_set_features_in_records(records: Iterable[Record]) -> None:
         return None
 
     batch_schema: Schema | None = None
+    batch_schema_index: Feature | None = None
     prepared_records: list[
         tuple[Record, FeatureManager, dict[str, Any], list[Feature], dict[str, Any]]
     ] = []
@@ -2210,6 +2213,7 @@ def bulk_set_features_in_records(records: Iterable[Record]) -> None:
             )
         if batch_schema is None:
             batch_schema = schema
+            batch_schema_index = batch_schema.index  # one DB query for the whole batch
         elif schema.id != batch_schema.id:
             raise ValidationError(
                 "Bulk setting features in records requires all records to have the same type schema."
@@ -2221,9 +2225,9 @@ def bulk_set_features_in_records(records: Iterable[Record]) -> None:
             explicit_features,
             values_by_feature_uid,
         ) = manager._resolve_feature_value_dictionary(record._features)
-        from .record import inject_index_into_feature_dict
 
-        inject_index_into_feature_dict(record, dictionary)
+        if batch_schema_index is not None and record.name is not None:
+            dictionary[batch_schema_index.name] = record.name
         prepared_rows.append(dictionary)
         prepared_records.append(
             (record, manager, dictionary, explicit_features, values_by_feature_uid)
@@ -2335,7 +2339,7 @@ def bulk_set_features_in_records(records: Iterable[Record]) -> None:
         feature_objects = manager._merge_feature_objects(
             explicit_features, looked_up_features
         )
-        if batch_schema.index is not None:
+        if batch_schema_index is not None:
             from .record import strip_index_for_record_persistence
 
             dictionary, feature_objects = strip_index_for_record_persistence(
@@ -2344,6 +2348,7 @@ def bulk_set_features_in_records(records: Iterable[Record]) -> None:
                 dictionary,
                 feature_objects,
                 values_by_feature_uid=values_by_feature_uid,
+                index_feature=batch_schema_index,
             )
         manager._collect_record_feature_writes(
             record=record,
@@ -2354,6 +2359,7 @@ def bulk_set_features_in_records(records: Iterable[Record]) -> None:
             links_by_model=links_by_model,
             not_validated_values=not_validated_values,
             resolved_records_by_feature_id=resolved_records_by_feature_id,
+            index_feature=batch_schema_index,
         )
     FeatureManager._raise_not_validated_values(not_validated_values)
     if feature_json_values:
@@ -2363,10 +2369,9 @@ def bulk_set_features_in_records(records: Iterable[Record]) -> None:
             save(links, ignore_conflicts=False)
         except Exception:
             save(links, ignore_conflicts=True)
-    from .record import get_type_schema_index
     from .save import bulk_update
 
-    if get_type_schema_index(records_with_features[0].type) is not None:
+    if batch_schema_index is not None:
         bulk_update(records_with_features)
     for record in records_with_features:
         del record._features

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -144,10 +144,13 @@ def inject_index_into_feature_dict(record: Record, dictionary: dict[str, Any]) -
 
 
 def pop_index_from_feature_dictionary(
-    dictionary: dict[str, Any], schema: Schema
+    dictionary: dict[str, Any],
+    schema: Schema,
+    index_feature: Feature | None = None,
 ) -> tuple[str | None, dict[str, Any]]:
     """Extract index value for `record.name` and remove it from feature payload."""
-    index_feature = schema.index
+    if index_feature is None:
+        index_feature = schema.index
     if index_feature is None:
         return None, dictionary
     index_name = index_feature.name
@@ -499,7 +502,7 @@ class RecordBatch:
 
             if index_feature is not None and self._resolved_type.schema is not None:
                 name_from_features, features = pop_index_from_feature_dictionary(
-                    features, self._resolved_type.schema
+                    features, self._resolved_type.schema, index_feature=index_feature
                 )
                 if name is None:
                     name = name_from_features

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -245,9 +245,11 @@ def strip_index_for_record_persistence(
     feature_objects: list[Feature],
     *,
     values_by_feature_uid: dict[str, Any] | None = None,
+    index_feature: Feature | None = None,
 ) -> tuple[dict[str, Any], list[Feature]]:
     """Move schema index values to `record.name` and drop them from link-table writes."""
-    index_feature = schema.index
+    if index_feature is None:
+        index_feature = schema.index
     if index_feature is None:
         return dictionary, feature_objects
 
@@ -464,10 +466,14 @@ class RecordBatch:
     def _build_records(self) -> list[Record]:
         import pandas as pd
 
+        from lamindb import settings
+
         index_feature = get_type_schema_index(self._resolved_type)
         records: list[Record] = []
         work_df = dataframe_for_record_batch(self._df, index_feature)
         row_dicts = work_df.to_dict(orient="records")
+        _search_names = settings.creation.search_names
+        settings.creation.search_names = False
         for row in row_dicts:
             row = dict(row)
             name = None
@@ -502,6 +508,7 @@ class RecordBatch:
             if features:
                 record_kwargs["features"] = features
             records.append(self._cls(name=name, **record_kwargs))
+        settings.creation.search_names = _search_names
         return records
 
     def save(self) -> SQLRecordList[Record]:

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -1547,3 +1547,42 @@ def test_record_features_accept_feature_object_keys():
     record.delete(permanent=True)
     feature_score.delete(permanent=True)
     feature_tag.delete(permanent=True)
+
+
+def test_from_dataframe_save_query_count_is_not_n_plus_one():
+    """Query count must stay O(1) — not grow with row count — when saving a batch."""
+    from django.db import connection
+    from django.test.utils import CaptureQueriesContext
+
+    id_feat = ln.Feature(name="qcount-id", dtype=str).save()
+    val_feat = ln.Feature(name="qcount-val", dtype=str).save()
+    schema = ln.Schema([val_feat], index=id_feat, name="qcount-schema").save()
+    sheet = ln.Record(name="qcount-sheet", is_type=True, schema=schema).save()
+
+    def make_df(n: int) -> pd.DataFrame:
+        return pd.DataFrame(
+            {"qcount-val": [f"v{i}" for i in range(n)]},
+            index=pd.Index([f"id{i}" for i in range(n)], name="qcount-id"),
+        )
+
+    with CaptureQueriesContext(connection) as ctx_10:
+        saved_10 = ln.Record.from_dataframe(make_df(10), type=sheet).save()
+    q_10 = len(ctx_10.captured_queries)
+
+    with CaptureQueriesContext(connection) as ctx_100:
+        saved_100 = ln.Record.from_dataframe(make_df(100), type=sheet).save()
+    q_100 = len(ctx_100.captured_queries)
+
+    # Allow a small constant tolerance for Django bulk_create batching differences.
+    # A true N+1 would produce ~10x more queries for 10x more rows.
+    assert abs(q_100 - q_10) <= 5, (
+        f"N+1 query regression: 10 rows fired {q_10} queries, "
+        f"100 rows fired {q_100} queries — count must not grow with row count"
+    )
+
+    for r in saved_10 + saved_100:
+        r.delete(permanent=True)
+    sheet.delete(permanent=True)
+    schema.delete(permanent=True)
+    id_feat.delete(permanent=True)
+    val_feat.delete(permanent=True)


### PR DESCRIPTION
In this PR we address the following issues:

1. `schema.index` called per row (4 separate call sites) `inject_index_into_feature_dict`, `strip_index_for_record_persistence`, `pop_index_from_feature_dictionary`, and `_collect_record_feature_writes` each call schema.index independently, which is a live DB query. With 10k rows × 4 calls × ~68ms network round-trip on Postgres approximately 45 minutes just for this.
2. `suggest_records_with_similar_names` called per row inside `_build_records`.  Every Record.__init__ triggers a similarity search in the DB (3 queries: _search, .first(), .exists()). For 10k rows that's ~30k extra DB queries.

## Materials

Is a follow-up optimization on:

- https://github.com/laminlabs/lamindb/pull/3752

Has been further optimized here:

- https://github.com/laminlabs/lamindb/pull/3769

Addresses:

- https://github.com/pfizer-collab/laminlabs/issues/1064