### PR TITLE
🐛 Also save source code in `Transform.from_path()`

### DIFF
--- a/lamindb/models/transform.py
+++ b/lamindb/models/transform.py
@@ -447,9 +447,9 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
         notebook_runner: str | None = None,
     ) -> tuple[Transform, str]:
         from .._finish import notebook_to_script
-        from ..core._settings import settings
 
         source_code_to_store = source_code
+        normalized_path = cls._normalize_local_path(path) if path is not None else None
         if source_code is not None:
             source_code_to_store, redaction_count = redact_secrets_in_source_code(
                 source_code
@@ -460,15 +460,16 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
                 )
             transform_hash = hash_string(source_code)
         else:
-            assert path is not None  # noqa: S101
-            if path.suffix != ".ipynb":
-                _, transform_hash, _ = hash_file(path)
+            assert normalized_path is not None  # noqa: S101
+            if normalized_path.suffix != ".ipynb":
+                _, transform_hash, _ = hash_file(normalized_path)
             else:
-                source_code_path = ln_setup.settings.cache_dir / path.name.replace(
-                    ".ipynb", ".py"
+                source_code_path = (
+                    ln_setup.settings.cache_dir
+                    / normalized_path.name.replace(".ipynb", ".py")
                 )
-                if path.exists():
-                    notebook_to_script(description, path, source_code_path)
+                if normalized_path.exists():
+                    notebook_to_script(description, normalized_path, source_code_path)
                     _, transform_hash, _ = hash_file(source_code_path)
                 else:
                     logger.debug(
@@ -482,35 +483,20 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
             else None
         )
 
-        if key is None:
-            assert path is not None  # noqa: S101
-            if ln_setup.settings.dev_dir is not None:
-                try:
-                    key = path.relative_to(ln_setup.settings.dev_dir).as_posix()
-                except ValueError as e:
-                    if "subpath" in str(e):
-                        logger.warning(
-                            f"path {path} is not within the configured dev directory "
-                            f"({ln_setup.settings.dev_dir}), falling back to using filename as transform key "
-                            f"('{path.name}')"
-                        )
-                        key = path.name
-                    else:
-                        raise
-            else:
-                key = path.name
-
-        if (
-            path is not None
-            and transform_ref is None
-            and transform_ref_type is None
-            and settings.sync_git_repo is not None
-            and path.suffix != ".ipynb"
-        ):
-            from ..core._sync_git import get_transform_reference_from_git_repo
-
-            transform_ref = get_transform_reference_from_git_repo(path)
-            transform_ref_type = "url"
+        if normalized_path is not None:
+            inferred_key, inferred_kind, inferred_ref, inferred_ref_type = (
+                cls._infer_from_file_metadata(
+                    path=normalized_path,
+                    key=key,
+                    kind=transform_kind,
+                )
+            )
+            key = inferred_key
+            if transform_kind is None:
+                transform_kind = inferred_kind
+            if transform_ref is None and transform_ref_type is None:
+                transform_ref = inferred_ref
+                transform_ref_type = inferred_ref_type
 
         if uid is None and aux_transform is None:
 
@@ -528,9 +514,9 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
             if len(transforms) != 0:
                 message = ""
                 found_key = False
-                if path is not None:
+                if normalized_path is not None:
                     for candidate in transforms:
-                        if candidate.key in path.as_posix():
+                        if candidate.key in normalized_path.as_posix():
                             key = candidate.key
                             resolved_uid, target_transform, message = (
                                 cls._process_aux_transform_for_source(
@@ -683,6 +669,44 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
         return transform, logging_message
 
     @classmethod
+    def _normalize_local_path(cls, path: Path) -> Path:
+        return path.expanduser().resolve(strict=False)
+
+    @classmethod
+    def _get_source_code_path_for_transform(
+        cls, *, path: Path, kind: TransformKind, description: str | None
+    ) -> Path | None:
+        if not path.exists():
+            return None
+        if kind == "notebook" and path.suffix == ".ipynb":
+            from .._finish import notebook_to_script
+
+            source_code_path = ln_setup.settings.cache_dir / path.name.replace(
+                ".ipynb", ".py"
+            )
+            notebook_to_script(description, path, source_code_path)
+            return source_code_path
+        return path
+
+    @classmethod
+    def _persist_source_code_from_path(
+        cls,
+        *,
+        transform: Transform,
+        path: Path,
+        kind: TransformKind,
+        description: str | None,
+    ) -> None:
+        source_code_path = cls._get_source_code_path_for_transform(
+            path=path, kind=kind, description=description
+        )
+        if source_code_path is None:
+            return
+        return_code = transform._update_source_code_from_path(source_code_path)
+        if return_code != "rerun-the-notebook":
+            transform.save()
+
+    @classmethod
     def _infer_from_file_metadata(
         cls,
         *,
@@ -694,30 +718,37 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
 
         from ..core._settings import settings
 
+        normalized_path = cls._normalize_local_path(path)
         if kind is None:
-            kind = "notebook" if path.suffix in {".ipynb", ".Rmd", ".qmd"} else "script"
+            kind = (
+                "notebook"
+                if normalized_path.suffix in {".ipynb", ".Rmd", ".qmd"}
+                else "script"
+            )
         if key is None:
             if ln_setup.settings.dev_dir is not None:
                 try:
-                    key = path.relative_to(ln_setup.settings.dev_dir).as_posix()
+                    key = normalized_path.relative_to(
+                        ln_setup.settings.dev_dir
+                    ).as_posix()
                 except ValueError as e:
                     if "subpath" in str(e):
                         logger.warning(
-                            f"path {path} is not within the configured dev directory "
+                            f"path {normalized_path} is not within the configured dev directory "
                             f"({ln_setup.settings.dev_dir}), falling back to using filename as transform key "
-                            f"('{path.name}')"
+                            f"('{normalized_path.name}')"
                         )
-                        key = path.name
+                        key = normalized_path.name
                     else:
                         raise
             else:
-                key = path.name
+                key = normalized_path.name
         reference = None
         reference_type = None
-        if settings.sync_git_repo is not None and path.suffix != ".ipynb":
+        if settings.sync_git_repo is not None and normalized_path.suffix != ".ipynb":
             from ..core._sync_git import get_transform_reference_from_git_repo
 
-            reference = get_transform_reference_from_git_repo(path)
+            reference = get_transform_reference_from_git_repo(normalized_path)
             reference_type = "url"
         return key, kind, reference, reference_type
 
@@ -745,7 +776,7 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
             Kind inference defaults to `"script"` and uses `"notebook"` for
             `.ipynb`, `.Rmd`, and `.qmd` files.
         """
-        path = Path(path)
+        path = cls._normalize_local_path(Path(path))
         inferred_key, inferred_kind, reference, reference_type = (
             cls._infer_from_file_metadata(
                 path=path,
@@ -761,6 +792,12 @@ class Transform(SQLRecord, IsVersioned, TracksRun):
             transform_kind=inferred_kind,
             key=inferred_key,
             version=version,
+        )
+        cls._persist_source_code_from_path(
+            transform=transform,
+            path=path,
+            kind=inferred_kind,
+            description=description,
         )
         if logging_message:
             logger.important(logging_message)

--- a/tests/core/test_track_script_or_notebook.py
+++ b/tests/core/test_track_script_or_notebook.py
@@ -1,3 +1,4 @@
+import os
 import signal
 import subprocess
 import sys
@@ -535,6 +536,30 @@ def test_create_or_load_transform_warns_when_outside_dev_dir(
             transform.delete(permanent=True)
 
 
+def test_create_or_load_transform_uses_dev_dir_relative_key_for_relative_path(tmp_path):
+    previous_dev_dir = ln_setup.settings.dev_dir
+    previous_cwd = Path.cwd()
+    path_in_dev_dir = tmp_path / "flows" / f"track-{time.time_ns()}.py"
+    path_in_dev_dir.parent.mkdir(parents=True, exist_ok=True)
+    path_in_dev_dir.write_text("print('track relative key test')\n")
+    transform: ln.Transform | None = None
+    try:
+        ln_setup.settings.dev_dir = tmp_path
+        os.chdir(tmp_path)
+        context._path = Path("flows") / path_in_dev_dir.name
+        transform, _ = ln.Transform._create_or_load_from_source(path=context._path)
+        assert transform.key == f"flows/{path_in_dev_dir.name}"
+    finally:
+        os.chdir(previous_cwd)
+        ln_setup.settings.dev_dir = previous_dev_dir
+        ln.context._uid = None
+        ln.context._run = None
+        ln.context._transform = None
+        ln.context._path = None
+        if transform is not None:
+            transform.delete(permanent=True)
+
+
 def test_run_scripts():
     # regular execution
     result = subprocess.run(  # noqa: S602
@@ -547,6 +572,8 @@ def test_run_scripts():
     assert "started new Run(" in result.stdout.decode()
     transform = ln.Transform.get("Ro1gl7n8YrdH0000")
     assert transform.latest_run.cli_args == "--param 42"
+    assert transform.source_code is not None
+    assert "ln.track(" in transform.source_code
 
     # updated key (filename change)
     result = subprocess.run(  # noqa: S602

--- a/tests/core/test_transform.py
+++ b/tests/core/test_transform.py
@@ -1,3 +1,4 @@
+import os
 import time
 from pathlib import Path
 from unittest.mock import patch
@@ -35,6 +36,48 @@ def test_transform_from_path_uses_dev_dir_relative_key(tmp_path):
         assert transform.key == f"pipelines/{path_in_dev_dir.name}"
     finally:
         ln_setup.settings.dev_dir = previous_dev_dir
+
+
+def test_transform_from_path_uses_dev_dir_relative_key_for_relative_path(tmp_path):
+    previous_dev_dir = ln_setup.settings.dev_dir
+    previous_cwd = Path.cwd()
+    path_in_dev_dir = tmp_path / "pipelines" / f"wf-{time.time_ns()}.py"
+    path_in_dev_dir.parent.mkdir(parents=True, exist_ok=True)
+    path_in_dev_dir.write_text("print('hello')\n")
+    try:
+        ln_setup.settings.dev_dir = tmp_path
+        os.chdir(tmp_path)
+        relative_path = Path("pipelines") / path_in_dev_dir.name
+        transform = ln.Transform.from_path(relative_path)
+        assert transform.key == f"pipelines/{path_in_dev_dir.name}"
+    finally:
+        os.chdir(previous_cwd)
+        ln_setup.settings.dev_dir = previous_dev_dir
+
+
+def test_transform_from_path_populates_source_code(tmp_path):
+    script_path = tmp_path / f"workflow-{time.time_ns()}.py"
+    script_body = "print('hello from from_path')\n"
+    script_path.write_text(script_body)
+
+    transform = ln.Transform.from_path(script_path)
+
+    assert transform.source_code == script_body
+
+
+def test_transform_from_path_persists_source_code_once(tmp_path):
+    script_path = tmp_path / f"workflow-{time.time_ns()}.py"
+    script_path.write_text("print('persist once')\n")
+
+    with patch.object(
+        ln.Transform,
+        "_update_source_code_from_path",
+        autospec=True,
+        wraps=ln.Transform._update_source_code_from_path,
+    ) as update_source_code:
+        ln.Transform.from_path(script_path)
+
+    assert update_source_code.call_count == 1
 
 
 def test_transform_recovery_based_on_hash():

--- a/tests/core/test_transform.py
+++ b/tests/core/test_transform.py
@@ -10,7 +10,8 @@ import pytest
 
 def test_transform_from_path_infers_kind_and_key(tmp_path):
     script_path = tmp_path / f"workflow-{time.time_ns()}.py"
-    script_path.write_text("print('hello')\n")
+    script_body = "print('hello')\n"
+    script_path.write_text(script_body)
     notebook_path = tmp_path / f"analysis-{time.time_ns()}.ipynb"
     notebook_path.write_text(
         '{"cells":[],"metadata":{},"nbformat":4,"nbformat_minor":5}\n'
@@ -21,6 +22,7 @@ def test_transform_from_path_infers_kind_and_key(tmp_path):
 
     assert script_transform.kind == "script"
     assert script_transform.key == script_path.name
+    assert script_transform.source_code == script_body
     assert notebook_transform.kind == "notebook"
     assert notebook_transform.key == notebook_path.name
 
@@ -53,16 +55,6 @@ def test_transform_from_path_uses_dev_dir_relative_key_for_relative_path(tmp_pat
     finally:
         os.chdir(previous_cwd)
         ln_setup.settings.dev_dir = previous_dev_dir
-
-
-def test_transform_from_path_populates_source_code(tmp_path):
-    script_path = tmp_path / f"workflow-{time.time_ns()}.py"
-    script_body = "print('hello from from_path')\n"
-    script_path.write_text(script_body)
-
-    transform = ln.Transform.from_path(script_path)
-
-    assert transform.source_code == script_body
 
 
 def test_transform_from_path_persists_source_code_once(tmp_path):


### PR DESCRIPTION
Fixes an omission in the recently introduced `Transform.from_path()` constructor:

- https://github.com/laminlabs/lamindb/pull/3759