### PR TITLE
♻️ Use `settings.is_configured` instead of deprecated `settings._instance_exists`

### DIFF
--- a/lamindb/base/users.py
+++ b/lamindb/base/users.py
@@ -52,7 +52,7 @@ def current_user_id() -> int:
                     raise e
             return user_id
 
-    if settings._instance_exists:
+    if settings.is_configured:
         slug = settings.instance.slug
         if slug not in user_id_cache:
             user_id_cache[slug] = query_user_id()

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3813,7 +3813,7 @@ def track_run_input(
     if is_run_input:
         if run is None:
             # Don't emit this warning when no global instance is configured.
-            if setup_settings._instance_exists:
+            if setup_settings.is_configured:
                 isettings = setup_settings.instance
                 if not (isettings._is_clone or isettings.is_read_only_connection):
                     logger.warning(WARNING_NO_INPUT)


### PR DESCRIPTION
Use new public `settings.is_configured` instead of deprecated `settings._instance_exists`.

Requires: 

- https://github.com/laminlabs/lamindb-setup/pull/1362

See:

- https://github.com/laminlabs/lamin-cli/pull/241