### PR TITLE
🚸 Allow `Artifact` registration also if cloud stats cannot be read

### DIFF
--- a/lamindb/examples/datasets/_core.py
+++ b/lamindb/examples/datasets/_core.py
@@ -371,8 +371,13 @@ def mudata_papalexi21_subset(with_uns: bool = False) -> MuData:
         >>> mdata[:, -300:].copy().write("papalexi21_subset_200x300_lamindb_demo_2023-07-25.h5mu")
     """
     import mudata as md
+    from packaging.version import parse as parse_version
 
-    md.set_options(pull_on_update=False)
+    # mudata 0.4 replaced set_options() with settings; default is already False
+    if parse_version(md.__version__) < parse_version("0.4.0"):
+        md.set_options(pull_on_update=False)
+    else:
+        md.settings.pull_on_update = False
 
     filepath, _ = urlretrieve(
         "https://lamindb-test.s3.amazonaws.com/papalexi21_subset_200x300_lamindb_demo_2023-07-25.h5mu",

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -214,11 +214,6 @@ OUTDATED_ARTIFACT_FILES_OVERWRITTEN_MSG = (
 )
 
 
-def _is_cloud_access_denied(error: OSError) -> bool:
-    # s3fs raises PermissionError; gcsfs raises OSError("Forbidden: ...")
-    return isinstance(error, PermissionError) or "forbidden" in str(error).lower()
-
-
 def process_pathlike(
     filepath: UPath,
     storage: Storage,
@@ -231,7 +226,7 @@ def process_pathlike(
             exists = filepath.exists()
         except OSError as e:
             # PermissionError is an OSError; s3fs raises it, gcsfs uses OSError("Forbidden: ...")
-            if not _is_cloud_access_denied(e):
+            if not isinstance(e, PermissionError) and "forbidden" not in str(e).lower():
                 raise
             logger.warning(f"failed to check existence of {filepath}, proceeding: {e}")
         else:

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -214,6 +214,11 @@ OUTDATED_ARTIFACT_FILES_OVERWRITTEN_MSG = (
 )
 
 
+def _is_cloud_access_denied(error: OSError) -> bool:
+    # s3fs raises PermissionError; gcsfs raises OSError("Forbidden: ...")
+    return isinstance(error, PermissionError) or "forbidden" in str(error).lower()
+
+
 def process_pathlike(
     filepath: UPath,
     storage: Storage,
@@ -223,10 +228,15 @@ def process_pathlike(
     """Determines the appropriate storage for a given path and whether to use an existing storage key."""
     if not skip_existence_check:
         try:  # check if file exists
-            if not filepath.exists():
+            exists = filepath.exists()
+        except OSError as e:
+            # PermissionError is an OSError; s3fs raises it, gcsfs uses OSError("Forbidden: ...")
+            if not _is_cloud_access_denied(e):
+                raise
+            logger.warning(f"failed to check existence of {filepath}, proceeding: {e}")
+        else:
+            if not exists:
                 raise FileNotFoundError(filepath)
-        except PermissionError:
-            pass
     if _s().check_path_is_child_of_root(filepath, storage.root):
         use_existing_storage_key = True
         return storage, use_existing_storage_key

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -396,18 +396,24 @@ def get_stat_or_artifact(
     n_files = None
     if settings.creation.artifact_skip_size_hash:
         return None, None, None, n_files, None
-    stat = path.stat()  # one network request
     if not isinstance(path, LocalPathClasses):
         size, hash, hash_type = None, None, None
-        if stat is not None:
-            # convert UPathStatResult to fsspec info dict
-            stat = stat.as_info()
-            if (store_type := stat["type"]) == "file":
-                size, hash, hash_type = get_stat_file_cloud(
-                    stat, protocol=path.protocol
-                )
-            elif store_type == "directory":
-                size, hash, hash_type, n_files = get_stat_dir_cloud(path)
+        try:
+            stat = path.stat()  # one network request
+            if stat is not None:
+                # convert UPathStatResult to fsspec info dict
+                stat = stat.as_info()
+                if (store_type := stat["type"]) == "file":
+                    size, hash, hash_type = get_stat_file_cloud(
+                        stat, protocol=path.protocol
+                    )
+                elif store_type == "directory":
+                    size, hash, hash_type, n_files = get_stat_dir_cloud(path)
+        except Exception as e:
+            logger.warning(
+                f"failed to retrieve stats for {path}, proceeding without size and hash: {e}"
+            )
+            return None, None, None, None, None
         if hash is None:
             logger.warning(f"did not add hash for {path}")
             return size, hash, hash_type, n_files, None

--- a/tests/pydata/test_artifact_basics.py
+++ b/tests/pydata/test_artifact_basics.py
@@ -41,7 +41,6 @@ from lamindb.errors import (
 from lamindb.models.artifact import (
     data_is_scversedatastructure,
     get_relative_path_to_directory,
-    get_stat_or_artifact,
     process_data,
 )
 from lamindb_setup.core.canonical_suffix import CanonicalSuffix
@@ -150,16 +149,6 @@ def test_cloud_path_init_missing_artifact_raises(monkeypatch):
     with pytest.raises(ValueError) as error:
         ln.Artifact(path, description="test")
     assert error.exconly() == f"ValueError: Artifact for path '{path}' not found."
-
-
-def test_get_stat_or_artifact_cloud_stat_failure_warns(ccaplog):
-    path = UPath("s3://lamindb-ci/test-data/test.csv")
-    with patch.object(path, "stat", side_effect=OSError("network error")):
-        result = get_stat_or_artifact(path, storage=SimpleNamespace())
-    assert result == (None, None, None, None, None)
-    assert "failed to retrieve stats for" in ccaplog.text
-    assert "proceeding without size and hash" in ccaplog.text
-    assert "network error" in ccaplog.text
 
 
 def test_path_init_existing_artifact():

--- a/tests/pydata/test_artifact_basics.py
+++ b/tests/pydata/test_artifact_basics.py
@@ -41,6 +41,7 @@ from lamindb.errors import (
 from lamindb.models.artifact import (
     data_is_scversedatastructure,
     get_relative_path_to_directory,
+    get_stat_or_artifact,
     process_data,
 )
 from lamindb_setup.core.canonical_suffix import CanonicalSuffix
@@ -149,6 +150,16 @@ def test_cloud_path_init_missing_artifact_raises(monkeypatch):
     with pytest.raises(ValueError) as error:
         ln.Artifact(path, description="test")
     assert error.exconly() == f"ValueError: Artifact for path '{path}' not found."
+
+
+def test_get_stat_or_artifact_cloud_stat_failure_warns(ccaplog):
+    path = UPath("s3://lamindb-ci/test-data/test.csv")
+    with patch.object(path, "stat", side_effect=OSError("network error")):
+        result = get_stat_or_artifact(path, storage=SimpleNamespace())
+    assert result == (None, None, None, None, None)
+    assert "failed to retrieve stats for" in ccaplog.text
+    assert "proceeding without size and hash" in ccaplog.text
+    assert "network error" in ccaplog.text
 
 
 def test_path_init_existing_artifact():

--- a/tests/storage/test_artifact_storage.py
+++ b/tests/storage/test_artifact_storage.py
@@ -81,6 +81,33 @@ def test_create_from_remote_path_stat_failure_warns(ccaplog):
     artifact.delete(permanent=True, storage=False)
 
 
+@pytest.mark.parametrize(
+    "error",
+    [
+        PermissionError("Access Denied"),
+        OSError("Forbidden: Request is prohibited by organization's policy."),
+    ],
+)
+def test_create_from_remote_path_exists_access_denied_warns(ccaplog, error):
+    filepath_str = "s3://lamindb-ci/test-data/test.csv"
+    path_cls = type(create_path(filepath_str))
+    with patch.object(path_cls, "exists", side_effect=error):
+        artifact = ln.Artifact(filepath_str, description="test exists access denied")
+    assert artifact.path.as_posix() == filepath_str
+    assert "failed to check existence" in ccaplog.text
+    assert str(error) in ccaplog.text
+    artifact.save()
+    artifact.delete(permanent=True, storage=False)
+
+
+def test_create_from_remote_path_exists_other_oserror_raises():
+    filepath_str = "s3://lamindb-ci/test-data/test.csv"
+    path_cls = type(create_path(filepath_str))
+    with patch.object(path_cls, "exists", side_effect=OSError("network error")):
+        with pytest.raises(OSError, match="network error"):
+            ln.Artifact(filepath_str, description="test exists other oserror")
+
+
 def test_versioning_arifact_from_existing_path(ccaplog):
     artifact1 = ln.Artifact("s3://lamindb-ci/test-data/test.parquet").save()
     artifact2 = ln.Artifact(

--- a/tests/storage/test_artifact_storage.py
+++ b/tests/storage/test_artifact_storage.py
@@ -1,4 +1,5 @@
 import shutil
+from unittest.mock import patch
 
 import anndata as ad
 import lamindb as ln
@@ -6,6 +7,7 @@ import pytest
 from lamindb.errors import (
     IntegrityError,
 )
+from lamindb_setup.core.upath import create_path
 
 
 def test_create_from_anndata_in_existing_cloud_storage():
@@ -57,6 +59,26 @@ def test_create_small_file_from_remote_path(
     ]
     artifact.delete(permanent=True, storage=False)
     ln.settings.creation.artifact_skip_size_hash = False
+
+
+def test_create_from_remote_path_stat_failure_warns(ccaplog):
+    filepath_str = "s3://lamindb-ci/test-data/test.csv"
+    path_cls = type(create_path(filepath_str))
+    with patch.object(path_cls, "stat", side_effect=OSError("network error")):
+        artifact = ln.Artifact(filepath_str, description="test stat failure")
+    assert artifact.hash is None
+    assert artifact.size is None
+    assert artifact._hash_type is None
+    assert artifact.n_files is None
+    assert artifact.path.as_posix() == filepath_str
+    assert "failed to retrieve stats" in ccaplog.text
+    assert "proceeding without size and hash" in ccaplog.text
+    assert "network error" in ccaplog.text
+    artifact.save()
+    loaded = ln.Artifact.get(artifact.uid)
+    assert loaded.hash is None
+    assert loaded.size is None
+    artifact.delete(permanent=True, storage=False)
 
 
 def test_versioning_arifact_from_existing_path(ccaplog):


### PR DESCRIPTION
`Artifact` creation from a cloud path no longer fails when storage is reachable but not fully readable.

If `lamindb` cannot fetch size or hash (network error, access denied, VPC Service Controls, and similar), it logs a warning and still creates the `artifact`, leaving those fields empty.

The same applies to the existence check: `PermissionError` (S3) and `Forbidden` (GCS) warn and continue. A path that is actually missing still raises `FileNotFoundError`.