### PR TITLE
⚡️ Additional performance improvements to `Record.from_dataframe()` if `schema.index` is present

### DIFF
--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -2391,7 +2391,9 @@ def bulk_set_features_in_records(records: Iterable[Record]) -> None:
     from .save import bulk_update
 
     if batch_schema_index is not None:
-        bulk_update(records_with_features)
+        # only `name` was modified (via strip_index_for_record_persistence)
+        # updating all fields generates a massive CASE WHEN SQL for large batches
+        bulk_update(records_with_features, update_fields=["name"])
     for record in records_with_features:
         del record._features
     return None

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -468,14 +468,10 @@ class RecordBatch:
     def _build_records(self) -> list[Record]:
         import pandas as pd
 
-        from lamindb import settings
-
         index_feature = get_type_schema_index(self._resolved_type)
         records: list[Record] = []
         work_df = dataframe_for_record_batch(self._df, index_feature)
         row_dicts = work_df.to_dict(orient="records")
-        _search_names = settings.creation.search_names
-        settings.creation.search_names = False
         for row in row_dicts:
             row = dict(row)
             name = None
@@ -506,11 +502,10 @@ class RecordBatch:
                 if name is None:
                     name = name_from_features
 
-            record_kwargs: dict[str, Any] = {"type": self._resolved_type}
+            record_kwargs: dict[str, Any] = {"type": self._resolved_type, "_search_names": False}
             if features:
                 record_kwargs["features"] = features
             records.append(self._cls(name=name, **record_kwargs))
-        settings.creation.search_names = _search_names
         return records
 
     def save(self) -> SQLRecordList[Record]:

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -912,6 +912,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         space_branch_kwargs = pop_space_branch_kwargs(kwargs)
         _skip_validation = kwargs.pop("_skip_validation", False)
         _aux = kwargs.pop("_aux", None)
+        _search_names = kwargs.pop("_search_names", None)
         if len(kwargs) > 0:
             valid_keywords = ", ".join([val[0] for val in _get_record_kwargs(Record)])
             raise FieldValidationError(
@@ -922,7 +923,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
             is_type = True
         if features is not None:
             self._features = features
-        super().__init__(
+        super_kwargs: dict[str, Any] = dict(
             name=name,
             type=type,
             is_type=is_type,
@@ -934,6 +935,9 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
             _aux=_aux,
             **space_branch_kwargs,
         )
+        if _search_names is not None:
+            super_kwargs["_search_names"] = _search_names
+        super().__init__(**super_kwargs)
 
     def save(self, *args, **kwargs) -> Record:
         if self.is_type:

--- a/lamindb/models/save.py
+++ b/lamindb/models/save.py
@@ -230,6 +230,7 @@ def bulk_update(
     records: Iterable[SQLRecord],
     ignore_conflicts: bool | None = False,
     batch_size: int = 10000,
+    update_fields: list[str] | None = None,
 ):
     """Update records in batches for safety and performance.
 
@@ -237,6 +238,7 @@ def bulk_update(
         records: Iterable of SQLRecord objects to update
         ignore_conflicts: Whether to ignore conflicts during update (currently unused but kept for consistency)
         batch_size: Number of records to process in each batch. If None, processes all at once.
+        update_fields: Specific fields to update. If None, updates all fields except created_at and id.
     """
     records_by_orm = defaultdict(list)
     for record in records:
@@ -250,7 +252,7 @@ def bulk_update(
                 f"starting update for {total_records} {model_name} records in batches of {batch_size}"
             )
 
-        field_names = [
+        field_names = update_fields or [
             field.name
             for field in registry._meta.fields
             if (field.name != "created_at" and field.name != "id")

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1206,9 +1206,10 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                     has_consciously_provided_uid = kwargs.pop(
                         "_has_consciously_provided_uid"
                     )
+                _search_names = kwargs.pop("_search_names", settings.creation.search_names)
                 if (
                     isinstance(self, (CanCurate, Collection, Transform))
-                    and settings.creation.search_names
+                    and _search_names
                     and not has_consciously_provided_uid
                 ):
                     name_field = getattr(self, "_name_field", "name")


### PR DESCRIPTION
In this PR, we make the following changes:

1. Preventing the generation of SQL for all columns, when schema.index is present, which brings down the processing time from 64s to 36s for 10k records. 
2. Passing `pass _search_names=False` directly as a kwarg to the constructor. The constructor would pop it from kwargs and use it as the local override, falling back to settings.creation.search_names if not provided.
