### PR TITLE
🐛 Fix implicit queries inside an atomic block after a failure

### DIFF
--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1583,15 +1583,14 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                     if is_locked:
                         no_write_msg = "It is not allowed to modify or create locked ('is_locked=True') records."
                     else:
-                        # Use a cached Space only. `self.space` follows the FK
-                        # descriptor and SELECTs. Versioned save() demotes the
-                        # previous head via demote_target.save() inside
-                        # transaction.atomic(), so an RLS failure on that inner
-                        # save is handled while the outer atomic block is still
-                        # open and the connection needs rollback. A SELECT here
-                        # would then raise TransactionManagementError and mask
-                        # NoWriteAccess.
+                        # `self.space` SELECTs via the FK. Skip that inside
+                        # atomic(): versioned save() demotes via a nested
+                        # save() in transaction.atomic(), so an RLS failure is
+                        # handled while the connection still needs rollback.
                         space = self.__dict__.get("space")
+                        conn = transaction.get_connection(self._state.db)
+                        if space is None and not conn.in_atomic_block:
+                            space = getattr(self, "space", None)
                         space_name = getattr(space, "name", None)
                         if space_name:
                             no_write_msg = (

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -650,7 +650,9 @@ def suggest_records_with_similar_names(
         if type is UNSET:
             # user passed nothing → search all type contexts
             # catches typed records with same name, fixes silent dup bug
-            logger.warning(f"tip: pass `type` to map {record.__class__.__name__.lower()} into a type hierarchy")
+            logger.warning(
+                f"tip: pass `type` to map {record.__class__.__name__.lower()} into a type hierarchy"
+            )
             subset = record.__class__.filter()
         elif type is None:
             # explicit type=None → root-level dedup (type IS NULL)
@@ -1575,16 +1577,32 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                     and "new row violates row-level security policy" in error_msg
                     and (
                         (is_locked := getattr(self, "is_locked", False))
-                        or hasattr(self, "space")
+                        or hasattr(self, "space_id")
                     )
                 ):
                     if is_locked:
                         no_write_msg = "It is not allowed to modify or create locked ('is_locked=True') records."
                     else:
-                        no_write_msg = (
-                            f"You're not allowed to write to the space '{self.space.name}'.\n"
-                            "Please contact administrators of the space if you need write access."
-                        )
+                        # Use a cached Space only. `self.space` follows the FK
+                        # descriptor and SELECTs. Versioned save() demotes the
+                        # previous head via demote_target.save() inside
+                        # transaction.atomic(), so an RLS failure on that inner
+                        # save is handled while the outer atomic block is still
+                        # open and the connection needs rollback. A SELECT here
+                        # would then raise TransactionManagementError and mask
+                        # NoWriteAccess.
+                        space = self.__dict__.get("space")
+                        space_name = getattr(space, "name", None)
+                        if space_name:
+                            no_write_msg = (
+                                f"You're not allowed to write to the space '{space_name}'.\n"
+                                "Please contact administrators of the space if you need write access."
+                            )
+                        else:
+                            no_write_msg = (
+                                "You're not allowed to write to this space.\n"
+                                "Please contact administrators of the space if you need write access."
+                            )
                     raise NoWriteAccess(no_write_msg) from None
                 elif (
                     isinstance(e, ProgrammingError)

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1592,7 +1592,7 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
                         if space is None and not conn.in_atomic_block:
                             space = getattr(self, "space", None)
                         space_name = getattr(space, "name", None)
-                        if space_name:
+                        if space_name is not None:
                             no_write_msg = (
                                 f"You're not allowed to write to the space '{space_name}'.\n"
                                 "Please contact administrators of the space if you need write access."

--- a/tests/pydata/test_sqlrecord.py
+++ b/tests/pydata/test_sqlrecord.py
@@ -9,6 +9,8 @@ import bionty as bt
 import lamindb as ln
 import pandas as pd
 import pytest
+from django.db import ProgrammingError
+from django.db.models import Model
 from lamindb.errors import FieldValidationError
 from lamindb.models import sqlrecord as sqlrecord_module
 from lamindb.models.sqlrecord import (
@@ -690,3 +692,27 @@ def test_explicit_default_ids_override_context():
     explicit_main.delete(permanent=True)
     space.delete(permanent=True)
     branch.delete(permanent=True)
+
+
+def test_versioned_save_rls_inside_atomic_raises_no_write_access():
+    # versioned save() demotes the previous head via a nested save() inside
+    # transaction.atomic(); an RLS failure on that inner save must become
+    # NoWriteAccess instead of TransactionManagementError from querying space.
+    transform_v1 = ln.Transform(
+        key="rls-atomic-versioned-save", source_code="print(1)"
+    ).save()
+    transform_v2 = ln.Transform(
+        key="rls-atomic-versioned-save",
+        source_code="print(2)",
+        revises=transform_v1,
+    )
+    rls_error = ProgrammingError(
+        'new row violates row-level security policy for table "lamindb_transform"'
+    )
+    try:
+        with patch.object(Model, "save", side_effect=rls_error):
+            with pytest.raises(ln.errors.NoWriteAccess) as error:
+                transform_v2.save()
+        assert "not allowed to write to this space" in str(error.value)
+    finally:
+        transform_v1.delete(permanent=True)


### PR DESCRIPTION
Fix https://laminlabs.slack.com/archives/C04884ZFESZ/p1783339648198229?thread_ts=1783188145.742009&cid=C04884ZFESZ

- Saving a new version of a record (for example `ln.track()` creating a new `Transform`) demotes the previous head with a nested `save()` inside `transaction.atomic()`. If that update is blocked by row-level security, Postgres raises `ProgrammingError: new row violates row-level security policy`.
- `save()` already maps that error to `NoWriteAccess`, but the handler then evaluated `hasattr(self, "space")`. On a Django FK that is not a cheap existence check: it `SELECT`s `Space`. That query still ran inside the broken atomic block, so Django raised `TransactionManagementError` and hid the original RLS / `NoWriteAccess` error.
- The handler now checks `space_id` instead of `space`, reads a cached `Space` when present, and only loads `self.space` when `connection.in_atomic_block` is false. Inside `atomic()` it falls back to a generic `"this space"` message instead of querying.

