### PR TITLE
:memo: Introduce `CanonicalSuffix` to better document how `Artifact.suffix` gets populated

### DIFF
--- a/lamindb/base/types.py
+++ b/lamindb/base/types.py
@@ -1,14 +1,18 @@
 """Base types.
 
-Central object types
---------------------
+Classes
+-------
+
+.. autoclass:: CanonicalSuffix
+
+Central types
+-------------
 
 .. autoclass:: ArtifactKind
 .. autoclass:: TransformKind
 .. autoclass:: BlockKind
 .. autoclass:: BranchStatus
 .. autoclass:: RunStatus
-.. autoclass:: CanonicalSuffix
 .. autoclass:: SimpleDtype
 .. autoclass:: SimpleDtypeStr
 .. autoclass:: SimpleDvalue
@@ -30,6 +34,7 @@ from typing import TYPE_CHECKING, Literal, Union
 
 import numpy as np
 from django.db.models.query_utils import DeferredAttribute as FieldAttr
+from lamindb_setup.core.canonical_suffix import CanonicalSuffix  # noqa: F401
 from lamindb_setup.types import AnyPathStr  # noqa: F401
 
 if TYPE_CHECKING:

--- a/lamindb/base/types.py
+++ b/lamindb/base/types.py
@@ -5,8 +5,8 @@ Classes
 
 .. autoclass:: CanonicalSuffix
 
-Central types
--------------
+Simple types
+------------
 
 .. autoclass:: ArtifactKind
 .. autoclass:: TransformKind

--- a/lamindb/base/types.py
+++ b/lamindb/base/types.py
@@ -8,6 +8,7 @@ Central object types
 .. autoclass:: BlockKind
 .. autoclass:: BranchStatus
 .. autoclass:: RunStatus
+.. autoclass:: CanonicalSuffix
 .. autoclass:: SimpleDtype
 .. autoclass:: SimpleDtypeStr
 .. autoclass:: SimpleDvalue

--- a/lamindb/core/loaders.py
+++ b/lamindb/core/loaders.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any, Callable, cast
 
 from lamin_utils import logger
 from lamindb_setup import settings as setup_settings
-from lamindb_setup.core.suffix import extract_suffixes_from_path
+from lamindb_setup.core.canonical_suffix import CanonicalSuffix
 from lamindb_setup.core.upath import (
     create_path,
     infer_filesystem,
@@ -223,7 +223,7 @@ def load_to_memory(
     May return None in interactive sessions for images.
     """
     filepath = create_path(filepath)
