### PR TITLE
:children_crossing: Adding the option to the lightning checkpointing callback to use `key_is_virtual`

### DIFF
--- a/lamindb/integrations/lightning.py
+++ b/lamindb/integrations/lightning.py
@@ -968,7 +968,7 @@ class Checkpoint(ArtifactPublishingModelCheckpoint):
         if self._original_dirpath is not None:
             prefix = str(self._original_dirpath).rstrip("/")
             return f"{prefix}/{run_uid}" if run_uid else prefix
-        if len(trainer.loggers) > 0:
+        if LoggerInfo(trainer).first_logger is not None:
             return self._logger_prefix(trainer, run_uid)
         return run_uid or ""
 
@@ -980,16 +980,17 @@ class Checkpoint(ArtifactPublishingModelCheckpoint):
 
     def _logger_prefix(self, trainer: pl.Trainer, run_uid: str | None) -> str:
         """Derive a key prefix from the trainer's first logger."""
-        assert trainer.loggers, "_logger_prefix requires at least one logger"
-        logger = trainer.loggers[0]
-        save_dir = logger.save_dir or trainer.default_root_dir
-        name = str(logger.name).rstrip("/")
-        if run_uid:
-            version = run_uid
-        else:
-            version = logger.version
-            version = version if isinstance(version, str) else f"version_{version}"
-        return f"{Path(save_dir).name}/{name}/{version.rstrip('/')}"
+        logger_info = LoggerInfo(trainer)
+        assert logger_info.first_logger is not None, (
+            "_logger_prefix requires at least one logger"
+        )
+        assert logger_info.save_dir is not None
+        assert logger_info.name is not None
+        assert logger_info.version is not None
+        save_dir = logger_info.save_dir
+        name = logger_info.name
+        version = run_uid or logger_info.version
+        return f"{save_dir.name}/{name}/{version}"
 
     @property
     def base_prefix(self) -> str:
@@ -1158,11 +1159,8 @@ class Checkpoint(ArtifactPublishingModelCheckpoint):
         if self._hparams_yaml_saved:
             return
 
-        log_dir = trainer.log_dir
-        if not log_dir:
-            return
-
-        hparams_path = Path(log_dir) / "hparams.yaml"
+        log_dir = LoggerInfo(trainer).trainer_log_dir_without_broadcast
+        hparams_path = log_dir / "hparams.yaml"
         if not hparams_path.exists():
             return
 
@@ -1303,17 +1301,9 @@ class SaveConfigCallback(_SaveConfigCallback):
         This method always uses `logger.save_dir` + `name` + `version`,
         giving a consistent directory layout regardless of logger type.
         """
-        if len(trainer.loggers) > 0:
-            first = trainer.loggers[0]
-            save_dir = (
-                first.save_dir
-                if first.save_dir is not None
-                else trainer.default_root_dir
-            )
-            name = first.name
-            version = first.version
-            version = version if isinstance(version, str) else f"version_{version}"
-            return Path(save_dir) / str(name) / version / self.config_filename
+        logger_dir = LoggerInfo(trainer).logger_dir
+        if logger_dir is not None:
+            return logger_dir / self.config_filename
         return Path(trainer.default_root_dir) / self.config_filename
 
     def _save_config(self, trainer: pl.Trainer, config_path: Path) -> None:
@@ -1403,6 +1393,68 @@ class Callback(pl.Callback):
 
         if feature_values:
             artifact.features.add_values(feature_values)
+
+
+class LoggerInfo:
+    """First-logger path metadata without accessing `trainer.log_dir`."""
+
+    def __init__(self, trainer: pl.Trainer):
+        self.trainer = trainer
+        self.first_logger: Any | None = (
+            trainer.loggers[0] if len(trainer.loggers) > 0 else None
+        )
+
+    @property
+    def save_dir(self) -> Path | None:
+        """Return the first logger's save directory."""
+        if self.first_logger is None:
+            return None
+        return Path(
+            getattr(self.first_logger, "save_dir", None)
+            or self.trainer.default_root_dir
+        )
+
+    @property
+    def name(self) -> str | None:
+        """Return the first logger's normalized name."""
+        if self.first_logger is None:
+            return None
+        return str(self.first_logger.name).rstrip("/")
+
+    @property
+    def version(self) -> str | None:
+        """Return the first logger's normalized version."""
+        if self.first_logger is None:
+            return None
+        version = self.first_logger.version
+        return (version if isinstance(version, str) else f"version_{version}").rstrip(
+            "/"
+        )
+
+    @property
+    def logger_dir(self) -> Path | None:
+        """Return ``save_dir/name/version`` for the first logger."""
+        if self.save_dir is None or self.name is None or self.version is None:
+            return None
+        return self.save_dir / self.name / self.version
+
+    @property
+    def trainer_log_dir_without_broadcast(self) -> Path:
+        """Return Lightning's local log directory without calling `trainer.log_dir`.
+
+        `trainer.log_dir` broadcasts the resolved path and therefore must be called
+        on all ranks. Checkpoint artifact side effects run only on global rank zero,
+        so they need a local path derivation that does not perform collectives.
+        """
+        if self.first_logger is not None:
+            log_dir = getattr(self.first_logger, "log_dir", None)
+            if log_dir is not None:
+                return Path(log_dir)
+
+            if self.logger_dir is not None:
+                return self.logger_dir
+
+        return Path(self.trainer.default_root_dir)
 
 
 __all__ = [

--- a/lamindb/integrations/lightning.py
+++ b/lamindb/integrations/lightning.py
@@ -139,7 +139,7 @@ class ArtifactPublisher(Protocol):
         key: str,
         description: str,
         kind: str | None = None,
-        key_is_virtual: bool | None = None,
+        key_is_virtual: bool = False,
         add_as_input_to_run: bool = False,
         skip_hash_lookup: bool = False,
     ) -> Any: ...
