### PR TITLE
🐛 Schema members should take precedence over flexible features

### DIFF
--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -681,20 +681,12 @@ class ComponentCurator(Curator):
                 # Schema features take precedence over flexible-fetched features
                 # of the same name. Remove any flexible-fetched feature whose name
                 # is explicitly defined by the schema, then append the schema version.
-                schema_feature_names = {
-                    f.name for f in schema_features if isinstance(f, Feature)
-                }
-                features_filtered: list[Feature] = [
+                schema_feature_names = {f.name for f in schema_features}  # type: ignore
+                features = [
                     f
                     for f in features
-                    if isinstance(f, Feature) and f.name not in schema_feature_names
-                ]
-                # schema_features is expected to be a list[Feature] (members of Schema)
-                # but we still guard via isinstance for type-checking.
-                features_filtered.extend(
-                    f for f in schema_features if isinstance(f, Feature)
-                )
-                features = features_filtered
+                    if f.name not in schema_feature_names  # type: ignore
+                ] + schema_features  # type: ignore
             else:
                 features.extend(schema_features)
         else:
@@ -1798,21 +1790,17 @@ class CatVector:
                     and self._schema
                     and self._schema.n_members
                 ):
-                    schema_members = [
-                        f
-                        for f in self._schema.members.to_list()  # type: ignore[attr-defined]
-                        if isinstance(f, Feature)
-                    ]
+                    schema_members = cast(
+                        list[Feature],
+                        self._schema.members.to_list(),  # type: ignore
+                    )
                     schema_feature_by_name = {f.name: f.id for f in schema_members}
-                    filtered_records: list[Any] = []
-                    for r in records:
-                        if isinstance(r, Feature):
-                            if (
-                                r.name in schema_feature_by_name
-                                and r.id != schema_feature_by_name[r.name]
-                            ):
-                                continue
-                        filtered_records.append(r)
+                    filtered_records: list[Any] = [
+                        r
+                        for r in cast(list[Feature], records)
+                        if r.name not in schema_feature_by_name
+                        or r.id == schema_feature_by_name[r.name]
+                    ]
                     records = cast(
                         SQLRecordList[Any],
                         SQLRecordList(filtered_records),

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -660,6 +660,7 @@ class ComponentCurator(Curator):
             dataset=dataset, schema=schema, require_saved_schema=require_saved_schema
         )
 
+        self._features = None
         categoricals = []
         features = []
         feature_ids: set[int] = set()
@@ -691,6 +692,8 @@ class ComponentCurator(Curator):
                 features.extend(schema_features)
         else:
             assert schema.itype is not None  # noqa: S101
+
+        self._features = features
 
         pandera_columns = {}
         self._pandera_schema = None
@@ -823,7 +826,13 @@ class ComponentCurator(Curator):
             slot=slot,
             maximal_set=schema.maximal_set,
             schema=schema,
+            component_curator=self,
         )
+
+    @property
+    def features(self) -> list[Feature] | None:
+        """The features for validating and annotating the DataFrame."""
+        return self._features
 
     @property
     @doc_args(CAT_MANAGER_DOCSTRING)
@@ -1519,6 +1528,7 @@ class CatVector:
         type_uid: str | None = None,
         maximal_set: bool = True,  # whether unvalidated categoricals cause validation failure.
         schema: Schema = None,
+        features: list[Feature] | None = None,
     ) -> None:
         self._values_getter = values_getter
         self._values_setter = values_setter
@@ -1539,6 +1549,9 @@ class CatVector:
         self._field_name = self._field.field.name
         self._filter_kwargs = {}
         self._schema = schema
