### PR TITLE
🚸 Simplify lineage during record export via `to_dataframe()`

### DIFF
--- a/docs/faq/track-run-inputs.md
+++ b/docs/faq/track-run-inputs.md
@@ -109,6 +109,16 @@ artifact.view_lineage()
 assert len(ln.Run.get(id=ln.context.run.id).input_artifacts.all()) == 2
 ```
 
+## How sheet exports are tracked
+
+For sheet-style exports (`Record(is_type=True)`):
+
+- `sheet.to_dataframe()` links the sheet (and exported rows, unless
+  `link_individual_inputs=False`) directly to the active run inputs
+  (`run.input_records`).
+- `sheet.to_artifact()` creates a mediating `__lamindb_record_export__` run and
+  links export inputs on that run before saving the artifact.
+
 ```bash
 rm -r test-run-inputs
 lamin delete --force test-run-inputs

--- a/docs/faq/track-run-inputs.md
+++ b/docs/faq/track-run-inputs.md
@@ -109,16 +109,6 @@ artifact.view_lineage()
 assert len(ln.Run.get(id=ln.context.run.id).input_artifacts.all()) == 2
 ```
 
-## How sheet exports are tracked
-
-For sheet-style exports (`Record(is_type=True)`):
-
-- `sheet.to_dataframe()` links the sheet (and exported rows, unless
-  `link_individual_inputs=False`) directly to the active run inputs
-  (`run.input_records`).
-- `sheet.to_artifact()` creates a mediating `__lamindb_record_export__` run and
-  links export inputs on that run before saving the artifact.
-
 ```bash
 rm -r test-run-inputs
 lamin delete --force test-run-inputs

--- a/lamindb/models/artifact_set.py
+++ b/lamindb/models/artifact_set.py
@@ -152,7 +152,7 @@ class RecordSet(Iterable):
         is_run_input: bool | Run | None = None,
         link_individual_inputs: bool = True,
         _record_type: Record | None = None,
-        _use_mediating_export_run: bool = False,
+        use_export_run: bool = False,
     ) -> DataFrame:
         import pandas as pd
 
@@ -287,7 +287,7 @@ class RecordSet(Iterable):
 
         record_type._set_export_run(
             is_run_input=is_run_input,
-            use_mediating_export_run=_use_mediating_export_run,
+            use_export_run=use_export_run,
         )
         run_for_input_linking = record_type._export_run
         if run_for_input_linking is not None:
@@ -295,15 +295,13 @@ class RecordSet(Iterable):
             if link_individual_inputs:
                 input_record_ids = qs.values_list("id", flat=True)
                 run_for_input_linking.input_records.add(*input_record_ids)
-        if _use_mediating_export_run and run_for_input_linking is not None:
+        if use_export_run and run_for_input_linking is not None:
             from datetime import datetime, timezone
 
             run_for_input_linking.finished_at = datetime.now(timezone.utc)
             run_for_input_linking._status_code = 0
             run_for_input_linking.save()
-        qs._record_export_run = (
-            run_for_input_linking if _use_mediating_export_run else None
-        )
+        qs._record_export_run = run_for_input_linking if use_export_run else None
         return df.sort_index()
 
     def to_artifact(
@@ -337,7 +335,7 @@ class RecordSet(Iterable):
         df = self.to_dataframe(
             is_run_input=is_run_input,
             link_individual_inputs=link_individual_inputs,
-            _use_mediating_export_run=True,
+            use_export_run=True,
             **kwargs,
         )
         record_type = getattr(qs, "_record_export_type", None)

--- a/lamindb/models/artifact_set.py
+++ b/lamindb/models/artifact_set.py
@@ -152,6 +152,7 @@ class RecordSet(Iterable):
         is_run_input: bool | Run | None = None,
         link_individual_inputs: bool = True,
         _record_type: Record | None = None,
+        _use_mediating_export_run: bool = False,
     ) -> DataFrame:
         import pandas as pd
 
@@ -284,19 +285,25 @@ class RecordSet(Iterable):
             desired_order.sort()
         df = reorder_subset_columns_in_df(df, desired_order, position=0)  # type: ignore
 
