### PR TITLE
✨ Allow users to move artifacts between managed storages

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1410,7 +1410,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             ),
         ]
 
-    _TRACK_FIELDS = ("space_id", "is_latest", "suffix", "key")
+    _TRACK_FIELDS = ("space_id", "storage_id", "is_latest", "suffix", "key")
 
     _len_full_uid: int = 20
     _len_stem_uid: int = 16
@@ -3314,13 +3314,96 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             )
 
         access_token = kwargs.pop("access_token", None)
-
         current_instance_uid = setup_settings.instance.uid
+        # Handle storage/space moves before key/suffix so path-based renames run
+        # against the final storage location (self.storage/path already reflect a
+        # newly assigned storage before save).
+        # Check storage change before space change. If both change and are consistent,
+        # move here and sync tracked values so the space-change flow below is skipped.
+        if self._field_changed("storage_id"):
+            old_storage_id = self._original_values["storage_id"]
+            new_storage = self.storage
+            if new_storage.space_id != self.space_id:
+                raise ValueError(
+                    "Cannot change the storage of an artifact"
+                    " to a storage location that is not in the same space."
+                )
+            old_storage = Storage.connect(self._state.db).get(id=old_storage_id)
+            if old_storage.instance_uid != current_instance_uid:
+                raise ValueError(
+                    "Cannot change the storage of an artifact"
+                    " in a storage location that is not managed by the current instance."
+                )
+            if new_storage.instance_uid != current_instance_uid:
+                raise ValueError(
+                    "Cannot change the storage of an artifact"
+                    " to a storage location that is not managed by the current instance."
+                )
+            # self.storage is already the target; restore the source for path resolution
+            self.storage_id = old_storage_id
+            _move_artifact_to_storage(self, new_storage, access_token=access_token)
+            # _move_artifact_to_storage sets storage_id to the target; sync so
+            # repeated saves don't re-enter this branch.
+            self._original_values["storage_id"] = self.storage_id
+            # If space changed too and matched the new storage, mark it handled
+            # so the space-change flow below does not run (no storage picker).
+            if self._field_changed("space_id"):
+                self._original_values["space_id"] = self.space_id
 
+        # when space is passed in init, storage is ignored, so space - storage consistency is enforced there
+        # Source storage: storage_id is unchanged here (storage+space was handled above).
         artifact_storage = self.storage
-        artifact_storage_instance_uid = artifact_storage.instance_uid
+        # here we check for storages managed by any instance
+        # not necessarily with managed credentials
+        # we check if the artifact storage is managed by the current instance further
+        if (
+            self._field_changed("space_id")
+            and artifact_storage.instance_uid is not None
+        ):
+            if artifact_storage.instance_uid != current_instance_uid:
+                raise ValueError(
+                    "Cannot change the space of an artifact"
+                    " in a storage location that is not managed by the current instance."
+                )
+            space = self.space
+            storage_type = artifact_storage.type
+            storages = Storage.connect(self._state.db).filter(
+                space=space, instance_uid=current_instance_uid, type=storage_type
+            )
+            n_storages = storages.count()
+            if n_storages == 0:
+                raise ValueError(
+                    f"No {storage_type} storage locations managed by the current instance found for the space '{space.name}'."
+                )
+            elif n_storages > 1:
+                storages = storages.order_by("id")
+                roots_str = "\n".join(
+                    f"{i}: {storage.root}" for i, storage in enumerate(storages)
+                )
+                choice = input(
+                    f"Select a storage location of type '{storage_type}' from the target space '{space.name}':"
+                    f" \n{roots_str}\n"
+                    "Enter the number or 'x' to cancel: "
+                )
+                if choice == "x":
+                    logger.warning("saving was cancelled")
+                    return None
+                storage = storages[int(choice)]
+            else:
+                storage = storages.one()
+            if artifact_storage != storage:
+                # try to transfer if both storages are writable / managed by an instance
+                # replaces artifact.storage with the new storage if successful
+                _move_artifact_to_storage(self, storage, access_token=access_token)
+            else:
+                logger.important("artifact is already in the target storage location")
+            # Keep tracked values in sync after handling a space update so
+            # repeated saves don't keep re-running this branch.
+            self._original_values["space_id"] = self.space_id
+            self._original_values["storage_id"] = self.storage_id
+
         is_not_artifact_storage_managed_by_current_instance = (
-            artifact_storage_instance_uid != current_instance_uid
+            self.storage.instance_uid != current_instance_uid
         )
 
         if self._field_changed("key", check_is_saved=False):
