### PR TITLE
🚸 Introduce `RecordSet` to allow exporting arbitrary sets of records with the semantics of `Record.to_dataframe()`

### DIFF
--- a/lamindb/models/__init__.py
+++ b/lamindb/models/__init__.py
@@ -172,7 +172,7 @@ from .collection import Collection, CollectionArtifact
 from .project import Project, Reference
 from .query_manager import RelatedManager, QueryManager
 from .query_set import BasicQuerySet, QuerySet, DB, SQLRecordList
-from .artifact_set import ArtifactSet
+from .artifact_set import ArtifactSet, RecordSet
 from .has_parents import HasParents
 from datetime import datetime as _datetime
 

--- a/lamindb/models/artifact_set.py
+++ b/lamindb/models/artifact_set.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from pyarrow.dataset import Dataset as PyArrowDataset
 
     from ..core._mapped_collection import MappedCollection
+    from .record import Record
     from .run import Run
 
 
@@ -149,6 +150,7 @@ class RecordSet(Iterable):
         record_metadata: bool = True,
         is_run_input: bool | Run | None = None,
         link_individual_inputs: bool = True,
+        _record_type: Record | None = None,
     ) -> DataFrame:
         import pandas as pd
 
@@ -181,24 +183,27 @@ class RecordSet(Iterable):
                 record_metadata=record_metadata,
             )
 
-        type_ids = list(qs.values_list("type_id", flat=True).distinct()[:2])
-        if len(type_ids) != 1 or type_ids[0] is None:
-            # Sheet-style export requires a single concrete record type context.
-            logger.warning(
-                "falling back to generic Record queryset export because the queryset "
-                "does not resolve to exactly one non-null `type_id`"
-            )
-            return BasicQuerySet.to_dataframe(
-                qs,
-                include=include,
-                features=features,
-                limit=limit,
-                order_by=order_by,
-                record_metadata=record_metadata,
-            )
+        if _record_type is not None:
+            record_type = _record_type
+        else:
+            type_ids = list(qs.values_list("type_id", flat=True).distinct()[:2])
+            if len(type_ids) != 1 or type_ids[0] is None:
+                # Sheet-style export requires a single concrete record type context.
+                logger.warning(
+                    "falling back to generic Record queryset export because the queryset "
+                    "does not resolve to exactly one non-null `type_id`"
+                )
+                return BasicQuerySet.to_dataframe(
+                    qs,
+                    include=include,
+                    features=features,
+                    limit=limit,
+                    order_by=order_by,
+                    record_metadata=record_metadata,
+                )
 
-        # `type_id` points to record types (`is_type=True`) by model design.
-        record_type = Record.get(id=type_ids[0])
+            # `type_id` points to record types (`is_type=True`) by model design.
+            record_type = Record.get(id=type_ids[0])
 
         logger.important(f"exporting {qs.count()} records of '{record_type.name}'")
 

--- a/lamindb/models/artifact_set.py
+++ b/lamindb/models/artifact_set.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Iterator
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, cast
 
 from django.db.models import Case, Q, TextField, Value, When
 from django.db.models.functions import Concat
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from pyarrow.dataset import Dataset as PyArrowDataset
 
     from ..core._mapped_collection import MappedCollection
