### PR TITLE
🚸 Do not treat the bionty default space differently from other entities

### DIFF
--- a/lamindb/core/_context.py
+++ b/lamindb/core/_context.py
@@ -531,7 +531,7 @@ class Context:
             transform: A transform (stem) `uid` or object. If `None`, auto-creates a `transform` with its `uid`.
             project: A project or its `name` or `uid` for labeling entities created during the run.
             space: A restricted space or its `name` or `uid` in which to store entities created during the run.
-                Default: the `"all"` space. Note that bionty entities ignore this setting and always get written to the `"all"` space.
+                Default: the `"all"` space.
                 If you want to manually move entities to a different space, set the `.space` field (:doc:`docs:permissions`).
             branch: A branch (or its `name` or `uid`) on which to store records.
             plan: A plan, typically an agent plan. Pass an artifact (or its `key` or `uid`).

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1167,8 +1167,6 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                 if (
                     issubclass(self.__class__, SQLRecord)
                     and self.__class__.__name__ != "Storage"
-                    # do not save bionty entities in restricted spaces by default
-                    and self.__class__.__module__ != "bionty.models"
                 ):
                     from lamindb import context as run_context
 

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1164,10 +1164,7 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                 return fk_record is not None
 
             if not os.getenv("LAMINDB_MULTI_INSTANCE") == "true":
-                if (
-                    issubclass(self.__class__, SQLRecord)
-                    and self.__class__.__name__ != "Storage"
-                ):
+                if issubclass(self.__class__, SQLRecord):
                     from lamindb import context as run_context
 
                     # Precedence is uniform across SQLRecord children:

--- a/tests/core/test_sqlrecord.py
+++ b/tests/core/test_sqlrecord.py
@@ -650,3 +650,16 @@ def test_explicit_default_ids_override_context():
     explicit_main.delete(permanent=True)
     space.delete(permanent=True)
     branch.delete(permanent=True)
+
+
+def test_context_space_applies_to_bionty_records():
+    suffix = uuid4().hex[:8]
+    space = ln.Space(name=f"ctx-bionty-space-{suffix}").save()
+
+    with patch.object(ln.context, "_space", space):
+        organism = bt.Organism(name=f"ctx-organism-{suffix}").save()
+
+    assert organism.space_id == space.id
+
+    organism.delete(permanent=True)
+    space.delete(permanent=True)

--- a/tests/core/test_sqlrecord.py
+++ b/tests/core/test_sqlrecord.py
@@ -650,16 +650,3 @@ def test_explicit_default_ids_override_context():
     explicit_main.delete(permanent=True)
     space.delete(permanent=True)
     branch.delete(permanent=True)
-
-
-def test_context_space_applies_to_bionty_records():
-    suffix = uuid4().hex[:8]
-    space = ln.Space(name=f"ctx-bionty-space-{suffix}").save()
-
-    with patch.object(ln.context, "_space", space):
-        organism = bt.Organism(name=f"ctx-organism-{suffix}").save()
-
-    assert organism.space_id == space.id
-
-    organism.delete(permanent=True)
-    space.delete(permanent=True)


### PR DESCRIPTION
There was a special case in which the configured default space would be ignored for `bionty` registries and the `Storage` registry.