### PR TITLE
🦺 Relax key checks

### DIFF
--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1125,20 +1125,13 @@ class Registry(ModelBase):
 def check_key(key: str) -> None:
     r"""Validate a storage/semantic key.
 
-    A valid key is a non-empty, `/`-separated relative path with no empty
-    segments (no leading/trailing `/`, no `//`), no `\\`, and no `.` or `..`
-    segments (rejects `./`, `/./`, `../`, `/../`, etc.).
+    Rejects backslashes and `.` / `..` path segments (`./`, `/./`, `../`,
+    `/../`, etc.).
     """
     if "\\" in key:
         raise ValueError(f"Backslashes are not allowed in key {key!r}.")
 
-    if key.startswith("/"):
-        raise ValueError(f"Key {key!r} should not start with a leading `/`.")
-
     for segment in key.split("/"):
-        if not segment:
-            raise ValueError(f"Empty segment detected in key {key!r}.")
-
         if segment in {".", ".."}:
             raise ValueError(
                 f"Relative path segment {segment!r} detected in key {key!r}."

--- a/tests/pydata/test_sqlrecord.py
+++ b/tests/pydata/test_sqlrecord.py
@@ -26,6 +26,9 @@ from lamindb.models.sqlrecord import (
         "myfile.parquet",
         "my folder/my file.parquet",
         "Introduction v2",
+        "/a",
+        "a/",
+        "a//b",
     ],
 )
 def test_check_key_valid(key):
@@ -35,11 +38,6 @@ def test_check_key_valid(key):
 @pytest.mark.parametrize(
     "key",
     [
-        "",
-        "/",
-        "/a",
-        "a/",
-        "a//b",
         ".",
         "..",
         "./a",
@@ -58,10 +56,6 @@ def test_check_key_invalid(key):
 def test_invalid_key_on_init():
     with pytest.raises(ValueError):
         ln.Transform(key="a/../b")
-    with pytest.raises(ValueError):
-        ln.Transform(key="")
-    with pytest.raises(ValueError):
-        ln.Transform(key="/a")
 
 
 def test_feature_describe():


### PR DESCRIPTION
Forbid only backslashes and relative segmens (`/./`, `/../`,` ./`,` ../`) in `key`.