@@ -3371,55 +3454,6 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                 )
             if not _handle_suffix_change_on_save(self):
                 return None
-
-        # when space is passed in init, storage is ignored, so space - storage consistency is enforced there
-        if (
-            self._field_changed("space_id")
-            # here we check for storages managed by any instance
-            # not necessarily with managed credentials
-            # we check if the artifact storage is managed by the current instance further
-            and artifact_storage_instance_uid is not None
-        ):
-            if is_not_artifact_storage_managed_by_current_instance:
-                raise ValueError(
-                    "Cannot change the space of an artifact"
-                    " in a storage location that is not managed by the current instance."
-                )
-            space = self.space
-            storage_type = artifact_storage.type
-            storages = Storage.connect(self._state.db).filter(
-                space=space, instance_uid=current_instance_uid, type=storage_type
-            )
-            n_storages = storages.count()
-            if n_storages == 0:
-                raise ValueError(
-                    f"No {storage_type} storage locations managed by the current instance found for the space '{space.name}'."
-                )
-            elif n_storages > 1:
-                storages = storages.order_by("id")
-                roots_str = "\n".join(
-                    f"{i}: {storage.root}" for i, storage in enumerate(storages)
-                )
-                choice = input(
-                    f"Select a storage location of type '{storage_type}' from the target space '{space.name}':"
-                    f" \n{roots_str}\n"
-                    "Enter the number or 'x' to cancel: "
-                )
-                if choice == "x":
-                    logger.warning("saving was cancelled")
-                    return None
-                storage = storages[int(choice)]
-            else:
-                storage = storages.one()
-            if artifact_storage != storage:
-                # try to transfer if both storages are writable / managed by an instance
-                # replaces artifact.storage with the new storage if successful
-                _move_artifact_to_storage(self, storage, access_token=access_token)
-            else:
-                logger.important("artifact is already in the target storage location")
-            # Keep tracked values in sync after handling a space update so
-            # repeated saves don't keep re-running this branch.
-            self._original_values["space_id"] = self.space_id
 
         if transfer not in {"record", "annotations"}:
             raise ValueError(

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3341,7 +3341,12 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                 )
             # self.storage is already the target; restore the source for path resolution
             self.storage_id = old_storage_id
-            _move_artifact_to_storage(self, new_storage, access_token=access_token)
+            if not _move_artifact_to_storage(
+                self, new_storage, access_token=access_token, ask_to_confirm=True
+            ):
+                # Keep the user's storage assignment if they cancel the move.
+                self.storage_id = new_storage.id
+                return None
             # _move_artifact_to_storage sets storage_id to the target; sync so
             # repeated saves don't re-enter this branch.
             self._original_values["storage_id"] = self.storage_id
@@ -3677,23 +3682,44 @@ def _safe_move(fs: AbstractFileSystem, source: str, target: str):
 
 
 def _move_artifact_to_storage(
-    artifact: Artifact, storage: Storage, access_token: str | None = None
-):
+    artifact: Artifact,
+    storage: Storage,
+    access_token: str | None = None,
+    ask_to_confirm: bool = False,
+) -> bool:
+    """Move an artifact's data to another storage location.
+
+    Resolves the source path from ``artifact`` (so ``artifact.storage`` must still
+    be the source) and the target path under ``storage``, then copies and removes
+    the source. On success, sets ``artifact.storage_id`` to the target.
+
+    Args:
+        artifact: Artifact whose data to move; its current storage is the source.
+        storage: Target storage location.
+        access_token: Optional token for cloud access during the move.
+        ask_to_confirm: If ``True``, prompt before moving; cancel returns ``False``.
+
+    Returns:
+        ``True`` if the move completed, ``False`` if the user cancelled.
+    """
     storage_key = _s().auto_storage_key_from_artifact(artifact)
 
     source_path = artifact.path
     target_path = storage.path / storage_key
