### PR TITLE
🔒️ Adjust run tracking permisison handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
           repository: laminlabs/laminhub
           token: ${{ secrets.GH_TOKEN_DEPLOY_LAMINAPP }}
           path: laminhub
-          ref: allow_track
+          ref: main
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
           repository: laminlabs/laminhub
           token: ${{ secrets.GH_TOKEN_DEPLOY_LAMINAPP }}
           path: laminhub
-          ref: main
+          ref: allow_track
 
       - uses: actions/setup-python@v6
         with:

--- a/lamindb/models/_lineage.py
+++ b/lamindb/models/_lineage.py
@@ -180,47 +180,18 @@ def track_run_inputs(
                     f"You’re not allowed to write to the instance {instance.slug}.\n"
                     "Please contact administrators of the instance if you need write access."
                 ) from None
+            # write access to *_input_of_runs is determined by the run space
             write_access_spaces = available_spaces["admin"] + available_spaces["write"]
-            no_write_access_spaces = {
-                dataset_space
-                for dataset in input_datasets
-                if (dataset_space := dataset.space) not in write_access_spaces
-            }
-            if (run_space := run.space) not in write_access_spaces:
-                no_write_access_spaces.add(run_space)
-
-            if not no_write_access_spaces:
-                # if there are no unavailable spaces, then this should be due to locking
-                locked_datasets = [
-                    dataset
-                    for dataset in input_datasets
-                    if getattr(dataset, "is_locked", False)
-                ]
-                if run.is_locked:
-                    locked_datasets.append(run)
-                # if no unavailable spaces and no locked datasets, just raise the original error
-                if not locked_datasets:
-                    raise e
-                no_write_msg = (
+            if run.space not in write_access_spaces:
+                raise NoWriteAccess(
+                    f"You’re not allowed to write to the space '{run.space.name}'.\n"
+                    "Please contact administrators of the space if you need write access."
+                ) from None
+            if run.is_locked:
+                raise NoWriteAccess(
                     "It is not allowed to modify locked objects: "
-                    + ", ".join(
-                        r.__class__.__name__ + f"(uid={r.uid})" for r in locked_datasets
-                    )
-                    + "."
-                )
-                raise NoWriteAccess(no_write_msg) from None
-
-            if len(no_write_access_spaces) > 1:
-                name_msg = ", ".join(
-                    f"'{space.name}'" for space in no_write_access_spaces
-                )
-                space_msg = "spaces"
-            else:
-                name_msg = f"'{no_write_access_spaces.pop().name}'"
-                space_msg = "space"
-            raise NoWriteAccess(
-                f"You’re not allowed to write to the {space_msg} {name_msg}.\n"
-                f"Please contact administrators of the {space_msg} if you need write access."
-            ) from None
+                    + f"Run(uid={run.uid})."
+                ) from None
+            raise e
         else:
             raise e

--- a/tests/permissions/test_rls_dbwritelog.py
+++ b/tests/permissions/test_rls_dbwritelog.py
@@ -458,12 +458,6 @@ def test_tracking_error():
     transform = ln.Transform(key="My transform").save()
     run = ln.Run(transform).save()
 
-    # this error because ln.setup.settings.instance._db_permissions is not jwt
-    # it is None
-    with pytest.raises(ln.errors.NoWriteAccess) as e:
-        track_run_inputs(artifact, run)
-    assert "You’re not allowed to write to the instance " in str(e)
-
     # the instance is local so we set this manually
     ln.setup.settings.instance._db_permissions = "jwt"
     # write access is determined by the run space, not the artifact space
@@ -493,7 +487,11 @@ def test_tracking_error():
     track_run_inputs(artifact, run_full_access)
     assert run_full_access in artifact.input_of_runs.all()
 
+    # without jwt, the same RLS failure is reported as instance-level
     ln.setup.settings.instance._db_permissions = None
+    with pytest.raises(ln.errors.NoWriteAccess) as e:
+        track_run_inputs(artifact, run)
+    assert "You’re not allowed to write to the instance " in str(e)
 
 
 def test_token_reset():

--- a/tests/permissions/test_rls_dbwritelog.py
+++ b/tests/permissions/test_rls_dbwritelog.py
@@ -466,27 +466,32 @@ def test_tracking_error():
 
     # the instance is local so we set this manually
     ln.setup.settings.instance._db_permissions = "jwt"
-    # artifact.space is not available for writes
-    with pytest.raises(ln.errors.NoWriteAccess) as e:
-        track_run_inputs(artifact, run)
-    assert "You’re not allowed to write to the space " in str(e)
+    # write access is determined by the run space, not the artifact space
+    track_run_inputs(artifact, run)
+    assert run in artifact.input_of_runs.all()
 
-    # this artifact is locked
-    artifact = ln.Artifact.get(description="test locking")
-    with pytest.raises(ln.errors.NoWriteAccess) as e:
-        track_run_inputs(artifact, run)
-    assert "It is not allowed to modify locked objects" in str(e)
+    # locked artifact is also allowed; only the run is checked
+    artifact_locked = ln.Artifact.get(description="test locking")
+    track_run_inputs(artifact_locked, run)
+    assert run in artifact_locked.input_of_runs.all()
+
+    run_full_access = ln.Run(transform)
+    run_full_access.space = ln.Space.get(name="full access")
+    run_full_access.save()
 
     # switch user role back to read
     with psycopg2.connect(pgurl) as conn, conn.cursor() as cur:
         cur.execute(
             "UPDATE hubmodule_account SET role = 'read' WHERE id = %s", (user_uuid,)
         )
-    # as the user is read-only now, 2 spaces are unavailable for writes (artifact.space, run.space)
-    artifact = ln.Artifact.get(description="test tracking error")
+    # default space is read-only now
     with pytest.raises(ln.errors.NoWriteAccess) as e:
         track_run_inputs(artifact, run)
-    assert "You’re not allowed to write to the spaces " in str(e)
+    assert "You’re not allowed to write to the space " in str(e)
+
+    # full access run is still writable; artifact space does not matter
+    track_run_inputs(artifact, run_full_access)
+    assert run_full_access in artifact.input_of_runs.all()
 
     ln.setup.settings.instance._db_permissions = None
 


### PR DESCRIPTION
Adjust for these changes: https://github.com/laminlabs/laminhub/pull/5985
Address https://github.com/pfizer-collab/laminlabs/issues/1169

Now it is possible to track `artifacts`, `collections`, `records` that are in a read-only `space` if the `run` is in a writable `space`.