### PR TITLE
:bug: In `artifact.describe()`, correctly deal with datasets that exceed the maximum number of preview features

### DIFF
--- a/lamindb/models/_django.py
+++ b/lamindb/models/_django.py
@@ -9,7 +9,6 @@ from django.db.models.fields.related import ForeignKey, ManyToManyField
 from django.db.models.fields.reverse_related import ManyToManyRel, ManyToOneRel
 from django.db.models.functions import JSONObject
 
-from ._feature_constants import SCHEMA_MEMBER_PREVIEW_LIMIT
 from ._relations import dict_related_model_to_related_name, get_schema_modules
 from .schema import Schema
 
@@ -17,6 +16,9 @@ if TYPE_CHECKING:
     from .artifact import Artifact, Collection
     from .record import Record
     from .run import Run
+
+
+SCHEMA_MEMBER_PREVIEW_LIMIT = 20
 
 
 def patch_many_to_many_descriptor() -> None:

--- a/lamindb/models/_django.py
+++ b/lamindb/models/_django.py
@@ -9,6 +9,7 @@ from django.db.models.fields.related import ForeignKey, ManyToManyField
 from django.db.models.fields.reverse_related import ManyToManyRel, ManyToOneRel
 from django.db.models.functions import JSONObject
 
+from ._feature_constants import SCHEMA_MEMBER_PREVIEW_LIMIT
 from ._relations import dict_related_model_to_related_name, get_schema_modules
 from .schema import Schema
 
@@ -349,7 +350,11 @@ def get_collection_with_related(
     }
 
 
-def get_schema_m2m_relations(artifact: Artifact, slot_schema: dict, limit: int = 20):
+def get_schema_m2m_relations(
+    artifact: Artifact,
+    slot_schema: dict,
+    limit: int = SCHEMA_MEMBER_PREVIEW_LIMIT,
+):
     """Fetch all many-to-many relationships for given feature sets."""
     from .can_curate import get_name_field
 

--- a/lamindb/models/_feature_constants.py
+++ b/lamindb/models/_feature_constants.py
@@ -1,0 +1,4 @@
+"""Shared constants for feature metadata handling."""
+
+# Number of schema members included when constructing feature preview metadata.
+SCHEMA_MEMBER_PREVIEW_LIMIT = 20

--- a/lamindb/models/_feature_constants.py
+++ b/lamindb/models/_feature_constants.py
@@ -1,4 +1,0 @@
-"""Shared constants for feature metadata handling."""
-
-# Number of schema members included when constructing feature preview metadata.
-SCHEMA_MEMBER_PREVIEW_LIMIT = 20

--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -47,6 +47,7 @@ from ._describe import (
     format_rich_tree,
 )
 from ._django import get_artifact_or_run_with_related