-    if source_path == target_path:
+
+    source_path_str = source_path.as_posix()
+    target_path_str = target_path.as_posix()
+    if source_path_str == target_path_str:
         raise ValueError("Cannot move to the same path.")
 
+    if ask_to_confirm and not _confirm_artifact_move(source_path_str, target_path_str):
+        return False
+
     fs = fs_for_moving(source_path, target_path, access_token=access_token)
-
-    source_path_str = str(source_path)
-    target_path_str = str(target_path)
-
     _safe_move(fs, source_path_str, target_path_str)
 
     artifact.storage_id = storage.id
+    return True
 
 
 # can't really just call .cache in .load because of double tracking

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -3353,9 +3353,11 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         # when space is passed in init, storage is ignored, so space - storage consistency is enforced there
         # Source storage: storage_id is unchanged here (storage+space was handled above).
         artifact_storage = self.storage
-        # here we check for storages managed by any instance
-        # not necessarily with managed credentials
-        # we check if the artifact storage is managed by the current instance further
+        # Only run the storage move/picker when the source storage is managed by some
+        # instance. If unmanaged (instance_uid is None), skip this block and allow a
+        # metadata-only space update — no storage transfer is needed.
+        # (instance_uid set means managed by some instance, not necessarily with
+        # writable credentials; we still require current-instance management below.)
         if (
             self._field_changed("space_id")
             and artifact_storage.instance_uid is not None

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -2546,6 +2546,11 @@ def transfer_to_default_db(
         fk_fields = [fk for fk in fk_fields if fk not in FKBULK]
     for fk in fk_fields:
         update_fk_to_default_db(record, fk, using_key, transfer_logs=transfer_logs)
+    # FK ids were remapped to the default DB; drop tracked *_id originals so save
+    # logic does not treat remapping as a user-requested field change.
+    if (original_values := getattr(record, "_original_values", None)) is not None:
+        for key in [key for key in original_values if key.endswith("_id")]:
+            del original_values[key]
     record.id = None
     record._state.db = "default"
     if save:

--- a/tests/pydata/test_artifact_basics.py
+++ b/tests/pydata/test_artifact_basics.py
@@ -2169,6 +2169,46 @@ def test_change_storage_for_artifact_in_foreign_managed_storage_raises_value_err
     source_storage.delete()
 
 
+def test_change_storage_to_foreign_managed_storage_raises_value_error(
+    tsv_file, tmp_path
+):
+    source_root = tmp_path / "storage-change-to-foreign-source"
+    target_root = tmp_path / "storage-change-to-foreign-target"
+    source_root.mkdir()
+    target_root.mkdir()
+    source_storage = ln.Storage(
+        root=source_root.resolve().as_posix(), type="local"
+    ).save()
+    target_storage = ln.Storage(
+        root=target_root.resolve().as_posix(), type="local"
+    ).save()
+    artifact = ln.Artifact(
+        tsv_file,
+        key="storage-change-to-foreign-storage.tsv",
+        storage=source_storage,
+    ).save()
+
+    ln.Storage.filter(id=target_storage.id).update(instance_uid="_not_exists_")
+    target_storage = ln.Storage.get(id=target_storage.id)
+    artifact.storage = target_storage
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Cannot change the storage of an artifact"
+            " to a storage location that is not managed by the current instance."
+        ),
+    ):
+        artifact.save()
+
+    artifact.storage = source_storage
+    artifact.delete(permanent=True)
+    ln.Storage.filter(id=target_storage.id).update(
+        instance_uid=lamindb_setup.settings.instance.uid
+    )
+    target_storage.delete()
+    source_storage.delete()
+
+
 def test_passing_foreign_keys_ids(tsv_file):
     suffix = uuid4().hex[:8]
     transform = ln.Transform(key="test passings foreign keys ids").save()

