### PR TITLE
🚸 Broaden name deduplication in `HasType` to search the hierarchy if no `type` is passed

### DIFF
--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -182,6 +182,7 @@ from .models import (
     DB,
 )
 from .models.save import save
+from .models.sqlrecord import UNSET
 from . import core
 from . import integrations
 from . import curators

--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -182,7 +182,7 @@ from .models import (
     DB,
 )
 from .models.save import save
-from .models.sqlrecord import UNSET
+from .models.sqlrecord import UNSET, Unset
 from . import core
 from . import integrations
 from . import curators

--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -182,7 +182,7 @@ from .models import (
     DB,
 )
 from .models.save import save
-from .models.sqlrecord import UNSET, Unset
+from .base.types import UNSET, Unset
 from . import core
 from . import integrations
 from . import curators
@@ -231,8 +231,6 @@ __all__ = [
     "examples",
     "errors",
     "setup",
-    # sentinels
-    "Unset",
     # low-level functionality
     "base",
     "core",

--- a/lamindb/__init__.py
+++ b/lamindb/__init__.py
@@ -231,6 +231,8 @@ __all__ = [
     "examples",
     "errors",
     "setup",
+    # sentinels
+    "Unset",
     # low-level functionality
     "base",
     "core",

--- a/lamindb/base/types.py
+++ b/lamindb/base/types.py
@@ -156,7 +156,7 @@ DtypeObject = SimpleDvalue  # backward compat
 class Unset:
     """Sentinel type to distinguish 'not passed' from explicit ``None``.
 
-    The singleton :data:`~lamindb.base.types.UNSET` is the only instance.
+    The singleton ``UNSET`` is the only instance.
     Use ``is`` checks to compare against it::
 
         if value is UNSET:

--- a/lamindb/base/types.py
+++ b/lamindb/base/types.py
@@ -26,8 +26,8 @@ Basic types
 .. autoclass:: ListLike
 .. autoclass:: FieldAttr
 
-Sentinel types
---------------
+Auxiliary types
+---------------
 
 .. autoclass:: Unset
 """
@@ -154,10 +154,10 @@ Dtype = DtypeStr  # backward compat
 DtypeObject = SimpleDvalue  # backward compat
 
 class Unset:
-    """Sentinel type to distinguish 'not passed' from explicit ``None``.
+    """Sentinel type to distinguish 'not passed' from explicit `None`.
 
-    The singleton ``UNSET`` is the only instance.
-    Use ``is`` checks to compare against it::
+    The `UNSET` constant is the only instance.
+    Use `is` checks to compare against it::
 
         if value is UNSET:
             ...  # user did not pass the argument
@@ -167,21 +167,13 @@ class Unset:
             ...  # user passed a real value
     """
 
-    _instance: Unset | None = None
-
-    def __new__(cls) -> Unset:
-        if cls._instance is None:
-            cls._instance = super().__new__(cls)
-        return cls._instance
-
-    def __repr__(self) -> str:
-        return "UNSET"
+    pass
 
 
 UNSET: Unset = Unset()
-"""Sentinel value to distinguish 'argument not passed' from explicit ``None``.
+"""Sentinel value to distinguish 'argument not passed' from explicit `None`.
 
-See :class:`~lamindb.base.types.Unset`.
+See `Unset`.
 """
 
 RegistryId = Literal[

--- a/lamindb/base/types.py
+++ b/lamindb/base/types.py
@@ -25,6 +25,11 @@ Basic types
 .. autoclass:: StrField
 .. autoclass:: ListLike
 .. autoclass:: FieldAttr
+
+Sentinel types
+--------------
+
+.. autoclass:: Unset
 """
 
 from __future__ import annotations
@@ -147,6 +152,37 @@ SimpleDtypeStr = Literal[
 DtypeStr = SimpleDtypeStr  # backward compat
 Dtype = DtypeStr  # backward compat
 DtypeObject = SimpleDvalue  # backward compat
+
+class Unset:
+    """Sentinel type to distinguish 'not passed' from explicit ``None``.
+
+    The singleton :data:`~lamindb.base.types.UNSET` is the only instance.
+    Use ``is`` checks to compare against it::
+
+        if value is UNSET:
+            ...  # user did not pass the argument
+        elif value is None:
+            ...  # user explicitly passed None
+        else:
+            ...  # user passed a real value
+    """
+
+    _instance: Unset | None = None
+
+    def __new__(cls) -> Unset:
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "UNSET"
+
+
+UNSET: Unset = Unset()
+"""Sentinel value to distinguish 'argument not passed' from explicit ``None``.
+
+See :class:`~lamindb.base.types.Unset`.
+"""
 
 RegistryId = Literal[
     "__lamindb_artifact__",

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -43,6 +43,8 @@ from .run import (
     TracksRun,
     TracksUpdates,
 )
+from lamindb.base.types import Unset
+
 from .sqlrecord import (
     UNSET,
     BaseSQLRecord,

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -51,6 +51,7 @@ from .sqlrecord import (
     Space,
     SQLRecord,
     UNSET,
+    Unset,
     _get_record_kwargs,
     pop_space_branch_kwargs,
 )
@@ -671,7 +672,7 @@ def process_init_feature_param(args, kwargs):
     name: str = kwargs.pop("name", None)
     dtype: SimpleDtype | SimpleDtypeStr | str | None = kwargs.pop("dtype", None)
     is_type: bool = kwargs.pop("is_type", False)
-    type_: Feature | str | None = kwargs.pop("type", UNSET)
+    type_: Feature | str | None | Unset = kwargs.pop("type", UNSET)
     description: str | None = kwargs.pop("description", None)
     space_branch_kwargs = pop_space_branch_kwargs(kwargs)
     _skip_validation = kwargs.pop("_skip_validation", False)
@@ -1221,7 +1222,7 @@ class Feature(SQLRecord, HasType, CanCurate, HasSynonyms, TracksRun, TracksUpdat
         | Registry
         | list[Registry]
         | FieldAttr,
-        type: Feature | None = UNSET,
+        type: Feature | None | Unset = UNSET,
         is_type: bool = False,
         unit: str | None = None,
         description: str | None = None,

--- a/lamindb/models/feature.py
+++ b/lamindb/models/feature.py
@@ -1221,7 +1221,7 @@ class Feature(SQLRecord, HasType, CanCurate, HasSynonyms, TracksRun, TracksUpdat
         | Registry
         | list[Registry]
         | FieldAttr,
-        type: Feature | None = None,
+        type: Feature | None = UNSET,
         is_type: bool = False,
         unit: str | None = None,
         description: str | None = None,

--- a/lamindb/models/project.py
+++ b/lamindb/models/project.py
@@ -252,8 +252,7 @@ class Reference(
         if len(args) == len(self._meta.concrete_fields):
             super().__init__(*args, **kwargs)
             return None
-        if len(args) > 0:
-            raise ValueError("Only keyword args allowed")
+        assert not args, "Only keyword args allowed."
         name: str = kwargs.pop("name", None)
         type: Reference | None | Unset = kwargs.pop("type", UNSET)
         is_type: bool = kwargs.pop("is_type", False)
@@ -518,8 +517,7 @@ class Project(
         if len(args) == len(self._meta.concrete_fields):
             super().__init__(*args, **kwargs)
             return None
-        if len(args) > 0:
-            raise ValueError("Only keyword args allowed")
+        assert not args, "Only keyword args allowed."
         name: str = kwargs.pop("name", None)
         type: Project | None | Unset = kwargs.pop("type", UNSET)
         is_type: bool = kwargs.pop("is_type", False)

--- a/lamindb/models/project.py
+++ b/lamindb/models/project.py
@@ -252,7 +252,7 @@ class Reference(
             super().__init__(*args, **kwargs)
             return None
         if len(args) > 0:
-            raise ValueError("Only one non-keyword arg allowed")
+            raise ValueError("Only keyword args allowed")
         name: str = kwargs.pop("name", None)
         type: Reference | None = kwargs.pop("type", UNSET)
         is_type: bool = kwargs.pop("is_type", False)
@@ -518,7 +518,7 @@ class Project(
             super().__init__(*args, **kwargs)
             return None
         if len(args) > 0:
-            raise ValueError("Only one non-keyword arg allowed")
+            raise ValueError("Only keyword args allowed")
         name: str = kwargs.pop("name", None)
         type: Project | None = kwargs.pop("type", UNSET)
         is_type: bool = kwargs.pop("is_type", False)

--- a/lamindb/models/project.py
+++ b/lamindb/models/project.py
@@ -28,7 +28,7 @@ from .has_parents import _query_relatives
 from .record import Record
 from .run import Run, TracksRun, TracksUpdates, User
 from .schema import Schema
-from .sqlrecord import BaseSQLRecord, HasType, IsLink, SQLRecord, ValidateFields
+from .sqlrecord import UNSET, BaseSQLRecord, HasType, IsLink, SQLRecord, ValidateFields
 from .transform import Transform
 from .ulabel import ULabel
 
@@ -217,7 +217,7 @@ class Reference(
     def __init__(
         self,
         name: str,
-        type: Reference | None = None,
+        type: Reference | None = UNSET,
         is_type: bool = False,
         abbr: str | None = None,
         url: str | None = None,
@@ -449,7 +449,7 @@ class Project(
     def __init__(
         self,
         name: str,
-        type: Project | None = None,
+        type: Project | None = UNSET,
         is_type: bool = False,
         abbr: str | None = None,
         url: str | None = None,

--- a/lamindb/models/project.py
+++ b/lamindb/models/project.py
@@ -28,7 +28,18 @@ from .has_parents import _query_relatives
 from .record import Record
 from .run import Run, TracksRun, TracksUpdates, User
 from .schema import Schema
-from .sqlrecord import UNSET, BaseSQLRecord, HasType, IsLink, SQLRecord, ValidateFields
+from lamindb.errors import FieldValidationError
+
+from .sqlrecord import (
+    UNSET,
+    BaseSQLRecord,
+    HasType,
+    IsLink,
+    SQLRecord,
+    ValidateFields,
+    _get_record_kwargs,
+    pop_space_branch_kwargs,
+)
 from .transform import Transform
 from .ulabel import ULabel
 
@@ -237,7 +248,44 @@ class Reference(
     ): ...
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        if len(args) == len(self._meta.concrete_fields):
+            super().__init__(*args, **kwargs)
+            return None
+        if len(args) > 0:
+            raise ValueError("Only one non-keyword arg allowed")
+        name: str = kwargs.pop("name", None)
+        type: Reference | None = kwargs.pop("type", UNSET)
+        is_type: bool = kwargs.pop("is_type", False)
+        abbr: str | None = kwargs.pop("abbr", None)
+        url: str | None = kwargs.pop("url", None)
+        pubmed_id: int | None = kwargs.pop("pubmed_id", None)
+        doi: str | None = kwargs.pop("doi", None)
+        description: str | None = kwargs.pop("description", None)
+        text: str | None = kwargs.pop("text", None)
+        date: DateType | None = kwargs.pop("date", None)
+        space_branch_kwargs = pop_space_branch_kwargs(kwargs)
+        _skip_validation = kwargs.pop("_skip_validation", False)
+        _aux = kwargs.pop("_aux", None)
+        if len(kwargs) > 0:
+            valid_keywords = ", ".join([val[0] for val in _get_record_kwargs(Reference)])
+            raise FieldValidationError(
+                f"Only {valid_keywords} are valid keyword arguments"
+            )
+        super().__init__(
+            name=name,
+            type=type,
+            is_type=is_type,
+            abbr=abbr,
+            url=url,
+            pubmed_id=pubmed_id,
+            doi=doi,
+            description=description,
+            text=text,
+            date=date,
+            _skip_validation=_skip_validation,
+            _aux=_aux,
+            **space_branch_kwargs,
+        )
 
     def query_references(self) -> QuerySet:
         """Query references of sub types.
@@ -466,7 +514,38 @@ class Project(
     ): ...
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        if len(args) == len(self._meta.concrete_fields):
+            super().__init__(*args, **kwargs)
+            return None
+        if len(args) > 0:
+            raise ValueError("Only one non-keyword arg allowed")
+        name: str = kwargs.pop("name", None)
+        type: Project | None = kwargs.pop("type", UNSET)
+        is_type: bool = kwargs.pop("is_type", False)
+        abbr: str | None = kwargs.pop("abbr", None)
+        url: str | None = kwargs.pop("url", None)
+        start_date: DateType | None = kwargs.pop("start_date", None)
+        end_date: DateType | None = kwargs.pop("end_date", None)
+        space_branch_kwargs = pop_space_branch_kwargs(kwargs)
+        _skip_validation = kwargs.pop("_skip_validation", False)
+        _aux = kwargs.pop("_aux", None)
+        if len(kwargs) > 0:
+            valid_keywords = ", ".join([val[0] for val in _get_record_kwargs(Project)])
+            raise FieldValidationError(
+                f"Only {valid_keywords} are valid keyword arguments"
+            )
+        super().__init__(
+            name=name,
+            type=type,
+            is_type=is_type,
+            abbr=abbr,
+            url=url,
+            start_date=start_date,
+            end_date=end_date,
+            _skip_validation=_skip_validation,
+            _aux=_aux,
+            **space_branch_kwargs,
+        )
 
     def query_projects(self) -> QuerySet:
         """Query projects of sub types.

--- a/lamindb/models/project.py
+++ b/lamindb/models/project.py
@@ -30,9 +30,10 @@ from .run import Run, TracksRun, TracksUpdates, User
 from .schema import Schema
 from lamindb.errors import FieldValidationError
 
+from lamindb.base.types import Unset
+
 from .sqlrecord import (
     UNSET,
-    Unset,
     BaseSQLRecord,
     HasType,
     IsLink,

--- a/lamindb/models/project.py
+++ b/lamindb/models/project.py
@@ -32,6 +32,7 @@ from lamindb.errors import FieldValidationError
 
 from .sqlrecord import (
     UNSET,
+    Unset,
     BaseSQLRecord,
     HasType,
     IsLink,
@@ -228,7 +229,7 @@ class Reference(
     def __init__(
         self,
         name: str,
-        type: Reference | None = UNSET,
+        type: Reference | None | Unset = UNSET,
         is_type: bool = False,
         abbr: str | None = None,
         url: str | None = None,
@@ -254,7 +255,7 @@ class Reference(
         if len(args) > 0:
             raise ValueError("Only keyword args allowed")
         name: str = kwargs.pop("name", None)
-        type: Reference | None = kwargs.pop("type", UNSET)
+        type: Reference | None | Unset = kwargs.pop("type", UNSET)
         is_type: bool = kwargs.pop("is_type", False)
         abbr: str | None = kwargs.pop("abbr", None)
         url: str | None = kwargs.pop("url", None)
@@ -497,7 +498,7 @@ class Project(
     def __init__(
         self,
         name: str,
-        type: Project | None = UNSET,
+        type: Project | None | Unset = UNSET,
         is_type: bool = False,
         abbr: str | None = None,
         url: str | None = None,
@@ -520,7 +521,7 @@ class Project(
         if len(args) > 0:
             raise ValueError("Only keyword args allowed")
         name: str = kwargs.pop("name", None)
-        type: Project | None = kwargs.pop("type", UNSET)
+        type: Project | None | Unset = kwargs.pop("type", UNSET)
         is_type: bool = kwargs.pop("is_type", False)
         abbr: str | None = kwargs.pop("abbr", None)
         url: str | None = kwargs.pop("url", None)

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -873,7 +873,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
     def __init__(
         self,
         name: str | None = None,
-        type: Record | None = None,
+        type: Record | None = UNSET,
         is_type: bool = False,
         features: dict[str | Feature, Any] | None = None,
         description: str | None = None,

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -31,6 +31,8 @@ from .query_set import (
     get_default_branch_ids,
 )
 from .run import Run, TracksRun, TracksUpdates, User, current_run, current_user_id
+from lamindb.base.types import Unset
+
 from .sqlrecord import (
     BaseSQLRecord,
     Branch,
@@ -39,7 +41,6 @@ from .sqlrecord import (
     Space,
     SQLRecord,
     UNSET,
-    Unset,
     _get_record_kwargs,
     pop_space_branch_kwargs,
 )

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -39,6 +39,7 @@ from .sqlrecord import (
     Space,
     SQLRecord,
     UNSET,
+    Unset,
     _get_record_kwargs,
     pop_space_branch_kwargs,
 )
@@ -873,7 +874,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
     def __init__(
         self,
         name: str | None = None,
-        type: Record | None = UNSET,
+        type: Record | None | Unset = UNSET,
         is_type: bool = False,
         features: dict[str | Feature, Any] | None = None,
         description: str | None = None,
@@ -901,7 +902,7 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         if len(args) > 0:
             raise ValueError("Only one non-keyword arg allowed")
         name: str = kwargs.pop("name", None)
-        type: str | None = kwargs.pop("type", UNSET)
+        type: Record | None | Unset = kwargs.pop("type", UNSET)
         is_type: bool = kwargs.pop("is_type", False)
         features: dict[str | Feature, Any] | None = kwargs.pop("features", None)
         description: str | None = kwargs.pop("description", None)

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -738,6 +738,8 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             coerce=coerce_dtype,
             n_features=n_features,
         )
+        # pop before update_attributes/super so it never reaches Django fields or getattr
+        type_explicitly_passed = validated_kwargs.pop("_type_explicitly_passed")
         if not features and not slots and not is_type and not itype:
             raise InvalidArgument(
                 "Please pass features or slots or itype or set is_type=True"
@@ -775,7 +777,7 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             validated_kwargs["uid"] = base62_16()
 
         validated_kwargs.update(space_branch_kwargs)
-        super().__init__(**validated_kwargs)
+        super().__init__(**validated_kwargs, _type_explicitly_passed=type_explicitly_passed)
 
     def query_schemas(self) -> QuerySet:
         """Query schemas of sub types.

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -739,7 +739,6 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             n_features=n_features,
         )
         # pop before update_attributes/super so it never reaches Django fields or getattr
-        type_val = validated_kwargs.pop("_type_val")
         if not features and not slots and not is_type and not itype:
             raise InvalidArgument(
                 "Please pass features or slots or itype or set is_type=True"
@@ -777,7 +776,7 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             validated_kwargs["uid"] = base62_16()
 
         validated_kwargs.update(space_branch_kwargs)
-        super().__init__(**validated_kwargs, _type_val=type_val)
+        super().__init__(**validated_kwargs)
 
     def query_schemas(self) -> QuerySet:
         """Query schemas of sub types.
@@ -860,8 +859,7 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         validated_kwargs = {
             "name": name,
             "description": description,
-            "type": None if type is UNSET else type,
-            "_type_val": type,
+            "type": type,
             "is_type": is_type,
             "_dtype_str": dtype,
             "otype": otype,

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -49,6 +49,7 @@ from .sqlrecord import (
     Space,
     SQLRecord,
     UNSET,
+    Unset,
     _get_record_kwargs,
     init_self_from_db,
     pop_space_branch_kwargs,
@@ -631,7 +632,7 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         name: str | None = None,
         description: str | None = None,
         itype: str | Registry | FieldAttr | None = None,
-        type: Schema | None = UNSET,
+        type: Schema | None | Unset = UNSET,
         is_type: bool = False,
         index: Feature | None = None,
         flexible: bool | None = None,
@@ -673,7 +674,7 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         description: str | None = kwargs.pop("description", None)
         itype: str | SQLRecord | DeferredAttribute | None = kwargs.pop("itype", None)
         flexible: bool | None = kwargs.pop("flexible", None)
-        type: Feature | None = kwargs.pop("type", UNSET)
+        type: Feature | None | Unset = kwargs.pop("type", UNSET)
         is_type: bool = kwargs.pop("is_type", False)
         otype: str | None = kwargs.pop("otype", None)
         suffix: str | None = kwargs.pop("suffix", None)

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -859,6 +859,7 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             "name": name,
             "description": description,
             "type": None if type is UNSET else type,
+            "_type_explicitly_passed": type is not UNSET,
             "is_type": is_type,
             "_dtype_str": dtype,
             "otype": otype,

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -739,7 +739,7 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             n_features=n_features,
         )
         # pop before update_attributes/super so it never reaches Django fields or getattr
-        type_explicitly_passed = validated_kwargs.pop("_type_explicitly_passed")
+        type_val = validated_kwargs.pop("_type_val")
         if not features and not slots and not is_type and not itype:
             raise InvalidArgument(
                 "Please pass features or slots or itype or set is_type=True"
@@ -777,7 +777,7 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             validated_kwargs["uid"] = base62_16()
 
         validated_kwargs.update(space_branch_kwargs)
-        super().__init__(**validated_kwargs, _type_explicitly_passed=type_explicitly_passed)
+        super().__init__(**validated_kwargs, _type_val=type_val)
 
     def query_schemas(self) -> QuerySet:
         """Query schemas of sub types.
@@ -861,7 +861,7 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             "name": name,
             "description": description,
             "type": None if type is UNSET else type,
-            "_type_explicitly_passed": type is not UNSET,
+            "_type_val": type,
             "is_type": is_type,
             "_dtype_str": dtype,
             "otype": otype,

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -631,7 +631,7 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         name: str | None = None,
         description: str | None = None,
         itype: str | Registry | FieldAttr | None = None,
-        type: Schema | None = None,
+        type: Schema | None = UNSET,
         is_type: bool = False,
         index: Feature | None = None,
         flexible: bool | None = None,

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -626,15 +626,15 @@ def suggest_records_with_similar_names(
     if isinstance(record, HasType):
         # "type" is always present in kwargs at this point (Solution A contract)
         type = kwargs["type"]
-        if type is None:
-            # explicit type=None → user wants a new root-level record, skip dedup
-            return None
-        elif type is UNSET:
+        if type is UNSET:
             # user passed nothing → search all type contexts
             # catches typed records with same name, fixes silent dup bug
             subset = record.__class__.filter()
+        elif type is None:
+            # explicit type=None → root-level dedup (type IS NULL)
+            subset = record.__class__.filter(type__isnull=True)
         else:
-            # specific type object → search within that type context only
+            # specific type object → scoped dedup within that type
             subset = record.__class__.filter(type=type)
     else:
         subset = record.__class__

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -108,24 +108,8 @@ if TYPE_CHECKING:
 
 T = TypeVar("T", bound="SQLRecord")
 
-class Unset:
-    """Sentinel type to distinguish 'not passed' from explicit ``None``.
+from lamindb.base.types import UNSET, Unset  # noqa: E402
 
-    Use ``is`` checks to compare against the singleton :data:`UNSET`.
-    """
-
-    _instance: Unset | None = None
-
-    def __new__(cls) -> Unset:
-        if cls._instance is None:
-            cls._instance = super().__new__(cls)
-        return cls._instance
-
-    def __repr__(self) -> str:
-        return "UNSET"
-
-
-UNSET: Unset = Unset()
 IPYTHON = getattr(builtins, "__IPYTHON__", False)
 UNIQUE_FIELD_NAMES = {
     "root",

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -114,8 +114,6 @@ class Unset:
     Use ``is`` checks to compare against the singleton :data:`UNSET`.
     """
 
-    __module__ = "lamindb"
-
     _instance: Unset | None = None
 
     def __new__(cls) -> Unset:

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1242,8 +1242,13 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                 from .transform import Transform
 
                 # capture user intent before validate_fields may add type=None
-                type_explicitly_passed = isinstance(self, HasType) and (
-                    "type" in kwargs or "type_id" in kwargs
+                # Schema passes _type_explicitly_passed explicitly because it converts
+                # UNSET→None in validated_kwargs before reaching here
+                type_explicitly_passed = kwargs.pop(
+                    "_type_explicitly_passed",
+                    isinstance(self, HasType) and (
+                        "type" in kwargs or "type_id" in kwargs
+                    ),
                 )
                 validate_fields(self, kwargs)
 

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -108,7 +108,7 @@ if TYPE_CHECKING:
 
 T = TypeVar("T", bound="SQLRecord")
 
-from lamindb.base.types import UNSET, Unset  # noqa: E402
+from lamindb.base.types import UNSET  # noqa: E402
 
 IPYTHON = getattr(builtins, "__IPYTHON__", False)
 UNIQUE_FIELD_NAMES = {
@@ -623,11 +623,11 @@ def suggest_records_with_similar_names(
     # the below needs to be .first() because there might be multiple records with the same
     # name field in case the record is versioned (e.g. for Transform key)
     if isinstance(record, HasType):
-        # "type" is always present in kwargs at this point (Solution A contract)
         type = kwargs["type"]
         if type is UNSET:
             # user passed nothing → search all type contexts
             # catches typed records with same name, fixes silent dup bug
+            logger.warning(f"tip: pass `type` to map {record.__class__.__name__.lower()} into a type hierarchy")
             subset = record.__class__.filter()
         elif type is None:
             # explicit type=None → root-level dedup (type IS NULL)

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -610,7 +610,7 @@ def get_branch_id_for_create(
 
 
 def suggest_records_with_similar_names(
-    record: SQLRecord, name_field: str, kwargs
+    record: SQLRecord, name_field: str, kwargs, type_explicitly_passed: bool = True
 ) -> SQLRecord | None:
     """Returns a record if found exact match, otherwise None.
 
@@ -624,16 +624,21 @@ def suggest_records_with_similar_names(
     # the below needs to be .first() because there might be multiple records with the same
     # name field in case the record is versioned (e.g. for Transform key)
     if isinstance(record, HasType):
-        if "type" not in kwargs:
-            # primary: search root-level (preserves existing behavior)
+        if not type_explicitly_passed:
+            # no type= passed by user: primary search root-level (preserves existing behavior)
             subset = record.__class__.filter(type__isnull=True)
             exact_match = subset.filter(**{name_field: kwargs[name_field]}).first()
             if exact_match is not None:
                 return exact_match
-            # fallback: search across all type contexts to catch typed records
+            # fallback exact match: search across all type contexts to catch typed records
             # with the same name and avoid silent duplicate creation
-            subset = record.__class__
-        elif kwargs["type"] is None:
+            # subset stays root-level for the fuzzy similarity search below (avoid noise)
+            fallback_match = record.__class__.filter(
+                **{name_field: kwargs[name_field]}
+            ).first()
+            if fallback_match is not None:
+                return fallback_match
+        elif kwargs.get("type") is None:
             # explicit type=None → always create new at root, skip dedup
             if not kwargs.get("is_type", False):
                 logger.warning(
@@ -1236,6 +1241,10 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                 from .collection import Collection
                 from .transform import Transform
 
+                # capture user intent before validate_fields may add type=None
+                type_explicitly_passed = isinstance(self, HasType) and (
+                    "type" in kwargs or "type_id" in kwargs
+                )
                 validate_fields(self, kwargs)
 
                 # do not search for names if an id is passed; this is important
@@ -1255,7 +1264,7 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                 ):
                     name_field = getattr(self, "_name_field", "name")
                     exact_match = suggest_records_with_similar_names(
-                        self, name_field, kwargs
+                        self, name_field, kwargs, type_explicitly_passed
                     )
                     if exact_match is not None:
                         if "version_tag" in kwargs:

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -451,7 +451,7 @@ def init_self_from_db(
 
 def update_attributes(record: SQLRecord, attributes: dict[str, str]):
     for key, value in attributes.items():
-        if getattr(record, key) != value and value is not None and value is not UNSET:
+        if value is not None and value is not UNSET and getattr(record, key) != value:
             if key not in {"uid", "_dtype_str", "otype", "hash"}:
                 logger.warning(f"updated {key} from {getattr(record, key)} to {value}")
                 setattr(record, key, value)

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -624,8 +624,17 @@ def suggest_records_with_similar_names(
     # the below needs to be .first() because there might be multiple records with the same
     # name field in case the record is versioned (e.g. for Transform key)
     if isinstance(record, HasType):
-        if kwargs.get("type", None) is None:
-            subset = record.__class__.filter(type__isnull=True)
+        if "type" not in kwargs:
+            # no type passed → search across all type contexts
+            subset = record.__class__
+        elif kwargs["type"] is None:
+            # explicit type=None → always create new at root, skip dedup
+            if not kwargs.get("is_type", False):
+                logger.warning(
+                    f"Creating a root-level {record.__class__.__name__.lower()} without"
+                    " a type. In most cases, objects should be created under a type."
+                )
+            return None
         else:
             subset = record.__class__.filter(type=kwargs["type"])
     else:

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -451,7 +451,7 @@ def init_self_from_db(
 
 def update_attributes(record: SQLRecord, attributes: dict[str, str]):
     for key, value in attributes.items():
-        if getattr(record, key) != value and value is not None:
+        if getattr(record, key) != value and value is not None and value is not UNSET:
             if key not in {"uid", "_dtype_str", "otype", "hash"}:
                 logger.warning(f"updated {key} from {getattr(record, key)} to {value}")
                 setattr(record, key, value)
@@ -610,7 +610,7 @@ def get_branch_id_for_create(
 
 
 def suggest_records_with_similar_names(
-    record: SQLRecord, name_field: str, kwargs, type_val=UNSET
+    record: SQLRecord, name_field: str, kwargs
 ) -> SQLRecord | None:
     """Returns a record if found exact match, otherwise None.
 
@@ -624,17 +624,18 @@ def suggest_records_with_similar_names(
     # the below needs to be .first() because there might be multiple records with the same
     # name field in case the record is versioned (e.g. for Transform key)
     if isinstance(record, HasType):
-        if type_val is None:
-            # explicit type=None → always create new at root, skip dedup
-            if not kwargs.get("is_type", False):
-                logger.warning(
-                    f"Creating a root-level {record.__class__.__name__.lower()} without"
-                    " a type. In most cases, objects should be created under a type."
-                )
-            return None
-        # UNSET: search all type contexts (catches typed records with same name, fixes silent dup bug)
-        # <object>: search within that type context only
-        subset = record.__class__ if type_val is UNSET else record.__class__.filter(type=type_val)
+        # "type" is always present in kwargs at this point (Solution A contract)
+        type = kwargs["type"]
+        if type is UNSET:
+            # user passed nothing → search all type contexts
+            # catches typed records with same name, fixes silent dup bug
+            subset = record.__class__.filter()
+        elif type is None:
+            # explicit type=None → search root-level (type IS NULL)
+            subset = record.__class__.filter(type__isnull=True)
+        else:
+            # specific type → search within that type context only
+            subset = record.__class__.filter(type=type)
     else:
         subset = record.__class__
     exact_match = subset.filter(**{name_field: kwargs[name_field]}).first()
@@ -1169,15 +1170,6 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
 
     def __init__(self, *args, **kwargs):
         skip_validation = kwargs.pop("_skip_validation", False)
-        # capture user intent before stripping: UNSET=not passed, None=explicit None, obj=typed
-        # Schema pre-computes this (converts UNSET→None for hashing) and passes it via _type_val
-        # `is` never calls __eq__, so FeaturePredicate objects are safe
-        if isinstance(self, HasType):
-            type_val = kwargs.pop("_type_val", kwargs.get("type", UNSET))
-            if type_val is UNSET:
-                kwargs.pop("type", None)
-        else:
-            type_val = UNSET
         if not args:
 
             def resolve_fk_or_id(field_name: str) -> bool:
@@ -1226,12 +1218,20 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                     # the current one), so the record is created on that branch.
                     kwargs["created_on"] = kwargs["branch"]
             if skip_validation:
+                # strip UNSET just before Django sees kwargs — FK descriptors reject non-model values
+                if isinstance(self, HasType) and kwargs.get("type", UNSET) is UNSET:
+                    kwargs.pop("type", None)
                 super().__init__(**kwargs)
             else:
                 from ..core._settings import settings
                 from .can_curate import CanCurate
                 from .collection import Collection
                 from .transform import Transform
+
+                # ensure "type" is always present in kwargs for HasType models so that
+                # suggest_records_with_similar_names can use kwargs["type"] unconditionally
+                if isinstance(self, HasType) and "type" not in kwargs:
+                    kwargs["type"] = UNSET
 
                 validate_fields(self, kwargs)
 
@@ -1252,7 +1252,7 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                 ):
                     name_field = getattr(self, "_name_field", "name")
                     exact_match = suggest_records_with_similar_names(
-                        self, name_field, kwargs, type_val
+                        self, name_field, kwargs
                     )
                     if exact_match is not None:
                         if "version_tag" in kwargs:
@@ -1282,6 +1282,9 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                             # track original values after replacing with the existing record
                             self._populate_tracked_fields()
                             return None
+                # strip UNSET just before Django sees kwargs — FK descriptors reject non-model values
+                if isinstance(self, HasType) and kwargs.get("type", UNSET) is UNSET:
+                    kwargs.pop("type", None)
                 super().__init__(**kwargs)
                 if isinstance(self, ValidateFields):
                     # this will trigger validation against django validators

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -114,6 +114,8 @@ class Unset:
     Use ``is`` checks to compare against the singleton :data:`UNSET`.
     """
 
+    __module__ = "lamindb"
+
     _instance: Unset | None = None
 
     def __new__(cls) -> Unset:

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -108,9 +108,24 @@ if TYPE_CHECKING:
 
 T = TypeVar("T", bound="SQLRecord")
 
-# Sentinel to distinguish "user didn't pass type=" from "user explicitly passed type=None".
-# Uses object() so identity checks (is) never call __eq__ on model instances.
-UNSET = object()
+class Unset:
+    """Sentinel type to distinguish 'not passed' from explicit ``None``.
+
+    Use ``is`` checks to compare against the singleton :data:`UNSET`.
+    """
+
+    _instance: Unset | None = None
+
+    def __new__(cls) -> Unset:
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "UNSET"
+
+
+UNSET: Unset = Unset()
 IPYTHON = getattr(builtins, "__IPYTHON__", False)
 UNIQUE_FIELD_NAMES = {
     "root",

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1217,15 +1217,6 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                     # `kwargs["branch"]` is now always a non-None Branch (explicit or
                     # the current one), so the record is created on that branch.
                     kwargs["created_on"] = kwargs["branch"]
-            # HasType models like Record, ULabel, Feature, Schema each explicitly
-            # pop and re-inject "type" (defaulting to UNSET) in their own __init__,
-            # so "type" is already in kwargs for them.
-            # Project and Reference pass kwargs straight through without touching "type",
-            # so we inject UNSET here to uphold the contract that kwargs["type"] is
-            # always readable — and so the strip below can use kwargs["type"] directly.
-            if isinstance(self, HasType) and "type" not in kwargs:
-                kwargs["type"] = UNSET
-
             if skip_validation:
                 # strip UNSET just before Django sees kwargs — FK descriptors reject non-model values
                 if isinstance(self, HasType) and kwargs["type"] is UNSET:

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -638,7 +638,7 @@ def suggest_records_with_similar_names(
             ).first()
             if fallback_match is not None:
                 return fallback_match
-        elif kwargs.get("type") is None:
+        elif "type" in kwargs and kwargs["type"] is None:
             # explicit type=None → always create new at root, skip dedup
             if not kwargs.get("is_type", False):
                 logger.warning(

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -625,7 +625,13 @@ def suggest_records_with_similar_names(
     # name field in case the record is versioned (e.g. for Transform key)
     if isinstance(record, HasType):
         if "type" not in kwargs:
-            # no type passed → search across all type contexts
+            # primary: search root-level (preserves existing behavior)
+            subset = record.__class__.filter(type__isnull=True)
+            exact_match = subset.filter(**{name_field: kwargs[name_field]}).first()
+            if exact_match is not None:
+                return exact_match
+            # fallback: search across all type contexts to catch typed records
+            # with the same name and avoid silent duplicate creation
             subset = record.__class__
         elif kwargs["type"] is None:
             # explicit type=None → always create new at root, skip dedup

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -610,7 +610,7 @@ def get_branch_id_for_create(
 
 
 def suggest_records_with_similar_names(
-    record: SQLRecord, name_field: str, kwargs, type_explicitly_passed: bool = True
+    record: SQLRecord, name_field: str, kwargs, type_val=UNSET
 ) -> SQLRecord | None:
     """Returns a record if found exact match, otherwise None.
 
@@ -624,21 +624,7 @@ def suggest_records_with_similar_names(
     # the below needs to be .first() because there might be multiple records with the same
     # name field in case the record is versioned (e.g. for Transform key)
     if isinstance(record, HasType):
-        if not type_explicitly_passed:
-            # no type= passed by user: primary search root-level (preserves existing behavior)
-            subset = record.__class__.filter(type__isnull=True)
-            exact_match = subset.filter(**{name_field: kwargs[name_field]}).first()
-            if exact_match is not None:
-                return exact_match
-            # fallback exact match: search across all type contexts to catch typed records
-            # with the same name and avoid silent duplicate creation
-            # subset stays root-level for the fuzzy similarity search below (avoid noise)
-            fallback_match = record.__class__.filter(
-                **{name_field: kwargs[name_field]}
-            ).first()
-            if fallback_match is not None:
-                return fallback_match
-        elif "type" in kwargs and kwargs["type"] is None:
+        if type_val is None:
             # explicit type=None → always create new at root, skip dedup
             if not kwargs.get("is_type", False):
                 logger.warning(
@@ -646,8 +632,9 @@ def suggest_records_with_similar_names(
                     " a type. In most cases, objects should be created under a type."
                 )
             return None
-        else:
-            subset = record.__class__.filter(type=kwargs["type"])
+        # UNSET: search all type contexts (catches typed records with same name, fixes silent dup bug)
+        # <object>: search within that type context only
+        subset = record.__class__ if type_val is UNSET else record.__class__.filter(type=type_val)
     else:
         subset = record.__class__
     exact_match = subset.filter(**{name_field: kwargs[name_field]}).first()
@@ -1182,10 +1169,15 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
 
     def __init__(self, *args, **kwargs):
         skip_validation = kwargs.pop("_skip_validation", False)
-        # strip sentinel before validate_fields and Django's Model.__init__ see it
+        # capture user intent before stripping: UNSET=not passed, None=explicit None, obj=typed
+        # Schema pre-computes this (converts UNSET→None for hashing) and passes it via _type_val
         # `is` never calls __eq__, so FeaturePredicate objects are safe
-        if isinstance(self, HasType) and kwargs.get("type", UNSET) is UNSET:
-            kwargs.pop("type", None)
+        if isinstance(self, HasType):
+            type_val = kwargs.pop("_type_val", kwargs.get("type", UNSET))
+            if type_val is UNSET:
+                kwargs.pop("type", None)
+        else:
+            type_val = UNSET
         if not args:
 
             def resolve_fk_or_id(field_name: str) -> bool:
@@ -1241,15 +1233,6 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                 from .collection import Collection
                 from .transform import Transform
 
-                # capture user intent before validate_fields may add type=None
-                # Schema passes _type_explicitly_passed explicitly because it converts
-                # UNSET→None in validated_kwargs before reaching here
-                type_explicitly_passed = kwargs.pop(
-                    "_type_explicitly_passed",
-                    isinstance(self, HasType) and (
-                        "type" in kwargs or "type_id" in kwargs
-                    ),
-                )
                 validate_fields(self, kwargs)
 
                 # do not search for names if an id is passed; this is important
@@ -1269,7 +1252,7 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                 ):
                     name_field = getattr(self, "_name_field", "name")
                     exact_match = suggest_records_with_similar_names(
-                        self, name_field, kwargs, type_explicitly_passed
+                        self, name_field, kwargs, type_val
                     )
                     if exact_match is not None:
                         if "version_tag" in kwargs:

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -626,15 +626,15 @@ def suggest_records_with_similar_names(
     if isinstance(record, HasType):
         # "type" is always present in kwargs at this point (Solution A contract)
         type = kwargs["type"]
-        if type is UNSET:
+        if type is None:
+            # explicit type=None → user wants a new root-level record, skip dedup
+            return None
+        elif type is UNSET:
             # user passed nothing → search all type contexts
             # catches typed records with same name, fixes silent dup bug
             subset = record.__class__.filter()
-        elif type is None:
-            # explicit type=None → search root-level (type IS NULL)
-            subset = record.__class__.filter(type__isnull=True)
         else:
-            # specific type → search within that type context only
+            # specific type object → search within that type context only
             subset = record.__class__.filter(type=type)
     else:
         subset = record.__class__
@@ -1217,21 +1217,25 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                     # `kwargs["branch"]` is now always a non-None Branch (explicit or
                     # the current one), so the record is created on that branch.
                     kwargs["created_on"] = kwargs["branch"]
+            # HasType models like Record, ULabel, Feature, Schema each explicitly
+            # pop and re-inject "type" (defaulting to UNSET) in their own __init__,
+            # so "type" is already in kwargs for them.
+            # Project and Reference pass kwargs straight through without touching "type",
+            # so we inject UNSET here to uphold the contract that kwargs["type"] is
+            # always readable — and so the strip below can use kwargs["type"] directly.
+            if isinstance(self, HasType) and "type" not in kwargs:
+                kwargs["type"] = UNSET
+
             if skip_validation:
                 # strip UNSET just before Django sees kwargs — FK descriptors reject non-model values
-                if isinstance(self, HasType) and kwargs.get("type", UNSET) is UNSET:
-                    kwargs.pop("type", None)
+                if isinstance(self, HasType) and kwargs["type"] is UNSET:
+                    kwargs.pop("type")
                 super().__init__(**kwargs)
             else:
                 from ..core._settings import settings
                 from .can_curate import CanCurate
                 from .collection import Collection
                 from .transform import Transform
-
-                # ensure "type" is always present in kwargs for HasType models so that
-                # suggest_records_with_similar_names can use kwargs["type"] unconditionally
-                if isinstance(self, HasType) and "type" not in kwargs:
-                    kwargs["type"] = UNSET
 
                 validate_fields(self, kwargs)
 
@@ -1283,8 +1287,8 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                             self._populate_tracked_fields()
                             return None
                 # strip UNSET just before Django sees kwargs — FK descriptors reject non-model values
-                if isinstance(self, HasType) and kwargs.get("type", UNSET) is UNSET:
-                    kwargs.pop("type", None)
+                if isinstance(self, HasType) and kwargs["type"] is UNSET:
+                    kwargs.pop("type")
                 super().__init__(**kwargs)
                 if isinstance(self, ValidateFields):
                     # this will trigger validation against django validators

--- a/lamindb/models/ulabel.py
+++ b/lamindb/models/ulabel.py
@@ -224,7 +224,7 @@ class ULabel(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
     def __init__(
         self,
         name: str,
-        type: ULabel | None = None,
+        type: ULabel | None = UNSET,
         is_type: bool = False,
         description: str | None = None,
         reference: str | None = None,

--- a/lamindb/models/ulabel.py
+++ b/lamindb/models/ulabel.py
@@ -26,6 +26,7 @@ from .sqlrecord import (
     IsLink,
     SQLRecord,
     UNSET,
+    Unset,
     _get_record_kwargs,
     pop_space_branch_kwargs,
 )
@@ -224,7 +225,7 @@ class ULabel(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
     def __init__(
         self,
         name: str,
-        type: ULabel | None = UNSET,
+        type: ULabel | None | Unset = UNSET,
         is_type: bool = False,
         description: str | None = None,
         reference: str | None = None,
@@ -250,7 +251,7 @@ class ULabel(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         if len(args) > 0:
             raise ValueError("Only one non-keyword arg allowed")
         name: str = kwargs.pop("name", None)
-        type: str | None = kwargs.pop("type", UNSET)
+        type: ULabel | None | Unset = kwargs.pop("type", UNSET)
         is_type: bool = kwargs.pop("is_type", False)
         description: str | None = kwargs.pop("description", None)
         reference: str | None = kwargs.pop("reference", None)

--- a/lamindb/models/ulabel.py
+++ b/lamindb/models/ulabel.py
@@ -13,6 +13,7 @@ from lamindb.base.fields import (
     ForeignKey,
     TextField,
 )
+from lamindb.base.types import Unset
 from lamindb.errors import FieldValidationError
 
 from ..base.uids import base62_8
@@ -26,7 +27,6 @@ from .sqlrecord import (
     IsLink,
     SQLRecord,
     UNSET,
-    Unset,
     _get_record_kwargs,
     pop_space_branch_kwargs,
 )

--- a/tests/pydata/test_record_basics.py
+++ b/tests/pydata/test_record_basics.py
@@ -1197,7 +1197,7 @@ def test_record_features_add_remove_values():
 
     # test passing ISO-format date string for date
 
-    test_record2 = ln.Record(name="test_record", type=None).save()
+    test_record2 = ln.Record(name="test_record_2").save()
     # we could also test different ways of formatting but don't yet do that
     # in to_dataframe() we enforce ISO format already
     feature_date = ln.Feature.get(name="feature_date")

--- a/tests/pydata/test_record_basics.py
+++ b/tests/pydata/test_record_basics.py
@@ -696,10 +696,18 @@ def test_name_lookup():
     # no type passed, only typed record exists → fallback returns the typed one
     label2 = ln.Record(name="label 1")
     assert label2 == label1
-    # root-level record exists → no-type search finds root first before typed
+    # explicit type=None → always skip dedup, always a new root-level record
+    label_new = ln.Record(name="label 1", type=None)
+    assert label_new != label1
+    assert label_new._state.adding  # not yet saved, truly a new record
+    # explicit type=None, even if a root-level record exists → still skips dedup
     root_label = ln.Record(name="root label 1").save()
-    label3 = ln.Record(name="root label 1")
-    assert label3 == root_label
+    label3 = ln.Record(name="root label 1", type=None)
+    assert label3 != root_label
+    assert label3._state.adding
+    # no type passed, root-level record exists → UNSET → search all → finds root_label
+    label4 = ln.Record(name="root label 1")
+    assert label4 == root_label
     root_label.delete(permanent=True)
     label1.delete(permanent=True)
     my_type.delete(permanent=True)

--- a/tests/pydata/test_record_basics.py
+++ b/tests/pydata/test_record_basics.py
@@ -696,16 +696,15 @@ def test_name_lookup():
     # no type passed, only typed record exists → fallback returns the typed one
     label2 = ln.Record(name="label 1")
     assert label2 == label1
-    # explicit type=None → always skip dedup, always a new root-level record
+    # explicit type=None → root-level dedup: label1 is typed so not found → new record
     label_new = ln.Record(name="label 1", type=None)
     assert label_new != label1
     assert label_new._state.adding  # not yet saved, truly a new record
-    # explicit type=None, even if a root-level record exists → still skips dedup
+    # explicit type=None, root-level record exists → root-level dedup finds it → returns it
     root_label = ln.Record(name="root label 1").save()
     label3 = ln.Record(name="root label 1", type=None)
-    assert label3 != root_label
-    assert label3._state.adding
-    # no type passed, root-level record exists → UNSET → search all → finds root_label
+    assert label3 == root_label
+    # no type passed (UNSET) → search all → finds the existing root-level record
     label4 = ln.Record(name="root label 1")
     assert label4 == root_label
     root_label.delete(permanent=True)

--- a/tests/pydata/test_record_basics.py
+++ b/tests/pydata/test_record_basics.py
@@ -690,14 +690,17 @@ def test_feature_manager_raise_not_validated_values():
 def test_name_lookup():
     my_type = ln.Record(name="MyType", is_type=True).save()
     label1 = ln.Record(name="label 1", type=my_type).save()
+    # same type → returns existing typed record
     label2 = ln.Record(name="label 1", type=my_type)
     assert label2 == label1
+    # no type passed, only typed record exists → fallback returns the typed one
     label2 = ln.Record(name="label 1")
-    assert label2 != label1
-    label2.save()
-    label3 = ln.Record(name="label 1")
-    assert label3 == label2
-    label2.delete(permanent=True)
+    assert label2 == label1
+    # root-level record exists → no-type search finds root first before typed
+    root_label = ln.Record(name="root label 1").save()
+    label3 = ln.Record(name="root label 1")
+    assert label3 == root_label
+    root_label.delete(permanent=True)
     label1.delete(permanent=True)
     my_type.delete(permanent=True)
 
@@ -1194,7 +1197,7 @@ def test_record_features_add_remove_values():
 
     # test passing ISO-format date string for date
 
-    test_record2 = ln.Record(name="test_record").save()
+    test_record2 = ln.Record(name="test_record", type=None).save()
     # we could also test different ways of formatting but don't yet do that
     # in to_dataframe() we enforce ISO format already
     feature_date = ln.Feature.get(name="feature_date")

--- a/tests/pydata/test_sqlrecord.py
+++ b/tests/pydata/test_sqlrecord.py
@@ -402,7 +402,7 @@ def test_get_record_kwargs():
             "dtype",
             "SimpleDtype | SimpleDtypeStr | ULabel | Record | Registry | list[Registry] | FieldAttr",
         ),
-        ("type", "Feature | None"),
+        ("type", "Feature | None | Unset"),
         ("is_type", "bool"),
         ("unit", "str | None"),
         ("description", "str | None"),

--- a/tests/pydata/test_sqlrecord.py
+++ b/tests/pydata/test_sqlrecord.py
@@ -287,10 +287,10 @@ def test_suggest_similar_names():
     assert ln.Record(name="Test experiment 1").uid == record1.uid
 
     assert suggest_records_with_similar_names(
-        record1, "name", {"name": "Test experiment 1"}
+        record1, "name", {"name": "Test experiment 1"}, type_explicitly_passed=False
     )
     assert not suggest_records_with_similar_names(
-        record2, "name", {"name": "Test experiment 123"}
+        record2, "name", {"name": "Test experiment 123"}, type_explicitly_passed=False
     )
 
     queryset = _search(

--- a/tests/pydata/test_sqlrecord.py
+++ b/tests/pydata/test_sqlrecord.py
@@ -288,10 +288,10 @@ def test_suggest_similar_names():
     assert ln.Record(name="Test experiment 1").uid == record1.uid
 
     assert suggest_records_with_similar_names(
-        record1, "name", {"name": "Test experiment 1"}, type_val=UNSET
+        record1, "name", {"name": "Test experiment 1", "type": UNSET}
     )
     assert not suggest_records_with_similar_names(
-        record2, "name", {"name": "Test experiment 123"}, type_val=UNSET
+        record2, "name", {"name": "Test experiment 123", "type": UNSET}
     )
 
     queryset = _search(

--- a/tests/pydata/test_sqlrecord.py
+++ b/tests/pydata/test_sqlrecord.py
@@ -12,6 +12,7 @@ import pytest
 from lamindb.errors import FieldValidationError
 from lamindb.models import sqlrecord as sqlrecord_module
 from lamindb.models.sqlrecord import (
+    UNSET,
     _get_record_kwargs,
     _search,
     check_key,
@@ -287,10 +288,10 @@ def test_suggest_similar_names():
     assert ln.Record(name="Test experiment 1").uid == record1.uid
 
     assert suggest_records_with_similar_names(
-        record1, "name", {"name": "Test experiment 1"}, type_explicitly_passed=False
+        record1, "name", {"name": "Test experiment 1"}, type_val=UNSET
     )
     assert not suggest_records_with_similar_names(
-        record2, "name", {"name": "Test experiment 123"}, type_explicitly_passed=False
+        record2, "name", {"name": "Test experiment 123"}, type_val=UNSET
     )
 
     queryset = _search(


### PR DESCRIPTION
When creating a `HasType` object:

- If no `type` is passed, search across the full type hierarchy.
- If `type` is passed, restrict to the corresponding hierarchy (including `type=None` meaning root).

Also adds a warning when `type=None` is explicitly passed for non-type objects, since root-level creation should be intentional and rare.

```python
>>> import lamindb as ln
>>> ln.ULabel(name="my-test-label")
! tip: pass `type` to map ulabel into a type hierarchy
```

Addresses:

- https://github.com/pfizer-collab/laminlabs/issues/1139