### PR TITLE
:children_crossing: Allow scoping `schema.itype` to a `Feature` type

### DIFF
--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -676,9 +676,19 @@ class ComponentCurator(Curator):
         feature_ids: set[int] = set()
 
         if schema.flexible:
-            features += (
-                Feature.connect(using).filter(name__in=self._dataset.keys()).to_list()
-            )
+            _itype = schema.itype
+            if _itype and _itype.startswith("Feature["):
+                # Scoped itype: "Feature[<uid>]" — only fetch features of that type.
+                _type_uid = _itype[len("Feature["):-1]
+                features += (
+                    Feature.connect(using)
+                    .filter(name__in=self._dataset.keys(), type__uid=_type_uid)
+                    .to_list()
+                )
+            else:
+                features += (
+                    Feature.connect(using).filter(name__in=self._dataset.keys()).to_list()
+                )
             feature_ids = {feature.id for feature in features}
 
         if schema.n_members and schema.n_members > 0:
@@ -1243,14 +1253,15 @@ class AnnDataCurator(SlotsCurator):
                     if slot == "var.T"
                     or (
                         slot == "var"
-                        and schema.slots["var"].itype not in {None, "Feature"}
+                        and schema.slots["var"].itype is not None
+                    and not schema.slots["var"].itype.startswith("Feature")
                     )
                     else getattr(self._dataset, slot)
                 )
             self._slots[slot] = ComponentCurator(df, slot_schema, slot=slot)
 
             # Handle var index naming for backward compat
-            if slot == "var" and schema.slots["var"].itype not in {None, "Feature"}:
+            if slot == "var" and schema.slots["var"].itype is not None and not schema.slots["var"].itype.startswith("Feature"):
                 logger.warning(
                     "auto-transposed `var` for backward compat, please indicate transposition in the schema definition by calling out `.T`: slots={'var.T': itype=bt.Gene.ensembl_gene_id}"
                 )
@@ -1348,10 +1359,7 @@ class MuDataCurator(SlotsCurator):
                     df = getattr(schema_dataset, modality_slot.rstrip(".T"))
 
             # Transpose var if necessary
-            if modality_slot == "var" and schema.slots[slot].itype not in {
-                None,
-                "Feature",
-            }:
+            if modality_slot == "var" and schema.slots[slot].itype is not None and not schema.slots[slot].itype.startswith("Feature"):
                 logger.warning(
                     "auto-transposed `var` for backward compat, please indicate transposition in the schema definition by calling out `.T`: slots={'var.T': itype=bt.Gene.ensembl_gene_id}"
                 )
@@ -1444,10 +1452,7 @@ class SpatialDataCurator(SlotsCurator):
                         raise InvalidArgument(f"Unrecognized slot format: {slot}")
 
             # Handle var transposition logic
-            if table_slot == "var" and schema.slots[slot].itype not in {
-                None,
-                "Feature",
-            }:
+            if table_slot == "var" and schema.slots[slot].itype is not None and not schema.slots[slot].itype.startswith("Feature"):
                 logger.warning(
                     "auto-transposed `var` for backward compat, please indicate transposition in the schema definition by calling out `.T`: slots={'var.T': itype=bt.Gene.ensembl_gene_id}"
                 )

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -676,31 +676,20 @@ class ComponentCurator(Curator):
         feature_ids: set[int] = set()
 
         if schema.flexible:
-            qs = Feature.connect(using).filter(name__in=self._dataset.keys())
             itype = schema.itype
             if itype and itype.startswith("Feature["):
-                # Scoped itype "Feature[<uid>]": restrict to features whose type
-                # is the root type OR any of its descendant types (recursive).
+                # Scoped itype "Feature[<uid>]": use query_features() which
+                # efficiently traverses the full sub-type hierarchy in one
+                # query per depth level (BFS implemented in _query_relatives).
                 # Note: startswith("Feature[") not startswith("Feature") because