-        record_type._set_export_run(is_run_input=is_run_input)
-        export_run = record_type._export_run
-        if export_run is not None:
-            export_run.input_records.add(record_type)
+        record_type._set_export_run(
+            is_run_input=is_run_input,
+            use_mediating_export_run=_use_mediating_export_run,
+        )
+        run_for_input_linking = record_type._export_run
+        if run_for_input_linking is not None:
+            run_for_input_linking.input_records.add(record_type)
             if link_individual_inputs:
                 input_record_ids = qs.values_list("id", flat=True)
-                export_run.input_records.add(*input_record_ids)
+                run_for_input_linking.input_records.add(*input_record_ids)
+        if _use_mediating_export_run and run_for_input_linking is not None:
             from datetime import datetime, timezone
 
-            export_run.finished_at = datetime.now(timezone.utc)
-            export_run._status_code = 0
-            export_run.save()
-        qs._record_export_run = export_run
+            run_for_input_linking.finished_at = datetime.now(timezone.utc)
+            run_for_input_linking._status_code = 0
+            run_for_input_linking.save()
+        qs._record_export_run = (
+            run_for_input_linking if _use_mediating_export_run else None
+        )
         return df.sort_index()
 
     def to_artifact(
@@ -330,6 +337,7 @@ class RecordSet(Iterable):
         df = self.to_dataframe(
             is_run_input=is_run_input,
             link_individual_inputs=link_individual_inputs,
+            _use_mediating_export_run=True,
             **kwargs,
         )
         record_type = getattr(qs, "_record_export_type", None)

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -1077,7 +1077,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         self,
         is_run_input: bool | Run | None = None,
         *,
-        use_mediating_export_run: bool = True,
+        use_export_run: bool = True,
     ) -> None:
         from lamindb.core._context import context
         from lamindb.models import Run, Transform
@@ -1085,7 +1085,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         if isinstance(is_run_input, Run):
             run = is_run_input
         elif is_run_input in {True, None}:
-            if use_mediating_export_run:
+            if use_export_run:
                 # If there is an active run context, link it as initiator of the
                 # internal record export run.
                 initiated_by_run = context.run
@@ -1141,7 +1141,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         recurse: bool = False,
         is_run_input: bool | Run | None = None,
         link_individual_inputs: bool = True,
-        _use_mediating_export_run: bool = False,
+        use_export_run: bool = False,
         **kwargs,
     ) -> pd.DataFrame:
         """Export to a pandas DataFrame.
@@ -1194,7 +1194,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
             is_run_input=is_run_input,
             link_individual_inputs=link_individual_inputs,
             _record_type=self,
-            _use_mediating_export_run=_use_mediating_export_run,
+            use_export_run=use_export_run,
             **kwargs,
         )
         self._export_run = getattr(qs, "_record_export_run", None)
@@ -1244,7 +1244,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
             self.to_dataframe(
                 is_run_input=is_run_input,
                 link_individual_inputs=link_individual_inputs,
-                _use_mediating_export_run=True,
+                use_export_run=True,
                 **kwargs,
             ),
             key=key,

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -1157,10 +1157,6 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         (`__lamindb_record_id__`, `__lamindb_record_uid__`, `__lamindb_record_name__`, etc.)
         are omitted. Sheets without `index` keep the previous export behavior.
 
-        When tracking is active, it links the record type (and optionally the
-        exported records) directly to the active run inputs. It does not create a
-        mediating ``__lamindb_record_export__`` run.
-
         Example:
 
             Export all records on a sheet::
@@ -1172,6 +1168,8 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
             is_run_input: Whether to track the record as a run input.
             link_individual_inputs: Whether to link all exported records as
                 inputs of the run. If `False`, only links the record type.
+            use_export_run: Whether to create and use a mediating
+                `__lamindb_record_export__` run for lineage.
             **kwargs: Keyword arguments passed to :meth:`~lamindb.models.QuerySet.to_dataframe`.
         """
         if isinstance(cls_or_self, type):
@@ -1216,9 +1214,6 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
 
         When the sheet schema defines :attr:`~lamindb.Schema.index`, the CSV is written
         with `index=True` so the index feature is preserved on export.
