### PR TITLE
:children_crossing: Deprecate `Schema.add_optional_feature()` in favor of `Schema.add()`

### DIFF
--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -1453,20 +1453,52 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         """
         return SchemaOptionals(self)
 
-    def add_optional_features(self, features: list[Feature]) -> None:
-        """Add optional features to the schema."""
-        self.features.add(*features)
-        self.optionals.add(features)
+    @staticmethod
+    def _normalize_feature_input(features: Feature | list[Feature]) -> list[Feature]:
+        if not isinstance(features, list):
+            features = [features]
+        if not all(isinstance(feature, Feature) for feature in features):
+            raise TypeError("features must be a Feature or list of Feature records!")
+        return features
+
+    def add(self, features: Feature | list[Feature], optional: bool = True) -> None:
+        """Add one or multiple features to the schema.
+
+        Args:
+            features: The feature or list of features to add.
+            optional: Whether the feature to be added is optional.
+        """
+        if not optional:
+            raise NotImplementedError(
+                "Passing optional=False is currently not supported for `Schema.add()`: "
+                "this could invalidate many artifacts and records, especially if a feature is not nullable."
+            )
+        normalized_features = self._normalize_feature_input(features)
+        self.features.add(*normalized_features)
+        if self.minimal_set is not False:
+            self.optionals.add(normalized_features)
         self.save(print_hash_mutation_warning=False)
 
+    def remove(self, features: Feature | list[Feature]) -> None:
+        """Remove one or multiple features from the schema."""
+        normalized_features = self._normalize_feature_input(features)
+        if self.maximal_set is True:
+            raise NotImplementedError(
+                "Removing features from a schema with `maximal_set=True` is currently not supported: "
+                "this could invalidate many artifacts."
+            )
+        self.features.remove(*normalized_features)
+        self.save(print_hash_mutation_warning=False)
+
+    @deprecated("add")
+    def add_optional_features(self, features: list[Feature]) -> None:
+        """Add optional features to the schema."""
+        self.add(features, optional=True)
+
+    @deprecated("remove")
     def remove_optional_features(self, features: list[Feature]) -> None:
         """Remove optional features from the schema."""
-        optional_features = self.optionals.get()
-        for feature in features:
-            assert feature in optional_features, f"Feature {feature} is not optional"
-        self.features.remove(*features)
-        self.optionals.remove(features)
-        self.save(print_hash_mutation_warning=False)
+        self.remove(features)
 
     @class_and_instance_method
     def describe(

--- a/tests/pydata/test_schema.py
+++ b/tests/pydata/test_schema.py
@@ -467,8 +467,9 @@ def test_schema_add_remove_optional_features_api(
     feature_batch = ln.Feature(name="batch", dtype=str).save()
     schema.add(feature_project)
     assert schema.hash != initial_hash
-    with pytest.raises(ValueError, match="optional=False"):
+    with pytest.raises(NotImplementedError) as error:
         schema.add(feature_program, optional=False)
+    assert "optional=False" in error.exconly()
     schema.add([feature_program])
     schema.remove([feature_project, feature_program])
     assert schema.hash == initial_hash

--- a/tests/pydata/test_schema.py
+++ b/tests/pydata/test_schema.py
@@ -457,14 +457,58 @@ def test_schema_mutations_feature_removal(
     schema.delete(permanent=True)
 
 
-def test_schema_add_remove_optional_features(mini_immuno_schema_flexible: ln.Schema):
+def test_schema_add_remove_optional_features_api(
+    mini_immuno_schema_flexible: ln.Schema,
+):
     schema = mini_immuno_schema_flexible
     initial_hash = schema.hash
     feature_project = ln.Feature(name="project", dtype=ln.Project).save()
-    schema.add_optional_features([feature_project])
+    feature_program = ln.Feature(name="program", dtype=ln.Project).save()
+    feature_batch = ln.Feature(name="batch", dtype=str).save()
+    schema.add(feature_project)
     assert schema.hash != initial_hash
-    schema.remove_optional_features([feature_project])
+    with pytest.raises(ValueError, match="optional=False"):
+        schema.add(feature_program, optional=False)
+    schema.add([feature_program])
+    schema.remove([feature_project, feature_program])
     assert schema.hash == initial_hash
+
+    with pytest.warns(DeprecationWarning):
+        schema.add_optional_features([feature_batch])
+    with pytest.warns(DeprecationWarning):
+        schema.remove_optional_features([feature_batch])
+    assert schema.hash == initial_hash
+
+    feature_project.delete(permanent=True)
+    feature_program.delete(permanent=True)
+    feature_batch.delete(permanent=True)
+
+
+def test_schema_add_remove_optional_features_minimal_set_false(
+    mini_immuno_schema_flexible: ln.Schema,
+):
+    schema = ln.Schema(
+        name="mini_immuno_minimal_set_false",
+        features=list(mini_immuno_schema_flexible.features.all()),
+        minimal_set=False,
+    ).save()
+    initial_hash = schema.hash
+    feature_project = ln.Feature(
+        name="project_minimal_set_false", dtype=ln.Project
+    ).save()
+
+    schema.add(feature_project)
+    assert feature_project in schema.features.all()
+    assert schema.optionals.get_uids() == []
+    assert schema.hash != initial_hash
+
+    schema.remove(feature_project)
+    assert feature_project not in schema.features.all()
+    assert schema.optionals.get_uids() == []
+    assert schema.hash == initial_hash
+
+    feature_project.delete(permanent=True)
+    schema.delete(permanent=True)
 
 
 def test_schema_components(mini_immuno_schema_flexible: ln.Schema):


### PR DESCRIPTION
The old syntax remains available deprecated.