### PR TITLE
👷 Much faster CI on mere docs updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,41 +40,52 @@ jobs:
       - id: set-matrix
         shell: bash
         run: |
-          GROUPS=$(jq -n -c '[]')
-          DOCS_GROUPS=$(jq -n -c '["tutorial", "guide", "tiledbsoma", "biology", "faq", "storage"]')
-          CORE_NON_DOCS_GROUPS=$(jq -n -c '["unit-pydata-sqlite", "unit-pydata-postgres", "unit-storage", "transfer", "cli", "permissions", "no-instance", "minimal"]')
-          CORE_GROUPS=$(jq -n -c --argjson non_docs "$CORE_NON_DOCS_GROUPS" --argjson docs "$DOCS_GROUPS" '$non_docs + $docs')
+          DOCS_GROUPS=("tutorial" "guide" "tiledbsoma" "biology" "faq" "storage")
+          CORE_NON_DOCS_GROUPS=("unit-pydata-sqlite" "unit-pydata-postgres" "unit-storage" "transfer" "cli" "permissions" "no-instance" "minimal")
+          CORE_GROUPS=("${CORE_NON_DOCS_GROUPS[@]}" "${DOCS_GROUPS[@]}")
+          GROUPS=()
 
           if [[ "${{ github.event_name }}" == "push" ]]; then
-            GROUPS=$(jq -n -c --argjson core "$CORE_GROUPS" '$core + ["curator", "integrations"]')
+            GROUPS=("${CORE_GROUPS[@]}" "curator" "integrations")
           else
             if [[ "${{ steps.changes.outputs.core }}" == "true" ]]; then
-              GROUPS=$(jq -n -c --argjson current "$GROUPS" --argjson groups "$CORE_GROUPS" '$current + $groups')
+              GROUPS+=("${CORE_GROUPS[@]}")
             fi
-
             if [[ "${{ steps.changes.outputs.docs }}" == "true" ]]; then
-              GROUPS=$(jq -n -c --argjson current "$GROUPS" --argjson groups "$DOCS_GROUPS" '$current + $groups')
+              GROUPS+=("${DOCS_GROUPS[@]}")
             fi
-
             if [[ "${{ steps.changes.outputs.curator }}" == "true" ]]; then
-              GROUPS=$(jq -n -c --argjson current "$GROUPS" '$current + ["curator"]')
+              GROUPS+=("curator")
             fi
-
             if [[ "${{ steps.changes.outputs.integrations }}" == "true" ]]; then
-              GROUPS=$(jq -n -c --argjson current "$GROUPS" '$current + ["integrations"]')
+              GROUPS+=("integrations")
             fi
           fi
 
