### PR TITLE
♻️ Raising error when loading project with same names

### DIFF
--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1253,6 +1253,15 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                             version_comment = ""
                             existing_record = exact_match
                         if existing_record is not None:
+                            if self.__class__.__name__ == "Project":
+                                raise ValueError(
+                                    f"Project with name '{kwargs[name_field]}' already exists "
+                                    f"(uid='{existing_record.uid}', "
+                                    f"space='{existing_record.space.name}', "
+                                    f"is_type={existing_record.is_type}). "
+                                    f"Load it with ln.Project.get(name='{kwargs[name_field]}') "
+                                    "or choose a different name."
+                                )
                             logger.important(
                                 f"returning {self.__class__.__name__.lower()} with same"
                                 f" {name_field}{version_comment}: '{kwargs[name_field]}'"

--- a/tests/pydata/test_sqlrecord.py
+++ b/tests/pydata/test_sqlrecord.py
@@ -278,6 +278,19 @@ def test_search_and_get(get_search_test_filepaths):
     artifact5.delete(permanent=True, storage=True)
 
 
+def test_project_duplicate_name_raises():
+    project = ln.Project(name="test-duplicate-project-name").save()
+
+    with pytest.raises(ValueError, match="already exists"):
+        ln.Project(name="test-duplicate-project-name").save()
+
+    # explicit load still works
+    loaded = ln.Project.get(name="test-duplicate-project-name")
+    assert loaded.uid == project.uid
+
+    project.delete(permanent=True)
+
+
 def test_suggest_similar_names():
     record1 = ln.Record(name="Test experiment 1").save()
     record2 = ln.Record(name="Test experiment 2").save()


### PR DESCRIPTION
Raise an error when trying to save a project with name that already exists, that points users to ln.Project.get(name=...)
Fixing:pfizer-collab/laminlabs#1139