+    from .run import Run
 
 
 UNORDERED_WARNING = (
@@ -128,6 +129,165 @@ class ArtifactSet(Iterable):
         # track only if successful
         track_run_input(artifacts, is_run_input)
         return ds
+
+
+class RecordSet(Iterable):
+    """Abstract class representing sets of records returned by queries.
+
+    This class automatically extends :class:`~lamindb.models.BasicQuerySet`
+    and :class:`~lamindb.models.QuerySet` when the base model is
+    :class:`~lamindb.Record`.
+    """
+
+    def to_dataframe(
+        self,
+        *,
+        include: str | list[str] | None = None,
+        features: str | list[str] | None = None,
+        limit: int | None = 20,
+        order_by: str | None = "-id",
+        record_metadata: bool = True,
+        is_run_input: bool | Run | None = None,
+        link_individual_inputs: bool = True,
+    ) -> DataFrame:
+        import pandas as pd
+
+        from .feature import convert_to_pandas_dtype
+        from .query_set import (
+            SEARCH_QUERY_DEFAULT_LIMIT,
+            BasicQuerySet,
+            encode_lamindb_fields_as_columns,
+            reorder_subset_columns_in_df,
+        )
+        from .record import (
+            Record,
+            apply_schema_index_to_export_dataframe,
+            drop_record_metadata_columns,
+            export_includes_record_metadata,
+        )
+
+        qs = cast(BasicQuerySet, self)
+
+        # Keep generic queryset export semantics for non-Record and mixed sets.
+        if getattr(qs, "model", None) is not Record:
+            return BasicQuerySet.to_dataframe(
+                qs,
+                include=include,
+                features=features,
+                limit=limit,
+                order_by=order_by,
+                record_metadata=record_metadata,
+            )
+        type_ids = list(qs.values_list("type_id", flat=True).distinct()[:2])
+        if len(type_ids) != 1 or type_ids[0] is None:
+            return BasicQuerySet.to_dataframe(
+                qs,
+                include=include,
+                features=features,
+                limit=limit,
+                order_by=order_by,
+                record_metadata=record_metadata,
+            )
+
+        record_type = Record.filter(id=type_ids[0]).one_or_none()
+        if record_type is None or not record_type.is_type:
+            return BasicQuerySet.to_dataframe(
+                qs,
+                include=include,
+                features=features,
+                limit=limit,
+                order_by=order_by,
+                record_metadata=record_metadata,
+            )
+
+        logger.important(f"exporting {qs.count()} records of '{record_type.name}'")
+
+        features_arg = "queryset" if features is None else features
+        limit_arg = None if limit == SEARCH_QUERY_DEFAULT_LIMIT else limit
+        order_by_arg = "id" if order_by == "-id" else order_by
+        index_feature = (
+            record_type.schema.index if record_type.schema is not None else None
+        )
+        include_record_metadata = export_includes_record_metadata(record_type.schema)
+        df = BasicQuerySet.to_dataframe(
+            qs,
+            include=include,
+            features=features_arg,
+            limit=limit_arg,
+            order_by=order_by_arg,
+            record_metadata=include_record_metadata,
+        )
+        if not include_record_metadata and record_type.schema is not None:
+            schema_feature_names = set(
+                record_type.schema.members.values_list("name", flat=True)
+            )
+            pk_name = record_type._meta.pk.name
+            if pk_name in df.columns and pk_name not in schema_feature_names:
+                df = df.drop(columns=[pk_name])
+        encoded_id = encode_lamindb_fields_as_columns(record_type.__class__, "id")
+        assert isinstance(encoded_id, str)  # noqa: S101
+        encoded_uid = encode_lamindb_fields_as_columns(record_type.__class__, "uid")
+        encoded_name = encode_lamindb_fields_as_columns(record_type.__class__, "name")
+        assert isinstance(encoded_name, str)  # noqa: S101
+        if include_record_metadata and df.index.name == "id":
+            df.index.name = encoded_id
+        if (
+            include_record_metadata
+            and "uid" in df.columns
+            and encoded_uid not in df.columns
+        ):
+            df = df.rename(columns={"uid": encoded_uid})
+        if index_feature is not None:
+            if "name" in df.columns and index_feature.name != "name":
+                df[index_feature.name] = df["name"]
+                df = df.drop(columns=["name"])
+            if encoded_name in df.columns:
+                df = df.drop(columns=[encoded_name])
+            df = apply_schema_index_to_export_dataframe(
+                df,
+                index_feature,
+                encoded_id=encoded_id,
+                encoded_name=encoded_name,
+                include_record_metadata=include_record_metadata,
+            )
+        elif "name" in df.columns and encoded_name not in df.columns:
+            df = df.rename(columns={"name": encoded_name})
+        if not include_record_metadata:
+            df = drop_record_metadata_columns(df)
+        if record_type.schema is not None:
+            all_features = record_type.schema.members.all()
+            index_feature_uid = None if index_feature is None else index_feature.uid
+            desired_order = [
+                feature.name
+                for feature in all_features
+                if index_feature_uid is None or feature.uid != index_feature_uid
+            ]
+            for feature in all_features:
+                if index_feature_uid is not None and feature.uid == index_feature_uid:
+                    continue
+                if feature.name not in df.columns:
+                    df[feature.name] = pd.Series(
+                        dtype=convert_to_pandas_dtype(feature._dtype_str)
+                    )
+        else:
+            desired_order = df.columns[2:].tolist()
+            desired_order.sort()
+        df = reorder_subset_columns_in_df(df, desired_order, position=0)  # type: ignore
+
+        record_type._set_export_run(is_run_input=is_run_input)
+        export_run = record_type._export_run
+        if export_run is not None:
+            export_run.input_records.add(record_type)
+            if link_individual_inputs:
+                input_record_ids = qs.values_list("id", flat=True)
+                export_run.input_records.add(*input_record_ids)
+            from datetime import datetime, timezone
+
+            export_run.finished_at = datetime.now(timezone.utc)
+            export_run._status_code = 0
+            export_run.save()
+        qs._record_export_run = export_run
+        return df.sort_index()
 
 
 def artifacts_from_path(artifacts: ArtifactSet, path: AnyPathStr) -> ArtifactSet:

--- a/lamindb/models/artifact_set.py
+++ b/lamindb/models/artifact_set.py
@@ -168,6 +168,19 @@ class RecordSet(Iterable):
 
         qs = cast(BasicQuerySet, self)
 
+        include_features = include == "features" or (
+            isinstance(include, list) and "features" in include
+        )
+        if not include_features:
+            return BasicQuerySet.to_dataframe(
+                qs,
+                include=include,
+                features=features,
+                limit=limit,
+                order_by=order_by,
+                record_metadata=record_metadata,
+            )
+
         type_ids = list(qs.values_list("type_id", flat=True).distinct()[:2])
         if len(type_ids) != 1 or type_ids[0] is None:
             # Sheet-style export requires a single concrete record type context.

--- a/lamindb/models/artifact_set.py
+++ b/lamindb/models/artifact_set.py
@@ -168,18 +168,13 @@ class RecordSet(Iterable):
 
         qs = cast(BasicQuerySet, self)
 
-        # Keep generic queryset export semantics for non-Record and mixed sets.
-        if getattr(qs, "model", None) is not Record:
-            return BasicQuerySet.to_dataframe(
-                qs,
-                include=include,
-                features=features,
-                limit=limit,
-                order_by=order_by,
-                record_metadata=record_metadata,
-            )
         type_ids = list(qs.values_list("type_id", flat=True).distinct()[:2])
         if len(type_ids) != 1 or type_ids[0] is None:
+            # Sheet-style export requires a single concrete record type context.
+            logger.warning(
+                "falling back to generic Record queryset export because the queryset "
+                "does not resolve to exactly one non-null `type_id`"
+            )
             return BasicQuerySet.to_dataframe(
                 qs,
                 include=include,
@@ -189,16 +184,8 @@ class RecordSet(Iterable):
                 record_metadata=record_metadata,
             )
 
-        record_type = Record.filter(id=type_ids[0]).one_or_none()
-        if record_type is None or not record_type.is_type:
-            return BasicQuerySet.to_dataframe(
-                qs,
-                include=include,
-                features=features,
-                limit=limit,
-                order_by=order_by,
-                record_metadata=record_metadata,
-            )
+        # `type_id` points to record types (`is_type=True`) by model design.
+        record_type = Record.get(id=type_ids[0])
 
         logger.important(f"exporting {qs.count()} records of '{record_type.name}'")
 

--- a/lamindb/models/query_set.py
+++ b/lamindb/models/query_set.py
@@ -1106,7 +1106,7 @@ def process_cols_from_include(
 def _queryset_class_factory(
     registry: Registry, queryset_cls: type[models.QuerySet]
 ) -> type[models.QuerySet]:
-    from lamindb.models import Artifact, ArtifactSet
+    from lamindb.models import Artifact, ArtifactSet, Record, RecordSet
 
     # If the model is Artifact, create a new class for BasicQuerySet or QuerySet that inherits from ArtifactSet.
     # This allows to add artifact specific functionality to all classes inheriting from BasicQuerySet.
@@ -1114,6 +1114,12 @@ def _queryset_class_factory(
     if registry is Artifact and not issubclass(queryset_cls, ArtifactSet):
         new_cls = type(
             "Artifact" + queryset_cls.__name__, (queryset_cls, ArtifactSet), {}
+        )
+    elif registry is Record and not issubclass(queryset_cls, RecordSet):
+        new_cls = type(
+            "Record" + queryset_cls.__name__,
+            (queryset_cls, RecordSet),
+            {"to_dataframe": RecordSet.to_dataframe},
         )
     else:
         new_cls = queryset_cls

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Iterable
-from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 import pgtrigger
@@ -25,13 +23,12 @@ from ..base.uids import base62_16
 from .artifact import Artifact
 from .can_curate import CanCurate
 from .collection import Collection
-from .feature import Feature, convert_to_pandas_dtype
+from .feature import Feature
 from .has_parents import HasParents, _query_relatives
 from .query_set import (
     QuerySet,
     encode_lamindb_fields_as_columns,
     get_default_branch_ids,
-    reorder_subset_columns_in_df,
 )
 from .run import Run, TracksRun, TracksUpdates, User, current_run, current_user_id
 from .sqlrecord import (
@@ -48,6 +45,8 @@ from .transform import Transform
 from .ulabel import ULabel
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     import pandas as pd
 
     from ._feature_manager import FeatureManager
@@ -1140,7 +1139,6 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
     def to_dataframe(
         cls_or_self,
         recurse: bool = False,
-        filters: Any | None = None,
         is_run_input: bool | Run | None = None,
         link_individual_inputs: bool = True,
         **kwargs,
@@ -1166,22 +1164,13 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
 
                 sample_sheet.to_dataframe()
 
-            Export only records with high GC content::
-
-                sample_sheet.to_dataframe(filters=gc_content > 0.55)
-
         Args:
             recurse: Whether to include records of sub-types recursively.
-            filters: Filters applied before export. Supports filter kwargs via
-                a `dict`, Django `Q` expressions, and feature predicates
-                (e.g. `my_feature > 5`), including iterables of expressions.
             is_run_input: Whether to track the record as a run input.
             link_individual_inputs: Whether to link all exported records as
                 inputs of the export run. If `False`, only links the record type.
             **kwargs: Keyword arguments passed to :meth:`~lamindb.models.QuerySet.to_dataframe`.
         """
-        import pandas as pd
-
         if isinstance(cls_or_self, type):
             return type(cls_or_self).to_dataframe(cls_or_self, **kwargs)  # type: ignore
         if not cls_or_self.is_type:
@@ -1197,107 +1186,18 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
             if recurse
             else self.records.filter(branch_id__in=branch_ids)
         )
-        if isinstance(filters, dict):
-            # Keep kwargs behavior aligned with the historic `self.records.filter(...)`
-            # semantics where fields like `name` target record fields.
-            qs = qs.filter(**filters)
-        elif filters is not None:
-            # Feature predicates are only supported through Record.filter(...).
-            qs = (
-                self.query_records()
-                if recurse
-                else self.__class__.filter(type=self, branch_id__in=branch_ids)
-            )
-            if isinstance(filters, Iterable) and not isinstance(filters, (str, bytes)):
-                qs = qs.filter(*filters)
-            else:
-                qs = qs.filter(filters)
-        logger.important(f"exporting {qs.count()} records of '{self.name}'")
-        if "order_by" not in kwargs:
-            kwargs["order_by"] = "id"
-        features_arg = kwargs.pop("features", "queryset")
-        index_feature = self.schema.index if self.schema is not None else None
-        include_record_metadata = export_includes_record_metadata(self.schema)
         df = qs.to_dataframe(
-            features=features_arg,
-            limit=None,
-            record_metadata=include_record_metadata,
+            is_run_input=is_run_input,
+            link_individual_inputs=link_individual_inputs,
             **kwargs,
         )
-        if not include_record_metadata and self.schema is not None:
-            schema_feature_names = set(
-                self.schema.members.values_list("name", flat=True)
-            )
-            pk_name = self._meta.pk.name
-            if pk_name in df.columns and pk_name not in schema_feature_names:
-                df = df.drop(columns=[pk_name])
-        encoded_id = encode_lamindb_fields_as_columns(self.__class__, "id")
-        assert isinstance(encoded_id, str)  # noqa: S101
-        encoded_uid = encode_lamindb_fields_as_columns(self.__class__, "uid")
-        encoded_name = encode_lamindb_fields_as_columns(self.__class__, "name")
-        assert isinstance(encoded_name, str)  # noqa: S101
-        # encode the django id, uid and name fields
-        if include_record_metadata and df.index.name == "id":
-            df.index.name = encoded_id
-        if (
-            include_record_metadata
-            and "uid" in df.columns
-            and encoded_uid not in df.columns
-        ):
-            df = df.rename(columns={"uid": encoded_uid})
-        if index_feature is not None:
-            if "name" in df.columns and index_feature.name != "name":
-                df[index_feature.name] = df["name"]
-                df = df.drop(columns=["name"])
-            if encoded_name in df.columns:
-                df = df.drop(columns=[encoded_name])
-            df = apply_schema_index_to_export_dataframe(
-                df,
-                index_feature,
-                encoded_id=encoded_id,
-                encoded_name=encoded_name,
-                include_record_metadata=include_record_metadata,
-            )
-        elif "name" in df.columns and encoded_name not in df.columns:
-            df = df.rename(columns={"name": encoded_name})
-        if not include_record_metadata:
-            df = drop_record_metadata_columns(df)
-        if self.schema is not None:
-            all_features = self.schema.members.all()
-            index_feature_uid = None if index_feature is None else index_feature.uid
-            desired_order = [
-                feature.name
-                for feature in all_features
-                if index_feature_uid is None or feature.uid != index_feature_uid
-            ]
-            for feature in all_features:
-                if index_feature_uid is not None and feature.uid == index_feature_uid:
-                    continue
-                if feature.name not in df.columns:
-                    df[feature.name] = pd.Series(
-                        dtype=convert_to_pandas_dtype(feature._dtype_str)
-                    )
-        else:
-            # sort alphabetically for now
-            desired_order = df.columns[2:].tolist()
-            desired_order.sort()
-        df = reorder_subset_columns_in_df(df, desired_order, position=0)  # type: ignore
-        self._set_export_run(is_run_input=is_run_input)
-        # always link the type record
-        self._export_run.input_records.add(self)
-        if link_individual_inputs:
-            input_record_ids = qs.values_list("id", flat=True)
-            self._export_run.input_records.add(*input_record_ids)
-        self._export_run.finished_at = datetime.now(timezone.utc)
-        self._export_run._status_code = 0  # completed
-        self._export_run.save()
-        return df.sort_index()  # order by id
+        self._export_run = getattr(qs, "_record_export_run", None)
+        return df
 
     def to_artifact(
         self,
         key: str | None = None,
         suffix: str | None = None,
-        filters: Any | None = None,
         is_run_input: bool | Run | None = None,
         link_individual_inputs: bool = True,
         **kwargs,
@@ -1317,14 +1217,9 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
 
                 sample_sheet.to_artifact()
 
-            Export only records with high GC content::
-
-                sample_sheet.to_artifact(filters=gc_content > 0.55)
-
         Args:
             key: `str | None = None` The artifact key.
             suffix: `str | None = None` The suffix to append to the default key if no key is passed.
-            filters: Filters applied before export.
             is_run_input: Whether to track the record as a run input.
             link_individual_inputs: Whether to link all exported records as
                 inputs of the export run. If `False`, only links the record type.
@@ -1338,7 +1233,6 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         description = f": {self.description}" if self.description is not None else ""
         return Artifact.from_dataframe(
             self.to_dataframe(
-                filters=filters,
                 is_run_input=is_run_input,
                 link_individual_inputs=link_individual_inputs,
                 **kwargs,

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -1190,6 +1190,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         df = qs.to_dataframe(
             is_run_input=is_run_input,
             link_individual_inputs=link_individual_inputs,
+            _record_type=self,
             **kwargs,
         )
         self._export_run = getattr(qs, "_record_export_run", None)

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -1186,6 +1186,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
             if recurse
             else self.records.filter(branch_id__in=branch_ids)
         )
+        kwargs.setdefault("include", "features")
         df = qs.to_dataframe(
             is_run_input=is_run_input,
             link_individual_inputs=link_individual_inputs,

--- a/tests/core/test_record_sheet_examples.py
+++ b/tests/core/test_record_sheet_examples.py
@@ -548,11 +548,11 @@ def test_record_export_applies_filters():
     sample1 = ln.Record(name="sample1", type=sample_sheet).save()
     sample2 = ln.Record(name="sample2", type=sample_sheet).save()
 
-    filtered_df = sample_sheet.to_dataframe(filters={"name": "sample1"})
+    filtered_df = ln.Record.filter(type=sample_sheet, name="sample1").to_dataframe()
     assert len(filtered_df) == 1
     assert filtered_df["__lamindb_record_name__"].to_list() == ["sample1"]
 
-    dataframe_export_run = sample_sheet._export_run
+    dataframe_export_run = sample_sheet.input_of_runs.order_by("-created_at").first()
     assert dataframe_export_run is not None
     assert dataframe_export_run.input_records.count() == 2
     assert set(dataframe_export_run.input_records.to_list("name")) == {
@@ -560,20 +560,9 @@ def test_record_export_applies_filters():
         "FilterSheet",
     }
 
-    artifact = sample_sheet.to_artifact(filters={"name": "sample1"})
-    try:
-        assert len(artifact.load()) == 1
-        assert artifact.run is not None
-        assert artifact.run.input_records.count() == 2
-        assert set(artifact.run.input_records.to_list("name")) == {
-            "sample1",
-            "FilterSheet",
-        }
-    finally:
-        artifact.delete(permanent=True)
-        sample1.delete(permanent=True)
-        sample2.delete(permanent=True)
-        sample_sheet.delete(permanent=True)
+    sample1.delete(permanent=True)
+    sample2.delete(permanent=True)
+    sample_sheet.delete(permanent=True)
 
 
 def test_record_export_applies_feature_predicate_filters():
@@ -584,11 +573,13 @@ def test_record_export_applies_feature_predicate_filters():
     sample1.features.add_values({"export_filter_score": 10})
     sample2.features.add_values({"export_filter_score": 20})
 
-    filtered_df = sample_sheet.to_dataframe(filters=export_filter_score > 15)
+    filtered_df = ln.Record.filter(
+        export_filter_score > 15, type=sample_sheet
+    ).to_dataframe()
     assert len(filtered_df) == 1
     assert filtered_df["__lamindb_record_name__"].to_list() == ["sample2"]
 
-    dataframe_export_run = sample_sheet._export_run
+    dataframe_export_run = sample_sheet.input_of_runs.order_by("-created_at").first()
     assert dataframe_export_run is not None
     assert dataframe_export_run.input_records.count() == 2
     assert set(dataframe_export_run.input_records.to_list("name")) == {
@@ -596,21 +587,28 @@ def test_record_export_applies_feature_predicate_filters():
         "PredicateFilterSheet",
     }
 
-    artifact = sample_sheet.to_artifact(filters=export_filter_score > 15)
-    try:
-        assert len(artifact.load()) == 1
-        assert artifact.run is not None
-        assert artifact.run.input_records.count() == 2
-        assert set(artifact.run.input_records.to_list("name")) == {
-            "sample2",
-            "PredicateFilterSheet",
-        }
-    finally:
-        artifact.delete(permanent=True)
-        sample1.delete(permanent=True)
-        sample2.delete(permanent=True)
-        sample_sheet.delete(permanent=True)
-        export_filter_score.delete(permanent=True)
+    sample1.delete(permanent=True)
+    sample2.delete(permanent=True)
+    sample_sheet.delete(permanent=True)
+    export_filter_score.delete(permanent=True)
+
+
+def test_record_queryset_to_dataframe_mixed_types_falls_back_to_generic():
+    sample_sheet1 = ln.Record(name="MixedTypeSheet1", is_type=True).save()
+    sample_sheet2 = ln.Record(name="MixedTypeSheet2", is_type=True).save()
+    sample1 = ln.Record(name="sample1", type=sample_sheet1).save()
+    sample2 = ln.Record(name="sample2", type=sample_sheet2).save()
+
+    mixed_df = ln.Record.filter(id__in=[sample1.id, sample2.id]).to_dataframe()
+    assert "name" in mixed_df.columns
+    assert "__lamindb_record_name__" not in mixed_df.columns
+    assert sample_sheet1.input_of_runs.count() == 0
+    assert sample_sheet2.input_of_runs.count() == 0
+
+    sample1.delete(permanent=True)
+    sample2.delete(permanent=True)
+    sample_sheet1.delete(permanent=True)
+    sample_sheet2.delete(permanent=True)
 
 
 def test_record_export_reuses_legacy_transform_uid(

--- a/tests/core/test_record_sheet_examples.py
+++ b/tests/core/test_record_sheet_examples.py
@@ -548,7 +548,9 @@ def test_record_export_applies_filters():
     sample1 = ln.Record(name="sample1", type=sample_sheet).save()
     sample2 = ln.Record(name="sample2", type=sample_sheet).save()
 
-    filtered_df = ln.Record.filter(type=sample_sheet, name="sample1").to_dataframe()
+    filtered_df = ln.Record.filter(type=sample_sheet, name="sample1").to_dataframe(
+        include="features"
+    )
     assert len(filtered_df) == 1
     assert filtered_df["__lamindb_record_name__"].to_list() == ["sample1"]
 
@@ -575,7 +577,7 @@ def test_record_export_applies_feature_predicate_filters():
 
     filtered_df = ln.Record.filter(
         export_filter_score > 15, type=sample_sheet
-    ).to_dataframe()
+    ).to_dataframe(include="features")
     assert len(filtered_df) == 1
     assert filtered_df["__lamindb_record_name__"].to_list() == ["sample2"]
 


### PR DESCRIPTION
One can now filter sets of records and export them to dataframe with the same semantics of `Record.to_dataframe()`.