### PR TITLE
🐛 Fix `schema.slots` when no instance is configured

### DIFF
--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -1411,7 +1411,9 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             return self._slots
         self._slots = {
             link.slot: link.component
-            for link in self.components.through.filter(composite_id=self.id)
+            for link in self.components.through.objects.using(self._state.db).filter(
+                composite_id=self.id
+            )
         }
         return self._slots
 

--- a/tests/no_instance/test_no_default_instance.py
+++ b/tests/no_instance/test_no_default_instance.py
@@ -44,7 +44,7 @@ def test_get_artifact_lamindata():
 
 def test_schema_slots_lamindata():
     db = ln.DB("laminlabs/lamindata")
-    collection = db.Collection.get(key="collection-with-schema")
+    schema = db.Schema.filter().first()
     # should not raise an error that instance is not configured
-    collection.schema.slots  # noqa: B018
-    collection.schema.describe()
+    schema.slots  # noqa: B018
+    schema.describe()

--- a/tests/no_instance/test_no_default_instance.py
+++ b/tests/no_instance/test_no_default_instance.py
@@ -42,7 +42,7 @@ def test_get_artifact_lamindata():
     assert isinstance(artifact.load(), pd.DataFrame)
 
 
-def test_schema_slots():
+def test_schema_slots_lamindata():
     db = ln.DB("laminlabs/lamindata")
     collection = db.Collection.get(key="collection-with-schema")
     # should not raise an error that instance is not configured

--- a/tests/no_instance/test_no_default_instance.py
+++ b/tests/no_instance/test_no_default_instance.py
@@ -40,3 +40,11 @@ def test_get_artifact_lamindata():
         key="example_datasets/small_dataset1.parquet"
     )
     assert isinstance(artifact.load(), pd.DataFrame)
+
+
+def test_schema_slots():
+    db = ln.DB("laminlabs/lamindata")
+    collection = db.Collection.get(key="collection-with-schema")
+    # should not raise an error that instance is not configured
+    collection.schema.slots  # noqa: B018
+    collection.schema.describe()


### PR DESCRIPTION
Fix 
```python
import lamindb as ln

db = ln.DB("laminlabs/lamindata")
collection = db.Collection.get(key="collection-with-schema")
collection.schema.slots
```
resulting into `lamindb_setup.errors.CurrentInstanceNotConfigured: No instance is connected!`
