### PR TITLE
🚸 Introduce `Feature.is_null()` as a predicate for filtering objects by whether they measure or do not measure a feature

### DIFF
--- a/docs/faq/pydantic-pandera.md
+++ b/docs/faq/pydantic-pandera.md
@@ -250,7 +250,8 @@ artifact.describe()
 ### Consumer: query the dataset
 
 ```python
-ln.Artifact.filter(perturbation="IFNG").to_dataframe()
+perturbation = ln.Feature.get(name="perturbation")
+ln.Artifact.filter(perturbation == "IFNG").to_dataframe()
 ```
 
 ### Consumer: understand validation

--- a/docs/query-search.md
+++ b/docs/query-search.md
@@ -204,7 +204,7 @@ You can query for whether a dataset is annotated by a feature:
 
 ```python
 perturbation = ln.Feature.get(name="perturbation")
-ln.Artifact.filter(perturbation.isnull(False)).to_dataframe(include="features")
+ln.Artifact.filter(perturbation.is_null(False)).to_dataframe(include="features")
 ```
 
 ## Cheat sheet: comparators

--- a/docs/query-search.md
+++ b/docs/query-search.md
@@ -170,14 +170,7 @@ The {class}`~lamindb.Feature` registry indexes variables across datasets to enab
 
 <img width="800px" src="https://lamin-site-assets.s3.amazonaws.com/.lamindb/VFFgFdAlJnssyOdk0001.svg">
 
-The {class}`~lamindb.Artifact`, {class}`~lamindb.Record`, and {class}`~lamindb.Run` registries can be queried by feature expressions:
-
-<!-- #region -->
-<!-- cannot run tabbed code on CI, see test_artifact_filter_by_multiple_features for tests -->
-
-::::{tab-set}
-
-:::{tab-item} Via objects / expressions
+The {class}`~lamindb.Artifact`, {class}`~lamindb.Record`, and {class}`~lamindb.Run` registries can be queried by features:
 
 ```python
 perturbation = ln.Feature.get(name="perturbation")
@@ -186,18 +179,6 @@ ln.Artifact.filter(
     perturbation == "DMSO",
     temperature > 21,
 ).to_dataframe(include="features")
-```
-
-:::
-
-::::
-
-<!-- #endregion -->
-
-Just like for fields holding dictionary values, you can query for dictionary keys in features whose `dtype` is `dict`:
-
-```python
-ln.Artifact.filter(study_metadata__detail1="123").to_dataframe(include="features")
 ```
 
 You can query for whether a dataset is annotated by a feature:

--- a/docs/query-search.md
+++ b/docs/query-search.md
@@ -170,30 +170,19 @@ The {class}`~lamindb.Feature` registry indexes variables across datasets to enab
 
 <img width="800px" src="https://lamin-site-assets.s3.amazonaws.com/.lamindb/VFFgFdAlJnssyOdk0001.svg">
 
-The {class}`~lamindb.Artifact`, {class}`~lamindb.Record`, and {class}`~lamindb.Run` registries can be queried by features:
+The {class}`~lamindb.Artifact`, {class}`~lamindb.Record`, and {class}`~lamindb.Run` registries can be queried by feature expressions:
 
 <!-- #region -->
 <!-- cannot run tabbed code on CI, see test_artifact_filter_by_multiple_features for tests -->
 
 ::::{tab-set}
 
-:::{tab-item} Via strings / kwargs
-
-```python
-ln.Artifact.filter(
-    perturbation="DMSO",
-    temperature__gt=26,
-).to_dataframe(include="features")
-```
-
-:::
-
 :::{tab-item} Via objects / expressions
 
 ```python
-perturbation = ln.Feature.get(name="perturbation")  # can optionally pass a feature type to disambiguate
+perturbation = ln.Feature.get(name="perturbation")
 temperature = ln.Feature.get(name="temperature")
-ln.Artifact.filter(    # note this is now an expression using the == syntax
+ln.Artifact.filter(
     perturbation == "DMSO",
     temperature > 21,
 ).to_dataframe(include="features")
@@ -214,7 +203,8 @@ ln.Artifact.filter(study_metadata__detail1="123").to_dataframe(include="features
 You can query for whether a dataset is annotated by a feature:
 
 ```python
