### PR TITLE
:children_crossing: Add dedicated agent skills

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches: [release]
     paths-ignore:
-      - ".agents/**"
+      - "lamindb/.agents/**"
   pull_request:
     paths-ignore:
-      - ".agents/**"
+      - "lamindb/.agents/**"
 
 jobs:
   pre-filter:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,11 @@ name: build
 on:
   push:
     branches: [release]
+    paths-ignore:
+      - ".agents/**"
   pull_request:
+    paths-ignore:
+      - ".agents/**"
 
 jobs:
   pre-filter:

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -3,7 +3,11 @@ name: profile
 on:
   push:
     branches: [main, release]
+    paths-ignore:
+      - ".agents/**"
   pull_request:
+    paths-ignore:
+      - ".agents/**"
 
 jobs:
   profile:

--- a/.github/workflows/profile.yml
+++ b/.github/workflows/profile.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches: [main, release]
     paths-ignore:
-      - ".agents/**"
+      - "lamindb/.agents/**"
   pull_request:
     paths-ignore:
-      - ".agents/**"
+      - "lamindb/.agents/**"
 
 jobs:
   profile:

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "sub/cellxgene-lamin"]
 	path = sub/cellxgene-lamin
 	url = https://github.com/laminlabs/cellxgene-lamin.git
+[submodule "lamindb/.agents"]
+	path = lamindb/.agents
+	url = https://github.com/laminlabs/lamin-skills


### PR DESCRIPTION
Official agent skills now automatically ship with any `lamindb` installation via `lamindb/.agents`. 

They're managed through a git submodule: https://github.com/laminlabs/lamin-skills

This way skills can be updated independently from the source code.