-                # the unscoped "Feature" itype should not filter by type__uid.
-                #
-                # BFS over the type hierarchy to collect all descendant type UIDs.
-                # Example: type_a → {type_a, type_a1, type_a2}, so features
-                # of type_a1 and type_a2 are also included.
+                # the unscoped "Feature" itype should not filter by type.
                 root_uid = itype[8:-1]  # len("Feature[") == 8
-                type_uids: set[str] = {root_uid}
-                queue = [root_uid]
-                while queue:
-                    uid = queue.pop()
-                    for child_uid in (
-                        Feature.connect(using)
-                        .filter(type__uid=uid, is_type=True)
-                        .values_list("uid", flat=True)
-                    ):
-                        if child_uid not in type_uids:
-                            type_uids.add(child_uid)
-                            queue.append(child_uid)
-                qs = qs.filter(type__uid__in=type_uids)
+                feature_type = Feature.connect(using).get(uid=root_uid)
+                qs = feature_type.query_features().filter(
+                    name__in=self._dataset.keys()
+                )
+            else:
+                qs = Feature.connect(using).filter(name__in=self._dataset.keys())
             features += qs.to_list()
             feature_ids = {feature.id for feature in features}
 

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -676,19 +676,15 @@ class ComponentCurator(Curator):
         feature_ids: set[int] = set()
 
         if schema.flexible:
-            _itype = schema.itype
-            if _itype and _itype.startswith("Feature["):
-                # Scoped itype: "Feature[<uid>]" — only fetch features of that type.
-                _type_uid = _itype[len("Feature["):-1]
-                features += (
-                    Feature.connect(using)
-                    .filter(name__in=self._dataset.keys(), type__uid=_type_uid)
-                    .to_list()
-                )
-            else:
-                features += (
-                    Feature.connect(using).filter(name__in=self._dataset.keys()).to_list()
-                )
+            qs = Feature.connect(using).filter(name__in=self._dataset.keys())
+            itype = schema.itype
+            if itype and itype.startswith("Feature["):
+                # Scoped itype "Feature[<uid>]": restrict to features of that type only.
+                # Note: startswith("Feature[") not startswith("Feature") because the
+                # unscoped "Feature" itype should not filter by type__uid.
+                type_uid = itype[8:-1]  # len("Feature[") == 8
+                qs = qs.filter(type__uid=type_uid)
+            features += qs.to_list()
             feature_ids = {feature.id for feature in features}
 
         if schema.n_members and schema.n_members > 0:
@@ -1254,6 +1250,10 @@ class AnnDataCurator(SlotsCurator):
                     or (
                         slot == "var"
                         and schema.slots["var"].itype is not None
+                    # startswith("Feature") covers both "Feature" and "Feature[uid]":
+                    # neither generic nor scoped Feature schemas use gene-ID indices,
+                    # so neither should be transposed. Only gene-registry itypes
+                    # (e.g. "bionty.Gene.ensembl_gene_id") need transposition.
                     and not schema.slots["var"].itype.startswith("Feature")
                     )
                     else getattr(self._dataset, slot)

--- a/lamindb/curators/core.py
+++ b/lamindb/curators/core.py
@@ -679,11 +679,28 @@ class ComponentCurator(Curator):
             qs = Feature.connect(using).filter(name__in=self._dataset.keys())
             itype = schema.itype
             if itype and itype.startswith("Feature["):