--- a/tests/pydata/test_artifact_basics.py
+++ b/tests/pydata/test_artifact_basics.py
@@ -2018,7 +2018,8 @@ def test_artifact_storage_change_same_space(tsv_file, tmp_path):
     assert new_storage.space_id == artifact.space_id
 
     artifact.storage = new_storage
-    artifact.save()
+    with patch("builtins.input", return_value="y"):
+        artifact.save()
 
     assert artifact.storage_id == new_storage.id
     assert artifact.storage_id != old_storage_id
@@ -2078,11 +2079,11 @@ def test_artifact_storage_and_space_change_consistent(tsv_file, tmp_path):
 
     artifact.space = space
     artifact.storage = new_storage
-    with patch(
-        "builtins.input",
-        side_effect=AssertionError("space-change flow should be skipped"),
-    ):
+    # Confirm move only — space-change storage picker must not run.
+    with patch("builtins.input", return_value="y") as input_mock:
         artifact.save()
+    assert input_mock.call_count == 1
+    assert "Continue? (y/n)" in input_mock.call_args.args[0]
 
     assert artifact.space_id == space.id
     assert artifact.storage_id == new_storage.id

--- a/tests/pydata/test_artifact_basics.py
+++ b/tests/pydata/test_artifact_basics.py
@@ -2006,6 +2006,166 @@ def test_artifact_space_change(tsv_file):
     space.delete(permanent=True)
 
 