@@ -162,13 +162,15 @@ class LaminArtifactPublisher:
         key: str,
         description: str,
         kind: str | None = None,
-        key_is_virtual: bool | None = None,
+        key_is_virtual: bool = False,
         add_as_input_to_run: bool = False,
         skip_hash_lookup: bool = False,
     ) -> ln.Artifact:
-        artifact_kwargs: dict[str, Any] = {"key": key, "description": description}
-        if key_is_virtual is not None:
-            artifact_kwargs["key_is_virtual"] = key_is_virtual
+        artifact_kwargs: dict[str, Any] = {
+            "key": key,
+            "description": description,
+            "key_is_virtual": key_is_virtual,
+        }
         if kind is not None:
             artifact_kwargs["kind"] = kind
         if add_as_input_to_run:

--- a/lamindb/integrations/lightning.py
+++ b/lamindb/integrations/lightning.py
@@ -139,7 +139,7 @@ class ArtifactPublisher(Protocol):
         key: str,
         description: str,
         kind: str | None = None,
-        key_is_virtual: bool = False,
+        key_is_virtual: bool = True,
         add_as_input_to_run: bool = False,
         skip_hash_lookup: bool = False,
     ) -> Any: ...
@@ -162,7 +162,7 @@ class LaminArtifactPublisher:
         key: str,
         description: str,
         kind: str | None = None,
-        key_is_virtual: bool = False,
+        key_is_virtual: bool = True,
         add_as_input_to_run: bool = False,
         skip_hash_lookup: bool = False,
     ) -> ln.Artifact:
@@ -833,7 +833,7 @@ class Checkpoint(ArtifactPublishingModelCheckpoint):
             an extra path segment. Prevents cross-run key collisions.
         key_is_virtual: Whether Lamin should treat checkpoint-related artifact
             keys as virtual keys. Pass `False` to store artifacts directly under
-            the provided key in the configured storage. The default `None`
+            the provided key in the configured storage. The default True
             preserves Lamin's artifact construction default.
         artifact_observers: Optional observer objects notified when checkpoint,
             config, or hparams artifacts are saved or when checkpoint files are
@@ -908,7 +908,7 @@ class Checkpoint(ArtifactPublishingModelCheckpoint):
         save_on_train_epoch_end: bool | None = None,
         enable_version_counter: bool = True,
         run_uid_is_version: bool = True,
-        key_is_virtual: bool | None = None,
+        key_is_virtual: bool = True,
         artifact_observers: list[ArtifactObserver] | None = None,
     ) -> None:
         self._original_dirpath = dirpath

