### PR TITLE
🦺 Error for leading slash in key

### DIFF
--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1132,6 +1132,9 @@ def check_key(key: str) -> None:
     if "\\" in key:
         raise ValueError(f"Backslashes are not allowed in key {key!r}.")
 
+    if key.startswith("/"):
+        raise ValueError(f"Key {key!r} should not start with a leading `/`.")
+
     for segment in key.split("/"):
         if not segment:
             raise ValueError(f"Empty segment detected in key {key!r}.")

--- a/tests/pydata/test_sqlrecord.py
+++ b/tests/pydata/test_sqlrecord.py
@@ -60,6 +60,8 @@ def test_invalid_key_on_init():
         ln.Transform(key="a/../b")
     with pytest.raises(ValueError):
         ln.Transform(key="")
+    with pytest.raises(ValueError):
+        ln.Transform(key="/a")
 
 
 def test_feature_describe():


### PR DESCRIPTION
Raise a separate clear error when a key has leading slash instead of raising for an empty segment.