+def test_artifact_storage_change_same_space(tsv_file, tmp_path):
+    artifact = ln.Artifact(tsv_file, key="test_storage_change_same_space.tsv").save()
+    old_path = artifact.path
+    old_storage_id = artifact.storage_id
+    storage_root = tmp_path / "storage-change-same-space"
+    storage_root.mkdir()
+    new_storage = ln.Storage(
+        root=storage_root.resolve().as_posix(), type="local"
+    ).save()
+    assert new_storage.space_id == artifact.space_id
+
+    artifact.storage = new_storage
+    artifact.save()
+
+    assert artifact.storage_id == new_storage.id
+    assert artifact.storage_id != old_storage_id
+    assert not old_path.exists()
+    assert artifact.path.exists()
+    assert artifact.path.as_posix().startswith(artifact.storage.root)
+
+    artifact.delete(permanent=True, storage=True)
+    new_storage.delete()
+
+
+def test_artifact_storage_change_different_space_raises(tsv_file, tmp_path):
+    artifact = ln.Artifact(
+        tsv_file, key="test_storage_change_different_space.tsv"
+    ).save()
+    space = ln.Space(
+        name="test storage change different space", uid="storchgsp1"
+    ).save()
+    storage_root = tmp_path / "storage-change-different-space"
+    storage_root.mkdir()
+    other_storage = ln.Storage(
+        root=storage_root.resolve().as_posix(), type="local"
+    ).save()
+    ln.Storage.filter(id=other_storage.id).update(space_id=space.id)
+    other_storage = ln.Storage.get(id=other_storage.id)
+
+    artifact.storage = other_storage
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Cannot change the storage of an artifact"
+            " to a storage location that is not in the same space."
+        ),
+    ):
+        artifact.save()
+
+    artifact.delete(permanent=True)
+    other_storage.delete()
+    space.delete(permanent=True)
+
+
+def test_artifact_storage_and_space_change_consistent(tsv_file, tmp_path):
+    artifact = ln.Artifact(
+        tsv_file, key="test_storage_and_space_change_consistent.tsv"
+    ).save()
+    old_path = artifact.path
+    space = ln.Space(
+        name="test storage and space change consistent", uid="storchgsp2"
+    ).save()
+    storage_root = tmp_path / "storage-and-space-change-consistent"
+    storage_root.mkdir()
+    new_storage = ln.Storage(
+        root=storage_root.resolve().as_posix(), type="local"
+    ).save()
+    ln.Storage.filter(id=new_storage.id).update(space_id=space.id)
+    new_storage = ln.Storage.get(id=new_storage.id)
+
+    artifact.space = space
+    artifact.storage = new_storage
+    with patch(
+        "builtins.input",
+        side_effect=AssertionError("space-change flow should be skipped"),
+    ):
+        artifact.save()
+
+    assert artifact.space_id == space.id
+    assert artifact.storage_id == new_storage.id
+    assert not old_path.exists()
+    assert artifact.path.exists()
+    assert artifact.path.as_posix().startswith(artifact.storage.root)
+
+    artifact.delete(permanent=True, storage=True)
+    new_storage.delete()
+    space.delete(permanent=True)
+
+
+def test_artifact_storage_and_space_change_inconsistent_raises(tsv_file, tmp_path):
+    artifact = ln.Artifact(
+        tsv_file, key="test_storage_and_space_change_inconsistent.tsv"
+    ).save()
+    space_a = ln.Space(
+        name="test storage and space change inconsistent a", uid="storchgsp3"
+    ).save()
+    space_b = ln.Space(
+        name="test storage and space change inconsistent b", uid="storchgsp4"
+    ).save()
+    storage_root = tmp_path / "storage-and-space-change-inconsistent"
+    storage_root.mkdir()
+    storage_b = ln.Storage(root=storage_root.resolve().as_posix(), type="local").save()
+    ln.Storage.filter(id=storage_b.id).update(space_id=space_b.id)
+    storage_b = ln.Storage.get(id=storage_b.id)
+
+    artifact.space = space_a
+    artifact.storage = storage_b
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Cannot change the storage of an artifact"
+            " to a storage location that is not in the same space."
+        ),
+    ):
+        artifact.save()
+
+    artifact.delete(permanent=True)
+    storage_b.delete()
+    space_a.delete(permanent=True)
+    space_b.delete(permanent=True)
+
+
+def test_change_storage_for_artifact_in_foreign_managed_storage_raises_value_error(
+    tsv_file, tmp_path
+):
+    source_root = tmp_path / "storage-change-foreign-source"
+    target_root = tmp_path / "storage-change-foreign-target"
+    source_root.mkdir()
+    target_root.mkdir()
+    source_storage = ln.Storage(
+        root=source_root.resolve().as_posix(), type="local"
+    ).save()
+    target_storage = ln.Storage(
+        root=target_root.resolve().as_posix(), type="local"
+    ).save()
+    artifact = ln.Artifact(
+        tsv_file,
+        key="storage-change-foreign-storage.tsv",
+        storage=source_storage,
+    ).save()
+
+    ln.Storage.filter(id=source_storage.id).update(instance_uid="_not_exists_")
+    artifact.storage = target_storage
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Cannot change the storage of an artifact"
+            " in a storage location that is not managed by the current instance."
+        ),
+    ):
+        artifact.save()
+
+    ln.Storage.filter(id=source_storage.id).update(
+        instance_uid=lamindb_setup.settings.instance.uid
+    )
+    artifact.delete(permanent=True, storage=True)
+    target_storage.delete()
+    source_storage.delete()
+
+
 def test_passing_foreign_keys_ids(tsv_file):
     suffix = uuid4().hex[:8]
     transform = ln.Transform(key="test passings foreign keys ids").save()

--- a/tests/pydata/test_artifact_basics.py
+++ b/tests/pydata/test_artifact_basics.py
@@ -2031,6 +2031,31 @@ def test_artifact_storage_change_same_space(tsv_file, tmp_path):
     new_storage.delete()
 
 
