### PR TITLE
:children_crossing: Actually label reverse accessor for `output_transforms`

### DIFF
--- a/lamindb/migrations/0189_v2_6.py
+++ b/lamindb/migrations/0189_v2_6.py
@@ -40,7 +40,7 @@ class Migration(migrations.Migration):
                 default=lamindb.models.run.current_run,
                 null=True,
                 on_delete=django.db.models.deletion.PROTECT,
-                related_name="+",
+                related_name="output_transforms",
                 to="lamindb.run",
             ),
         ),

--- a/lamindb/migrations/0190_squashed.py
+++ b/lamindb/migrations/0190_squashed.py
@@ -4118,7 +4118,7 @@ class Migration(migrations.Migration):
                         default=lamindb.models.run.current_run,
                         null=True,
                         on_delete=django.db.models.deletion.PROTECT,
-                        related_name="+",
+                        related_name="output_transforms",
                         to="lamindb.run",
                     ),
                 ),

--- a/lamindb/models/run.py
+++ b/lamindb/models/run.py
@@ -322,6 +322,8 @@ class Run(SQLRecord, TracksUpdates):
 
     Collections are *recreated* if they trigger a hash lookup match for an existing collection.
     """
+    output_transforms: RelatedManager[Transform]
+    """The transforms created in this run ← :attr:`~lamindb.Transform.run`."""
     params: dict | None = models.JSONField(null=True)
     """Parameters (plain JSON values)."""
     extra_data: dict | None = models.JSONField(null=True)

--- a/lamindb/models/transform.py
+++ b/lamindb/models/transform.py
@@ -237,7 +237,7 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
     references: RelatedManager[Reference]
     """Linked references ← :attr:`~lamindb.Reference.transforms`."""
     run: Run | None = ForeignKey(
-        Run, PROTECT, null=True, default=current_run, related_name="+"
+        Run, PROTECT, null=True, default=current_run, related_name="output_transforms"
     )
     """The run that created the transform ← :attr:`~lamindb.Run.output_transforms`."""
     updated_at: datetime = DateTimeField(

--- a/lamindb/models/transform.py
+++ b/lamindb/models/transform.py
@@ -30,7 +30,7 @@ from ._is_versioned import (
     increment_base62,
 )
 from ._is_versioned import bump_version as bump_version_function
-from .run import Run, TracksRun, User
+from .run import Run, TracksRun, User, current_run
 from .sqlrecord import (
     BaseSQLRecord,
     Branch,
@@ -61,9 +61,7 @@ if TYPE_CHECKING:
 class Transform(SQLRecord, IsVersioned, TracksRun):
     """Data transformations such as scripts, notebooks, functions, or pipelines.
 
-    If you execute a transform, you generate a run
-    (:class:`~lamindb.Run`).
-
+    If you execute a transform, you generate a run (:class:`~lamindb.Run`).
 
     Args:
         key: `str | None = None` A short name or path-like semantic key.
@@ -238,6 +236,10 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
     """Linked projects ← :attr:`~lamindb.Project.transforms`."""
     references: RelatedManager[Reference]
     """Linked references ← :attr:`~lamindb.Reference.transforms`."""
+    run: Run | None = ForeignKey(
+        Run, PROTECT, null=True, default=current_run, related_name="+"
+    )
+    """The run that created the transform ← :attr:`~lamindb.Run.output_transforms`."""
     updated_at: datetime = DateTimeField(
         editable=False, db_default=models.functions.Now(), db_index=True
     )

--- a/lamindb/models/transform.py
+++ b/lamindb/models/transform.py
@@ -212,7 +212,7 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
     ulabels: RelatedManager[ULabel] = models.ManyToManyField(
         "ULabel", through="TransformULabel", related_name="transforms"
     )
-    """ULabel annotations of this transform ← :attr:`~lamindb.ULabel.transforms`."""
+    """`ULabel` annotations of this transform ← :attr:`~lamindb.ULabel.transforms`."""
     linked_in_records: RelatedManager[Record] = models.ManyToManyField(
         "Record", through="RecordTransform", related_name="linked_transforms"
     )
@@ -247,7 +247,7 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
     created_by: User = ForeignKey(
         User, PROTECT, default=current_user_id, related_name="created_transforms"
     )
-    """Creator of record ← :attr:`~lamindb.User.created_transforms`."""
+    """The user that created the transform ← :attr:`~lamindb.User.created_transforms`."""
     ablocks: RelatedManager[TransformBlock]
     """Attached blocks ← :attr:`~lamindb.TransformBlock.transform`."""
 


### PR DESCRIPTION
So that one can do `run.output_transforms` in analogy with `run.output_artifacts`.