--- a/lamindb/integrations/lightning.py
+++ b/lamindb/integrations/lightning.py
@@ -139,6 +139,7 @@ class ArtifactPublisher(Protocol):
         key: str,
         description: str,
         kind: str | None = None,
+        key_is_virtual: bool | None = None,
         add_as_input_to_run: bool = False,
         skip_hash_lookup: bool = False,
     ) -> Any: ...
@@ -161,10 +162,13 @@ class LaminArtifactPublisher:
         key: str,
         description: str,
         kind: str | None = None,
+        key_is_virtual: bool | None = None,
         add_as_input_to_run: bool = False,
         skip_hash_lookup: bool = False,
     ) -> ln.Artifact:
         artifact_kwargs: dict[str, Any] = {"key": key, "description": description}
+        if key_is_virtual is not None:
+            artifact_kwargs["key_is_virtual"] = key_is_virtual
         if kind is not None:
             artifact_kwargs["kind"] = kind
         if add_as_input_to_run:
@@ -825,6 +829,10 @@ class Checkpoint(ArtifactPublishingModelCheckpoint):
             logger case the logger's auto-incremented version is replaced;
             for the dirpath and no-logger cases the run UID is appended as
             an extra path segment. Prevents cross-run key collisions.
+        key_is_virtual: Whether Lamin should treat checkpoint-related artifact
+            keys as virtual keys. Pass `False` to store artifacts directly under
+            the provided key in the configured storage. The default `None`
+            preserves Lamin's artifact construction default.
         artifact_observers: Optional observer objects notified when checkpoint,
             config, or hparams artifacts are saved or when checkpoint files are
             removed locally. Observers follow :class:`ArtifactObserver` and
@@ -898,6 +906,7 @@ class Checkpoint(ArtifactPublishingModelCheckpoint):
         save_on_train_epoch_end: bool | None = None,
         enable_version_counter: bool = True,
         run_uid_is_version: bool = True,
+        key_is_virtual: bool | None = None,
         artifact_observers: list[ArtifactObserver] | None = None,
     ) -> None:
         self._original_dirpath = dirpath
@@ -920,6 +929,7 @@ class Checkpoint(ArtifactPublishingModelCheckpoint):
         self._feature_annotator = FeatureAnnotator(features)
         self._hparams_yaml_saved = False
         self._run_uid_is_version = run_uid_is_version
+        self._key_is_virtual = key_is_virtual
         self._trainer: pl.Trainer | None = None
         self._artifact_publisher: ArtifactPublisher = LaminArtifactPublisher()
 
@@ -1040,6 +1050,7 @@ class Checkpoint(ArtifactPublishingModelCheckpoint):
             key=key,
             description=description,
             kind=kind,
+            key_is_virtual=self._key_is_virtual,
             add_as_input_to_run=add_as_input_to_run,
             skip_hash_lookup=skip_hash_lookup,
         )

