### PR TITLE
:children_crossing: If a path inside a folder-like artifact is passed to `Artifact()`, return the existing folder-like artifact

### DIFF
--- a/lamindb/core/loaders.py
+++ b/lamindb/core/loaders.py
@@ -29,6 +29,7 @@ from lamindb_setup.core.upath import (
 
 if TYPE_CHECKING:
     from anndata import AnnData
+    from lamindb_setup.core.upath import UPath  # noqa
     from lamindb_setup.types import AnyPathStr
     from mudata import MuData
     from pandas import DataFrame

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -6,7 +6,16 @@ import types
 import warnings
 from collections import defaultdict
 from pathlib import Path, PurePath, PurePosixPath
-from typing import TYPE_CHECKING, Any, Iterator, Literal, TypeVar, Union, overload
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Iterator,
+    Literal,
+    Protocol,
+    TypeVar,
+    Union,
+    overload,
+)
 
 import fsspec
 import lamindb_setup as ln_setup
@@ -1272,14 +1281,25 @@ def _automanaged_folder_parent(path_str: str) -> str | None:
     return path_str[: idx + len_prefix + slash]
 
 
-def _get_artifact_by_automanaged_path(get_fn, path_str: str) -> Artifact:
+class _ArtifactGetByPath(Protocol):
+    def get(self, *, path: str) -> Artifact: ...
+
+
+def _get_artifact_by_automanaged_path(
+    registry_or_queryset: _ArtifactGetByPath, path_str: str
+) -> Artifact:
+    """Look up an artifact by an automanaged `.lamindb/` path.
+
+    `registry_or_queryset` is `Artifact` or `Artifact.connect(slug)`. If the exact path
+    is missing, retries with the `.lamindb/<child>` folder parent (a file inside a folder artifact).
+    """
     try:
-        return get_fn(path=path_str)
+        return registry_or_queryset.get(path=path_str)
     except Artifact.DoesNotExist:
         folder_path = _automanaged_folder_parent(path_str)
         if folder_path is None:
             raise
-        return get_fn(path=folder_path)
+        return registry_or_queryset.get(path=folder_path)
 
 
 class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