+        self._features = features
+        if self._features is not None:
+            return
         if filter_str and filter_str != "unsaved":
             self._filter_kwargs.update(
                 resolve_relation_filters(
@@ -1591,16 +1604,9 @@ class CatVector:
     @property
     def is_validated(self) -> bool:
         """Whether the vector is validated."""
-        # if nothing was validated, something likely is fundamentally wrong
-        # should probably add a setting `at_least_one_validated`
         result = True
         if len(self.values) > 0 and len(self.values) == len(self._non_validated):
             logger.warning(f"no values were validated for {self._key}!")
-        # len(self._non_validated) != 0
-        #     if maximal_set is True, return False
-        #     if maximal_set is False, return True
-        # len(self._non_validated) == 0
-        #     return True
         if len(self._non_validated) != 0:
             if self._maximal_set:
                 result = False
@@ -1659,6 +1665,9 @@ class CatVector:
         """Save features or labels records in the default instance."""
         from lamindb.models.has_parents import keep_topmost_matches
         from lamindb.models.save import save as ln_save
+
+        if self._features is not None:
+            return self._features, []
 
         model_field = self._registry.__get_name_with_module__()
 
@@ -2048,6 +2057,7 @@ class DataFrameCatManager:
         slot: str | None = None,
         maximal_set: bool = False,
         schema: Schema | None = None,
+        component_curator: ComponentCurator | None = None,
     ) -> None:
         self._non_validated = None
         self._index = index
@@ -2089,6 +2099,7 @@ class DataFrameCatManager:
             if schema.id is None
             else f"schemas__id={schema.id}",
             schema=schema,
+            features=component_curator.features,
         )
         for feature in self._categoricals:
             result = parse_dtype(feature._dtype_str)[0]

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import copy
 import re
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 import lamindb_setup as ln_setup
 import numpy as np
@@ -678,11 +678,23 @@ class ComponentCurator(Curator):
             else:
                 schema_features = schema.members.to_list()  # type: ignore
             if feature_ids:
-                features.extend(
-                    feature
-                    for feature in schema_features
-                    if feature.id not in feature_ids  # type: ignore
+                # Schema features take precedence over flexible-fetched features
+                # of the same name. Remove any flexible-fetched feature whose name
+                # is explicitly defined by the schema, then append the schema version.
+                schema_feature_names = {
+                    f.name for f in schema_features if isinstance(f, Feature)
+                }
+                features_filtered: list[Feature] = [
+                    f
+                    for f in features
+                    if isinstance(f, Feature) and f.name not in schema_feature_names
+                ]
+                # schema_features is expected to be a list[Feature] (members of Schema)
+                # but we still guard via isinstance for type-checking.
+                features_filtered.extend(
+                    f for f in schema_features if isinstance(f, Feature)
                 )
+                features = features_filtered
             else:
                 features.extend(schema_features)
         else:
@@ -1777,6 +1789,34 @@ class CatVector:
                 records = subtype_query_set.filter(
                     **{f"{field_name}__in": validated_values}
                 ).to_list()
+                # If the schema explicitly defines a Feature with this name, prefer that
+                # specific Feature instance over any duplicates that may exist in the DB.
+                # This prevents ambiguity errors for schema-defined column/features in
+                # flexible schemas when duplicate root-level Features exist.
+                if (
+                    registry.__name__ == "Feature"
+                    and self._schema
+                    and self._schema.n_members
+                ):
+                    schema_members = [
+                        f
+                        for f in self._schema.members.to_list()  # type: ignore[attr-defined]
+                        if isinstance(f, Feature)
+                    ]
+                    schema_feature_by_name = {f.name: f.id for f in schema_members}
+                    filtered_records: list[Any] = []
+                    for r in records:
+                        if isinstance(r, Feature):
+                            if (
+                                r.name in schema_feature_by_name
+                                and r.id != schema_feature_by_name[r.name]
+                            ):
+                                continue
+                        filtered_records.append(r)
+                    records = cast(
+                        SQLRecordList[Any],
+                        SQLRecordList(filtered_records),
+                    )
                 records = keep_topmost_matches(records)
             else:
                 existing_and_public_records = _from_values(

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -660,7 +660,6 @@ class ComponentCurator(Curator):
             dataset=dataset, schema=schema, require_saved_schema=require_saved_schema
         )
 
-        self._features = None
         categoricals = []
         features = []
         feature_ids: set[int] = set()
@@ -692,8 +691,6 @@ class ComponentCurator(Curator):
                 features.extend(schema_features)
         else:
             assert schema.itype is not None  # noqa: S101
-
-        self._features = features
 
         pandera_columns = {}
         self._pandera_schema = None
@@ -826,13 +823,7 @@ class ComponentCurator(Curator):
             slot=slot,
             maximal_set=schema.maximal_set,
             schema=schema,
-            component_curator=self,
         )
-
-    @property
-    def features(self) -> list[Feature] | None:
-        """The features for validating and annotating the DataFrame."""
-        return self._features
 
     @property
     @doc_args(CAT_MANAGER_DOCSTRING)
@@ -1528,7 +1519,6 @@ class CatVector:
         type_uid: str | None = None,
         maximal_set: bool = True,  # whether unvalidated categoricals cause validation failure.
         schema: Schema = None,
-        features: list[Feature] | None = None,
     ) -> None:
         self._values_getter = values_getter
         self._values_setter = values_setter