--- a/tests/integrations/test_lightning.py
+++ b/tests/integrations/test_lightning.py
@@ -708,6 +708,43 @@ def test_checkpoint_hparams_yaml_with_hparams(
     shutil.rmtree(tmp_path / "test_logs", ignore_errors=True)
 
 
+def test_checkpoint_hparams_yaml_does_not_call_trainer_log_dir(
+    dirpath: str,
+    tmp_path: Path,
+):
+    """Checkpoint should avoid trainer.log_dir while saving hparams.yaml."""
+    from lightning.pytorch.loggers import CSVLogger
+
+    class TrainerStub:
+        def __init__(self, logger: CSVLogger, default_root_dir: Path):
+            self.loggers = [logger]
+            self.default_root_dir = default_root_dir
+
+        @property
+        def log_dir(self) -> str:
+            raise AssertionError("trainer.log_dir must not be called")
+
+    logger = CSVLogger(save_dir=tmp_path, name="test_logs")
+    hparams_path = Path(logger.log_dir) / "hparams.yaml"
+    hparams_path.parent.mkdir(parents=True, exist_ok=True)
+    hparams_path.write_text("hidden_size: 64\n")
+
+    callback = ll.Checkpoint(
+        dirpath=dirpath, monitor="train_loss", run_uid_is_version=False
+    )
+    trainer = cast("pl.Trainer", TrainerStub(logger, tmp_path))
+    callback._save_hparams_yaml(trainer)
+
+    hparams_key = f"{dirpath.rstrip('/')}/checkpoints/hparams.yaml"
+    hparams_artifact = ln.Artifact.filter(key=hparams_key).one_or_none()
+
+    assert hparams_artifact is not None
+    assert callback.last_hparams_artifact == hparams_artifact
+
+    hparams_artifact.delete(permanent=True)
+    shutil.rmtree(tmp_path / "test_logs", ignore_errors=True)
+
+
 @pytest.mark.parametrize(
     ("use_dirpath", "use_logger"),
     [

--- a/tests/integrations/test_lightning.py
+++ b/tests/integrations/test_lightning.py
@@ -1147,7 +1147,6 @@ def test_save_config_artifact_tracked_as_run_input(
 
 
 def test_checkpoint_forwards_key_is_virtual_to_artifact_publisher(
-    instance,
     dirpath: str,
     tmp_path: Path,
 ):

--- a/tests/integrations/test_lightning.py
+++ b/tests/integrations/test_lightning.py
@@ -1146,6 +1146,46 @@ def test_save_config_artifact_tracked_as_run_input(
     ln.finish()
 
 
+def test_checkpoint_forwards_key_is_virtual_to_artifact_publisher(
+    instance,
+    dirpath: str,
+    tmp_path: Path,
+):
+    """Checkpoint should pass explicit key virtuality to its artifact publisher."""
+
+    class RecordingPublisher:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        def create_artifact(self, local_path: Path | str, **kwargs: Any) -> Any:
+            self.calls.append({"local_path": local_path, **kwargs})
+            return MagicMock(path="s3://bucket/config.yaml")
+
+        def storage_uri(self, artifact: Any) -> str:
+            return str(artifact.path)
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("trainer:\n  max_epochs: 1\n", encoding="utf-8")
+    checkpoint = ll.Checkpoint(dirpath=dirpath, key_is_virtual=False)
+    publisher = RecordingPublisher()
+    checkpoint._artifact_publisher = publisher
+    trainer = MagicMock(loggers=[])
+
+    checkpoint.save_config_artifact(trainer, config_path)
+
+    assert publisher.calls == [
+        {
+            "local_path": config_path,
+            "key": f"{dirpath.rstrip('/')}/config.yaml",
+            "description": "Lightning CLI config",
+            "kind": "config",
+            "key_is_virtual": False,
+            "add_as_input_to_run": True,
+            "skip_hash_lookup": True,
+        }
+    ]
+
+
 def test_checkpoint_subclass_receives_artifact_events(
     dataloader: DataLoader,
     dirpath: str,

--- a/tests/integrations/test_lightning.py
+++ b/tests/integrations/test_lightning.py
@@ -1202,7 +1202,7 @@ def test_checkpoint_forwards_key_is_virtual_to_artifact_publisher(
 
     config_path = tmp_path / "config.yaml"
     config_path.write_text("trainer:\n  max_epochs: 1\n", encoding="utf-8")
-    checkpoint = ll.Checkpoint(dirpath=dirpath, key_is_virtual=True)
+    checkpoint = ll.Checkpoint(dirpath=dirpath, key_is_virtual=False)
     publisher = RecordingPublisher()
     checkpoint._artifact_publisher = publisher
     trainer = MagicMock(loggers=[])
@@ -1215,7 +1215,7 @@ def test_checkpoint_forwards_key_is_virtual_to_artifact_publisher(
             "key": f"{dirpath.rstrip('/')}/config.yaml",
             "description": "Lightning CLI config",
             "kind": "config",
-            "key_is_virtual": True,
+            "key_is_virtual": False,
             "add_as_input_to_run": True,
             "skip_hash_lookup": True,
         }

--- a/tests/integrations/test_lightning.py
+++ b/tests/integrations/test_lightning.py
@@ -1166,7 +1166,7 @@ def test_checkpoint_forwards_key_is_virtual_to_artifact_publisher(
 
     config_path = tmp_path / "config.yaml"
     config_path.write_text("trainer:\n  max_epochs: 1\n", encoding="utf-8")
-    checkpoint = ll.Checkpoint(dirpath=dirpath, key_is_virtual=False)
+    checkpoint = ll.Checkpoint(dirpath=dirpath, key_is_virtual=True)
     publisher = RecordingPublisher()
     checkpoint._artifact_publisher = publisher
     trainer = MagicMock(loggers=[])
@@ -1179,7 +1179,7 @@ def test_checkpoint_forwards_key_is_virtual_to_artifact_publisher(
             "key": f"{dirpath.rstrip('/')}/config.yaml",
             "description": "Lightning CLI config",
             "kind": "config",
-            "key_is_virtual": False,
+            "key_is_virtual": True,
             "add_as_input_to_run": True,
             "skip_hash_lookup": True,
         }


### PR DESCRIPTION
This pull request refactors the Lightning integration in `lamindb` to improve how logger directory metadata is handled and adds more explicit control over artifact key virtuality. The changes introduce a new `LoggerInfo` helper class to consistently and safely access logger paths, and ensure that the `key_is_virtual` flag is properly propagated through artifact creation. Additional tests are provided to verify these behaviors.

**Logger directory handling improvements:**

* Introduced the `LoggerInfo` helper class to encapsulate logic for accessing the first logger's `save_dir`, `name`, `version`, and derived paths, avoiding direct use of `trainer.log_dir` and improving robustness in multi-rank settings. (`lamindb/integrations/lightning.py`)
* Refactored methods such as `_base_prefix`, `_logger_prefix`, `_save_hparams_yaml`, and `_config_path` to use `LoggerInfo` for consistent and safe path resolution, replacing direct attribute access and logic duplication. (`lamindb/integrations/lightning.py`) [[1]](diffhunk://#diff-29121641debb275a774528a5ede40e8bbb31c2a81c136738e9dd0dcf6ce26941L959-R971) [[2]](diffhunk://#diff-29121641debb275a774528a5ede40e8bbb31c2a81c136738e9dd0dcf6ce26941L971-R993) [[3]](diffhunk://#diff-29121641debb275a774528a5ede40e8bbb31c2a81c136738e9dd0dcf6ce26941L1148-R1163) [[4]](diffhunk://#diff-29121641debb275a774528a5ede40e8bbb31c2a81c136738e9dd0dcf6ce26941L1293-R1306)
* Does not call trainer.log_dir anymore when trying to find/save the hparams.yml file. This caused a hard to find bug where the training hangs in DDP. The property on the Trainer class actually has a comment in the docstring about this, but it is easily missed: https://github.com/Lightning-AI/pytorch-lightning/blob/9fed5c27d2a62ff0efd6c3573599921d6ff67c14/src/lightning/pytorch/trainer/trainer.py#L1320

**Artifact key virtuality:**

* Added the `key_is_virtual` parameter to artifact creation methods and the `Checkpoint` callback, ensuring it is passed through to the artifact publisher and allowing users to control whether artifacts are stored under virtual or physical keys. (`lamindb/integrations/lightning.py`) [[1]](diffhunk://#diff-29121641debb275a774528a5ede40e8bbb31c2a81c136738e9dd0dcf6ce26941R142) [[2]](diffhunk://#diff-29121641debb275a774528a5ede40e8bbb31c2a81c136738e9dd0dcf6ce26941R165-R173) [[3]](diffhunk://#diff-29121641debb275a774528a5ede40e8bbb31c2a81c136738e9dd0dcf6ce26941R834-R837) [[4]](diffhunk://#diff-29121641debb275a774528a5ede40e8bbb31c2a81c136738e9dd0dcf6ce26941R911) [[5]](diffhunk://#diff-29121641debb275a774528a5ede40e8bbb31c2a81c136738e9dd0dcf6ce26941R934) [[6]](diffhunk://#diff-29121641debb275a774528a5ede40e8bbb31c2a81c136738e9dd0dcf6ce26941R1056)

**Testing enhancements:**

* Added tests to verify that `Checkpoint` avoids calling `trainer.log_dir` when saving `hparams.yaml`, and that the `key_is_virtual` flag is correctly forwarded to the artifact publisher. (`tests/integrations/test_lightning.py`) [[1]](diffhunk://#diff-d3c46aee295a155df51c05f6c73751864a0fc54f779c9a3008cf094d0412fbd2R711-R747) [[2]](diffhunk://#diff-d3c46aee295a155df51c05f6c73751864a0fc54f779c9a3008cf094d0412fbd2R1186-R1224)