### PR TITLE
🐛 Repair missing artifact storage on duplicate upload

### DIFF
--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -667,19 +667,38 @@ def get_artifact_kwargs_from_data(
     }
     if isinstance(stat_or_artifact, Artifact):
         existing_artifact = stat_or_artifact
-        # if the artifact was unsuccessfully saved, we want to
-        # enable re-uploading after returning the artifact object
-        # the upload is triggered by whether the privates are returned
-        if existing_artifact._storage_ongoing or not existing_artifact.path.exists():
-            privates["key"] = key
-            returned_privates = privates  # upload or repair necessary
-        else:
-            returned_privates = {"key": key}
-        returned_privates["is_artifact_storage_managed_by_current_instance"] = (
+        storage_object_exists = existing_artifact.path.exists()
+        storage_is_managed = (
             existing_artifact.storage.instance_uid == setup_settings.instance.uid
         )
-        return existing_artifact, returned_privates
-    else:
+        # A record in foreign/read-only storage cannot be repaired by this instance.
+        # Ignore that hash match and construct a writable artifact instead.
+        if not storage_object_exists and not storage_is_managed:
+            stat_or_artifact = get_stat_or_artifact(
+                path=path,
+                storage=storage,
+                key=key,
+                instance=using,
+                is_replace=is_replace,
+                skip_hash_lookup=True,
+                skip_key_revises_lookup=skip_key_revises_lookup,
+                target_branch_id=target_branch_id,
+            )
+        else:
+            # if the artifact was unsuccessfully saved, we want to
+            # enable re-uploading after returning the artifact object
+            # the upload is triggered by whether the privates are returned
+            if existing_artifact._storage_ongoing or not storage_object_exists:
+                privates["key"] = key
+                privates["is_storage_repair"] = not storage_object_exists
+                returned_privates = privates  # upload or repair necessary
+            else:
+                returned_privates = {"key": key}
+            returned_privates["is_artifact_storage_managed_by_current_instance"] = (
+                storage_is_managed
+            )
+            return existing_artifact, returned_privates
+    if not isinstance(stat_or_artifact, Artifact):
         size, hash, hash_type, n_files, revises = stat_or_artifact
 
     # update local path
@@ -2013,7 +2032,12 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                 self._local_filepath = privates["local_filepath"]
                 self._cloud_filepath = privates["cloud_filepath"]
                 self._memory_rep = privates["memory_rep"]
-                self._to_store = not privates["check_path_in_storage"]
+                is_storage_repair = privates.get("is_storage_repair", False)
+                self._to_store = (
+                    is_storage_repair or not privates["check_path_in_storage"]
+                )
+                if is_storage_repair:
+                    self._is_storage_repair = True
 
                 if (
                     self._to_store
@@ -2037,12 +2061,14 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             if kwargs_or_artifact._key_is_virtual and kwargs_or_artifact.key is None:
                 attr_to_update["key"] = key
             elif self.key != key and key is not None:
-                if not self.path.exists():
-                    logger.warning(f"updating previous key {self.key} to new key {key}")
-                    self.key = key
-                    # Keep tracked state aligned with this internal dedup-time key
-                    # normalization so save() doesn't treat it as a user key edit.
-                    self._original_values["key"] = key
+                is_storage_repair = privates.get("is_storage_repair", False)
+                if is_storage_repair:
+                    # Keep the persisted key and physical storage key. This matches
+                    # healthy hash deduplication and prevents a supplied key from
+                    # overwriting an unrelated storage object.
+                    logger.warning(
+                        f"repairing missing storage object at existing key {self.key}; ignoring passed key {key}"
+                    )
                 else:
                     logger.warning(
                         f"key {self.key} on existing artifact differs from passed key {key}, keeping original key; update manually if needed or pass skip_hash_lookup=True if you want to duplicate the artifact"
@@ -3543,7 +3569,10 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                 f"Unable to save the artifact because the local path {local_filepath} does not exist."
             )
 
-        flag_complete = has_local_filepath and getattr(self, "_to_store", False)
+        cloud_filepath = getattr(self, "_cloud_filepath", None)
+        has_source_filepath = has_local_filepath or cloud_filepath is not None
+        flag_complete = has_source_filepath and getattr(self, "_to_store", False)
+        is_storage_repair = getattr(self, "_is_storage_repair", False)
         if flag_complete:
             if is_not_artifact_storage_managed_by_current_instance:
                 raise ValueError(
@@ -3552,7 +3581,10 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             # _storage_ongoing indicates whether the storage saving / upload process is ongoing
             self._storage_ongoing = True  # will be updated to False once complete
 
-        self._save_skip_storage(**kwargs)
+        # Existing repair records must remain unchanged until storage succeeds.
+        # A failed repair therefore leaves the persisted metadata intact.
+        if not is_storage_repair:
+            self._save_skip_storage(**kwargs)
 
         using = None
         if "using" in kwargs:
@@ -3569,7 +3601,8 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             # often it is ACID in the filesystem itself
             # for example, s3 won't have the failed file, so just skip the delete in this case
             raise_file_not_found_error = False
-            self._delete_skip_storage()
+            if not is_storage_repair:
+                self._delete_skip_storage()
         else:
             # this is the case when it is cleaned on .replace
             raise_file_not_found_error = True
@@ -3589,6 +3622,8 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             # pass kwargs below because it can contain `using` or other things
             # affecting the connection
             super().save(**kwargs)
+            if is_storage_repair:
+                del self._is_storage_repair
 
         # this is only for keep_artifacts_local
         if local_path is not None and not state_was_adding:
@@ -3616,6 +3651,8 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             del self._external_features
         if hasattr(self, "_local_filepath"):
             del self._local_filepath
+        if hasattr(self, "_cloud_filepath"):
+            del self._cloud_filepath
         return self
 
 

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -670,9 +670,9 @@ def get_artifact_kwargs_from_data(
         # if the artifact was unsuccessfully saved, we want to
         # enable re-uploading after returning the artifact object
         # the upload is triggered by whether the privates are returned
-        if existing_artifact._storage_ongoing:
+        if existing_artifact._storage_ongoing or not existing_artifact.path.exists():
             privates["key"] = key
-            returned_privates = privates  # re-upload necessary
+            returned_privates = privates  # upload or repair necessary
         else:
             returned_privates = {"key": key}
         returned_privates["is_artifact_storage_managed_by_current_instance"] = (
@@ -2043,9 +2043,6 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                     # Keep tracked state aligned with this internal dedup-time key
                     # normalization so save() doesn't treat it as a user key edit.
                     self._original_values["key"] = key
-                    assert self.path.exists(), (  # noqa: S101
-                        f"The underlying file for artifact {self} does not exist anymore, clean up the artifact record."
-                    )  # noqa: S101
                 else:
                     logger.warning(
                         f"key {self.key} on existing artifact differs from passed key {key}, keeping original key; update manually if needed or pass skip_hash_lookup=True if you want to duplicate the artifact"

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -82,8 +82,8 @@ from .has_parents import view_lineage
 from .query_set import QuerySet, SQLRecordList
 from .run import Run, TracksRun, TracksUpdates, User
 from .save import (
-    _finish_storage_repair,
     _mark_storage_repair_ongoing,
+    _save_storage_repair_metadata,
     check_and_attempt_clearing,
     check_and_attempt_upload,
 )
@@ -685,12 +685,15 @@ def get_artifact_kwargs_from_data(
         requires_storage_write = (
             existing_artifact._storage_ongoing or not storage_object_exists
         )
+        persisted_storage_repair = (
+            existing_artifact._aux is not None and existing_artifact._aux.get("sr") == 1
+        )
         # A record in foreign/read-only storage cannot be repaired by this instance.
         # Ignore that hash match and construct a writable artifact instead.
         local_repair_source = local_filepath is not None
         if (
             storage_object_exists is None
-            or (not storage_object_exists and not storage_is_managed)
+            or (requires_storage_write and not storage_is_managed)
             or (requires_storage_write and not local_repair_source)
         ):
             stat_or_artifact = get_stat_or_artifact(
@@ -709,7 +712,9 @@ def get_artifact_kwargs_from_data(
             # the upload is triggered by whether the privates are returned
             if existing_artifact._storage_ongoing or not storage_object_exists:
                 privates["key"] = key
-                privates["is_storage_repair"] = not storage_object_exists
+                privates["is_storage_repair"] = (
+                    not storage_object_exists or persisted_storage_repair
+                )
                 returned_privates = privates  # upload or repair necessary
             else:
                 returned_privates = {"key": key}
@@ -3658,12 +3663,17 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             self, "_storage_repair_upload_succeeded", False
         )
         if flag_complete or repair_upload_succeeded:
-            self._storage_ongoing = False
-            # pass kwargs below because it can contain `using` or other things
-            # affecting the connection
-            super().save(**kwargs)
             if is_storage_repair:
-                _finish_storage_repair(self, using=using)
+                _save_storage_repair_metadata(
+                    self,
+                    using=using,
+                    save_kwargs=kwargs,
+                )
+            else:
+                self._storage_ongoing = False
+                # pass kwargs below because it can contain `using` or other things
+                # affecting the connection
+                super().save(**kwargs)
 
         # this is only for keep_artifacts_local
         if local_path is not None and not state_was_adding:

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -667,13 +667,21 @@ def get_artifact_kwargs_from_data(
     }
     if isinstance(stat_or_artifact, Artifact):
         existing_artifact = stat_or_artifact
-        storage_object_exists = existing_artifact.path.exists()
+        try:
+            storage_object_exists = existing_artifact.path.exists()
+        except Exception as error:
+            logger.warning(
+                f"could not verify storage for same-hash artifact {existing_artifact.uid}: {error}"
+            )
+            storage_object_exists = None
         storage_is_managed = (
             existing_artifact.storage.instance_uid == setup_settings.instance.uid
         )
         # A record in foreign/read-only storage cannot be repaired by this instance.
         # Ignore that hash match and construct a writable artifact instead.
-        if not storage_object_exists and not storage_is_managed:
+        if storage_object_exists is None or (
+            not storage_object_exists and not storage_is_managed
+        ):
             stat_or_artifact = get_stat_or_artifact(
                 path=path,
                 storage=storage,
@@ -3573,6 +3581,15 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
         has_source_filepath = has_local_filepath or cloud_filepath is not None
         flag_complete = has_source_filepath and getattr(self, "_to_store", False)
         is_storage_repair = getattr(self, "_is_storage_repair", False)
+        repair_upload_succeeded = getattr(
+            self, "_storage_repair_upload_succeeded", False
+        )
+        if (
+            is_storage_repair
+            and not has_source_filepath
+            and not repair_upload_succeeded
+        ):
+            raise RuntimeError("Cannot retry storage repair without a source path.")
         if flag_complete:
             if is_not_artifact_storage_managed_by_current_instance:
                 raise ValueError(
@@ -3603,27 +3620,36 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             raise_file_not_found_error = False
             if not is_storage_repair:
                 self._delete_skip_storage()
-        else:
+        elif not is_storage_repair:
             # this is the case when it is cleaned on .replace
             raise_file_not_found_error = True
-        # this is triggered by an exception in check_and_attempt_upload or by replace.
-        exception_clear = check_and_attempt_clearing(
-            self,
-            raise_file_not_found_error=raise_file_not_found_error,
-            using=using,
-        )
+        # A successful repair has no stale object to clear: its cleanup key, if
+        # present, names the destination that was just restored.
+        if exception_upload is not None or not is_storage_repair:
+            exception_clear = check_and_attempt_clearing(
+                self,
+                raise_file_not_found_error=raise_file_not_found_error,
+                using=using,
+            )
+        else:
+            exception_clear = None
         if exception_upload is not None:
             raise exception_upload
         if exception_clear is not None:
             raise exception_clear
         # the saving / upload process has been successful
-        if flag_complete:
+        repair_upload_succeeded = getattr(
+            self, "_storage_repair_upload_succeeded", False
+        )
+        if flag_complete or repair_upload_succeeded:
             self._storage_ongoing = False
             # pass kwargs below because it can contain `using` or other things
             # affecting the connection
             super().save(**kwargs)
             if is_storage_repair:
                 del self._is_storage_repair
+                del self._storage_repair_upload_succeeded
+                self._clear_storagekey = None
 
         # this is only for keep_artifacts_local
         if local_path is not None and not state_was_adding:

--- a/lamindb/models/artifact.py
+++ b/lamindb/models/artifact.py
@@ -81,7 +81,12 @@ from .feature import Feature, JsonValue
 from .has_parents import view_lineage
 from .query_set import QuerySet, SQLRecordList
 from .run import Run, TracksRun, TracksUpdates, User
-from .save import check_and_attempt_clearing, check_and_attempt_upload
+from .save import (
+    _finish_storage_repair,
+    _mark_storage_repair_ongoing,
+    check_and_attempt_clearing,
+    check_and_attempt_upload,
+)
 from .schema import Schema
 from .sqlrecord import (
     BaseSQLRecord,
@@ -677,10 +682,16 @@ def get_artifact_kwargs_from_data(
         storage_is_managed = (
             existing_artifact.storage.instance_uid == setup_settings.instance.uid
         )
+        requires_storage_write = (
+            existing_artifact._storage_ongoing or not storage_object_exists
+        )
         # A record in foreign/read-only storage cannot be repaired by this instance.
         # Ignore that hash match and construct a writable artifact instead.
-        if storage_object_exists is None or (
-            not storage_object_exists and not storage_is_managed
+        local_repair_source = local_filepath is not None
+        if (
+            storage_object_exists is None
+            or (not storage_object_exists and not storage_is_managed)
+            or (requires_storage_write and not local_repair_source)
         ):
             stat_or_artifact = get_stat_or_artifact(
                 path=path,
@@ -2085,7 +2096,10 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             # an existing artifact might have an imcomplete upload and hence we should
             # re-populate _local_filepath because this is what triggers the upload
             set_private_attributes()
-            populate_recreating_run(self, run)
+            if privates.get("is_storage_repair", False):
+                self._storage_repair_run = run
+            else:
+                populate_recreating_run(self, run)
             return None
         else:
             kwargs = kwargs_or_artifact
@@ -3577,8 +3591,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                 f"Unable to save the artifact because the local path {local_filepath} does not exist."
             )
 
-        cloud_filepath = getattr(self, "_cloud_filepath", None)
-        has_source_filepath = has_local_filepath or cloud_filepath is not None
+        has_source_filepath = has_local_filepath
         flag_complete = has_source_filepath and getattr(self, "_to_store", False)
         is_storage_repair = getattr(self, "_is_storage_repair", False)
         repair_upload_succeeded = getattr(
@@ -3596,7 +3609,10 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
                     "Cannot save an artifact to a storage location that is not managed by the current instance."
                 )
             # _storage_ongoing indicates whether the storage saving / upload process is ongoing
-            self._storage_ongoing = True  # will be updated to False once complete
+            if is_storage_repair:
+                _mark_storage_repair_ongoing(self, using=kwargs.get("using"))
+            else:
+                self._storage_ongoing = True  # will be updated to False once complete
 
         # Existing repair records must remain unchanged until storage succeeds.
         # A failed repair therefore leaves the persisted metadata intact.
@@ -3647,9 +3663,7 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             # affecting the connection
             super().save(**kwargs)
             if is_storage_repair:
-                del self._is_storage_repair
-                del self._storage_repair_upload_succeeded
-                self._clear_storagekey = None
+                _finish_storage_repair(self, using=using)
 
         # this is only for keep_artifacts_local
         if local_path is not None and not state_was_adding:
@@ -3677,8 +3691,6 @@ class Artifact(SQLRecord, IsVersioned, TracksRun, TracksUpdates):
             del self._external_features
         if hasattr(self, "_local_filepath"):
             del self._local_filepath
-        if hasattr(self, "_cloud_filepath"):
-            del self._cloud_filepath
         return self
 
 

--- a/lamindb/models/save.py
+++ b/lamindb/models/save.py
@@ -40,6 +40,39 @@ def _prepare_cross_instance_create(record: SQLRecord, using: str | None) -> None
         record.run_id = None
 
 
+def _mark_storage_repair_ongoing(artifact: Artifact, using: str | None = None) -> None:
+    """Persist only the repair marker before touching storage."""
+    artifact._storage_ongoing = True
+    manager = artifact.__class__.objects
+    if using is not None:
+        manager = manager.using(using)
+    updated = manager.filter(pk=artifact.pk).update(_aux=artifact._aux)
+    if updated != 1:
+        raise RuntimeError("Could not mark artifact storage repair as ongoing.")
+
+
+def _finish_storage_repair(artifact: Artifact, using: str | None = None) -> None:
+    """Finalize deferred lineage and clear private repair state."""
+    from ._lineage import populate_recreating_run
+    from .artifact import Artifact
+
+    pending_run = getattr(artifact, "_storage_repair_run", None)
+    if pending_run is not None:
+        with transaction.atomic(using=using):
+            previous_run_id = artifact.run_id
+            populate_recreating_run(artifact, pending_run)
+            if artifact.run_id != previous_run_id:
+                super(Artifact, artifact).save(update_fields=["run"], using=using)
+    for attribute in (
+        "_is_storage_repair",
+        "_storage_repair_upload_succeeded",
+        "_storage_repair_run",
+    ):
+        if hasattr(artifact, attribute):
+            delattr(artifact, attribute)
+    artifact._clear_storagekey = None
+
+
 def save(
     records: Iterable[SQLRecord],
     ignore_conflicts: bool | None = False,
@@ -135,12 +168,12 @@ def save(
         with transaction.atomic():
             for record in artifacts:
                 # will switch to True after the successful upload / saving
-                has_source = (
-                    getattr(record, "_local_filepath", None) is not None
-                    or getattr(record, "_cloud_filepath", None) is not None
-                )
+                has_source = getattr(record, "_local_filepath", None) is not None
                 if has_source and getattr(record, "_to_store", False):
-                    record._storage_ongoing = True
+                    if getattr(record, "_is_storage_repair", False):
+                        _mark_storage_repair_ongoing(record, using=using)
+                    else:
+                        record._storage_ongoing = True
                 if not getattr(record, "_is_storage_repair", False):
                     record._save_skip_storage(using=using)
         store_artifacts(artifacts, using=using)
@@ -320,13 +353,9 @@ def check_and_attempt_upload(
     **kwargs,
 ) -> Exception | None:
     # kwargs are propagated to .upload_from in the end
-    # New artifacts, replacements, and repairs can use either a local or cloud source.
+    # New artifacts, replacements, and repairs upload from local sources.
     local_filepath = getattr(artifact, "_local_filepath", None)
-    cloud_filepath = getattr(artifact, "_cloud_filepath", None)
-    should_upload_cloud_source = cloud_filepath is not None and getattr(
-        artifact, "_to_store", False
-    )
-    if local_filepath is not None or should_upload_cloud_source:
+    if local_filepath is not None:
         is_storage_repair = getattr(artifact, "_is_storage_repair", False)
         if is_storage_repair:
             # A stale cleanup key from an earlier failed repair points at the
@@ -374,8 +403,6 @@ def check_and_attempt_upload(
             artifact._storage_repair_upload_succeeded = True
         if local_filepath is not None:
             del artifact._local_filepath
-        if cloud_filepath is not None:
-            del artifact._cloud_filepath
     # returning None means proceed (either success or no action needed)
     return None
 
@@ -512,9 +539,7 @@ def store_artifacts(artifacts: Iterable[Artifact], using: str | None = None) -> 
                 # each .save() is a separate transaction below
                 super(Artifact, artifact).save(using=using)
             if is_storage_repair:
-                del artifact._is_storage_repair
-                del artifact._storage_repair_upload_succeeded
-                artifact._clear_storagekey = None
+                _finish_storage_repair(artifact, using=using)
         except Exception as error:
             exception = error
             break
@@ -595,11 +620,8 @@ def upload_artifact(
     )
     if getattr(artifact, "_to_store", False):
         logger.save(f"storing artifact '{artifact.uid}' at '{storage_path}'")
-        source_path = getattr(artifact, "_local_filepath", None)
-        if source_path is None:
-            source_path = artifact._cloud_filepath
         paths.store_file_or_folder(
-            source_path,
+            artifact._local_filepath,
             storage_path,
             print_progress=print_progress,
             **kwargs,

--- a/lamindb/models/save.py
+++ b/lamindb/models/save.py
@@ -205,11 +205,12 @@ def save(
             bulk_set_features_in_records(records_with_lazy_features, using=using)
 
     if artifacts:
-        new_artifact_object_ids = {
-            id(record)
+        candidate_new_artifact_uids = {
+            id(record): record.uid
             for record in artifacts
             if record._state.adding or record.pk is None
         }
+        new_artifact_object_ids = set()
         for record in artifacts:
             _prepare_cross_instance_create(record, using)
         _ensure_using_connection(Artifact, using)
@@ -224,6 +225,9 @@ def save(
                         record._storage_ongoing = True
                 if not getattr(record, "_is_storage_repair", False):
                     record._save_skip_storage(using=using)
+                    candidate_uid = candidate_new_artifact_uids.get(id(record))
+                    if candidate_uid is not None and record.uid == candidate_uid:
+                        new_artifact_object_ids.add(id(record))
         store_artifacts(
             artifacts,
             using=using,

--- a/lamindb/models/save.py
+++ b/lamindb/models/save.py
@@ -135,11 +135,14 @@ def save(
         with transaction.atomic():
             for record in artifacts:
                 # will switch to True after the successful upload / saving
-                if getattr(record, "_local_filepath", None) is not None and getattr(
-                    record, "_to_store", False
-                ):
+                has_source = (
+                    getattr(record, "_local_filepath", None) is not None
+                    or getattr(record, "_cloud_filepath", None) is not None
+                )
+                if has_source and getattr(record, "_to_store", False):
                     record._storage_ongoing = True
-                record._save_skip_storage(using=using)
+                if not getattr(record, "_is_storage_repair", False):
+                    record._save_skip_storage(using=using)
         store_artifacts(artifacts, using=using)
 
     # this function returns None as potentially 10k records might be saved
@@ -317,9 +320,18 @@ def check_and_attempt_upload(
     **kwargs,
 ) -> Exception | None:
     # kwargs are propagated to .upload_from in the end
-    # if Artifact object is either newly instantiated or replace() was called on
-    # a local env it will have a _local_filepath and needs to be uploaded
-    if getattr(artifact, "_local_filepath", None) is not None:
+    # New artifacts, replacements, and repairs can use either a local or cloud source.
+    local_filepath = getattr(artifact, "_local_filepath", None)
+    cloud_filepath = getattr(artifact, "_cloud_filepath", None)
+    should_upload_cloud_source = cloud_filepath is not None and getattr(
+        artifact, "_to_store", False
+    )
+    if local_filepath is not None or should_upload_cloud_source:
+        is_storage_repair = getattr(artifact, "_is_storage_repair", False)
+        if is_storage_repair:
+            # A stale cleanup key from an earlier failed repair points at the
+            # destination we are about to restore and must not survive a retry.
+            artifact._clear_storagekey = None
         try:
             storage_path, cache_path = upload_artifact(
                 artifact,
@@ -340,7 +352,7 @@ def check_and_attempt_upload(
                 )  # type: ignore
             return exception
         # copies (if on-disk) or moves the temporary file (if in-memory) to the cache
-        if os.getenv("LAMINDB_MULTI_INSTANCE") is None:
+        if local_filepath is not None and os.getenv("LAMINDB_MULTI_INSTANCE") is None:
             # this happens only after the actual upload was performed
             # we avoid failing here in case any problems happen in copy_or_move_to_cache
             # because the cache copying or cleanup is not absolutely necessary
@@ -358,7 +370,12 @@ def check_and_attempt_upload(
                     logger.warning(f"A problem with cache on saving: {e}")
         # after successful upload, we should remove the attribute so that another call
         # call to save won't upload again, the user should call replace() then
-        del artifact._local_filepath
+        if is_storage_repair:
+            artifact._storage_repair_upload_succeeded = True
+        if local_filepath is not None:
+            del artifact._local_filepath
+        if cloud_filepath is not None:
+            del artifact._cloud_filepath
     # returning None means proceed (either success or no action needed)
     return None
 
@@ -460,27 +477,57 @@ def store_artifacts(artifacts: Iterable[Artifact], using: str | None = None) -> 
 
     # upload new local artifacts
     for artifact in artifacts:
+        is_storage_repair = getattr(artifact, "_is_storage_repair", False)
         # failure here sets ._clear_storagekey
         # for cleanup below
         exception = check_and_attempt_upload(artifact, using)
         if exception is not None:
+            if is_storage_repair:
+                exception_clear = check_and_attempt_clearing(
+                    artifact, raise_file_not_found_error=False, using=using
+                )
+                if exception_clear is not None:
+                    logger.warning(
+                        f"clean up of {artifact._clear_storagekey} after the repair upload error failed"  # type: ignore
+                    )
             break
 
-        stored_artifacts += [artifact]
+        repair_upload_succeeded = getattr(
+            artifact, "_storage_repair_upload_succeeded", False
+        )
+        if is_storage_repair and not repair_upload_succeeded:
+            exception = RuntimeError(
+                "Cannot retry storage repair without a source path."
+            )
+            break
         # update to show successful saving
         # only update if _storage_ongoing was set to True before
         # this should be a single transaction for the updates of all the artifacts
         # but then it would just abort all artifacts, even those successfully stored before
         # TODO: there should also be some kind of exception handling here
         # but this requires refactoring
-        if artifact._storage_ongoing:
-            artifact._storage_ongoing = False
-            # each .save() is a separate transaction below
-            super(Artifact, artifact).save(using=using)
+        try:
+            if artifact._storage_ongoing or repair_upload_succeeded:
+                artifact._storage_ongoing = False
+                # each .save() is a separate transaction below
+                super(Artifact, artifact).save(using=using)
+            if is_storage_repair:
+                del artifact._is_storage_repair
+                del artifact._storage_repair_upload_succeeded
+                artifact._clear_storagekey = None
+        except Exception as error:
+            exception = error
+            break
+
+        stored_artifacts += [artifact]
         # if check_and_attempt_upload was successful
         # then this can have only ._clear_storagekey from .replace
-        exception = check_and_attempt_clearing(
-            artifact, raise_file_not_found_error=True, using=using
+        exception = (
+            None
+            if is_storage_repair
+            else check_and_attempt_clearing(
+                artifact, raise_file_not_found_error=True, using=using
+            )
         )
         if exception is not None:
             logger.warning(f"clean up of {artifact._clear_storagekey} failed")  # type: ignore
@@ -491,15 +538,17 @@ def store_artifacts(artifacts: Iterable[Artifact], using: str | None = None) -> 
         with transaction.atomic():
             for artifact in artifacts:
                 if artifact not in stored_artifacts:
-                    artifact._delete_skip_storage(using=using)
-                    # clean up storage after failure in check_and_attempt_upload
-                    exception_clear = check_and_attempt_clearing(
-                        artifact, raise_file_not_found_error=False, using=using
-                    )
-                    if exception_clear is not None:
-                        logger.warning(
-                            f"clean up of {artifact._clear_storagekey} after the upload error failed"  # type: ignore
+                    is_storage_repair = getattr(artifact, "_is_storage_repair", False)
+                    if not is_storage_repair:
+                        artifact._delete_skip_storage(using=using)
+                        # clean up storage after failure in check_and_attempt_upload
+                        exception_clear = check_and_attempt_clearing(
+                            artifact, raise_file_not_found_error=False, using=using
                         )
+                        if exception_clear is not None:
+                            logger.warning(
+                                f"clean up of {artifact._clear_storagekey} after the upload error failed"  # type: ignore
+                            )
         error_message = prepare_error_message(artifacts, stored_artifacts, exception)
         # this is bad because we're losing the original traceback
         # needs to be refactored - also, the orginal error should be raised

--- a/lamindb/models/save.py
+++ b/lamindb/models/save.py
@@ -62,7 +62,7 @@ def _prepare_storage_repair_metadata_save(artifact: Artifact) -> None:
 
 
 def _finish_storage_repair(artifact: Artifact, using: str | None = None) -> None:
-    """Finalize deferred lineage and clear private repair state."""
+    """Finalize deferred repair lineage inside the metadata transaction."""
     from ._lineage import populate_recreating_run
     from .artifact import Artifact
 
@@ -72,6 +72,10 @@ def _finish_storage_repair(artifact: Artifact, using: str | None = None) -> None
         populate_recreating_run(artifact, pending_run)
         if artifact.run_id != previous_run_id:
             super(Artifact, artifact).save(update_fields=["run"], using=using)
+
+
+def _clear_storage_repair_state(artifact: Artifact) -> None:
+    """Clear private repair state after the metadata transaction commits."""
     for attribute in (
         "_is_storage_repair",
         "_storage_repair_upload_succeeded",
@@ -88,8 +92,6 @@ def _save_storage_repair_metadata(
     save_kwargs: dict | None = None,
 ) -> None:
     """Atomically persist repaired metadata, markers, and deferred lineage."""
-    from .artifact import Artifact
-
     kwargs = {} if save_kwargs is None else save_kwargs.copy()
     if using is not None:
         kwargs["using"] = using
@@ -99,12 +101,16 @@ def _save_storage_repair_metadata(
     try:
         with transaction.atomic(using=using):
             _prepare_storage_repair_metadata_save(artifact)
-            super(Artifact, artifact).save(**kwargs)
+            artifact._save_skip_storage(**kwargs)
             _finish_storage_repair(artifact, using=using)
+        _clear_storage_repair_state(artifact)
     except Exception:
         # The database transaction rolled back; keep the in-memory object retryable
         # and aligned with the persisted repair markers.
         artifact.run_id = previous_run_id
+        artifact._state.fields_cache.pop("run", None)
+        if hasattr(artifact, "_recreating_run_id"):
+            del artifact._recreating_run_id
         artifact._storage_ongoing = True
         artifact._aux["sr"] = 1
         raise

--- a/lamindb/models/save.py
+++ b/lamindb/models/save.py
@@ -43,12 +43,22 @@ def _prepare_cross_instance_create(record: SQLRecord, using: str | None) -> None
 def _mark_storage_repair_ongoing(artifact: Artifact, using: str | None = None) -> None:
     """Persist only the repair marker before touching storage."""
     artifact._storage_ongoing = True
+    artifact._aux["sr"] = 1
     manager = artifact.__class__.objects
     if using is not None:
         manager = manager.using(using)
     updated = manager.filter(pk=artifact.pk).update(_aux=artifact._aux)
     if updated != 1:
         raise RuntimeError("Could not mark artifact storage repair as ongoing.")
+
+
+def _prepare_storage_repair_metadata_save(artifact: Artifact) -> None:
+    """Clear repair markers in the metadata written after upload."""
+    artifact._storage_ongoing = False
+    if artifact._aux is not None:
+        artifact._aux.pop("sr", None)
+        if not artifact._aux:
+            artifact._aux = None
 
 
 def _finish_storage_repair(artifact: Artifact, using: str | None = None) -> None:
@@ -58,11 +68,10 @@ def _finish_storage_repair(artifact: Artifact, using: str | None = None) -> None
 
     pending_run = getattr(artifact, "_storage_repair_run", None)
     if pending_run is not None:
-        with transaction.atomic(using=using):
-            previous_run_id = artifact.run_id
-            populate_recreating_run(artifact, pending_run)
-            if artifact.run_id != previous_run_id:
-                super(Artifact, artifact).save(update_fields=["run"], using=using)
+        previous_run_id = artifact.run_id
+        populate_recreating_run(artifact, pending_run)
+        if artifact.run_id != previous_run_id:
+            super(Artifact, artifact).save(update_fields=["run"], using=using)
     for attribute in (
         "_is_storage_repair",
         "_storage_repair_upload_succeeded",
@@ -71,6 +80,32 @@ def _finish_storage_repair(artifact: Artifact, using: str | None = None) -> None
         if hasattr(artifact, attribute):
             delattr(artifact, attribute)
     artifact._clear_storagekey = None
+
+
+def _save_storage_repair_metadata(
+    artifact: Artifact,
+    using: str | None = None,
+    save_kwargs: dict | None = None,
+) -> None:
+    """Atomically persist repaired metadata, markers, and deferred lineage."""
+    from .artifact import Artifact
+
+    kwargs = {} if save_kwargs is None else save_kwargs.copy()
+    if using is not None:
+        kwargs["using"] = using
+    previous_run_id = artifact.run_id
+    try:
+        with transaction.atomic(using=using):
+            _prepare_storage_repair_metadata_save(artifact)
+            super(Artifact, artifact).save(**kwargs)
+            _finish_storage_repair(artifact, using=using)
+    except Exception:
+        # The database transaction rolled back; keep the in-memory object retryable
+        # and aligned with the persisted repair markers.
+        artifact.run_id = previous_run_id
+        artifact._storage_ongoing = True
+        artifact._aux["sr"] = 1
+        raise
 
 
 def save(
@@ -162,6 +197,11 @@ def save(
             bulk_set_features_in_records(records_with_lazy_features, using=using)
 
     if artifacts:
+        new_artifact_object_ids = {
+            id(record)
+            for record in artifacts
+            if record._state.adding or record.pk is None
+        }
         for record in artifacts:
             _prepare_cross_instance_create(record, using)
         _ensure_using_connection(Artifact, using)
@@ -176,7 +216,11 @@ def save(
                         record._storage_ongoing = True
                 if not getattr(record, "_is_storage_repair", False):
                     record._save_skip_storage(using=using)
-        store_artifacts(artifacts, using=using)
+        store_artifacts(
+            artifacts,
+            using=using,
+            new_artifact_object_ids=new_artifact_object_ids,
+        )
 
     # this function returns None as potentially 10k records might be saved
     # refreshing all of them from the DB would mean a severe performance penalty
@@ -491,7 +535,11 @@ def check_and_attempt_clearing(
     return None
 
 
-def store_artifacts(artifacts: Iterable[Artifact], using: str | None = None) -> None:
+def store_artifacts(
+    artifacts: Iterable[Artifact],
+    using: str | None = None,
+    new_artifact_object_ids: set[int] | None = None,
+) -> None:
     """Upload artifacts in a list of database-committed artifacts to storage.
 
     If any upload fails, subsequent artifacts are cleaned up from the DB.
@@ -535,11 +583,12 @@ def store_artifacts(artifacts: Iterable[Artifact], using: str | None = None) -> 
         # but this requires refactoring
         try:
             if artifact._storage_ongoing or repair_upload_succeeded:
-                artifact._storage_ongoing = False
-                # each .save() is a separate transaction below
-                super(Artifact, artifact).save(using=using)
-            if is_storage_repair:
-                _finish_storage_repair(artifact, using=using)
+                if is_storage_repair:
+                    _save_storage_repair_metadata(artifact, using=using)
+                else:
+                    artifact._storage_ongoing = False
+                    # each .save() is a separate transaction below
+                    super(Artifact, artifact).save(using=using)
         except Exception as error:
             exception = error
             break
@@ -564,7 +613,11 @@ def store_artifacts(artifacts: Iterable[Artifact], using: str | None = None) -> 
             for artifact in artifacts:
                 if artifact not in stored_artifacts:
                     is_storage_repair = getattr(artifact, "_is_storage_repair", False)
-                    if not is_storage_repair:
+                    was_new = (
+                        new_artifact_object_ids is None
+                        or id(artifact) in new_artifact_object_ids
+                    )
+                    if not is_storage_repair and was_new:
                         artifact._delete_skip_storage(using=using)
                         # clean up storage after failure in check_and_attempt_upload
                         exception_clear = check_and_attempt_clearing(

--- a/lamindb/models/save.py
+++ b/lamindb/models/save.py
@@ -546,8 +546,11 @@ def upload_artifact(
     )
     if getattr(artifact, "_to_store", False):
         logger.save(f"storing artifact '{artifact.uid}' at '{storage_path}'")
+        source_path = getattr(artifact, "_local_filepath", None)
+        if source_path is None:
+            source_path = artifact._cloud_filepath
         paths.store_file_or_folder(
-            artifact._local_filepath,
+            source_path,
             storage_path,
             print_progress=print_progress,
             **kwargs,

--- a/lamindb/models/save.py
+++ b/lamindb/models/save.py
@@ -93,6 +93,8 @@ def _save_storage_repair_metadata(
     kwargs = {} if save_kwargs is None else save_kwargs.copy()
     if using is not None:
         kwargs["using"] = using
+    if kwargs.get("update_fields") is not None:
+        kwargs["update_fields"] = set(kwargs["update_fields"]) | {"_aux"}
     previous_run_id = artifact.run_id
     try:
         with transaction.atomic(using=using):

--- a/tests/pydata/test_artifact_basics.py
+++ b/tests/pydata/test_artifact_basics.py
@@ -540,10 +540,145 @@ def test_existing_hash_repairs_missing_storage_object(tmp_path):
 
     duplicate.save()
     assert duplicate.path.exists()
-    assert duplicate.key == "uploads/duplicate.jpg"
+    assert duplicate.key == "uploads/original.jpg"
     assert duplicate.description == "duplicate description"
 
+    duplicate.description = "description after repair"
+    duplicate.save()
+    assert ln.Artifact.get(id=duplicate.id).description == "description after repair"
+
     duplicate.delete(permanent=True)
+
+
+def test_existing_hash_repair_failure_preserves_record(tmp_path):
+    original_path = tmp_path / "original-failure.jpg"
+    duplicate_path = tmp_path / "duplicate-failure.jpg"
+    original_path.write_bytes(b"repair-failure")
+    duplicate_path.write_bytes(original_path.read_bytes())
+
+    original = ln.Artifact(
+        original_path,
+        key="uploads/original-failure.jpg",
+        description="original description",
+    ).save()
+    original.path.unlink()
+
+    duplicate = ln.Artifact(
+        duplicate_path,
+        key="uploads/duplicate-failure.jpg",
+        description="duplicate description",
+    )
+    upload_error = RuntimeError("simulated upload failure")
+    with (
+        patch(
+            "lamindb.models.artifact.check_and_attempt_upload",
+            return_value=upload_error,
+        ),
+        pytest.raises(RuntimeError, match="simulated upload failure"),
+    ):
+        duplicate.save()
+
+    persisted = ln.Artifact.get(id=original.id)
+    assert persisted.key == "uploads/original-failure.jpg"
+    assert persisted.description == "original description"
+    persisted.delete(permanent=True, storage=False)
+
+
+def test_existing_hash_repairs_from_registered_storage(tmp_path):
+    storage_root = tmp_path / "registered-repair-storage"
+    storage_root.mkdir()
+    original_path = storage_root / "physical" / "original.txt"
+    duplicate_path = storage_root / "physical" / "duplicate.txt"
+    original_path.parent.mkdir()
+    original_path.write_text("registered-repair")
+    storage = ln.Storage(root=storage_root.resolve().as_posix(), type="local").save()
+
+    original = ln.Artifact(original_path, key="virtual/original.txt").save()
+    original_real_key = original._real_key
+    original.path.unlink()
+    duplicate_path.write_text("registered-repair")
+
+    duplicate = ln.Artifact(
+        duplicate_path,
+        key="virtual/duplicate.txt",
+        skip_hash_lookup=False,
+    )
+    duplicate.save()
+
+    assert duplicate.id == original.id
+    assert duplicate._real_key == original_real_key
+    assert duplicate.path.read_text() == "registered-repair"
+
+    duplicate.delete(permanent=True, storage=True)
+    duplicate_path.unlink()
+    storage.delete()
+
+
+def test_missing_hash_match_in_foreign_storage_creates_writable_artifact(tmp_path):
+    storage_root = tmp_path / "foreign-repair-storage"
+    storage_root.mkdir()
+    foreign_path = storage_root / "foreign.txt"
+    duplicate_path = tmp_path / "writable.txt"
+    foreign_path.write_text("foreign-repair")
+    duplicate_path.write_text("foreign-repair")
+    storage = ln.Storage(root=storage_root.resolve().as_posix(), type="local").save()
+    foreign_artifact = ln.Artifact(foreign_path).save()
+    foreign_artifact.path.unlink()
+    storage.instance_uid = "foreign-instance"
+    storage.save()
+
+    duplicate = ln.Artifact(duplicate_path, key="uploads/writable.txt")
+
+    assert duplicate._state.adding
+    assert duplicate.storage.instance_uid == lamindb_setup.settings.instance.uid
+    duplicate.save()
+    assert duplicate.path.exists()
+
+    duplicate.delete(permanent=True)
+    foreign_artifact.delete(permanent=True, storage=False)
+    storage.delete()
+
+
+def test_existing_hash_repair_rejects_occupied_target_key(tmp_path):
+    storage_root = tmp_path / "conflict-storage"
+    storage_root.mkdir()
+    storage = ln.Storage(root=storage_root.resolve().as_posix(), type="local").save()
+    occupied_path = tmp_path / "occupied.txt"
+    original_path = tmp_path / "missing.txt"
+    duplicate_path = tmp_path / "duplicate.txt"
+    occupied_path.write_text("occupied-content")
+    original_path.write_text("repair-content")
+    duplicate_path.write_text("repair-content")
+
+    occupied = ln.Artifact(
+        occupied_path,
+        key="uploads/occupied.txt",
+        key_is_virtual=False,
+        storage=storage,
+    ).save()
+    original = ln.Artifact(
+        original_path,
+        key="uploads/missing.txt",
+        key_is_virtual=False,
+        storage=storage,
+    ).save()
+    original.path.unlink()
+
+    duplicate = ln.Artifact(
+        duplicate_path,
+        key="uploads/occupied.txt",
+        key_is_virtual=False,
+        storage=storage,
+    )
+    duplicate.save()
+
+    assert duplicate.id == original.id
+    assert duplicate.key == "uploads/missing.txt"
+    assert duplicate.path.read_text() == "repair-content"
+    assert occupied.path.read_text() == "occupied-content"
+    occupied.delete(permanent=True, storage=True)
+    duplicate.delete(permanent=True, storage=True)
+    storage.delete()
 
 
 def test_invalid_suffix_is_empty(tmp_path):

--- a/tests/pydata/test_artifact_basics.py
+++ b/tests/pydata/test_artifact_basics.py
@@ -484,6 +484,68 @@ def test_upload_checks_hash_by_default(tmp_path):
     artifact_1.delete(permanent=True)
 
 
+def test_existing_hash_keeps_completed_storage_object(tmp_path):
+    original_path = tmp_path / "original.jpg"
+    duplicate_path = tmp_path / "duplicate.jpg"
+    original_path.write_bytes(b"same-content")
+    duplicate_path.write_bytes(original_path.read_bytes())
+
+    original = ln.Artifact(
+        original_path,
+        key="uploads/original.jpg",
+        description="original description",
+    ).save()
+    original_artifact_path = original.path
+
+    duplicate = ln.Artifact(
+        duplicate_path,
+        key="uploads/duplicate.jpg",
+        description="duplicate description",
+    )
+
+    assert not duplicate._state.adding
+    assert duplicate.id == original.id
+    assert duplicate.key == "uploads/original.jpg"
+    assert not hasattr(duplicate, "_local_filepath")
+
+    duplicate.save()
+    assert duplicate.path == original_artifact_path
+    assert duplicate.description == "duplicate description"
+
+    duplicate.delete(permanent=True)
+
+
+def test_existing_hash_repairs_missing_storage_object(tmp_path):
+    original_path = tmp_path / "original.jpg"
+    duplicate_path = tmp_path / "duplicate.jpg"
+    original_path.write_bytes(b"same-content")
+    duplicate_path.write_bytes(original_path.read_bytes())
+
+    original = ln.Artifact(
+        original_path,
+        key="uploads/original.jpg",
+        description="original description",
+    ).save()
+    original.path.unlink()
+
+    duplicate = ln.Artifact(
+        duplicate_path,
+        key="uploads/duplicate.jpg",
+        description="duplicate description",
+    )
+
+    assert not duplicate._state.adding
+    assert duplicate.id == original.id
+    assert duplicate._local_filepath == duplicate_path
+
+    duplicate.save()
+    assert duplicate.path.exists()
+    assert duplicate.key == "uploads/duplicate.jpg"
+    assert duplicate.description == "duplicate description"
+
+    duplicate.delete(permanent=True)
+
+
 def test_invalid_suffix_is_empty(tmp_path):
     filepath = tmp_path / "test.xyz"
     filepath.write_text("test-content")

--- a/tests/pydata/test_artifact_basics.py
+++ b/tests/pydata/test_artifact_basics.py
@@ -572,10 +572,17 @@ def test_existing_hash_repair_failure_preserves_record(tmp_path, save_mode):
         description="duplicate description",
     )
     healthy = None
+    collision = None
     if save_mode == "bulk":
         healthy_path = tmp_path / "healthy-existing.txt"
         healthy_path.write_text("healthy-existing")
         healthy = ln.Artifact(healthy_path, key="uploads/healthy-existing.txt").save()
+        collision = ln.Artifact(
+            healthy_path,
+            key="uploads/healthy-existing.txt",
+            skip_hash_lookup=True,
+        )
+        assert collision._state.adding
     upload_error = RuntimeError("simulated upload failure")
     upload_patch = (
         patch(
@@ -592,7 +599,7 @@ def test_existing_hash_repair_failure_preserves_record(tmp_path, save_mode):
         if save_mode == "single":
             duplicate.save()
         else:
-            ln.save([duplicate, healthy])
+            ln.save([duplicate, collision])
 
     persisted = ln.Artifact.get(id=original.id)
     assert persisted.key == "uploads/original-failure.jpg"
@@ -600,6 +607,7 @@ def test_existing_hash_repair_failure_preserves_record(tmp_path, save_mode):
     assert persisted._storage_ongoing
     assert persisted._aux["sr"] == 1
     if healthy is not None:
+        assert collision.id == healthy.id
         assert ln.Artifact.filter(id=healthy.id).exists()
         healthy.delete(permanent=True)
     persisted.delete(permanent=True, storage=False)
@@ -811,6 +819,8 @@ def test_existing_hash_repair_retry(tmp_path, failure_stage):
             pytest.raises(RuntimeError, match="simulated database failure"),
         ):
             duplicate.save()
+        assert duplicate._is_storage_repair
+        assert duplicate._storage_repair_upload_succeeded
 
     assert ln.Artifact.get(id=original.id).description == "original description"
     duplicate.save()

--- a/tests/pydata/test_artifact_basics.py
+++ b/tests/pydata/test_artifact_basics.py
@@ -515,7 +515,8 @@ def test_existing_hash_keeps_completed_storage_object(tmp_path):
     duplicate.delete(permanent=True)
 
 
-def test_existing_hash_repairs_missing_storage_object(tmp_path):
+@pytest.mark.parametrize("source_kind", ["local", "cloud"])
+def test_existing_hash_repairs_missing_storage_object(tmp_path, source_kind):
     original_path = tmp_path / "original.jpg"
     duplicate_path = tmp_path / "duplicate.jpg"
     original_path.write_bytes(b"same-content")
@@ -533,10 +534,16 @@ def test_existing_hash_repairs_missing_storage_object(tmp_path):
         key="uploads/duplicate.jpg",
         description="duplicate description",
     )
+    if source_kind == "cloud":
+        duplicate._cloud_filepath = UPath(duplicate._local_filepath)
+        del duplicate._local_filepath
 
     assert not duplicate._state.adding
     assert duplicate.id == original.id
-    assert duplicate._local_filepath == duplicate_path
+    if source_kind == "local":
+        assert duplicate._local_filepath == duplicate_path
+    else:
+        assert duplicate._cloud_filepath == UPath(duplicate_path)
 
     duplicate.save()
     assert duplicate.path.exists()
@@ -550,7 +557,8 @@ def test_existing_hash_repairs_missing_storage_object(tmp_path):
     duplicate.delete(permanent=True)
 
 
-def test_existing_hash_repair_failure_preserves_record(tmp_path):
+@pytest.mark.parametrize("save_mode", ["single", "bulk"])
+def test_existing_hash_repair_failure_preserves_record(tmp_path, save_mode):
     original_path = tmp_path / "original-failure.jpg"
     duplicate_path = tmp_path / "duplicate-failure.jpg"
     original_path.write_bytes(b"repair-failure")
@@ -569,14 +577,22 @@ def test_existing_hash_repair_failure_preserves_record(tmp_path):
         description="duplicate description",
     )
     upload_error = RuntimeError("simulated upload failure")
-    with (
+    upload_patch = (
         patch(
             "lamindb.models.artifact.check_and_attempt_upload",
             return_value=upload_error,
-        ),
-        pytest.raises(RuntimeError, match="simulated upload failure"),
-    ):
-        duplicate.save()
+        )
+        if save_mode == "single"
+        else patch(
+            "lamindb.models.save.upload_artifact",
+            side_effect=upload_error,
+        )
+    )
+    with upload_patch, pytest.raises(RuntimeError, match="simulated upload failure"):
+        if save_mode == "single":
+            duplicate.save()
+        else:
+            ln.save([duplicate])
 
     persisted = ln.Artifact.get(id=original.id)
     assert persisted.key == "uploads/original-failure.jpg"
@@ -679,6 +695,104 @@ def test_existing_hash_repair_rejects_occupied_target_key(tmp_path):
     occupied.delete(permanent=True, storage=True)
     duplicate.delete(permanent=True, storage=True)
     storage.delete()
+
+
+def test_bulk_existing_hash_repair_succeeds(tmp_path):
+    original_path = tmp_path / "bulk-success-original.txt"
+    duplicate_path = tmp_path / "bulk-success-duplicate.txt"
+    original_path.write_text("bulk-repair-success")
+    duplicate_path.write_text("bulk-repair-success")
+    original = ln.Artifact(
+        original_path,
+        key="uploads/bulk-success-original.txt",
+        description="original description",
+    ).save()
+    original.path.unlink()
+    duplicate = ln.Artifact(
+        duplicate_path,
+        key="uploads/bulk-success-duplicate.txt",
+        description="repaired description",
+    )
+
+    ln.save([duplicate])
+
+    persisted = ln.Artifact.get(id=original.id)
+    assert persisted.path.read_text() == "bulk-repair-success"
+    assert persisted.description == "repaired description"
+    persisted.delete(permanent=True)
+
+
+def test_inaccessible_same_hash_storage_does_not_abort_construction(tmp_path):
+    original_path = tmp_path / "inaccessible-original.txt"
+    duplicate_path = tmp_path / "inaccessible-duplicate.txt"
+    original_path.write_text("inaccessible-storage")
+    duplicate_path.write_text("inaccessible-storage")
+    original = ln.Artifact(
+        original_path, key="uploads/inaccessible-original.txt"
+    ).save()
+    storage_path_type = type(original.path)
+
+    with patch.object(
+        storage_path_type,
+        "exists",
+        side_effect=PermissionError("storage is not accessible"),
+    ):
+        duplicate = ln.Artifact(
+            duplicate_path,
+            key="uploads/inaccessible-duplicate.txt",
+        )
+
+    assert duplicate._state.adding
+    original.delete(permanent=True)
+
+
+@pytest.mark.parametrize("failure_stage", ["cleanup", "database"])
+def test_existing_hash_repair_retry(tmp_path, failure_stage):
+    original_path = tmp_path / "retry-original.txt"
+    duplicate_path = tmp_path / "retry-duplicate.txt"
+    original_path.write_text("repair-retry")
+    duplicate_path.write_text("repair-retry")
+    original = ln.Artifact(
+        original_path,
+        key="uploads/retry-original.txt",
+        description="original description",
+    ).save()
+    original.path.unlink()
+    duplicate = ln.Artifact(
+        duplicate_path,
+        key="uploads/retry-duplicate.txt",
+        description="repaired description",
+    )
+
+    if failure_stage == "cleanup":
+        with (
+            patch(
+                "lamindb.models.save.upload_artifact",
+                side_effect=RuntimeError("simulated upload failure"),
+            ),
+            patch(
+                "lamindb.models.artifact.check_and_attempt_clearing",
+                return_value=RuntimeError("simulated cleanup failure"),
+            ),
+            pytest.raises(RuntimeError, match="simulated upload failure"),
+        ):
+            duplicate.save()
+        assert duplicate._clear_storagekey is not None
+    else:
+        with (
+            patch(
+                "lamindb.models.sqlrecord.SQLRecord.save",
+                side_effect=RuntimeError("simulated database failure"),
+            ),
+            pytest.raises(RuntimeError, match="simulated database failure"),
+        ):
+            duplicate.save()
+
+    assert ln.Artifact.get(id=original.id).description == "original description"
+    duplicate.save()
+    assert duplicate.path.read_text() == "repair-retry"
+    assert ln.Artifact.get(id=original.id).description == "repaired description"
+    duplicate.delete(permanent=True)
 
 
 def test_invalid_suffix_is_empty(tmp_path):

--- a/tests/pydata/test_artifact_basics.py
+++ b/tests/pydata/test_artifact_basics.py
@@ -515,8 +515,7 @@ def test_existing_hash_keeps_completed_storage_object(tmp_path):
     duplicate.delete(permanent=True)
 
 
-@pytest.mark.parametrize("source_kind", ["local", "cloud"])
-def test_existing_hash_repairs_missing_storage_object(tmp_path, source_kind):
+def test_existing_hash_repairs_missing_storage_object(tmp_path):
     original_path = tmp_path / "original.jpg"
     duplicate_path = tmp_path / "duplicate.jpg"
     original_path.write_bytes(b"same-content")
@@ -534,16 +533,9 @@ def test_existing_hash_repairs_missing_storage_object(tmp_path, source_kind):
         key="uploads/duplicate.jpg",
         description="duplicate description",
     )
-    if source_kind == "cloud":
-        duplicate._cloud_filepath = UPath(duplicate._local_filepath)
-        del duplicate._local_filepath
-
     assert not duplicate._state.adding
     assert duplicate.id == original.id
-    if source_kind == "local":
-        assert duplicate._local_filepath == duplicate_path
-    else:
-        assert duplicate._cloud_filepath == UPath(duplicate_path)
+    assert duplicate._local_filepath == duplicate_path
 
     duplicate.save()
     assert duplicate.path.exists()
@@ -597,6 +589,7 @@ def test_existing_hash_repair_failure_preserves_record(tmp_path, save_mode):
     persisted = ln.Artifact.get(id=original.id)
     assert persisted.key == "uploads/original-failure.jpg"
     assert persisted.description == "original description"
+    assert persisted._storage_ongoing
     persisted.delete(permanent=True, storage=False)
 
 
@@ -793,6 +786,47 @@ def test_existing_hash_repair_retry(tmp_path, failure_stage):
     assert duplicate.path.read_text() == "repair-retry"
     assert ln.Artifact.get(id=original.id).description == "repaired description"
     duplicate.delete(permanent=True)
+
+
+def test_existing_hash_repair_defers_recreating_run(tmp_path):
+    original_path = tmp_path / "lineage-original.txt"
+    duplicate_path = tmp_path / "lineage-duplicate.txt"
+    original_path.write_text("lineage-repair")
+    duplicate_path.write_text("lineage-repair")
+    transform = ln.Transform(key="artifact repair lineage").save()
+    original_run = ln.Run(transform).save()
+    repair_run = ln.Run(transform).save()
+    original = ln.Artifact(
+        original_path,
+        key="uploads/lineage-original.txt",
+        run=original_run,
+    ).save()
+    original.path.unlink()
+
+    duplicate = ln.Artifact(
+        duplicate_path,
+        key="uploads/lineage-duplicate.txt",
+        run=repair_run,
+    )
+    assert repair_run not in duplicate.recreating_runs.all()
+
+    with (
+        patch(
+            "lamindb.models.artifact.check_and_attempt_upload",
+            return_value=RuntimeError("simulated upload failure"),
+        ),
+        pytest.raises(RuntimeError, match="simulated upload failure"),
+    ):
+        duplicate.save()
+
+    assert repair_run not in duplicate.recreating_runs.all()
+    duplicate.save()
+    assert repair_run in duplicate.recreating_runs.all()
+
+    duplicate.delete(permanent=True)
+    repair_run.delete(permanent=True)
+    original_run.delete(permanent=True)
+    transform.delete(permanent=True)
 
 
 def test_invalid_suffix_is_empty(tmp_path):

--- a/tests/pydata/test_artifact_basics.py
+++ b/tests/pydata/test_artifact_basics.py
@@ -537,10 +537,13 @@ def test_existing_hash_repairs_missing_storage_object(tmp_path):
     assert duplicate.id == original.id
     assert duplicate._local_filepath == duplicate_path
 
-    duplicate.save()
+    duplicate.save(update_fields=["description"])
     assert duplicate.path.exists()
     assert duplicate.key == "uploads/original.jpg"
     assert duplicate.description == "duplicate description"
+    persisted = ln.Artifact.get(id=duplicate.id)
+    assert not persisted._storage_ongoing
+    assert persisted._aux is None or "sr" not in persisted._aux
 
     duplicate.description = "description after repair"
     duplicate.save()

--- a/tests/pydata/test_artifact_basics.py
+++ b/tests/pydata/test_artifact_basics.py
@@ -568,6 +568,11 @@ def test_existing_hash_repair_failure_preserves_record(tmp_path, save_mode):
         key="uploads/duplicate-failure.jpg",
         description="duplicate description",
     )
+    healthy = None
+    if save_mode == "bulk":
+        healthy_path = tmp_path / "healthy-existing.txt"
+        healthy_path.write_text("healthy-existing")
+        healthy = ln.Artifact(healthy_path, key="uploads/healthy-existing.txt").save()
     upload_error = RuntimeError("simulated upload failure")
     upload_patch = (
         patch(
@@ -584,12 +589,16 @@ def test_existing_hash_repair_failure_preserves_record(tmp_path, save_mode):
         if save_mode == "single":
             duplicate.save()
         else:
-            ln.save([duplicate])
+            ln.save([duplicate, healthy])
 
     persisted = ln.Artifact.get(id=original.id)
     assert persisted.key == "uploads/original-failure.jpg"
     assert persisted.description == "original description"
     assert persisted._storage_ongoing
+    assert persisted._aux["sr"] == 1
+    if healthy is not None:
+        assert ln.Artifact.filter(id=healthy.id).exists()
+        healthy.delete(permanent=True)
     persisted.delete(permanent=True, storage=False)
 
 
@@ -771,6 +780,25 @@ def test_existing_hash_repair_retry(tmp_path, failure_stage):
         ):
             duplicate.save()
         assert duplicate._clear_storagekey is not None
+        interrupted = ln.Artifact.get(id=original.id)
+        assert interrupted._storage_ongoing
+        assert interrupted._aux["sr"] == 1
+        interrupted.path.write_text("partial-repair")
+        duplicate = ln.Artifact(
+            duplicate_path,
+            key="uploads/retry-duplicate.txt",
+            description="repaired description",
+        )
+        assert duplicate._is_storage_repair
+        with (
+            patch(
+                "lamindb.models.artifact.check_and_attempt_upload",
+                return_value=RuntimeError("simulated retry failure"),
+            ),
+            pytest.raises(RuntimeError, match="simulated retry failure"),
+        ):
+            duplicate.save()
+        assert ln.Artifact.filter(id=original.id).exists()
     else:
         with (
             patch(
@@ -786,6 +814,28 @@ def test_existing_hash_repair_retry(tmp_path, failure_stage):
     assert duplicate.path.read_text() == "repair-retry"
     assert ln.Artifact.get(id=original.id).description == "repaired description"
     duplicate.delete(permanent=True)
+
+
+def test_ongoing_foreign_artifact_uses_writable_fallback(tmp_path):
+    storage_root = tmp_path / "foreign-ongoing-storage"
+    storage_root.mkdir()
+    foreign_path = storage_root / "foreign-ongoing.txt"
+    duplicate_path = tmp_path / "writable-ongoing.txt"
+    foreign_path.write_text("foreign-ongoing")
+    duplicate_path.write_text("foreign-ongoing")
+    storage = ln.Storage(root=storage_root.resolve().as_posix(), type="local").save()
+    foreign_artifact = ln.Artifact(foreign_path).save()
+    foreign_artifact._storage_ongoing = True
+    foreign_artifact._save_skip_storage()
+    storage.instance_uid = "foreign-instance"
+    storage.save()
+
+    duplicate = ln.Artifact(duplicate_path, key="uploads/writable-ongoing.txt")
+
+    assert duplicate._state.adding
+    assert duplicate.storage.instance_uid == lamindb_setup.settings.instance.uid
+    foreign_artifact.delete(permanent=True, storage=False)
+    storage.delete()
 
 
 def test_existing_hash_repair_defers_recreating_run(tmp_path):
@@ -820,6 +870,24 @@ def test_existing_hash_repair_defers_recreating_run(tmp_path):
         duplicate.save()
 
     assert repair_run not in duplicate.recreating_runs.all()
+
+    def add_lineage_then_fail(artifact, run):
+        artifact.recreating_runs.add(run)
+        raise RuntimeError("simulated lineage failure")
+
+    with (
+        patch(
+            "lamindb.models._lineage.populate_recreating_run",
+            side_effect=add_lineage_then_fail,
+        ),
+        pytest.raises(RuntimeError, match="simulated lineage failure"),
+    ):
+        duplicate.save()
+
+    persisted = ln.Artifact.get(id=original.id)
+    assert persisted._storage_ongoing
+    assert persisted._aux["sr"] == 1
+    assert repair_run not in persisted.recreating_runs.all()
     duplicate.save()
     assert repair_run in duplicate.recreating_runs.all()
 


### PR DESCRIPTION
Repairs missing storage objects when an existing same-hash artifact is uploaded again, while leaving healthy stored artifacts untouched.