-
-        `to_artifact()` uses a mediating ``__lamindb_record_export__`` run to capture
-        export lineage before persisting the artifact.
 
         Example:
 

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -1073,56 +1073,64 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         """
         return _query_relatives([self], "records")  # type: ignore
 
-    def _set_export_run(self, is_run_input: bool | Run | None = None) -> None:
+    def _set_export_run(
+        self,
+        is_run_input: bool | Run | None = None,
+        *,
+        use_mediating_export_run: bool = True,
+    ) -> None:
         from lamindb.core._context import context
         from lamindb.models import Run, Transform
 
         if isinstance(is_run_input, Run):
             run = is_run_input
         elif is_run_input in {True, None}:
-            # If there is an active run context, link it as initiator of the
-            # internal record export run.
-            initiated_by_run = context.run
-            # Compatibility path for older instances:
-            # historically, "__lamindb_record_export__" transforms could have
-            # arbitrary UIDs. We now standardize on a fixed UID to make creation
-            # idempotent under concurrency and to avoid duplicate internal
-            # transforms. This follows the fixed-UID pattern already used by
-            # "save_vitessce_config" (integrations/_vitessce.py) and
-            # "__lamindb_transfer__/{instance_uid}" (models/sqlrecord.py).
-            # After a few lamindb release cycles (once legacy UIDs are no
-            # longer expected), this normalization branch can be removed.
-            export_transform_uid = "v6KpQx9mRt2B0000"
-            transform = Transform.objects.filter(uid=export_transform_uid).first()
-            if transform is None:
-                transform = (
-                    Transform.objects.filter(
-                        key="__lamindb_record_export__", kind="function"
+            if use_mediating_export_run:
+                # If there is an active run context, link it as initiator of the
+                # internal record export run.
+                initiated_by_run = context.run
+                # Compatibility path for older instances:
+                # historically, "__lamindb_record_export__" transforms could have
+                # arbitrary UIDs. We now standardize on a fixed UID to make creation
+                # idempotent under concurrency and to avoid duplicate internal
+                # transforms. This follows the fixed-UID pattern already used by
+                # "save_vitessce_config" (integrations/_vitessce.py) and
+                # "__lamindb_transfer__/{instance_uid}" (models/sqlrecord.py).
+                # After a few lamindb release cycles (once legacy UIDs are no
+                # longer expected), this normalization branch can be removed.
+                export_transform_uid = "v6KpQx9mRt2B0000"
+                transform = Transform.objects.filter(uid=export_transform_uid).first()
+                if transform is None:
+                    transform = (
+                        Transform.objects.filter(
+                            key="__lamindb_record_export__", kind="function"
+                        )
+                        .order_by("created_at")
+                        .first()
                     )
-                    .order_by("created_at")
-                    .first()
+                if transform is None:
+                    transform, _ = Transform.objects.get_or_create(
+                        uid=export_transform_uid,
+                        defaults={
+                            "key": "__lamindb_record_export__",
+                            "kind": "function",
+                        },
+                    )
+                elif transform.uid != export_transform_uid:
+                    transform.uid = export_transform_uid
+                    transform.save()
+                # Export is treated as a discrete user action, so always create a new
+                # run. Transfer reuses runs to avoid repeated sync bookkeeping runs.
+                run = Run(
+                    transform=transform,
+                    initiated_by_run=initiated_by_run,
+                    status="started",
                 )
-            if transform is None:
-                transform, _ = Transform.objects.get_or_create(
-                    uid=export_transform_uid,
-                    defaults={
-                        "key": "__lamindb_record_export__",
-                        "kind": "function",
-                    },
-                )
-            elif transform.uid != export_transform_uid:
-                transform.uid = export_transform_uid
-                transform.save()
-            # Export is treated as a discrete user action, so always create a new
-            # run. Transfer reuses runs to avoid repeated sync bookkeeping runs.
-            run = Run(
-                transform=transform,
-                initiated_by_run=initiated_by_run,
-                status="started",
-            )
-            run.space = self.space
-            run.save()  # type: ignore
-            run.initiated_by_run = initiated_by_run  # available in memory
+                run.space = self.space
+                run.save()  # type: ignore
+                run.initiated_by_run = initiated_by_run  # available in memory
+            else:
+                run = context.run
         else:
             run = None
         self._export_run = run
@@ -1133,6 +1141,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         recurse: bool = False,
         is_run_input: bool | Run | None = None,
         link_individual_inputs: bool = True,
+        _use_mediating_export_run: bool = False,
         **kwargs,
     ) -> pd.DataFrame:
         """Export to a pandas DataFrame.