-          # Ensure unique group names.
-          UNIQUE_GROUPS=$(echo "$GROUPS" | jq -c 'unique')
-          MATRIX=$(jq -n -c --argjson groups "$UNIQUE_GROUPS" '{group: $groups}')
+          # Ensure unique group names while preserving insertion order.
+          UNIQUE_GROUPS=()
+          declare -A SEEN=()
+          for group in "${GROUPS[@]}"; do
+            if [[ -z "${SEEN[$group]+x}" ]]; then
+              UNIQUE_GROUPS+=("$group")
+              SEEN[$group]=1
+            fi
+          done
+
+          if (( ${#UNIQUE_GROUPS[@]} == 0 )); then
+            MATRIX='{"group":[]}'
+          else
+            GROUPS_JSON=$(printf '"%s",' "${UNIQUE_GROUPS[@]}")
+            GROUPS_JSON="[${GROUPS_JSON%,}]"
+            MATRIX="{\"group\":${GROUPS_JSON}}"
+          fi
 
           # Output as single line for GitHub Actions
-          echo "matrix=$(echo "$MATRIX" | jq -c .)" >> $GITHUB_OUTPUT
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
 
           # Pretty print for debugging
           echo "Generated matrix:"
-          echo "$MATRIX" | jq .
+          echo "$MATRIX"
 
   test:
     needs: pre-filter

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,8 +65,9 @@ jobs:
             fi
           fi
 
-          # Ensure unique group names while preserving order.
-          MATRIX=$(jq -n -c --argjson groups "$GROUPS" '{group: ($groups | reduce .[] as $g ([]; if index($g) then . else . + [$g] end))}')
+          # Ensure unique group names.
+          UNIQUE_GROUPS=$(echo "$GROUPS" | jq -c 'unique')
+          MATRIX=$(jq -n -c --argjson groups "$UNIQUE_GROUPS" '{group: $groups}')
 
           # Output as single line for GitHub Actions
           echo "matrix=$(echo "$MATRIX" | jq -c .)" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,13 @@ jobs:
 
       - uses: dorny/paths-filter@v3
         id: changes
-        if: github.event_name != 'push'
         with:
           filters: |
+            docs:
+              - 'docs/**'
+            core:
+              - '**'
+              - '!docs/**'
             curator:
               - 'lamindb/curators/**'
               - 'lamindb/examples/cellxgene/**'
@@ -35,24 +39,28 @@ jobs:
       - id: set-matrix
         shell: bash
         run: |
-          BASE_GROUPS=$(jq -n -c '["unit-pydata-sqlite", "unit-pydata-postgres", "unit-storage", "tutorial", "guide", "tiledbsoma", "biology", "faq", "storage", "transfer", "cli", "permissions", "no-instance", "minimal"]')
-          ADDITIONAL_GROUPS=[]
+          GROUPS=$(jq -n -c '[]')
+          CORE_GROUPS=$(jq -n -c '["unit-pydata-sqlite", "unit-pydata-postgres", "unit-storage", "tutorial", "guide", "tiledbsoma", "biology", "faq", "storage", "transfer", "cli", "permissions", "no-instance", "minimal"]')
+          DOCS_GROUPS=$(jq -n -c '["tutorial", "guide", "tiledbsoma", "biology", "faq", "storage"]')
 
-          if [[ "${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "repository_dispatch" ]]; then
-            # Run everything on push and dispatch
-            ADDITIONAL_GROUPS=$(jq -n -c '["curator", "integrations"]')
-          else
-            # Otherwise check which paths changed
-            if [[ "${{ steps.changes.outputs.curator }}" == "true" ]]; then
-              ADDITIONAL_GROUPS=$(jq -n -c --argjson groups "$ADDITIONAL_GROUPS" '$groups + ["curator"]')
-            fi
-            if [[ "${{ steps.changes.outputs.integrations }}" == "true" ]]; then
-              ADDITIONAL_GROUPS=$(jq -n -c --argjson groups "$ADDITIONAL_GROUPS" '$groups + ["integrations"]')
-            fi
+          if [[ "${{ steps.changes.outputs.core }}" == "true" ]]; then
+            GROUPS=$(jq -n -c --argjson current "$GROUPS" --argjson groups "$CORE_GROUPS" '$current + $groups')
           fi
 
-          # Combine base groups with any additional groups
-          MATRIX=$(jq -n -c --argjson base "$BASE_GROUPS" --argjson additional "$ADDITIONAL_GROUPS" '{group: ($base + $additional)}')
+          if [[ "${{ steps.changes.outputs.docs }}" == "true" ]]; then
+            GROUPS=$(jq -n -c --argjson current "$GROUPS" --argjson groups "$DOCS_GROUPS" '$current + $groups')
+          fi
+
+          if [[ "${{ steps.changes.outputs.curator }}" == "true" ]]; then
+            GROUPS=$(jq -n -c --argjson current "$GROUPS" '$current + ["curator"]')
+          fi
+
+          if [[ "${{ steps.changes.outputs.integrations }}" == "true" ]]; then
+            GROUPS=$(jq -n -c --argjson current "$GROUPS" '$current + ["integrations"]')
+          fi
+
+          # Ensure unique group names while preserving order.
+          MATRIX=$(jq -n -c --argjson groups "$GROUPS" '{group: ($groups | reduce .[] as $g ([]; if index($g) then . else . + [$g] end))}')
 
           # Output as single line for GitHub Actions
           echo "matrix=$(echo "$MATRIX" | jq -c .)" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
 
       - uses: dorny/paths-filter@v3
         id: changes
+        if: github.event_name != 'push'
         with:
           filters: |
             docs:
@@ -43,20 +44,24 @@ jobs:
           CORE_GROUPS=$(jq -n -c '["unit-pydata-sqlite", "unit-pydata-postgres", "unit-storage", "tutorial", "guide", "tiledbsoma", "biology", "faq", "storage", "transfer", "cli", "permissions", "no-instance", "minimal"]')
           DOCS_GROUPS=$(jq -n -c '["tutorial", "guide", "tiledbsoma", "biology", "faq", "storage"]')
 
-          if [[ "${{ steps.changes.outputs.core }}" == "true" ]]; then
-            GROUPS=$(jq -n -c --argjson current "$GROUPS" --argjson groups "$CORE_GROUPS" '$current + $groups')
-          fi
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            GROUPS=$(jq -n -c --argjson core "$CORE_GROUPS" '$core + ["curator", "integrations"]')
+          else
+            if [[ "${{ steps.changes.outputs.core }}" == "true" ]]; then
+              GROUPS=$(jq -n -c --argjson current "$GROUPS" --argjson groups "$CORE_GROUPS" '$current + $groups')
+            fi
 
-          if [[ "${{ steps.changes.outputs.docs }}" == "true" ]]; then
-            GROUPS=$(jq -n -c --argjson current "$GROUPS" --argjson groups "$DOCS_GROUPS" '$current + $groups')
-          fi
+            if [[ "${{ steps.changes.outputs.docs }}" == "true" ]]; then
+              GROUPS=$(jq -n -c --argjson current "$GROUPS" --argjson groups "$DOCS_GROUPS" '$current + $groups')
+            fi
 
-          if [[ "${{ steps.changes.outputs.curator }}" == "true" ]]; then
-            GROUPS=$(jq -n -c --argjson current "$GROUPS" '$current + ["curator"]')
-          fi
+            if [[ "${{ steps.changes.outputs.curator }}" == "true" ]]; then
+              GROUPS=$(jq -n -c --argjson current "$GROUPS" '$current + ["curator"]')
+            fi
 
-          if [[ "${{ steps.changes.outputs.integrations }}" == "true" ]]; then
-            GROUPS=$(jq -n -c --argjson current "$GROUPS" '$current + ["integrations"]')
+            if [[ "${{ steps.changes.outputs.integrations }}" == "true" ]]; then
+              GROUPS=$(jq -n -c --argjson current "$GROUPS" '$current + ["integrations"]')
+            fi
           fi
 
           # Ensure unique group names while preserving order.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,9 @@ jobs:
         shell: bash
         run: |
           GROUPS=$(jq -n -c '[]')
-          CORE_GROUPS=$(jq -n -c '["unit-pydata-sqlite", "unit-pydata-postgres", "unit-storage", "tutorial", "guide", "tiledbsoma", "biology", "faq", "storage", "transfer", "cli", "permissions", "no-instance", "minimal"]')
           DOCS_GROUPS=$(jq -n -c '["tutorial", "guide", "tiledbsoma", "biology", "faq", "storage"]')
+          CORE_NON_DOCS_GROUPS=$(jq -n -c '["unit-pydata-sqlite", "unit-pydata-postgres", "unit-storage", "transfer", "cli", "permissions", "no-instance", "minimal"]')
+          CORE_GROUPS=$(jq -n -c --argjson non_docs "$CORE_NON_DOCS_GROUPS" --argjson docs "$DOCS_GROUPS" '$non_docs + $docs')
 
           if [[ "${{ github.event_name }}" == "push" ]]; then
             GROUPS=$(jq -n -c --argjson core "$CORE_GROUPS" '$core + ["curator", "integrations"]')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,29 +43,29 @@ jobs:
           DOCS_GROUPS=("tutorial" "guide" "tiledbsoma" "biology" "faq" "storage")
           CORE_NON_DOCS_GROUPS=("unit-pydata-sqlite" "unit-pydata-postgres" "unit-storage" "transfer" "cli" "permissions" "no-instance" "minimal")
           CORE_GROUPS=("${CORE_NON_DOCS_GROUPS[@]}" "${DOCS_GROUPS[@]}")
-          GROUPS=()
+          SELECTED_GROUPS=()
 
           if [[ "${{ github.event_name }}" == "push" ]]; then
-            GROUPS=("${CORE_GROUPS[@]}" "curator" "integrations")
+            SELECTED_GROUPS=("${CORE_GROUPS[@]}" "curator" "integrations")
           else
             if [[ "${{ steps.changes.outputs.core }}" == "true" ]]; then
-              GROUPS+=("${CORE_GROUPS[@]}")
+              SELECTED_GROUPS+=("${CORE_GROUPS[@]}")
             fi
             if [[ "${{ steps.changes.outputs.docs }}" == "true" ]]; then
-              GROUPS+=("${DOCS_GROUPS[@]}")
+              SELECTED_GROUPS+=("${DOCS_GROUPS[@]}")
             fi
             if [[ "${{ steps.changes.outputs.curator }}" == "true" ]]; then
-              GROUPS+=("curator")
+              SELECTED_GROUPS+=("curator")
             fi
             if [[ "${{ steps.changes.outputs.integrations }}" == "true" ]]; then
-              GROUPS+=("integrations")
+              SELECTED_GROUPS+=("integrations")
             fi
           fi
 
           # Ensure unique group names while preserving insertion order.
           UNIQUE_GROUPS=()
           declare -A SEEN=()
-          for group in "${GROUPS[@]}"; do
+          for group in "${SELECTED_GROUPS[@]}"; do
             if [[ -z "${SEEN[$group]+x}" ]]; then
               UNIQUE_GROUPS+=("$group")
               SEEN[$group]=1


### PR DESCRIPTION
Many features of LaminDB meanwhile have a counterpart in the UI and anything other than documenting API and UI together is fragmented and confusing.

This PR refactors the CI so that docs edits trigger much fewer tests; in particular they skip heavy unit and CLI tests.

This makes maintaining mere docs changes here in this repo much faster paced, and hence, documenting UI-specific changes becomes much less of a burden.