+def test_artifact_storage_change_cancel_keeps_assignment(tsv_file, tmp_path):
+    artifact = ln.Artifact(tsv_file, key="test_storage_change_cancel.tsv").save()
+    old_path = artifact.path
+    old_storage_id = artifact.storage_id
+    storage_root = tmp_path / "storage-change-cancel"
+    storage_root.mkdir()
+    new_storage = ln.Storage(
+        root=storage_root.resolve().as_posix(), type="local"
+    ).save()
+
+    artifact.storage = new_storage
+    with patch("builtins.input", return_value="n"):
+        assert artifact.save() is None
+
+    # Cancel restores the in-memory target assignment and does not move data.
+    assert artifact.storage_id == new_storage.id
+    assert old_path.exists()
+    artifact_db = ln.Artifact.get(id=artifact.id)
+    assert artifact_db.storage_id == old_storage_id
+
+    artifact.storage = artifact_db.storage
+    artifact.delete(permanent=True)
+    new_storage.delete()
+
+
 def test_artifact_storage_change_different_space_raises(tsv_file, tmp_path):
     artifact = ln.Artifact(
         tsv_file, key="test_storage_change_different_space.tsv"

--- a/tests/pydata/test_artifact_basics.py
+++ b/tests/pydata/test_artifact_basics.py
@@ -2026,7 +2026,7 @@ def test_artifact_storage_change_same_space(tsv_file, tmp_path):
     assert artifact.path.exists()
     assert artifact.path.as_posix().startswith(artifact.storage.root)
 
-    artifact.delete(permanent=True, storage=True)
+    artifact.delete(permanent=True)
     new_storage.delete()
 
 
@@ -2090,7 +2090,7 @@ def test_artifact_storage_and_space_change_consistent(tsv_file, tmp_path):
     assert artifact.path.exists()
     assert artifact.path.as_posix().startswith(artifact.storage.root)
 
-    artifact.delete(permanent=True, storage=True)
+    artifact.delete(permanent=True)
     new_storage.delete()
     space.delete(permanent=True)
 
@@ -2159,12 +2159,12 @@ def test_change_storage_for_artifact_in_foreign_managed_storage_raises_value_err
         artifact.save()
 
     # Failed save leaves the rejected storage on the in-memory object; restore
-    # source storage so delete(storage=True) removes the file from the right root.
+    # source storage so delete removes the file from the right root.
     ln.Storage.filter(id=source_storage.id).update(
         instance_uid=lamindb_setup.settings.instance.uid
     )
     artifact.storage = source_storage
-    artifact.delete(permanent=True, storage=True)
+    artifact.delete(permanent=True)
     target_storage.delete()
     source_storage.delete()
 

--- a/tests/pydata/test_artifact_basics.py
+++ b/tests/pydata/test_artifact_basics.py
@@ -2158,9 +2158,12 @@ def test_change_storage_for_artifact_in_foreign_managed_storage_raises_value_err
     ):
         artifact.save()
 
+    # Failed save leaves the rejected storage on the in-memory object; restore
+    # source storage so delete(storage=True) removes the file from the right root.
     ln.Storage.filter(id=source_storage.id).update(
         instance_uid=lamindb_setup.settings.instance.uid
     )
+    artifact.storage = source_storage
     artifact.delete(permanent=True, storage=True)
     target_storage.delete()
     source_storage.delete()


### PR DESCRIPTION
Artifacts can now be moved between storage locations by assigning `storage` and saving — similar to changing `space`.

### Move between storages

```python
artifact.storage = other_storage  # same space, managed by this instance
artifact.save()  # prompts to confirm, then moves the file
```

Both the current and target storage must be managed by the current instance, and the target must be in the same space as the artifact.

### Change space and storage together

If both are updated consistently, the file is moved once and the interactive storage picker from the space-change flow is skipped:

```python
artifact.space = new_space
artifact.storage = storage_in_new_space
artifact.save()
```

Inconsistent updates error:

```python
artifact.space = space_a
artifact.storage = storage_in_space_b
artifact.save()  # ValueError: ... not in the same space
```

### Cancel

On an explicit storage change, save confirms before moving. Declining leaves data in place and keeps the in-memory assignment:

```python
artifact.storage = other_storage
artifact.save()  # Continue? (y/n) → n → returns None, no move
```