-ln.Artifact.filter(perturbation__isnull=False).to_dataframe(include="features")
+perturbation = ln.Feature.get(name="perturbation")
+ln.Artifact.filter(perturbation.isnull(False)).to_dataframe(include="features")
 ```
 
 ## Cheat sheet: comparators

--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -859,7 +859,22 @@ def _filter_one_feature_clause(
                 value_subquery = ArtifactJsonValue.objects.filter(
                     jsonvalue__feature=feature
                 ).values("artifact_id")
+            elif queryset.model is Run:
+                from .run import RunJsonValue
+
+                value_subquery = RunJsonValue.objects.filter(
+                    jsonvalue__feature=feature
+                ).values("run_id")
+            elif queryset.model is Record:
+                value_subquery = RecordJson.objects.filter(feature=feature).values(
+                    "record_id"
+                )
+            else:
+                raise NotImplementedError
+            if value:  # True
                 return queryset.exclude(id__in=Subquery(value_subquery))
+            else:
+                return queryset.filter(id__in=Subquery(value_subquery))
 
         if comparator in {"__startswith", "__contains"}:
             logger.important(

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1392,45 +1392,20 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
 
         Annotate with features via :meth:`~lamindb.models.FeatureManager.set_values`:
 
-        .. tab-set::
+        .. code-block:: python
 
-            .. tab-item:: Via strings
-
-                .. code-block:: python
-
-                    artifact.features.set_values({
-                        "species_name": "human",
-                        "scientist_names": ["Barbara McClintock", "Edgar Anderson"],
-                        "temperature_in_celsius": 27.6,
-                        "experiment": "Experiment 1"
-                    })
-
-            .. tab-item:: Via objects
-
-                .. code-block:: python
-
-                    artifact.features.set_values({
-                        species_name: "human",
-                        scientist_names: ["Barbara McClintock", "Edgar Anderson"],
-                        temperature: 27.6,
-                        experiment: "Experiment 1"
-                    })
+            artifact.features.set_values({
+                species_name: "human",
+                scientist_names: ["Barbara McClintock", "Edgar Anderson"],
+                temperature: 27.6,
+                experiment: "Experiment 1"
+            })
 
         Query artifacts by features:
 
-        .. tab-set::
+        .. code-block:: python
 
-            .. tab-item:: Via strings
-
-                .. code-block:: python
-
-                    ln.Artifact.filter(scientist_names="Barbara McClintock")
-
-            .. tab-item:: Via objects
-
-                .. code-block:: python
-
-                    ln.Artifact.filter(scientist_names == "Barbara McClintock")
+            ln.Artifact.filter(scientist_names == "Barbara McClintock")
 
         Get all feature annotations as a dictionary::
 

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1413,6 +1413,12 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     def __le__(self, value: Any) -> FeaturePredicate:
         return FeaturePredicate(self, "__lte", value)
 
+    def isnull(self, value: bool = True) -> FeaturePredicate:
+        """Build a predicate for null-style feature presence checks."""
+        if not isinstance(value, bool):
+            raise TypeError("Feature.isnull() expects a bool value.")
+        return FeaturePredicate(self, "__isnull", value)
+
     # manually sync this docstring across all other children of HasType
     def query_features(self) -> QuerySet:
         """Query features of sub types.

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1414,7 +1414,15 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         return FeaturePredicate(self, "__lte", value)
 
     def is_null(self, value: bool = True) -> FeaturePredicate:
-        """Build a predicate for null-style feature presence checks."""
+        """Build a predicate for null-style feature presence checks.
+
+        Example::
+
+            perturbation = ln.Feature.get(name="perturbation")
+            ln.Artifact.filter(perturbation.is_null(False)).to_dataframe(
+                include="features"
+            )
+        """
         if not isinstance(value, bool):
             raise TypeError("Feature.is_null() expects a bool value.")
         return FeaturePredicate(self, "__isnull", value)

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1413,10 +1413,10 @@ class Feature(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
     def __le__(self, value: Any) -> FeaturePredicate:
         return FeaturePredicate(self, "__lte", value)
 
-    def isnull(self, value: bool = True) -> FeaturePredicate:
+    def is_null(self, value: bool = True) -> FeaturePredicate:
         """Build a predicate for null-style feature presence checks."""
         if not isinstance(value, bool):
-            raise TypeError("Feature.isnull() expects a bool value.")
+            raise TypeError("Feature.is_null() expects a bool value.")
         return FeaturePredicate(self, "__isnull", value)
 
     # manually sync this docstring across all other children of HasType

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -622,21 +622,10 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
 
     Query records by features:
 
-    .. tab-set::
+    .. code-block:: python
 
-        .. tab-item:: Via objects
-
-            .. code-block:: python
-
-                ln.Record.filter(gc_content == 0.55)  # exact match
-                ln.Record.filter(gc_content > 0.5)    # greater than
-
-        .. tab-item:: Via strings
-
-            .. code-block:: python
-
-                ln.Record.filter(gc_content=0.55)  # exact match
-                ln.Record.filter(gc_content__gt=0.5)    # greater than
+        ln.Record.filter(gc_content == 0.55)  # exact match
+        ln.Record.filter(gc_content > 0.5)    # greater than
 
     Query records by field::
 

--- a/tests/core/test_artifact_features_annotations.py
+++ b/tests/core/test_artifact_features_annotations.py
@@ -542,6 +542,43 @@ def test_feature_predicate_queries_safe_hybrid():
     hek293.delete(permanent=True)
 
 
+def test_feature_predicate_isnull():
+    perturbation_type = ln.ULabel(name="isnull-perturbation-type", is_type=True).save()
+    dmso = ln.ULabel(name="isnull-dmso", type=perturbation_type).save()
+    perturbation = ln.Feature(
+        name="isnull_perturbation", dtype=perturbation_type
+    ).save()
+    score = ln.Feature(name="isnull_score", dtype=float).save()
+
+    annotated = ln.Artifact(
+        ".gitignore", key="isnull-annotated-artifact", skip_hash_lookup=True
+    ).save()
+    not_annotated = ln.Artifact(
+        ".gitignore", key="isnull-not-annotated-artifact", skip_hash_lookup=True
+    ).save()
+    annotated.features.set_values({perturbation: dmso, score: 3.5})
+
+    assert annotated in ln.Artifact.filter(perturbation.isnull(False))
+    assert not_annotated not in ln.Artifact.filter(perturbation.isnull(False))
+    assert not_annotated in ln.Artifact.filter(perturbation.isnull())
+    assert annotated not in ln.Artifact.filter(perturbation.isnull())
+
+    assert annotated in ln.Artifact.filter(score.isnull(False))
+    assert not_annotated not in ln.Artifact.filter(score.isnull(False))
+    assert not_annotated in ln.Artifact.filter(score.isnull(True))
+    assert annotated not in ln.Artifact.filter(score.isnull(True))
+
+    with pytest.raises(TypeError):
+        perturbation.isnull("false")  # type: ignore[arg-type]
+
+    not_annotated.delete(permanent=True)
+    annotated.delete(permanent=True)
+    score.delete(permanent=True)
+    perturbation.delete(permanent=True)
+    dmso.delete(permanent=True)
+    perturbation_type.delete(permanent=True)
+
+
 def test_features_add_with_schema():
     df = mini_immuno.get_dataset1(otype="DataFrame")
     artifact = ln.Artifact.from_dataframe(df, description="test dataset").save()

--- a/tests/core/test_artifact_features_annotations.py
+++ b/tests/core/test_artifact_features_annotations.py
@@ -542,7 +542,7 @@ def test_feature_predicate_queries_safe_hybrid():
     hek293.delete(permanent=True)
 
 
-def test_feature_predicate_isnull():
+def test_feature_predicate_is_null():
     perturbation_type = ln.ULabel(name="isnull-perturbation-type", is_type=True).save()
     dmso = ln.ULabel(name="isnull-dmso", type=perturbation_type).save()
     perturbation = ln.Feature(
@@ -558,18 +558,18 @@ def test_feature_predicate_isnull():
     ).save()
     annotated.features.set_values({perturbation: dmso, score: 3.5})
 
-    assert annotated in ln.Artifact.filter(perturbation.isnull(False))
-    assert not_annotated not in ln.Artifact.filter(perturbation.isnull(False))
-    assert not_annotated in ln.Artifact.filter(perturbation.isnull())
-    assert annotated not in ln.Artifact.filter(perturbation.isnull())
+    assert annotated in ln.Artifact.filter(perturbation.is_null(False))
+    assert not_annotated not in ln.Artifact.filter(perturbation.is_null(False))
+    assert not_annotated in ln.Artifact.filter(perturbation.is_null())
+    assert annotated not in ln.Artifact.filter(perturbation.is_null())
 
-    assert annotated in ln.Artifact.filter(score.isnull(False))
-    assert not_annotated not in ln.Artifact.filter(score.isnull(False))
-    assert not_annotated in ln.Artifact.filter(score.isnull(True))
-    assert annotated not in ln.Artifact.filter(score.isnull(True))
+    assert annotated in ln.Artifact.filter(score.is_null(False))
+    assert not_annotated not in ln.Artifact.filter(score.is_null(False))
+    assert not_annotated in ln.Artifact.filter(score.is_null(True))
+    assert annotated not in ln.Artifact.filter(score.is_null(True))
 
     with pytest.raises(TypeError):
-        perturbation.isnull("false")  # type: ignore[arg-type]
+        perturbation.is_null("false")  # type: ignore[arg-type]
 
     not_annotated.delete(permanent=True)
     annotated.delete(permanent=True)

--- a/tests/core/test_record_basics.py
+++ b/tests/core/test_record_basics.py
@@ -1504,6 +1504,7 @@ def test_record_feature_predicate_query():
     record_type = ln.Record(name="PredRecordType", is_type=True).save()
     record_a = ln.Record(name="pred_record_a", type=record_type).save()
     record_b = ln.Record(name="pred_record_b", type=record_type).save()
+    record_c = ln.Record(name="pred_record_c", type=record_type).save()
     record_a.features.add_values({"pred_record_age": 42})
     record_b.features.add_values({"pred_record_age": 10})
 
@@ -1513,8 +1514,16 @@ def test_record_feature_predicate_query():
     assert record_b in neq_results
     assert record_a not in neq_results
 
+    assert record_a in ln.Record.filter(age.is_null(False))
+    assert record_b in ln.Record.filter(age.is_null(False))
+    assert record_c not in ln.Record.filter(age.is_null(False))
+    assert record_c in ln.Record.filter(age.is_null())
+    assert record_a not in ln.Record.filter(age.is_null())
+    assert record_b not in ln.Record.filter(age.is_null())
+
     record_a.delete(permanent=True)
     record_b.delete(permanent=True)
+    record_c.delete(permanent=True)
     record_type.delete(permanent=True)
     age.delete(permanent=True)
 


### PR DESCRIPTION
To simplify the docs and the mental model, we now simply advocate using feature expressions instead of name-based kwargs. Adopting that pattern avoids name collisions and is also know from other libraries.