@@ -1842,7 +1862,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                     try:
                         # exclude trash?
                         existing_artifact = _get_artifact_by_automanaged_path(
-                            Artifact.get, path_str
+                            Artifact, path_str
                         )
                         logger.important(
                             f"initializing from existing artifact with uid={existing_artifact.uid}"
@@ -1865,7 +1885,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                     try:
                         # exclude trash?
                         existing_artifact = _get_artifact_by_automanaged_path(
-                            Artifact.connect(slug).get, path_str
+                            Artifact.connect(slug), path_str
                         )
                     except Artifact.DoesNotExist as e:
                         raise ValueError(

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1255,6 +1255,29 @@ def _sqlrecord_or_id(
         return model.objects.get(id=sqlrecord_id)
 
 
+def _automanaged_folder_parent(path_str: str) -> str | None:
+    """If `path_str` is nested under `.lamindb/<child>/...`, return that child path."""
+    prefix = _s().AUTO_KEY_PREFIX
+    idx = path_str.find(prefix)
+    if idx == -1:
+        return None
+    rest = path_str[idx + len(prefix) :]
+    slash = rest.find("/")
+    if slash == -1:
+        return None
+    return path_str[: idx + len(prefix) + slash]
+
+
+def _get_artifact_by_automanaged_path(get_fn, path_str: str) -> Artifact:
+    try:
+        return get_fn(path=path_str)
+    except Artifact.DoesNotExist:
+        folder_path = _automanaged_folder_parent(path_str)
+        if folder_path is None:
+            raise
+        return get_fn(path=folder_path)
+
+
 class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
     """Datasets & models stored as files, folders, or arrays.
 
@@ -1814,7 +1837,9 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                     # the query further will still search in the instance managing the storage of the artifact
                     try:
                         # exclude trash?
-                        existing_artifact = Artifact.get(path=path_str)
+                        existing_artifact = _get_artifact_by_automanaged_path(
+                            Artifact.get, path_str
+                        )
                         logger.important(
                             f"initializing from existing artifact with uid={existing_artifact.uid}"
                         )
@@ -1835,7 +1860,9 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                         )
                     try:
                         # exclude trash?
-                        existing_artifact = Artifact.connect(slug).get(path=path_str)
+                        existing_artifact = _get_artifact_by_automanaged_path(
+                            Artifact.connect(slug).get, path_str
+                        )
                     except Artifact.DoesNotExist as e:
                         raise ValueError(
                             f"Artifact for path '{path_str}' not found."

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -1256,16 +1256,20 @@ def _sqlrecord_or_id(
 
 
 def _automanaged_folder_parent(path_str: str) -> str | None:
-    """If `path_str` is nested under `.lamindb/<child>/...`, return that child path."""
+    """If `path_str` is nested under `.lamindb/<child>/...`, return that child path.
+
+    Example: `s3://bucket/.lamindb/{uid}/nested/file.txt` → `s3://bucket/.lamindb/{uid}`.
+    """
     prefix = _s().AUTO_KEY_PREFIX
     idx = path_str.find(prefix)
     if idx == -1:
         return None
-    rest = path_str[idx + len(prefix) :]
+    len_prefix = len(prefix)
+    rest = path_str[idx + len_prefix :]
     slash = rest.find("/")
     if slash == -1:
         return None
-    return path_str[: idx + len(prefix) + slash]
+    return path_str[: idx + len_prefix + slash]
 
 
 def _get_artifact_by_automanaged_path(get_fn, path_str: str) -> Artifact:

--- a/tests/pydata/test_artifact_basics.py
+++ b/tests/pydata/test_artifact_basics.py
@@ -1,7 +1,4 @@
-"""Artifact tests.
-
-Also see `test_artifact_folders.py` for tests of folder-like artifacts.
-"""
+"""Artifact tests."""
 
 # ruff: noqa: F811
 
@@ -149,6 +146,119 @@ def test_cloud_path_init_missing_artifact_raises(monkeypatch):
     with pytest.raises(ValueError) as error:
         ln.Artifact(path, description="test")
     assert error.exconly() == f"ValueError: Artifact for path '{path}' not found."
+
+
+_FOLDER_ARTIFACT_PATHS = [
+    (
+        "s3://my-storage/.lamindb/abcdefghijklmnop/subdir/file.txt",
+        "s3://my-storage/.lamindb/abcdefghijklmnop",
+    ),
+    (
+        "s3://my-storage/.lamindb/abcdefghijklmnop.zarr/group/arr",
+        "s3://my-storage/.lamindb/abcdefghijklmnop.zarr",
+    ),
+]
+
+
+@pytest.mark.parametrize("nested_path,folder_path", _FOLDER_ARTIFACT_PATHS)
+def test_cloud_path_init_file_in_folder_artifact_current_instance(
+    monkeypatch, nested_path, folder_path
+):
+    dummy = SimpleNamespace(uid="abcdefghijklmnop0000")
+    looked_up = []
+
+    def fake_get(cls, idlike=None, **kwargs):
+        path = kwargs.get("path")
+        looked_up.append(path)
+        if path == folder_path:
+            return dummy
+        raise ln.Artifact.DoesNotExist
+
+    inits = []
+
+    monkeypatch.setattr(ln.Artifact, "get", classmethod(fake_get))
+    monkeypatch.setattr(
+        "lamindb.models.sqlrecord.init_self_from_db",
+        lambda self, existing, db="default": inits.append(existing),
+    )
+
+    ln.Artifact(nested_path)
+    assert looked_up == [nested_path, folder_path]
+    assert inits == [dummy]
+
+
+@pytest.mark.parametrize("nested_path,folder_path", _FOLDER_ARTIFACT_PATHS)
+def test_cloud_path_init_file_in_folder_artifact_associated_instance(
+    monkeypatch, nested_path, folder_path
+):
+    dummy = SimpleNamespace(
+        uid="abcdefghijklmnop0000", _state=SimpleNamespace(db="owner/instance")
+    )
+
+    def fake_current_get(cls, idlike=None, **kwargs):
+        raise ln.Artifact.DoesNotExist
+
+    monkeypatch.setattr(ln.Artifact, "get", classmethod(fake_current_get))
+    monkeypatch.setattr(
+        "lamindb.models.artifact.select_storage_or_parent",
+        lambda _: {"instance_uid": "instance-uid", "root": "s3://my-storage"},
+    )
+    monkeypatch.setattr(
+        "lamindb.models.artifact.get_instance_slug_by_uid",
+        lambda _: "owner/instance",
+    )
+
+    looked_up = []
+
+    class DummyConnection:
+        def get(self, **kwargs):
+            path = kwargs.get("path")
+            looked_up.append(path)
+            if path == folder_path:
+                return dummy
+            raise ln.Artifact.DoesNotExist
+
+    monkeypatch.setattr(
+        ln.Artifact,
+        "connect",
+        classmethod(lambda cls, instance: DummyConnection()),
+    )
+    inits = []
+    monkeypatch.setattr(
+        "lamindb.models.sqlrecord.init_self_from_db",
+        lambda self, existing, db="default": inits.append((existing, db)),
+    )
+
+    ln.Artifact(nested_path)
+    assert looked_up == [nested_path, folder_path]
+    assert inits == [(dummy, "owner/instance")]
+
+
+def test_cloud_path_init_file_in_folder_artifact_missing_raises(monkeypatch):
+    nested_path = "s3://my-storage/.lamindb/abcdefghijklmnop/subdir/file.txt"
+    monkeypatch.setattr(
+        "lamindb.models.artifact.select_storage_or_parent",
+        lambda _: {"instance_uid": "instance-uid", "root": "s3://my-storage"},
+    )
+    monkeypatch.setattr(
+        "lamindb.models.artifact.get_instance_slug_by_uid",
+        lambda _: "owner/instance",
+    )
+
+    class DummyConnection:
+        def get(self, **_kwargs):
+            raise ln.Artifact.DoesNotExist
+
+    monkeypatch.setattr(
+        ln.Artifact,
+        "connect",
+        classmethod(lambda cls, instance: DummyConnection()),
+    )
+    with pytest.raises(ValueError) as error:
+        ln.Artifact(nested_path, description="test")
+    assert (
+        error.exconly() == f"ValueError: Artifact for path '{nested_path}' not found."
+    )
 
 
 def test_path_init_existing_artifact():


### PR DESCRIPTION
If a path in `.lamindb/` is provided to `Artifact()` and is already also a child of a folder registered as an `Artifact`, then that folder-like `Artifact` is returned, similar to how an artifact is returned upon matching the full path or a `hash`.

Before this change, a file inside a folder-like artifact under `.lamindb/` did not resolve to that folder. Now `Artifact()` retries the `.lamindb/<child>` parent:

```python
folder = ln.Artifact("./my_folder", key="my_folder").save()
# stored at s3://bucket/.lamindb/{uid}/...

nested = f"{folder.path}/subdir/file.txt"
artifact = ln.Artifact(nested)
assert artifact.uid == folder.uid
```

The same lookup runs in the current database and, if needed, in the storage’s managing database.

Addresses:

-  https://github.com/pfizer-collab/laminlabs/issues/1157