### PR TITLE
:construction_worker: Deal with deprecated modules in test coverage compute

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,18 @@
+# Codecov configuration for lamindb
+#
+# WHY this threshold exists:
+# The `integrations` CI group (which covers lamindb/integrations/lightning.py and
+# other integrations) only runs on PRs that touch lamindb/integrations/** or
+# tests/integrations/**. On all other PRs, those ~450 lines are never instrumented,
+# so Codecov sees them as 0% covered and reports a spurious project-level drop of
+# ~2-3%. The 3% threshold here absorbs that variance without masking real regressions.
+coverage:
+  status:
+    project:
+      default:
+        target: auto      # compare against the base branch, not a fixed %
+        threshold: 3%     # allow up to 3% drop before failing (covers missing integration runs)
+    patch:
+      default:
+        target: 70%       # at least 70% of newly added lines must be covered
+        threshold: 0%     # no tolerance on patch — fail if target not met

--- a/tests/no_instance/test_import_side_effects.py
+++ b/tests/no_instance/test_import_side_effects.py
@@ -133,3 +133,37 @@ def test_storage_import_side_effects(
 
     result = _probe_modules_loaded(code)
     _assert_modules(result, expected_after, label)
+
+
+def test_deprecated_base_ids():
+    """lamindb.base.ids is deprecated in favour of lamindb.base.uids."""
+    import warnings
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        import lamindb.base.ids  # noqa: F401
+
+    assert any(issubclass(warning.category, DeprecationWarning) for warning in w)
+
+
+def test_deprecated_core_exceptions():
+    """lamindb.core.exceptions is deprecated in favour of lamindb.errors."""
+    import warnings
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        import lamindb.core.exceptions  # noqa: F401
+
+    assert any(issubclass(warning.category, DeprecationWarning) for warning in w)
+
+
+def test_setup_shim_imports():
+    """lamindb.setup.core, .errors and .types are thin re-export shims."""
+    import lamindb.setup.core  # noqa: F401
+    import lamindb.setup.errors  # noqa: F401
+    import lamindb.setup.types  # noqa: F401
+
+
+def test_core_storage_types_import():
+    """lamindb.core.storage.types is a TYPE_CHECKING-only module."""
+    import lamindb.core.storage.types  # noqa: F401


### PR DESCRIPTION
This PR is aimed at increasing the test coverage 