### PR TITLE
✨ Add MCP installation extra

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -178,7 +178,7 @@ def install_ci(session, group):
             "uv pip install --system --no-deps ./sub/pertdb",
         )
     elif group == "cli":
-        pass
+        extras += "mcp"
     elif group == "permissions":
         pass
     elif group == "profile":
@@ -197,9 +197,10 @@ def install_ci(session, group):
     # installing this after lamindb to be sure that these packages won't be reinstaled
     # during lamindb installation
     if IS_PR or group == "docs" or group == "profile":
+        local_cli = "./sub/lamin-cli[mcp]" if group == "cli" else "./sub/lamin-cli"
         run(
             session,
-            "uv pip install --system ./sub/lamindb-setup ./sub/lamin-cli ./sub/bionty ./sub/pertdb",
+            f"uv pip install --system ./sub/lamindb-setup {local_cli} ./sub/bionty ./sub/pertdb",
         )
     if group == "permissions":
         # have to install after lamindb installation

--- a/pyproject.full.toml
+++ b/pyproject.full.toml
@@ -23,6 +23,9 @@ dependencies = [
 Home = "https://github.com/laminlabs/lamindb"
 
 [project.optional-dependencies]
+mcp = [
+    "lamindb-core[mcp]==2.10.0",
+]
 gcp = [
     "lamindb_setup[gcp]",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ Home = "https://github.com/laminlabs/lamindb"
 [project.optional-dependencies]
 # full: keep in sync with pyproject.full.toml dependencies (excluding lamindb-core).
 # If you change duplicated deps here, update pyproject.full.toml too, and vice versa.
+mcp = [
+    "lamin_cli[mcp]==1.19.3",
+]
 full = [
     # LaminDB optional modules, included to avoid users forgetting about extras
     "bionty>=2.3.1,<3",  # 30kB pure python, no dependencies


### PR DESCRIPTION
Expose MCP support through LaminDB’s optional dependency groups and install the local CLI MCP extra in CI. This PR depends on the companion lamin-cli change being released; its exact CLI/core version pins and lamin-cli submodule pointer must then be updated before merging.