### PR TITLE
🚸 Support tracking `pixi` environments

### DIFF
--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -401,9 +401,19 @@ def save_context_core(
             return "rerun-the-notebook"
     if run is not None:
         base_path = ln_setup.settings.cache_dir / "environments" / f"run_{run.uid}"
-        paths = [base_path / "run_env_pip.txt", base_path / "r_environment.txt"]
-        existing_paths = [path for path in paths if path.exists()]
-        if len(existing_paths) == 2:
+        # Accept any non-empty env file written by track_python_environment.
+        # Size is checked here so an empty file (e.g. from a failed pip freeze) never
+        # reaches the hash lookup and can't collide with unrelated data artifacts.
+        _candidate_names = ("pixi.lock", "run_env_pip.txt", "r_environment.txt")
+        existing_paths = [
+            base_path / name
+            for name in _candidate_names
+            if (base_path / name).is_file() and (base_path / name).stat().st_size > 0
+        ]
+        if (
+            (base_path / "run_env_pip.txt") in existing_paths
+            and (base_path / "r_environment.txt") in existing_paths
+        ):
             # let's not store the python environment for an R session for now
             existing_paths = [base_path / "r_environment.txt"]
 
@@ -421,26 +431,40 @@ def save_context_core(
 
                 # Set description based on what we're saving
                 if len(existing_paths) == 1:
-                    if existing_paths[0].name == "run_env_pip.txt":
-                        description = "requirements.txt"
-                    elif existing_paths[0].name == "r_environment.txt":
-                        description = "r_environment.txt"
+                    _description_map = {
+                        "run_env_pip.txt": "requirements.txt",
+                        "pixi.lock": "pixi.lock",
+                        "r_environment.txt": "r_environment.txt",
+                    }
+                    description = _description_map.get(
+                        existing_paths[0].name, existing_paths[0].name
+                    )
                     size, env_hash, _ = hash_file(artifact_path)
                 else:
                     description = "environments"
                     size, env_hash, _, _ = hash_dir(artifact_path)
 
-                artifact = (
-                    ln.Artifact.objects.filter(hash=env_hash)
-                    .exclude(
-                        size=0
-                    )  # exclude empty files, which may occur for one reason or another
-                    .one_or_none()
-                )
-                new_env_artifact = artifact is None
+                if size == 0:
+                    # Belt-and-suspenders: discovery already filters empty files, but
+                    # guard here too so an empty hash never reaches the DB query.
+                    # An empty hash (MD5 of b"") can collide with data artifacts that
+                    # were registered with a placeholder hash.
+                    logger.warning(
+                        "environment file is empty, skipping linking an environment"
+                    )
+                else:
+                    # Scope reuse to __lamindb_run__ artifacts only — data artifacts
+                    # with a coincidental or placeholder hash must not be returned here.
+                    artifact = (
+                        ln.Artifact.objects.filter(
+                            hash=env_hash, kind="__lamindb_run__"
+                        )
+                        .exclude(size=0)
+                        .one_or_none()
+                    )
+                    new_env_artifact = artifact is None
 
-                if new_env_artifact:
-                    if size > 0:
+                    if new_env_artifact:
                         artifact = ln.Artifact(
                             artifact_path,
                             description=description,
@@ -448,14 +472,10 @@ def save_context_core(
                             run=False,
                         )
                         artifact.save(upload=True, print_progress=False)
-                    else:
-                        logger.warning(
-                            "environment file is empty, skipping linking an environment"
-                        )
 
-                run.environment = artifact
-                if new_env_artifact:
-                    logger.debug(f"saved run.environment: {run.environment}")
+                    run.environment = artifact
+                    if new_env_artifact:
+                        logger.debug(f"saved run.environment: {run.environment}")
 
     # set finished_at
     if finished_at and run is not None:

--- a/lamindb/_finish.py
+++ b/lamindb/_finish.py
@@ -431,14 +431,10 @@ def save_context_core(
 
                 # Set description based on what we're saving
                 if len(existing_paths) == 1:
-                    _description_map = {
-                        "run_env_pip.txt": "requirements.txt",
-                        "pixi.lock": "pixi.lock",
-                        "r_environment.txt": "r_environment.txt",
-                    }
-                    description = _description_map.get(
-                        existing_paths[0].name, existing_paths[0].name
-                    )
+                    filename = existing_paths[0].name
+                    # use the filename as description, except pip freeze which is
+                    # stored as run_env_pip.txt but shown as requirements.txt
+                    description = "requirements.txt" if filename == "run_env_pip.txt" else filename
                     size, env_hash, _ = hash_file(artifact_path)
                 else:
                     description = "environments"

--- a/lamindb/core/_track_environment.py
+++ b/lamindb/core/_track_environment.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import lamindb_setup as ln_setup
@@ -11,21 +13,73 @@ if TYPE_CHECKING:
     from lamindb.models import Run
 
 
+def _find_pixi_project_root() -> Path | None:
+    """Return the pixi project root if this process is running inside a pixi env."""
+    # sys.prefix inside a pixi env looks like: .../<project>/.pixi/envs/<name>
+    prefix = Path(sys.prefix).resolve()
+    parts = prefix.parts
+    try:
+        idx = parts.index(".pixi")
+    except ValueError:
+        idx = -1
+    if idx > 0 and idx + 1 < len(parts) and parts[idx + 1] == "envs":
+        return Path(*parts[:idx])
+    # Fallback: walk up from cwd looking for pixi.toml
+    for path in (Path.cwd(), *Path.cwd().parents):
+        if (path / "pixi.toml").exists():
+            return path
+    return None
+
+
+def _track_pixi_lock(env_dir: Path) -> bool:
+    root = _find_pixi_project_root()
+    if root is None:
+        return False
+    lock = root / "pixi.lock"
+    if not lock.is_file() or lock.stat().st_size == 0:
+        return False
+    env_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(lock, env_dir / "pixi.lock")
+    logger.info(f"tracked pixi.lock > {env_dir / 'pixi.lock'}")
+    return True
+
+
+def _track_pip_freeze(env_dir: Path) -> bool:
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "freeze"],
+            capture_output=True,
+            text=True,
+        )
+    except OSError as e:
+        logger.warning(f"could not run pip freeze: {e}")
+        return False
+    if result.returncode != 0:
+        err = (result.stderr or "").strip()
+        logger.warning(
+            "could not run pip freeze"
+            + (f": {err}" if err else f" (exit code {result.returncode})")
+        )
+        return False
+    if not result.stdout.strip():
+        logger.warning("pip freeze returned empty output, skipping environment tracking")
+        return False
+    env_dir.mkdir(parents=True, exist_ok=True)
+    filepath = env_dir / "run_env_pip.txt"
+    filepath.write_text(result.stdout)
+    logger.info(f"tracked pip freeze > {filepath}")
+    return True
+
+
 def track_python_environment(run: Run) -> None:
     env_dir = ln_setup.settings.cache_dir / "environments" / f"run_{run.uid}"
-    filepath = env_dir / "run_env_pip.txt"
-    if not env_dir.exists():
-        filepath.parent.mkdir(parents=True)
-    # create a requirements.txt
+    # Prefer pixi lockfile when running inside a pixi environment.
+    if _track_pixi_lock(env_dir):
+        return
     # we don't create a conda environment.yml mostly for its slowness
-    try:
-        with open(filepath, "w") as f:
-            result = subprocess.run(
-                [sys.executable, "-m", "pip", "freeze"],
-                stdout=f,
-            )
-    except OSError as e:
-        result = None
-        logger.warning(f"could not run pip freeze with error {e}")
-    if result is not None and result.returncode == 0:
-        logger.info(f"tracked pip freeze > {str(filepath)}")
+    if _track_pip_freeze(env_dir):
+        return
+    logger.warning(
+        "could not track Python environment"
+        " (no pixi.lock found, pip freeze unavailable)"
+    )

--- a/tests/pydata/test_track_script_or_notebook.py
+++ b/tests/pydata/test_track_script_or_notebook.py
@@ -724,6 +724,70 @@ def test_logstream_tracker_exception_handling():
             log_path.unlink()
 
 
+def test_track_environment_pixi_lock_copied_when_detected(tmp_path, monkeypatch):
+    """pixi.lock is copied to cache when sys.prefix is inside .pixi/envs/; nothing
+    written when sys.prefix is a normal venv or pixi.lock is absent."""
+    from lamindb.core._track_environment import _find_pixi_project_root, _track_pixi_lock
+
+    project_root = (tmp_path / "my_project").resolve()
+    (project_root / ".pixi" / "envs" / "default").mkdir(parents=True)
+    (project_root / "pixi.toml").write_text("[project]\nname = 'test'\n")
+    lock_content = "version: 6\nenvironments:\n  default:\n    packages: []\n"
+    (project_root / "pixi.lock").write_text(lock_content)
+
+    fake_prefix = str(project_root / ".pixi" / "envs" / "default")
+    monkeypatch.setattr("lamindb.core._track_environment.sys.prefix", fake_prefix)
+
+    # pixi env detected and lock copied
+    assert _find_pixi_project_root() == project_root
+    env_dir = tmp_path / "env_cache"
+    assert _track_pixi_lock(env_dir) is True
+    assert (env_dir / "pixi.lock").read_text() == lock_content
+
+    # normal venv prefix → not detected, no file written
+    monkeypatch.setattr("lamindb.core._track_environment.sys.prefix", str(tmp_path / "venv"))
+    monkeypatch.chdir(tmp_path)
+    assert _find_pixi_project_root() is None
+
+    # pixi detected but lock absent → not copied
+    (project_root / "pixi.lock").unlink()
+    monkeypatch.setattr("lamindb.core._track_environment.sys.prefix", fake_prefix)
+    env_dir2 = tmp_path / "env_cache2"
+    assert _track_pixi_lock(env_dir2) is False
+    assert not (env_dir2 / "pixi.lock").exists()
+
+
+def test_track_environment_pip_freeze_no_empty_file_on_failure(tmp_path):
+    """No empty file is written when pip freeze fails (non-zero exit) or
+    returns blank output — both would otherwise produce the empty-MD5 hash."""
+    import subprocess as _subprocess
+    from lamindb.core._track_environment import _track_pip_freeze
+
+    env_dir = tmp_path / "env_cache"
+
+    # case 1: pip missing (non-zero exit)
+    def pip_missing(cmd, **kwargs):
+        r = _subprocess.CompletedProcess(cmd, returncode=1)
+        r.stdout = ""
+        r.stderr = "No module named pip"
+        return r
+
+    with patch("lamindb.core._track_environment.subprocess.run", side_effect=pip_missing):
+        assert _track_pip_freeze(env_dir) is False
+    assert not (env_dir / "run_env_pip.txt").exists()
+
+    # case 2: pip exits 0 but blank output (empty env)
+    def pip_blank(cmd, **kwargs):
+        r = _subprocess.CompletedProcess(cmd, returncode=0)
+        r.stdout = "   \n"
+        r.stderr = ""
+        return r
+
+    with patch("lamindb.core._track_environment.subprocess.run", side_effect=pip_blank):
+        assert _track_pip_freeze(env_dir) is False
+    assert not (env_dir / "run_env_pip.txt").exists()
+
+
 def test_logstream_tracker_cleanup_sigint_chains_to_keyboard_interrupt():
     tracker = LogStreamTracker()
     run = MockRun("sigint")


### PR DESCRIPTION
In this PR, we extend environment tracking to support pixi-managed Python environments, which deliberately omit pip and therefore caused ln.track() to silently produce an empty run_env_pip.txt and subsequently crash.

Fixing -> pfizer-collab/laminlabs#1170