-                # Scoped itype "Feature[<uid>]": restrict to features of that type only.
-                # Note: startswith("Feature[") not startswith("Feature") because the
-                # unscoped "Feature" itype should not filter by type__uid.
-                type_uid = itype[8:-1]  # len("Feature[") == 8
-                qs = qs.filter(type__uid=type_uid)
+                # Scoped itype "Feature[<uid>]": restrict to features whose type
+                # is the root type OR any of its descendant types (recursive).
+                # Note: startswith("Feature[") not startswith("Feature") because
+                # the unscoped "Feature" itype should not filter by type__uid.
+                #
+                # BFS over the type hierarchy to collect all descendant type UIDs.
+                # Example: type_a → {type_a, type_a1, type_a2}, so features
+                # of type_a1 and type_a2 are also included.
+                root_uid = itype[8:-1]  # len("Feature[") == 8
+                type_uids: set[str] = {root_uid}
+                queue = [root_uid]
+                while queue:
+                    uid = queue.pop()
+                    for child_uid in (
+                        Feature.connect(using)
+                        .filter(type__uid=uid, is_type=True)
+                        .values_list("uid", flat=True)
+                    ):
+                        if child_uid not in type_uids:
+                            type_uids.add(child_uid)
+                            queue.append(child_uid)
+                qs = qs.filter(type__uid__in=type_uids)
             features += qs.to_list()
             feature_ids = {feature.id for feature in features}
 

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -143,7 +143,7 @@ def transfer_schema_members(
     # Only Feature schemas require member-level transfer here.
     # Non-Feature schemas (e.g. large Gene schemas) can have huge memberships
     # and are handled via regular mapping/lookup paths.
-    if source_schema.itype != "Feature":
+    if source_schema.itype is None or not source_schema.itype.startswith("Feature"):
         return None
 
     index_feature_uid = source_schema._index_feature_uid
@@ -818,7 +818,17 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         optional_features = []
         features_registry: Registry = None
         if itype is not None:
-            if itype != "Composite":
+            # If a Feature instance with is_type=True is passed, encode as
+            # "Feature[uid]" to scope the schema to only that feature type.
+            # This check must come before the "Composite" string comparison to
+            # avoid triggering SQLRecord.__bool__ on the Feature instance.
+            if isinstance(itype, Feature) and getattr(itype, "is_type", False):
+                if itype._state.adding:
+                    raise InvalidArgument(
+                        f"Please save the feature type '{itype.name}' before using it as itype."
+                    )
+                itype = f"Feature[{itype.uid}]"
+            elif itype != "Composite":
                 itype = serialize_dtype(itype, is_itype=True)
             else:
                 warnings.warn(
@@ -850,7 +860,7 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
                     optional_features = optional_features_manual
         # n_features stays None if no features passed (flexible schema)
         if dtype is None:
-            dtype = None if itype is not None and itype == "Feature" else NUMBER_TYPE
+            dtype = None if itype is not None and itype.startswith("Feature") else NUMBER_TYPE
         else:
             dtype = get_type_str(dtype)
         if slots:

--- a/tests/pydata/test_schema.py
+++ b/tests/pydata/test_schema.py
@@ -830,3 +830,37 @@ def test_schema_describe_handles_legacy_none_itype():
 
     schema.delete(permanent=True)
     feature.delete(permanent=True)
+
+
+def test_schema_itype_scoped_to_feature_type():
+    """Schema(itype=feature_type) scopes the schema to only that feature type."""
+    import pandas as pd
+    from lamindb.curators import DataFrameCurator
+
+    # Two feature type namespaces.
+    type_a = ln.Feature(name="TypeA", is_type=True).save()
+    type_b = ln.Feature(name="TypeB", is_type=True).save()
+
+    # One feature per namespace.
+    feat_a = ln.Feature(name="feat_in_type_a", dtype=float, type=type_a).save()
+    feat_b = ln.Feature(name="feat_in_type_b", dtype=float, type=type_b).save()
+
+    # Schema scoped to TypeA only — itype stored as "Feature[<uid>]".
+    schema = ln.Schema(itype=type_a).save()
+    assert schema.itype == f"Feature[{type_a.uid}]"
+    assert schema.flexible is True
+    assert schema.dtype is None
+
+    # Curator must pick up only feat_a, not feat_b.
+    df = pd.DataFrame({"feat_in_type_a": [1.0], "feat_in_type_b": [2.0]})
+    curator = DataFrameCurator(df, schema)
+    pandera_cols = set(curator._atomic_curator._pandera_schema.columns.keys())
+    assert "feat_in_type_a" in pandera_cols
+    assert "feat_in_type_b" not in pandera_cols
+
+    # Cleanup.
+    schema.delete(permanent=True)
+    feat_a.delete(permanent=True)
+    feat_b.delete(permanent=True)
+    type_a.delete(permanent=True)
+    type_b.delete(permanent=True)

--- a/tests/pydata/test_schema.py
+++ b/tests/pydata/test_schema.py
@@ -833,34 +833,63 @@ def test_schema_describe_handles_legacy_none_itype():
 
 
 def test_schema_itype_scoped_to_feature_type():
-    """Schema(itype=feature_type) scopes the schema to only that feature type."""
+    """Schema(itype=feature_type) scopes recursively through the type hierarchy.
+
+    Hierarchy used in this test:
+        type_a
+        ├── type_a1  (sub-type of type_a)
+        │   ├── feat_a1_1
+        │   └── feat_a1_2
+        └── type_a2  (sub-type of type_a)
+            └── feat_a2_1
+        type_b  (unrelated — must be excluded)
+        └── feat_b
+    """
     import pandas as pd
     from lamindb.curators import DataFrameCurator
 
-    # Two feature type namespaces.
+    # Root type and an unrelated type.
     type_a = ln.Feature(name="TypeA", is_type=True).save()
     type_b = ln.Feature(name="TypeB", is_type=True).save()
 
-    # One feature per namespace.
-    feat_a = ln.Feature(name="feat_in_type_a", dtype=float, type=type_a).save()
-    feat_b = ln.Feature(name="feat_in_type_b", dtype=float, type=type_b).save()
+    # Sub-types of type_a (one level down).
+    type_a1 = ln.Feature(name="TypeA1", is_type=True, type=type_a).save()
+    type_a2 = ln.Feature(name="TypeA2", is_type=True, type=type_a).save()
 
-    # Schema scoped to TypeA only — itype stored as "Feature[<uid>]".
+    # Leaf features.
+    feat_a1_1 = ln.Feature(name="feat_a1_1", dtype=float, type=type_a1).save()
+    feat_a1_2 = ln.Feature(name="feat_a1_2", dtype=float, type=type_a1).save()
+    feat_a2_1 = ln.Feature(name="feat_a2_1", dtype=float, type=type_a2).save()
+    feat_b = ln.Feature(name="feat_b", dtype=float, type=type_b).save()
+
+    # Schema scoped to type_a — itype stored as "Feature[<uid>]".
     schema = ln.Schema(itype=type_a).save()
     assert schema.itype == f"Feature[{type_a.uid}]"
     assert schema.flexible is True
     assert schema.dtype is None
 
-    # Curator must pick up only feat_a, not feat_b.
-    df = pd.DataFrame({"feat_in_type_a": [1.0], "feat_in_type_b": [2.0]})
+    # Curator must pick up features from type_a1 AND type_a2 (recursive),
+    # but exclude feat_b which belongs to the unrelated type_b.
+    df = pd.DataFrame({
+        "feat_a1_1": [1.0],
+        "feat_a1_2": [2.0],
+        "feat_a2_1": [3.0],
+        "feat_b": [4.0],
+    })
     curator = DataFrameCurator(df, schema)
     pandera_cols = set(curator._atomic_curator._pandera_schema.columns.keys())
-    assert "feat_in_type_a" in pandera_cols
-    assert "feat_in_type_b" not in pandera_cols
+    assert "feat_a1_1" in pandera_cols
+    assert "feat_a1_2" in pandera_cols
+    assert "feat_a2_1" in pandera_cols
+    assert "feat_b" not in pandera_cols
 
     # Cleanup.
     schema.delete(permanent=True)
-    feat_a.delete(permanent=True)
+    feat_a1_1.delete(permanent=True)
+    feat_a1_2.delete(permanent=True)
+    feat_a2_1.delete(permanent=True)
     feat_b.delete(permanent=True)
+    type_a1.delete(permanent=True)
+    type_a2.delete(permanent=True)
     type_a.delete(permanent=True)
     type_b.delete(permanent=True)


### PR DESCRIPTION
This PR is to enabling scoping of features in the schema
Fixes: https://github.com/pfizer-collab/laminlabs/issues/1176