+from ._feature_constants import SCHEMA_MEMBER_PREVIEW_LIMIT
 from ._label_manager import _get_labels
 from ._relations import (
     dict_related_model_to_related_name,
@@ -533,7 +534,9 @@ def get_features_data(
                     # features.first() is a lot slower than features[0] here
                     name_field = get_name_field(features[0])
                     feature_names = list(
-                        features.values_list(name_field, flat=True)[:20]
+                        features.values_list(name_field, flat=True)[
+                            :SCHEMA_MEMBER_PREVIEW_LIMIT
+                        ]
                     )
                     schema_data[slot] = (schema, feature_names)
                     for feature_name in feature_names:
@@ -659,7 +662,11 @@ def describe_features(
     # internal features that contain labels (only `Feature` features contain labels)
     internal_feature_labels_slot: dict[str, list] = {}
     for feature_name, feature_row in internal_feature_labels.items():
-        slot, _ = feature_data.get(feature_name)
+        slot_and_dtype = feature_data.get(feature_name)
+        if slot_and_dtype is None:
+            # Gracefully handle incomplete feature metadata.
+            continue
+        slot, _ = slot_and_dtype
         internal_feature_labels_slot.setdefault(slot, []).append(feature_row)
 
     dataset_features_tree_children = []

--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -46,8 +46,7 @@ from ._describe import (
     describe_header,
     format_rich_tree,
 )
-from ._django import get_artifact_or_run_with_related
-from ._feature_constants import SCHEMA_MEMBER_PREVIEW_LIMIT
+from ._django import SCHEMA_MEMBER_PREVIEW_LIMIT, get_artifact_or_run_with_related
 from ._label_manager import _get_labels
 from ._relations import (
     dict_related_model_to_related_name,

--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -660,13 +660,29 @@ def describe_features(
     # Dataset features section
     # internal features that contain labels (only `Feature` features contain labels)
     internal_feature_labels_slot: dict[str, list] = {}
+    skipped_internal_feature_labels: list[str] = []
     for feature_name, feature_row in internal_feature_labels.items():
         slot_and_dtype = feature_data.get(feature_name)
         if slot_and_dtype is None:
-            # Gracefully handle incomplete feature metadata.
+            # Internal categorical values can exist for features omitted from the
+            # schema-member preview (`SCHEMA_MEMBER_PREVIEW_LIMIT`).
+            skipped_internal_feature_labels.append(feature_name)
             continue
         slot, _ = slot_and_dtype
         internal_feature_labels_slot.setdefault(slot, []).append(feature_row)
+    if skipped_internal_feature_labels:
+        skipped_preview = _format_values(
+            sorted(skipped_internal_feature_labels),
+            n=5,
+            quotes=False,
+        )
+        logger.warning(
+            "Skipping values for "
+            f"{len(skipped_internal_feature_labels)} internal feature(s) in "
+            f"describe(): {skipped_preview}. "
+            "These features are outside the schema preview limit "
+            f"({SCHEMA_MEMBER_PREVIEW_LIMIT})."
+        )
 
     dataset_features_tree_children = []
     for slot, (schema, feature_names_or_n) in schema_data.items():

--- a/tests/pydata/test_artifact_describe_to_dataframe.py
+++ b/tests/pydata/test_artifact_describe_to_dataframe.py
@@ -169,26 +169,24 @@ def test_describe_to_dataframe_example_dataset():
 
     # Regression: describe should not fail when internal categorical features
     # exceed the schema member preview limit used in feature metadata.
-    extra_obs_features = [
+    extra_df_features = [
         ln.Feature(name=f"extra_cat_{i:02d}", dtype=str).save() for i in range(25)
     ]
-    obs_schema = ln.Schema(
-        features=extra_obs_features,
-        name="many-obs-feature-schema",
+    wide_df_schema = ln.Schema(
+        features=extra_df_features,
+        name="many-df-feature-schema",
     ).save()
-    anndata_schema = ln.Schema(
-        otype="AnnData",
-        slots={"obs": obs_schema},
-        name="many-obs-anndata-schema",
+    wide_df = pd.DataFrame(
+        {f"extra_cat_{i:02d}": pd.Categorical(["A", "B", "B"]) for i in range(25)}
+    )
+    artifact3 = ln.Artifact.from_dataframe(
+        wide_df,
+        key="examples/dataset_with_many_df_features.parquet",
+        schema=wide_df_schema,
     ).save()
-    adata_wide = ln.examples.datasets.mini_immuno.get_dataset1(otype="AnnData")
-    for i in range(25):
-        adata_wide.obs[f"extra_cat_{i:02d}"] = pd.Categorical(["A", "B", "B"])
-    artifact3 = ln.Artifact.from_anndata(
-        adata_wide,
-        key="examples/dataset_with_many_obs_features.h5ad",
-        schema=anndata_schema,
-    ).save()
+    artifact3.features.add_values(
+        {f"extra_cat_{i:02d}": "A" if i % 2 == 0 else "B" for i in range(25)}
+    )
     output_wide = artifact3.describe(return_str=True)
     assert "Dataset features" in output_wide
     assert "extra_cat_19" in output_wide
@@ -264,8 +262,7 @@ def test_describe_to_dataframe_example_dataset():
     artifact.delete(permanent=True)
     artifact2.delete(permanent=True)
     artifact3.delete(permanent=True)
-    anndata_schema.delete(permanent=True)
-    obs_schema.delete(permanent=True)
+    wide_df_schema.delete(permanent=True)
     ln.Schema.get(name="anndata_ensembl_gene_ids_and_valid_features_in_obs").delete(
         permanent=True
     )

--- a/tests/pydata/test_artifact_describe_to_dataframe.py
+++ b/tests/pydata/test_artifact_describe_to_dataframe.py
@@ -167,6 +167,32 @@ def test_describe_to_dataframe_example_dataset():
     assert "created_by:" in output
     assert "created_at:" in output
 
+    # Regression: describe should not fail when internal categorical features
+    # exceed the schema member preview limit used in feature metadata.
+    extra_obs_features = [
+        ln.Feature(name=f"extra_cat_{i:02d}", dtype=str).save() for i in range(25)
+    ]
+    obs_schema = ln.Schema(
+        features=extra_obs_features,
+        name="many-obs-feature-schema",
+    ).save()
+    anndata_schema = ln.Schema(
+        otype="AnnData",
+        slots={"obs": obs_schema},
+        name="many-obs-anndata-schema",
+    ).save()
+    adata_wide = ln.examples.datasets.mini_immuno.get_dataset1(otype="AnnData")
+    for i in range(25):
+        adata_wide.obs[f"extra_cat_{i:02d}"] = pd.Categorical(["A", "B", "B"])
+    artifact3 = ln.Artifact.from_anndata(
+        adata_wide,
+        key="examples/dataset_with_many_obs_features.h5ad",
+        schema=anndata_schema,
+    ).save()
+    output_wide = artifact3.describe(return_str=True)
+    assert "Dataset features" in output_wide
+    assert "extra_cat_19" in output_wide
+
     # dataset section
     assert (
         artifact.features.describe(return_str=True)
@@ -237,6 +263,9 @@ def test_describe_to_dataframe_example_dataset():
 
     artifact.delete(permanent=True)
     artifact2.delete(permanent=True)
+    artifact3.delete(permanent=True)
+    anndata_schema.delete(permanent=True)
+    obs_schema.delete(permanent=True)
     ln.Schema.get(name="anndata_ensembl_gene_ids_and_valid_features_in_obs").delete(
         permanent=True
     )

--- a/tests/pydata/test_artifact_describe_to_dataframe.py
+++ b/tests/pydata/test_artifact_describe_to_dataframe.py
@@ -6,6 +6,9 @@ import numpy as np
 import pandas as pd
 import pytest
 from lamindb.models._describe import describe_postgres, describe_sqlite
+from lamindb.models._feature_constants import SCHEMA_MEMBER_PREVIEW_LIMIT
+
+N_WIDE_DF_FEATURES = SCHEMA_MEMBER_PREVIEW_LIMIT + 5
 
 
 def _check_df_equality(actual_df: pd.DataFrame, expected_df: pd.DataFrame) -> bool:
@@ -170,14 +173,18 @@ def test_describe_to_dataframe_example_dataset():
     # Regression: describe should not fail when internal categorical features
     # exceed the schema member preview limit used in feature metadata.
     extra_df_features = [
-        ln.Feature(name=f"extra_cat_{i:02d}", dtype=str).save() for i in range(25)
+        ln.Feature(name=f"extra_cat_{i:02d}", dtype=str).save()
+        for i in range(N_WIDE_DF_FEATURES)
     ]
     wide_df_schema = ln.Schema(
         features=extra_df_features,
         name="many-df-feature-schema",
     ).save()
     wide_df = pd.DataFrame(
-        {f"extra_cat_{i:02d}": pd.Categorical(["A", "B", "B"]) for i in range(25)}
+        {
+            f"extra_cat_{i:02d}": pd.Categorical(["A", "B", "B"])
+            for i in range(N_WIDE_DF_FEATURES)
+        }
     )
     artifact3 = ln.Artifact.from_dataframe(
         wide_df,
@@ -185,11 +192,14 @@ def test_describe_to_dataframe_example_dataset():
         schema=wide_df_schema,
     ).save()
     artifact3.features.add_values(
-        {f"extra_cat_{i:02d}": "A" if i % 2 == 0 else "B" for i in range(25)}
+        {
+            f"extra_cat_{i:02d}": "A" if i % 2 == 0 else "B"
+            for i in range(N_WIDE_DF_FEATURES)
+        }
     )
     output_wide = artifact3.describe(return_str=True)
     assert "Dataset features" in output_wide
-    assert "extra_cat_19" in output_wide
+    assert f"extra_cat_{SCHEMA_MEMBER_PREVIEW_LIMIT - 1:02d}" in output_wide
 
     # dataset section
     assert (

--- a/tests/pydata/test_artifact_describe_to_dataframe.py
+++ b/tests/pydata/test_artifact_describe_to_dataframe.py
@@ -50,7 +50,7 @@ def _check_df_equality(actual_df: pd.DataFrame, expected_df: pd.DataFrame) -> bo
 
 # parallels the `registries` guide
 # please also see the test_querset.py tests
-def test_describe_to_dataframe_example_dataset():
+def test_describe_to_dataframe_example_dataset(ccaplog):
     ln.examples.datasets.mini_immuno.save_mini_immuno_datasets()
     artifact = ln.Artifact.get(key="examples/dataset1.h5ad")
     artifact2 = ln.Artifact.get(key="examples/dataset2.h5ad")
@@ -200,6 +200,7 @@ def test_describe_to_dataframe_example_dataset():
     output_wide = artifact3.describe(return_str=True)
     assert "Dataset features" in output_wide
     assert f"extra_cat_{SCHEMA_MEMBER_PREVIEW_LIMIT - 1:02d}" in output_wide
+    assert "Skipping values for 5 internal feature(s) in describe()" in ccaplog.text
 
     # dataset section
     assert (

--- a/tests/pydata/test_artifact_describe_to_dataframe.py
+++ b/tests/pydata/test_artifact_describe_to_dataframe.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from lamindb.models._describe import describe_postgres, describe_sqlite
-from lamindb.models._feature_constants import SCHEMA_MEMBER_PREVIEW_LIMIT
+from lamindb.models._django import SCHEMA_MEMBER_PREVIEW_LIMIT
 
 N_WIDE_DF_FEATURES = SCHEMA_MEMBER_PREVIEW_LIMIT + 5
 


### PR DESCRIPTION
Resolves:

- https://github.com/pfizer-collab/laminlabs/issues/1182