@@ -1148,7 +1157,9 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         (`__lamindb_record_id__`, `__lamindb_record_uid__`, `__lamindb_record_name__`, etc.)
         are omitted. Sheets without `index` keep the previous export behavior.
 
-        It will also track the record as an input to the current run.
+        When tracking is active, it links the record type (and optionally the
+        exported records) directly to the active run inputs. It does not create a
+        mediating ``__lamindb_record_export__`` run.
 
         Example:
 
@@ -1160,7 +1171,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
             recurse: Whether to include records of sub-types recursively.
             is_run_input: Whether to track the record as a run input.
             link_individual_inputs: Whether to link all exported records as
-                inputs of the export run. If `False`, only links the record type.
+                inputs of the run. If `False`, only links the record type.
             **kwargs: Keyword arguments passed to :meth:`~lamindb.models.QuerySet.to_dataframe`.
         """
         if isinstance(cls_or_self, type):
@@ -1183,6 +1194,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
             is_run_input=is_run_input,
             link_individual_inputs=link_individual_inputs,
             _record_type=self,
+            _use_mediating_export_run=_use_mediating_export_run,
             **kwargs,
         )
         self._export_run = getattr(qs, "_record_export_run", None)
@@ -1204,6 +1216,9 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
 
         When the sheet schema defines :attr:`~lamindb.Schema.index`, the CSV is written
         with `index=True` so the index feature is preserved on export.
+
+        `to_artifact()` uses a mediating ``__lamindb_record_export__`` run to capture
+        export lineage before persisting the artifact.
 
         Example:
 
@@ -1229,6 +1244,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
             self.to_dataframe(
                 is_run_input=is_run_input,
                 link_individual_inputs=link_individual_inputs,
+                _use_mediating_export_run=True,
                 **kwargs,
             ),
             key=key,

--- a/tests/core/test_record_sheet_examples.py
+++ b/tests/core/test_record_sheet_examples.py
@@ -115,9 +115,7 @@ def test_record_example_compound_treatment(
         ],
     }
 
-    assert sample_sheet1.input_of_runs.count() == 0
     df = sample_sheet1.to_dataframe()
-    assert sample_sheet1.input_of_runs.count() == 0
     assert df.index.name == "name"
     assert df.index.tolist() == ["Sample 1", "Sample 2"]
     assert "name" not in df.columns

--- a/tests/core/test_record_sheet_examples.py
+++ b/tests/core/test_record_sheet_examples.py
@@ -115,9 +115,9 @@ def test_record_example_compound_treatment(
         ],
     }
 
-    assert sample_sheet1.input_of_runs.count() == 1
+    assert sample_sheet1.input_of_runs.count() == 0
     df = sample_sheet1.to_dataframe()
-    assert sample_sheet1.input_of_runs.count() == 2
+    assert sample_sheet1.input_of_runs.count() == 0
     assert df.index.name == "name"
     assert df.index.tolist() == ["Sample 1", "Sample 2"]
     assert "name" not in df.columns
@@ -531,9 +531,7 @@ def test_record_export_links_record_type_when_link_records_false(
     _, sample_sheet = populate_sheets_compound_treatment
 
     sample_sheet.to_dataframe(link_individual_inputs=False)
-    dataframe_export_run = sample_sheet.input_of_runs.order_by("-created_at").first()
-    assert dataframe_export_run.input_records.count() == 1
-    assert dataframe_export_run.input_records.get().id == sample_sheet.id
+    assert sample_sheet.input_of_runs.count() == 0
 
     artifact = sample_sheet.to_artifact(link_individual_inputs=False)
     try:
@@ -554,13 +552,7 @@ def test_record_export_applies_filters():
     assert len(filtered_df) == 1
     assert filtered_df["__lamindb_record_name__"].to_list() == ["sample1"]
 
-    dataframe_export_run = sample_sheet.input_of_runs.order_by("-created_at").first()
-    assert dataframe_export_run is not None
-    assert dataframe_export_run.input_records.count() == 2
-    assert set(dataframe_export_run.input_records.to_list("name")) == {
-        "sample1",
-        "FilterSheet",
-    }
+    assert sample_sheet.input_of_runs.count() == 0
 
     sample1.delete(permanent=True)
     sample2.delete(permanent=True)
@@ -597,13 +589,7 @@ def test_record_export_applies_feature_predicate_filters():
     assert len(filtered_df) == 1
     assert filtered_df["__lamindb_record_name__"].to_list() == ["sample2"]
 
-    dataframe_export_run = sample_sheet.input_of_runs.order_by("-created_at").first()
-    assert dataframe_export_run is not None
-    assert dataframe_export_run.input_records.count() == 2
-    assert set(dataframe_export_run.input_records.to_list("name")) == {
-        "sample2",
-        "PredicateFilterSheet",
-    }
+    assert sample_sheet.input_of_runs.count() == 0
 
     sample1.delete(permanent=True)
     sample2.delete(permanent=True)
@@ -677,3 +663,34 @@ def test_record_export_populates_initiated_by_run(
     finally:
         ln.context._run = None
         artifact.delete(permanent=True)
+
+
+def test_record_dataframe_tracks_active_run_without_export_run():
+    sheet = ln.Record(name="DataFrameInputSheet", is_type=True).save()
+    record_a = ln.Record(name="row_a", type=sheet).save()
+    record_b = ln.Record(name="row_b", type=sheet).save()
+    transform = ln.Transform(key="test_record_dataframe_tracks_active_run").save()
+    ln.track(transform=transform, new_run=True)
+    active_run = ln.context.run
+    try:
+        _ = sheet.to_dataframe()
+        active_run = ln.Run.get(id=active_run.id)
+        assert set(active_run.input_records.to_list("id")) == {
+            sheet.id,
+            record_a.id,
+            record_b.id,
+        }
+        assert (
+            ln.Run.filter(
+                initiated_by_run=active_run,
+                transform__key="__lamindb_record_export__",
+            ).count()
+            == 0
+        )
+    finally:
+        ln.context._run = None
+        ln.Run.filter(transform=transform).delete(permanent=True)
+        record_a.delete(permanent=True)
+        record_b.delete(permanent=True)
+        sheet.delete(permanent=True)
+        transform.delete(permanent=True)

--- a/tests/core/test_record_sheet_examples.py
+++ b/tests/core/test_record_sheet_examples.py
@@ -527,34 +527,62 @@ def test_record_export_links_record_type_when_link_records_false(
     populate_sheets_compound_treatment: tuple[ln.Record, ln.Record],  # noqa: F811
 ):
     _, sample_sheet = populate_sheets_compound_treatment
-
-    sample_sheet.to_dataframe(link_individual_inputs=False)
-    assert sample_sheet.input_of_runs.count() == 0
-
-    artifact = sample_sheet.to_artifact(link_individual_inputs=False)
+    transform = ln.Transform(
+        key="test_record_export_links_record_type_when_link_records_false",
+        kind="function",
+    ).save()
+    ln.track(transform=transform, new_run=True)
+    active_run = ln.context.run
     try:
+        sample_sheet.to_dataframe(link_individual_inputs=False)
+        dataframe_export_run = sample_sheet.input_of_runs.order_by(
+            "-created_at"
+        ).first()
+        assert dataframe_export_run is not None
+        assert dataframe_export_run.id == active_run.id
+        assert dataframe_export_run.input_records.count() == 1
+        assert dataframe_export_run.input_records.get().id == sample_sheet.id
+
+        artifact = sample_sheet.to_artifact(link_individual_inputs=False)
         assert artifact.run.input_records.count() == 1
         assert artifact.run.input_records.get().id == sample_sheet.id
     finally:
-        artifact.delete(permanent=True)
+        ln.context._run = None
+        if "artifact" in locals():
+            artifact.delete(permanent=True)
 
 
 def test_record_export_applies_filters():
     sample_sheet = ln.Record(name="FilterSheet", is_type=True).save()
     sample1 = ln.Record(name="sample1", type=sample_sheet).save()
     sample2 = ln.Record(name="sample2", type=sample_sheet).save()
+    transform = ln.Transform(
+        key="test_record_export_applies_filters", kind="function"
+    ).save()
+    ln.track(transform=transform, new_run=True)
+    active_run = ln.context.run
+    try:
+        filtered_df = ln.Record.filter(type=sample_sheet, name="sample1").to_dataframe(
+            include="features"
+        )
+        assert len(filtered_df) == 1
+        assert filtered_df["__lamindb_record_name__"].to_list() == ["sample1"]
 
-    filtered_df = ln.Record.filter(type=sample_sheet, name="sample1").to_dataframe(
-        include="features"
-    )
-    assert len(filtered_df) == 1
-    assert filtered_df["__lamindb_record_name__"].to_list() == ["sample1"]
-
-    assert sample_sheet.input_of_runs.count() == 0
-
-    sample1.delete(permanent=True)
-    sample2.delete(permanent=True)
-    sample_sheet.delete(permanent=True)
+        dataframe_export_run = sample_sheet.input_of_runs.order_by(
+            "-created_at"
+        ).first()
+        assert dataframe_export_run is not None
+        assert dataframe_export_run.id == active_run.id
+        assert dataframe_export_run.input_records.count() == 2
+        assert set(dataframe_export_run.input_records.to_list("name")) == {
+            "sample1",
+            "FilterSheet",
+        }
+    finally:
+        ln.context._run = None
+        sample1.delete(permanent=True)
+        sample2.delete(permanent=True)
+        sample_sheet.delete(permanent=True)
 
 
 def test_recordset_to_artifact_uses_default_record_exports_key():
@@ -580,19 +608,35 @@ def test_record_export_applies_feature_predicate_filters():
     export_filter_score = ln.Feature(name="export_filter_score", dtype=int).save()
     sample1.features.add_values({"export_filter_score": 10})
     sample2.features.add_values({"export_filter_score": 20})
+    transform = ln.Transform(
+        key="test_record_export_applies_feature_predicate_filters",
+        kind="function",
+    ).save()
+    ln.track(transform=transform, new_run=True)
+    active_run = ln.context.run
+    try:
+        filtered_df = ln.Record.filter(
+            export_filter_score > 15, type=sample_sheet
+        ).to_dataframe(include="features")
+        assert len(filtered_df) == 1
+        assert filtered_df["__lamindb_record_name__"].to_list() == ["sample2"]
 
-    filtered_df = ln.Record.filter(
-        export_filter_score > 15, type=sample_sheet
-    ).to_dataframe(include="features")
-    assert len(filtered_df) == 1
-    assert filtered_df["__lamindb_record_name__"].to_list() == ["sample2"]
-
-    assert sample_sheet.input_of_runs.count() == 0
-
-    sample1.delete(permanent=True)
-    sample2.delete(permanent=True)
-    sample_sheet.delete(permanent=True)
-    export_filter_score.delete(permanent=True)
+        dataframe_export_run = sample_sheet.input_of_runs.order_by(
+            "-created_at"
+        ).first()
+        assert dataframe_export_run is not None
+        assert dataframe_export_run.id == active_run.id
+        assert dataframe_export_run.input_records.count() == 2
+        assert set(dataframe_export_run.input_records.to_list("name")) == {
+            "sample2",
+            "PredicateFilterSheet",
+        }
+    finally:
+        ln.context._run = None
+        sample1.delete(permanent=True)
+        sample2.delete(permanent=True)
+        sample_sheet.delete(permanent=True)
+        export_filter_score.delete(permanent=True)
 
 
 def test_record_queryset_to_dataframe_mixed_types_falls_back_to_generic():
@@ -661,34 +705,3 @@ def test_record_export_populates_initiated_by_run(
     finally:
         ln.context._run = None
         artifact.delete(permanent=True)
-
-
-def test_record_dataframe_tracks_active_run_without_export_run():
-    sheet = ln.Record(name="DataFrameInputSheet", is_type=True).save()
-    record_a = ln.Record(name="row_a", type=sheet).save()
-    record_b = ln.Record(name="row_b", type=sheet).save()
-    transform = ln.Transform(key="test_record_dataframe_tracks_active_run").save()
-    ln.track(transform=transform, new_run=True)
-    active_run = ln.context.run
-    try:
-        _ = sheet.to_dataframe()
-        active_run = ln.Run.get(id=active_run.id)
-        assert set(active_run.input_records.to_list("id")) == {
-            sheet.id,
-            record_a.id,
-            record_b.id,
-        }
-        assert (
-            ln.Run.filter(
-                initiated_by_run=active_run,
-                transform__key="__lamindb_record_export__",
-            ).count()
-            == 0
-        )
-    finally:
-        ln.context._run = None
-        ln.Run.filter(transform=transform).delete(permanent=True)
-        record_a.delete(permanent=True)
-        record_b.delete(permanent=True)
-        sheet.delete(permanent=True)
-        transform.delete(permanent=True)

--- a/tests/core/test_track_script_or_notebook.py
+++ b/tests/core/test_track_script_or_notebook.py
@@ -376,31 +376,6 @@ def test_track_input_record(create_record, kind):
     assert record in getattr(ln.context.run, f"input_{kind}s").all()  # regular input
 
 
-def test_track_input_record_dataframe_links_parent_run_only():
-    sheet = ln.Record(name="track-input-record-sheet", is_type=True).save()
-    row = ln.Record(name="track-input-record-row", type=sheet).save()
-    transform = ln.Transform(key="test-track-record-dataframe-input").save()
-    ln.track(transform=transform, new_run=True)
-    run = ln.context.run
-    try:
-        sheet.to_dataframe()
-        run = ln.Run.get(id=run.id)
-        assert set(run.input_records.to_list("id")) == {sheet.id, row.id}
-        assert (
-            ln.Run.filter(
-                initiated_by_run=run,
-                transform__key="__lamindb_record_export__",
-            ).count()
-            == 0
-        )
-    finally:
-        ln.context._run = None
-        ln.Run.filter(transform=transform).delete(permanent=True)
-        row.delete(permanent=True)
-        sheet.delete(permanent=True)
-        transform.delete(permanent=True)
-
-
 def test_track_notebook_colab():
     notebook_path = "/fileId=1KskciVXleoTeS_OGoJasXZJreDU9La_l"
     ln.context._track_notebook(path_str=notebook_path)

--- a/tests/core/test_track_script_or_notebook.py
+++ b/tests/core/test_track_script_or_notebook.py
@@ -376,6 +376,31 @@ def test_track_input_record(create_record, kind):
     assert record in getattr(ln.context.run, f"input_{kind}s").all()  # regular input
 
 
+def test_track_input_record_dataframe_links_parent_run_only():
+    sheet = ln.Record(name="track-input-record-sheet", is_type=True).save()
+    row = ln.Record(name="track-input-record-row", type=sheet).save()
+    transform = ln.Transform(key="test-track-record-dataframe-input").save()
+    ln.track(transform=transform, new_run=True)
+    run = ln.context.run
+    try:
+        sheet.to_dataframe()
+        run = ln.Run.get(id=run.id)
+        assert set(run.input_records.to_list("id")) == {sheet.id, row.id}
+        assert (
+            ln.Run.filter(
+                initiated_by_run=run,
+                transform__key="__lamindb_record_export__",
+            ).count()
+            == 0
+        )
+    finally:
+        ln.context._run = None
+        ln.Run.filter(transform=transform).delete(permanent=True)
+        row.delete(permanent=True)
+        sheet.delete(permanent=True)
+        transform.delete(permanent=True)
+
+
 def test_track_notebook_colab():
     notebook_path = "/fileId=1KskciVXleoTeS_OGoJasXZJreDU9La_l"
     ln.context._track_notebook(path_str=notebook_path)


### PR DESCRIPTION
There is no need for the auxiliary `__lamindb_record_export__` run in this case.