@@ -1549,9 +1539,6 @@ class CatVector:
         self._field_name = self._field.field.name
         self._filter_kwargs = {}
         self._schema = schema
-        self._features = features
-        if self._features is not None:
-            return
         if filter_str and filter_str != "unsaved":
             self._filter_kwargs.update(
                 resolve_relation_filters(
@@ -1604,9 +1591,16 @@ class CatVector:
     @property
     def is_validated(self) -> bool:
         """Whether the vector is validated."""
+        # if nothing was validated, something likely is fundamentally wrong
+        # should probably add a setting `at_least_one_validated`
         result = True
         if len(self.values) > 0 and len(self.values) == len(self._non_validated):
             logger.warning(f"no values were validated for {self._key}!")
+        # len(self._non_validated) != 0
+        #     if maximal_set is True, return False
+        #     if maximal_set is False, return True
+        # len(self._non_validated) == 0
+        #     return True
         if len(self._non_validated) != 0:
             if self._maximal_set:
                 result = False
@@ -1665,9 +1659,6 @@ class CatVector:
         """Save features or labels records in the default instance."""
         from lamindb.models.has_parents import keep_topmost_matches
         from lamindb.models.save import save as ln_save
-
-        if self._features is not None:
-            return self._features, []
 
         model_field = self._registry.__get_name_with_module__()
 
@@ -2057,7 +2048,6 @@ class DataFrameCatManager:
         slot: str | None = None,
         maximal_set: bool = False,
         schema: Schema | None = None,
-        component_curator: ComponentCurator | None = None,
     ) -> None:
         self._non_validated = None
         self._index = index
@@ -2099,7 +2089,6 @@ class DataFrameCatManager:
             if schema.id is None
             else f"schemas__id={schema.id}",
             schema=schema,
-            features=component_curator.features,
         )
         for feature in self._categoricals:
             result = parse_dtype(feature._dtype_str)[0]

--- a/tests/pydata/test_curator_basics.py
+++ b/tests/pydata/test_curator_basics.py
@@ -519,6 +519,53 @@ def test_curator_partial_null_bool_int():
     count.delete(permanent=True)
 
 
+def test_flexible_schema_schema_feature_takes_precedence():
+    """Schema-defined features must win over flexible-fetched duplicates.
+
+    When a flexible schema has an explicit member (e.g. nucleus_count, nullable=True)
+    and a duplicate feature with the same name but different settings exists in the DB
+    (e.g. nucleus_count, nullable=False), the curator must use the schema's version for
+    validation — not whichever duplicate the broad name-only flexible fetch returns first.
+    """
+    # Schema feature: nucleus_count is int and nullable
+    nucleus_count = ln.Feature(name="nucleus_count", dtype=int, nullable=True).save()
+
+    # Create a duplicate root-level feature with same name but nullable=False.
+    # We bypass the constructor's "existing record" lookup via _skip_validation,
+    # but still go through normal field assignment.
+    duplicate = ln.Feature(
+        name="nucleus_count", dtype=int, nullable=False, _skip_validation=True
+    ).save()
+
+    # Sanity check: we truly have two distinct Feature rows with different nullable settings.
+    features = ln.Feature.filter(name="nucleus_count").to_list()
+    nullable_values = {f.nullable for f in features}
+    assert nullable_values == {True, False}
+
+    schema = ln.Schema(
+        features=[nucleus_count],
+        flexible=True,
+    ).save()
+
+    # Data has a null in nucleus_count — valid only if nullable=True (schema feature) wins
+    df = pd.DataFrame(
+        {
+            "nucleus_count": pd.array([1, None, 3], dtype="Int64"),
+            "extra_col": ["a", "b", "c"],
+        }
+    )
+
+    curator = ln.curators.DataFrameCurator(df, schema)
+    # Should pass: the schema feature (nullable=True) must take precedence over the
+    # duplicate (nullable=False) that the flexible fetch also returns.
+    curator.validate()
+
+    # Clean up
+    schema.delete(permanent=True)
+    nucleus_count.delete(permanent=True)
+    duplicate.delete(permanent=True)
+
+
 def test_pandera_dataframe_schema(
     df,
     df_missing_sample_type_column,


### PR DESCRIPTION
Here we make minor fixes to make sure, if a `schema` with `schema.flexible is True` has feature names identical to concrete features of the schema (those in `schema.members`), the schema members are given precedence. 

Fixes:

- https://github.com/pfizer-collab/laminlabs/issues/1112