### PR TITLE
🚸 Reject non-Q positional arguments to filter()

### DIFF
--- a/lamindb/models/query_set.py
+++ b/lamindb/models/query_set.py
@@ -28,7 +28,7 @@ from lamindb_setup.core import deprecated
 from lamindb_setup.core._docs import doc_args
 
 from ..base.types import BRANCH_STATUS_TO_CODE, RUN_STATUS_TO_CODE
-from ..errors import DoesNotExist, MultipleResultsFound
+from ..errors import DoesNotExist, InvalidArgument, MultipleResultsFound
 from ._is_versioned import IsVersioned, _adjust_is_latest_when_deleting_is_versioned
 from .can_curate import CanCurate, _inspect, _standardize, _validate
 from .query_manager import SEARCH_QUERY_DEFAULT_LIMIT, _lookup, _search
@@ -1080,6 +1080,35 @@ def process_cols_from_include(
     return result
 
 
+def _ensure_filter_queries(queries: tuple) -> None:
+    """Reject positional filter arguments that are not query expressions.
+
+    `Registry.filter()` used to swallow non-`Q` positional args and return an
+    unfiltered queryset. Django itself errors, but with an unhelpful
+    `ValueError: too many values to unpack`. Require `Q` objects (or
+    `FeaturePredicate` / Django conditional expressions) and point callers at
+    `get()` / keyword lookups instead.
+    """
+    from .feature import FeaturePredicate
+
+    for query in queries:
+        if isinstance(query, (Q, FeaturePredicate)) or getattr(
+            query, "conditional", False
+        ):
+            continue
+        if isinstance(query, str):
+            raise InvalidArgument(
+                "filter() does not accept a string as a positional argument. "
+                f"Did you mean get({query!r})? To query, pass a Q object or "
+                f"keyword arguments, e.g. filter(uid={query!r})."
+            )
+        raise InvalidArgument(
+            "filter() positional arguments must be Q objects. "
+            "Pass field lookups as keyword arguments, e.g. filter(uid='...'), "
+            "or use get() to retrieve a single record by uid."
+        )
+
+
 def _queryset_class_factory(
     registry: Registry, queryset_cls: type[models.QuerySet]
 ) -> type[models.QuerySet]:
@@ -1138,6 +1167,7 @@ class BasicQuerySet(models.QuerySet):
 
     def filter(self, *queries, **expressions) -> BasicQuerySet:
         """Query a set of records."""
+        _ensure_filter_queries(queries)
         expressions = map_query_kwargs(self, expressions)
         if queries or expressions:
             return super().filter(*queries, **expressions)
@@ -1527,6 +1557,8 @@ class QuerySet(BasicQuerySet):
         from lamindb.models import Artifact, Record, Run
 
         from .feature import FeaturePredicate
+
+        _ensure_filter_queries(queries)
 
         feature_predicates = [q for q in queries if isinstance(q, FeaturePredicate)]
         queries = tuple(q for q in queries if not isinstance(q, FeaturePredicate))

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -827,6 +827,11 @@ class Registry(ModelBase):
             queries: One or multiple `Q` objects.
             expressions: Fields and values passed as Django query expressions.
 
+        Raises:
+            :exc:`lamindb.errors.InvalidArgument`: If a positional argument is
+                not a `Q` object. Pass field lookups as keyword arguments or use
+                :meth:`~lamindb.models.SQLRecord.get` to look up a record by uid.
+
         See Also:
             - Guide: :doc:`docs:query-search`
             - Django documentation: `Queries <https://docs.djangoproject.com/en/stable/topics/db/queries/>`__

--- a/tests/pydata/test_queryset.py
+++ b/tests/pydata/test_queryset.py
@@ -280,6 +280,21 @@ def test_one_first():
         qs.one_or_none()
 
 
+def test_filter_rejects_non_q_positional_args():
+    uid = "1y7UO5uJgJCx0000"
+    with pytest.raises(InvalidArgument, match=re.escape(f"Did you mean get({uid!r})")):
+        ln.Transform.filter(uid)
+    with pytest.raises(InvalidArgument, match=re.escape(f"Did you mean get({uid!r})")):
+        ln.Artifact.filter(uid)
+    with pytest.raises(InvalidArgument, match=re.escape(f"Did you mean get({uid!r})")):
+        ln.Transform.filter().filter(uid)
+    with pytest.raises(InvalidArgument, match="positional arguments must be Q objects"):
+        ln.Transform.filter(123)
+
+    assert ln.Transform.filter(ln.Q(uid=uid)).count() == 0
+    assert ln.Transform.filter(uid=uid).count() == 0
+
+
 def test_filter_related_field_name():
     with pytest.raises(
         FieldError,


### PR DESCRIPTION
## Summary
- `Registry.filter(uid)` no longer returns an unfiltered queryset or fails with Django's cryptic `ValueError: too many values to unpack`.
- Positional args must be `Q` objects (or `FeaturePredicate` / Django conditional expressions). A uid-like string now raises `InvalidArgument` and points callers at `get()` / keyword lookups.

Fixes #2206

## Test plan
- [x] `tests/pydata/test_queryset.py::test_filter_rejects_non_q_positional_args`
- [x] Existing filter / `Q` / `FeaturePredicate` tests (`test_filter_related_field_name`, `test_filter_unknown_field`, `test_filter_status_field`, `test_get_filter_branch`, `test_feature_predicate_queries_safe_hybrid`, `test_artifact_filter_by_multiple_features`)