### PR TITLE
🦺 Check key on init of `sqlrecord` and saving `artifact`

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -76,6 +76,7 @@ from .sqlrecord import (
     Space,
     SQLRecord,
     _get_record_kwargs,
+    check_key,
 )
 from .storage import Storage
 from .ulabel import ULabel
@@ -3326,6 +3327,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             new_key = self.key
             if new_key is None:
                 raise InvalidArgument("Cannot update an artifact key to None.")
+            check_key(new_key)
             new_key_raw_suffix = CanonicalSuffix.extract_from_path(
                 PurePosixPath(new_key)
             )[1]

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1124,6 +1124,26 @@ class Registry(ModelBase):
         return cls._available_fields
 
 
+def check_key(key: str) -> None:
+    r"""Validate a storage/semantic key.
+
+    A valid key is a non-empty, `/`-separated relative path with no empty
+    segments (no leading/trailing `/`, no `//`), no `\\`, and no `.` or `..`
+    segments (rejects `./`, `/./`, `../`, `/../`, etc.).
+    """
+    if "\\" in key:
+        raise ValueError(f"Backslashes are not allowed in key {key!r}.")
+
+    for segment in key.split("/"):
+        if not segment:
+            raise ValueError(f"Empty segment detected in key {key!r}.")
+
+        if segment in {".", ".."}:
+            raise ValueError(
+                f"Relative path segment {segment!r} detected in key {key!r}."
+            )
+
+
 class BaseSQLRecord(models.Model, metaclass=Registry):
     """Base SQL metadata record.
 
@@ -1163,6 +1183,9 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                 kwargs.pop(fk_id_field, None)
                 return fk_record is not None
 
+            # check key if it is passed
+            if (key := kwargs.get("key")) is not None:
+                check_key(key)
             if not os.getenv("LAMINDB_MULTI_INSTANCE") == "true":
                 if issubclass(self.__class__, SQLRecord):
                     from lamindb import context as run_context

--- a/tests/pydata/test_artifact_basics.py
+++ b/tests/pydata/test_artifact_basics.py
@@ -749,6 +749,18 @@ def test_create_from_dataframe(example_dataframe: pd.DataFrame):
         path.unlink(missing_ok=True)
 
 
+def test_invalid_key_on_artifact_save():
+    artifact = ln.Artifact.from_dataframe(
+        pd.DataFrame({"a": [1]}), key="check-key-ok.parquet"
+    ).save()
+    try:
+        artifact.key = "a/../b"
+        with pytest.raises(ValueError):
+            artifact.save()
+    finally:
+        artifact.delete(permanent=True)
+
+
 def test_dataframe_validate_suffix(example_dataframe: pd.DataFrame):
     df = example_dataframe
     artifact = ln.Artifact.from_dataframe(df, key="test_.parquet")

--- a/tests/pydata/test_sqlrecord.py
+++ b/tests/pydata/test_sqlrecord.py
@@ -14,9 +14,64 @@ from lamindb.models import sqlrecord as sqlrecord_module
 from lamindb.models.sqlrecord import (
     _get_record_kwargs,
     _search,
+    check_key,
     get_name_field,
     suggest_records_with_similar_names,
 )
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "myfile.parquet",
+        "my folder/my file.parquet",
+        "Introduction v2",
+    ],
+)
+def test_check_key_valid(key):
+    check_key(key)
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "",
+        "/",
+        "/a",
+        "a/",
+        "a//b",
+        ".",
+        "..",
+        "./a",
+        "a/./b",
+        "../a",
+        "a/../b",
+        "/../a",
+        r"a\b",
+    ],
+)
+def test_check_key_invalid(key):
+    with pytest.raises(ValueError):
+        check_key(key)
+
+
+def test_invalid_key_on_init():
+    with pytest.raises(ValueError):
+        ln.Transform(key="a/../b")
+    with pytest.raises(ValueError):
+        ln.Transform(key="")
+
+
+def test_invalid_key_on_artifact_save():
+    artifact = ln.Artifact.from_dataframe(
+        pd.DataFrame({"a": [1]}), key="check-key-ok.parquet"
+    ).save()
+    try:
+        artifact.key = "a/../b"
+        with pytest.raises(ValueError):
+            artifact.save()
+    finally:
+        artifact.delete(permanent=True)
 
 
 def test_feature_describe():

--- a/tests/pydata/test_sqlrecord.py
+++ b/tests/pydata/test_sqlrecord.py
@@ -62,18 +62,6 @@ def test_invalid_key_on_init():
         ln.Transform(key="")
 
 
-def test_invalid_key_on_artifact_save():
-    artifact = ln.Artifact.from_dataframe(
-        pd.DataFrame({"a": [1]}), key="check-key-ok.parquet"
-    ).save()
-    try:
-        artifact.key = "a/../b"
-        with pytest.raises(ValueError):
-            artifact.save()
-    finally:
-        artifact.delete(permanent=True)
-
-
 def test_feature_describe():
     description = textwrap.dedent("""\
     Feature


### PR DESCRIPTION
Keys on `sqlrecords` (`artifacts`, `transforms`, etc.) are now validated when set, so unsafe path-like keys are rejected early.

**What’s allowed:** relative, `/`-separated keys such as `myfolder/my file.parquet` or `Introduction v2`.

**What’s rejected:** empty keys, backslashes, leading/trailing/`//` slashes, and `.` / `..` segments (`./`, `../`, `/../`, etc.).

Validation runs on `sqlrecord` creation and when changing an `artifact` `key` on `save`.