### PR TITLE
:bug: Import `Unset` in `models/schema.py`

### DIFF
--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -19,7 +19,7 @@ from lamindb.base.fields import (
     IntegerField,
     TextField,
 )
-from lamindb.base.types import CanonicalSuffix, FieldAttr, ListLike
+from lamindb.base.types import CanonicalSuffix, FieldAttr, ListLike, Unset
 from lamindb.base.uids import base62_16
 from lamindb.base.utils import class_and_instance_method
 from lamindb.errors import FieldValidationError, InvalidArgument


### PR DESCRIPTION
## Summary

`lamindb/models/schema.py` uses `Unset` in two annotations (the `type` parameter of `Schema.__init__` and a local annotation in `_init_from_kwargs`) but never imports it — ruff flags both as F821. Sibling modules (`models/ulabel.py`, `models/feature.py`) that use the same `Type | None | Unset = UNSET` pattern all import it via `from lamindb.base.types import Unset`.

There's no runtime crash today (parameter annotations are deferred and local-variable annotations are never evaluated), but the missing import breaks `typing.get_type_hints()` on these signatures, mypy, and IDE type resolution.

Fix: added `Unset` to the existing `from lamindb.base.types import ...` line, matching the sibling modules.

## Testing
`python -m py_compile` passes; `ruff check --select F821` on the file goes from 2 errors to clean. No runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)