-    _, raw_suffix = extract_suffixes_from_path(filepath)
+    _, raw_suffix = CanonicalSuffix.extract_from_path(filepath)
     loader = FILE_LOADERS.get(raw_suffix, None)
     if loader is None:
         raise NotImplementedError(

--- a/lamindb/core/storage/__init__.py
+++ b/lamindb/core/storage/__init__.py
@@ -9,7 +9,7 @@ Array accessors.
 
 from typing import TYPE_CHECKING, Any
 
-from lamindb_setup.core.canonical_suffix import VALID_SUFFIXES
+from lamindb_setup.core.canonical_suffix import CanonicalSuffix  # for backward compat
 from lamindb_setup.core.upath import LocalPathClasses, UPath, infer_filesystem
 
 from .paths import delete_storage
@@ -68,3 +68,9 @@ def __getattr__(name: str) -> Any:
 
     globals()[name] = attr
     return attr
+
+
+class VALID_SUFFIXES:  # for backward compatibility
+    SIMPLE = CanonicalSuffix.simple_formats
+    COMPOSITE = CanonicalSuffix.composite_formats
+    ENCODING = CanonicalSuffix.encoding_formats

--- a/lamindb/core/storage/__init__.py
+++ b/lamindb/core/storage/__init__.py
@@ -1,9 +1,5 @@
 """Storage API.
 
-Valid suffixes.
-
-.. autodata:: VALID_SUFFIXES
-
 Array accessors.
 
 .. autoclass:: AnnDataAccessor
@@ -13,7 +9,7 @@ Array accessors.
 
 from typing import TYPE_CHECKING, Any
 
-from lamindb_setup.core.suffix import VALID_SUFFIXES
+from lamindb_setup.core.canonical_suffix import VALID_SUFFIXES
 from lamindb_setup.core.upath import LocalPathClasses, UPath, infer_filesystem
 
 from .paths import delete_storage

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -19,7 +19,6 @@ from lamindb_setup.core._hub_core import (
     get_instance_slug_by_uid,
     select_storage_or_parent,
 )
-from lamindb_setup.core.canonical_suffix import CanonicalSuffix
 from lamindb_setup.core.hashing import HASH_LENGTH, hash_dir, hash_file
 from lamindb_setup.core.upath import (
     LocalPathClasses,
@@ -29,6 +28,8 @@ from lamindb_setup.core.upath import (
     get_stat_dir_cloud,
     get_stat_file_cloud,
 )
+
+from lamindb.base.types import CanonicalSuffix
 
 from ..base.fields import (
     BigIntegerField,

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -19,8 +19,8 @@ from lamindb_setup.core._hub_core import (
     get_instance_slug_by_uid,
     select_storage_or_parent,
 )
+from lamindb_setup.core.canonical_suffix import CanonicalSuffix
 from lamindb_setup.core.hashing import HASH_LENGTH, hash_dir, hash_file
-from lamindb_setup.core.suffix import extract_suffixes_from_path
 from lamindb_setup.core.upath import (
     LocalPathClasses,
     UPath,
@@ -285,7 +285,7 @@ def process_data(
 
     if key is not None:
         key_path = PurePosixPath(key)
-        _, key_raw_suffix = extract_suffixes_from_path(key_path)
+        _, key_raw_suffix = CanonicalSuffix.extract_from_path(key_path)
         # use suffix as the (adata) format if the format is not provided
         if is_anndata and format is None and key_raw_suffix != "":
             format = key_raw_suffix[1:]
@@ -308,7 +308,7 @@ def process_data(
             using_key=using_key,
             skip_existence_check=skip_existence_check,
         )
-        suffix, raw_suffix = extract_suffixes_from_path(path)
+        suffix, raw_suffix = CanonicalSuffix.extract_from_path(path)
         memory_rep = None
     elif (
         is_anndata
@@ -1122,7 +1122,7 @@ class LazyArtifact:
         self.kwargs["overwrite_versions"] = overwrite_versions
 
         if (key := kwargs.get("key")) is not None and (
-            key_raw_suffix := extract_suffixes_from_path(PurePosixPath(key))[1]
+            key_raw_suffix := CanonicalSuffix.extract_from_path(PurePosixPath(key))[1]
         ) != suffix:
             raise ValueError(
                 f"The suffix argument {suffix} and the suffix of key {key_raw_suffix} should be the same."
@@ -1480,12 +1480,10 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
     )
     """Storage location, e.g. an S3 or GCP bucket or a local directory ← :attr:`~lamindb.Storage.artifacts`."""
     suffix: str = CharField(max_length=30, db_index=True, editable=False)
-    # Initially, we thought about having this be nullable to indicate folders
-    # But, for instance, .zarr is stored in a folder that ends with a .zarr suffix
-    """Canonical suffix inferred from the artifact path.
+    """A canonical suffix inferred from the artifact path.
 
     The inferred value is one of the recognized valid suffixes in
-    :class:`lamindb_setup.core.suffix.VALID_SUFFIXES`:
+    :class:`lamindb_setup.core.canonical_suffix.CanonicalSuffix`:
     simple suffixes (e.g. `".csv"`, `".h5ad"`), composite suffixes
     (e.g. `".anndata.zarr"`), and supported compression combinations
     (e.g. `".csv.gz"`, `".h5ad.tar.gz"`).
@@ -3284,7 +3282,9 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             new_key = self.key
             if new_key is None:
                 raise InvalidArgument("Cannot update an artifact key to None.")
-            new_key_raw_suffix = extract_suffixes_from_path(PurePosixPath(new_key))[1]
+            new_key_raw_suffix = CanonicalSuffix.extract_from_path(
+                PurePosixPath(new_key)
+            )[1]
             if new_key_raw_suffix != self.suffix:
                 raise InvalidArgument(
                     f"The suffix '{new_key_raw_suffix}' of the provided key is incorrect, it should be '{self.suffix}'."

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1480,7 +1480,9 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         Storage, PROTECT, related_name="artifacts", editable=False
     )
     """Storage location, e.g. an S3 or GCP bucket or a local directory ← :attr:`~lamindb.Storage.artifacts`."""
-    suffix: CanonicalSuffix = CharField(max_length=30, db_index=True, editable=False)
+    suffix: CanonicalSuffix | str = CharField(
+        max_length=30, db_index=True, editable=False
+    )
     """A canonical suffix informing the storage format.
 
     Note that unkown formats map to the empty string `""`.

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1483,18 +1483,19 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
     suffix: CanonicalSuffix | str = CharField(
         max_length=30, db_index=True, editable=False
     )
-    """A canonical suffix informing the storage format.
+    """:class:`~lamindb.base.types.CanonicalSuffix` or user-defined strings.
 
-    Note that unkown formats map to the empty string `""`.
+    A canonical suffix such as `".csv"`, `".parquet"`, or `".zarr"` indicates the storage format of an artifact.
 
-    See :class:`~lamindb.base.types.CanonicalSuffix` for how to extend the set of known formats.
+    Unknown formats map to the empty string: `""`.
+    Known formats are based on MIME types and can be extended via :class:`~lamindb.base.types.CanonicalSuffix`.
     """
     kind: ArtifactKind | str | None = CharField(
         max_length=20,
         db_index=True,
         null=True,
     )
-    """:class:`~lamindb.base.types.ArtifactKind` or custom `str` value (default `None`)."""
+    """:class:`~lamindb.base.types.ArtifactKind` or user-defined strings (default `None`)."""
     otype: (
         Literal["DataFrame", "AnnData", "MuData", "SpatialData", "tiledbsoma"]
         | str

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1479,17 +1479,12 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         Storage, PROTECT, related_name="artifacts", editable=False
     )
     """Storage location, e.g. an S3 or GCP bucket or a local directory ← :attr:`~lamindb.Storage.artifacts`."""
-    suffix: str = CharField(max_length=30, db_index=True, editable=False)
-    """A canonical suffix inferred from the artifact path.
+    suffix: CanonicalSuffix = CharField(max_length=30, db_index=True, editable=False)
+    """A canonical suffix informing the storage format.
 
-    The inferred value is one of the recognized valid suffixes in
-    :class:`lamindb_setup.core.canonical_suffix.CanonicalSuffix`:
-    simple suffixes (e.g. `".csv"`, `".h5ad"`), composite suffixes
-    (e.g. `".anndata.zarr"`), and supported compression combinations
-    (e.g. `".csv.gz"`, `".h5ad.tar.gz"`).
+    Note that unkown formats map to the empty string `""`.
 
-    If a path has no recognized suffix (for example `test.xyz`), the stored value is
-    the empty string `""`.
+    See :class:`~lamindb.base.types.CanonicalSuffix` for how to extend the set of known formats.
     """
     kind: ArtifactKind | str | None = CharField(
         max_length=20,

--- a/lamindb/setup/__init__.py
+++ b/lamindb/setup/__init__.py
@@ -12,5 +12,15 @@ from ._merge import merge  # noqa: F401
 from ._switch import switch  # noqa: F401
 
 del connect  # we have this at the root level, hence, we don't want it here
-__doc__ = _lamindb_setup.__doc__.replace("lamindb_setup", "lamindb.setup")
+__doc__ = _lamindb_setup.__doc__.replace("lamindb_setup", "lamindb.setup").replace(
+    """.. autofunction:: delete""",
+    """.. autofunction:: delete
+
+Change management
+-----------------
+
+.. autofunction:: switch
+.. autofunction:: merge
+""",
+)
 settings.__doc__ = settings.__doc__.replace("lamindb_setup", "lamindb.setup")

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -184,9 +184,7 @@ def test_create_from_path_file(get_test_filepaths, key_is_virtual, key, descript
     test_filepath = get_test_filepaths[3]
     suffix = get_test_filepaths[4]  # path suffix
     if key is not None:
-        key_suffix, _ = CanonicalSuffix.extract_from_path(
-            PurePosixPath(key)
-        )  # key suffix
+        key_suffix = CanonicalSuffix.from_path(PurePosixPath(key))
     else:
         key_suffix = None
     # this tests if insufficient information is being provided

--- a/tests/core/test_artifact_basics.py
+++ b/tests/core/test_artifact_basics.py
@@ -43,7 +43,7 @@ from lamindb.models.artifact import (
     get_relative_path_to_directory,
     process_data,
 )
-from lamindb_setup.core.suffix import extract_suffixes_from_path
+from lamindb_setup.core.canonical_suffix import CanonicalSuffix
 from lamindb_setup.core.upath import (
     CloudPath,
     LocalPathClasses,
@@ -184,7 +184,9 @@ def test_create_from_path_file(get_test_filepaths, key_is_virtual, key, descript
     test_filepath = get_test_filepaths[3]
     suffix = get_test_filepaths[4]  # path suffix
     if key is not None:
-        key_suffix, _ = extract_suffixes_from_path(PurePosixPath(key))  # key suffix
+        key_suffix, _ = CanonicalSuffix.extract_from_path(
+            PurePosixPath(key)
+        )  # key suffix
     else:
         key_suffix = None
     # this tests if insufficient information is being provided


### PR DESCRIPTION
# Summary

This PR documents the changes introduced in the PR below:

- https://github.com/laminlabs/lamindb/pull/3782

Needs:

- https://github.com/laminlabs/lamindb-setup/pull/1358

# Docs

## `Artifact.suffix`

https://fc498cea.lamindb.pages.dev/lamindb.artifact#lamindb.Artifact.suffix

The new type annotation for the `suffix` makes it clearer what kind of strings are stored in it and links back to the more comprehensive `CanonicalSuffix` document.

This is similar to how the `kind` field links to `ArtifactKind` and how many other fields link to special types.

Before | After
--- | ---
<img width="630" height="258" alt="image" src="https://github.com/user-attachments/assets/71ab985b-56fe-4aac-a7f9-b4f85cf5c0e7" /> | <img width="764" height="358" alt="image" src="https://github.com/user-attachments/assets/13a326ef-4d06-4dcf-a490-810c8d6a9885" />

## `base.types`

https://fc498cea.lamindb.pages.dev/lamindb.base.types#lamindb.base.types.CanonicalSuffix

Before | After
--- | ---
Was mixed with much lower-level concepts. | Has a clear place next to the other basic types.
<img width="1094" height="929" alt="image" src="https://github.com/user-attachments/assets/d2fff5e3-cf17-42ed-a083-29c5b8c4252c" /> | <img width="1280" height="978" alt="image" src="https://github.com/user-attachments/assets/86bcb34c-f720-45b5-b903-c405adb45f57" />
/ | Has a clear set of examples.
/ | <img width="698" height="902" alt="image" src="https://github.com/user-attachments/assets/6e2a00bb-72cc-4530-98c8-1a4becc896b5" />
/ | Clearly lists the known formats.
/ | <img width="620" height="892" alt="image" src="https://github.com/user-attachments/assets/d31e5d46-21b0-4fdc-8bfb-9a47fcbd8385" />