### PR TITLE
🐛 Fix error on large uploads and lacking progress print for `gcsfs`

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3428,10 +3428,13 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         else:
             kwargs["transfer"] = transfer
         state_was_adding = self._state.adding
-        print_progress = kwargs.pop("print_progress", True)
         store_kwargs = kwargs.pop(
             "store_kwargs", {}
         )  # kwargs for .upload_from in the end
+        # prefer top-level print_progress; fall back to store_kwargs (popped to avoid double-pass).
+        print_progress = kwargs.pop(
+            "print_progress", store_kwargs.pop("print_progress", True)
+        )
         local_path = None
         if upload and setup_settings.instance.keep_artifacts_local:
             # switch local storage location to cloud


### PR DESCRIPTION
Related https://github.com/laminlabs/lamindb-setup/pull/1375

Fixes an indefinite hang in cloud transfers on jupyter notebooks, where an upload or download would freeze while asyncio logged `AssertionError: Data should not be empty` from `_SelectorSocketTransport._write_send` around 100k times per second.

Both symptoms are one event: when the backend closes a connection mid-request, asyncio can be left with a socket writer registered for an empty write buffer, and `_write_send` asserts before it reaches the code that would unregister it, so the loop re-runs the failing callback forever and starves every other transfer sharing the fsspec IO loop.

The new `lamindb_setup/core/_asyncio_write_spin.py` installs an exception handler that unregisters the stuck writer and aborts the transport, so the interrupted request fails like a normal dropped connection and the backend retries it. It only touches selector loops and this one assertion, so everything else is unaffected.

Reported without a diagnosis in fsspec/gcsfs#604 and fsspec/s3fs#909; a surviving variant of python/cpython#115514 that still reproduces on 3.13.12.