### PR TITLE
🚸 Make number of features fetched during `artifact.describe()` configurable

### DIFF
--- a/lamindb/core/_settings.py
+++ b/lamindb/core/_settings.py
@@ -104,11 +104,7 @@ class Settings:
 
     @property
     def annotation(self) -> AnnotationSettings:
-        """Artifact annotation settings.
-
-        For example, `ln.settings.creation.search_names = False` will disable
-        searching for records with similar names during creation.
-        """
+        """Artifact annotation settings."""
         return annotation_settings
 
     # note: this setting should probably be deprecated soon

--- a/lamindb/core/subsettings/_annotation_settings.py
+++ b/lamindb/core/subsettings/_annotation_settings.py
@@ -1,8 +1,8 @@
 class AnnotationSettings:
     n_max_records: int = 1000
-    """Maximal number of records to annotate with during automated annotation.
+    """Maximal number of `SQLRecord` objects to annotate with during automated annotation.
 
-    If the number of records to annotate exceeds this limit, print a warning and do not annotate.
+    If the number of objects to annotate exceeds this limit, print a warning and do not annotate.
 
     The number is calculated per feature for labels, and per schema for features.
     """

--- a/lamindb/models/_describe.py
+++ b/lamindb/models/_describe.py
@@ -247,7 +247,9 @@ def add_two_column_items_to_tree(tree: Tree, two_column_items: list) -> None:
 def describe_artifact(
     record: Artifact,
     related_data: dict | None = None,
+    n_max_features: int | None = None,
 ) -> Tree:
+    from ._django import SCHEMA_MEMBER_PREVIEW_LIMIT
     from ._feature_manager import describe_features
     from ._label_manager import describe_labels
 
@@ -255,10 +257,13 @@ def describe_artifact(
         fk_data = related_data.get("fk", {})
     else:
         fk_data = {}
+    if n_max_features is None:
+        n_max_features = SCHEMA_MEMBER_PREVIEW_LIMIT
     tree = describe_header(record)
     dataset_features_tree, external_features_tree = describe_features(
         record,
         related_data=related_data,
+        schema_member_preview_limit=n_max_features,
     )
     labels_tree = describe_labels(record, related_data=related_data)
     two_column_items = []  # type: ignore
@@ -646,8 +651,12 @@ def describe_schema(record: Schema, slot: str | None = None) -> Tree:
     return tree
 
 
-def describe_postgres(record):
-    from ._django import get_artifact_or_run_with_related, get_collection_with_related
+def describe_postgres(record, n_max_features: int | None = None):
+    from ._django import (
+        SCHEMA_MEMBER_PREVIEW_LIMIT,
+        get_artifact_or_run_with_related,
+        get_collection_with_related,
+    )
 
     model_name = record.__class__.__name__
     msg = f"{colors.green(model_name)}{record.__repr__(include_foreign_keys=False).lstrip(model_name)}\n"
@@ -655,16 +664,23 @@ def describe_postgres(record):
         msg += f"  {colors.italic('Database instance')}\n"
         msg += f"    slug: {record._state.db}\n"
     if model_name in {"Artifact", "Run"}:
+        if n_max_features is None:
+            n_max_features = SCHEMA_MEMBER_PREVIEW_LIMIT
         result = get_artifact_or_run_with_related(
             record,
             include_feature_link=True,
             include_fk=True,
             include_m2m=True,
             include_schema=True,
+            schema_member_preview_limit=n_max_features,
         )
         related_data = result.get("related_data", {})
         if model_name == "Artifact":
-            tree = describe_artifact(record, related_data=related_data)
+            tree = describe_artifact(
+                record,
+                related_data=related_data,
+                n_max_features=n_max_features,
+            )
         else:
             tree = describe_run(record, related_data=related_data)
     elif model_name == "Record":
@@ -688,7 +704,9 @@ def describe_postgres(record):
     return tree
 
 
-def describe_sqlite(record):
+def describe_sqlite(record, n_max_features: int | None = None):
+    from ._django import SCHEMA_MEMBER_PREVIEW_LIMIT
+
     model_name = record.__class__.__name__
     msg = f"{colors.green(model_name)}{record.__repr__(include_foreign_keys=False).lstrip(model_name)}\n"
     if record._state.db is not None and record._state.db != "default":
@@ -723,7 +741,14 @@ def describe_sqlite(record):
         )
     if model_name in {"Artifact", "Run", "Record"}:
         if model_name == "Artifact":
-            tree = describe_artifact(record)
+            tree = describe_artifact(
+                record,
+                n_max_features=(
+                    n_max_features
+                    if n_max_features is not None
+                    else SCHEMA_MEMBER_PREVIEW_LIMIT
+                ),
+            )
         elif model_name == "Run":
             tree = describe_run(record)
         else:
@@ -777,6 +802,7 @@ def describe_postgres_sqlite(
     record,
     return_str: bool = False,
     include: None | Literal["comments"] = None,
+    n_max_features: int | None = None,
 ) -> str | None:
     from ._describe import format_rich_tree
 
@@ -784,8 +810,8 @@ def describe_postgres_sqlite(
         not record._state.adding
         and connections[record._state.db].vendor == "postgresql"
     ):
-        tree = describe_postgres(record)
+        tree = describe_postgres(record, n_max_features=n_max_features)
     else:
-        tree = describe_sqlite(record)
+        tree = describe_sqlite(record, n_max_features=n_max_features)
     append_readme_blocks_to_tree(record, tree, include=include)
     return format_rich_tree(tree, return_str=return_str)

--- a/lamindb/models/_django.py
+++ b/lamindb/models/_django.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from .run import Run
 
 
-SCHEMA_MEMBER_PREVIEW_LIMIT = 20
+SCHEMA_MEMBER_PREVIEW_LIMIT = 50
 
 
 def patch_many_to_many_descriptor() -> None:
@@ -87,6 +87,7 @@ def get_artifact_or_run_with_related(
     include_m2m: bool = False,
     include_feature_link: bool = False,
     include_schema: bool = False,
+    schema_member_preview_limit: int = SCHEMA_MEMBER_PREVIEW_LIMIT,
 ) -> dict[str, Any]:
     """Fetch an artifact with its related data."""
     from ._label_manager import EXCLUDE_LABELS
@@ -258,7 +259,9 @@ def get_artifact_or_run_with_related(
         elif k == "m2m_schemas":
             if v:
                 related_data["m2m_schemas"] = get_schema_m2m_relations(
-                    record, {i["schema"]: i["slot"] for i in v}
+                    record,
+                    {i["schema"]: i["slot"] for i in v},
+                    limit=schema_member_preview_limit,
                 )
 
     def convert_link_data_to_m2m(

--- a/lamindb/models/_feature_manager.py
+++ b/lamindb/models/_feature_manager.py
@@ -485,6 +485,7 @@ def get_features_data(
     related_data: dict | None = None,
     to_dict: bool = False,
     external_only: bool = False,
+    schema_member_preview_limit: int = SCHEMA_MEMBER_PREVIEW_LIMIT,
 ):
     from .artifact import Artifact
 
@@ -534,7 +535,7 @@ def get_features_data(
                     name_field = get_name_field(features[0])
                     feature_names = list(
                         features.values_list(name_field, flat=True)[
-                            :SCHEMA_MEMBER_PREVIEW_LIMIT
+                            :schema_member_preview_limit
                         ]
                     )
                     schema_data[slot] = (schema, feature_names)
@@ -642,6 +643,7 @@ def get_features_data(
 def describe_features(
     self: Artifact | Run | Record,
     related_data: dict | None = None,
+    schema_member_preview_limit: int = SCHEMA_MEMBER_PREVIEW_LIMIT,
 ) -> tuple[Tree | None, Tree | None]:
     """Describe features of an artifact or collection."""
     if self._state.adding:
@@ -655,6 +657,7 @@ def describe_features(
     ) = get_features_data(
         self,
         related_data=related_data,
+        schema_member_preview_limit=schema_member_preview_limit,
     )
 
     # Dataset features section
@@ -665,7 +668,7 @@ def describe_features(
         slot_and_dtype = feature_data.get(feature_name)
         if slot_and_dtype is None:
             # Internal categorical values can exist for features omitted from the
-            # schema-member preview (`SCHEMA_MEMBER_PREVIEW_LIMIT`).
+            # schema-member preview (`schema_member_preview_limit`).
             skipped_internal_feature_labels.append(feature_name)
             continue
         slot, _ = slot_and_dtype
@@ -681,7 +684,7 @@ def describe_features(
             f"{len(skipped_internal_feature_labels)} internal feature(s) in "
             f"describe(): {skipped_preview}. "
             "These features are outside the schema preview limit "
-            f"({SCHEMA_MEMBER_PREVIEW_LIMIT})."
+            f"({schema_member_preview_limit})."
         )
 
     dataset_features_tree_children = []

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -1567,11 +1567,15 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
         cls_or_self,
         return_str: bool = False,
         include: None | Literal["comments"] = None,
+        n_max_features: int | None = None,
     ) -> None | str:
         """Describe schema."""
         if isinstance(cls_or_self, type):
             return type(cls_or_self).describe(
-                cls_or_self, return_str=return_str, include=include
+                cls_or_self,
+                return_str=return_str,
+                include=include,
+                n_max_features=n_max_features,
             )  # type: ignore
         if cls_or_self.pk is None:
             raise ValueError("Schema must be saved before describing")

--- a/lamindb/models/schema.py
+++ b/lamindb/models/schema.py
@@ -1574,8 +1574,6 @@ class Schema(SQLRecord, HasType, CanCurate, TracksRun, TracksUpdates):
             return type(cls_or_self).describe(
                 cls_or_self,
                 return_str=return_str,
-                include=include,
-                n_max_features=n_max_features,
             )  # type: ignore
         if cls_or_self.pk is None:
             raise ValueError("Schema must be saved before describing")

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1675,6 +1675,7 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
         cls_or_self,
         return_str: bool = False,
         include: None | Literal["comments"] = None,
+        n_max_features: int | None = None,
     ) -> None | str:
         """Describe record including relations.
 
@@ -1682,14 +1683,24 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
             return_str: Return a string instead of printing.
             include: Include additional content. Use ``"comments"`` to display
                 readme and comment blocks.
+            n_max_features: Max number of internal schema members shown
+                in ``Artifact.describe()`` previews.
         """
         from ._describe import describe_postgres_sqlite
 
         if isinstance(cls_or_self, type):
-            return type(cls_or_self).describe(cls_or_self, return_str=return_str)  # type: ignore
+            return type(cls_or_self).describe(  # type: ignore
+                cls_or_self,
+                return_str=return_str,
+                include=include,
+                n_max_features=n_max_features,
+            )
         else:
             return describe_postgres_sqlite(
-                cls_or_self, return_str=return_str, include=include
+                cls_or_self,
+                return_str=return_str,
+                include=include,
+                n_max_features=n_max_features,
             )
 
     def __repr__(

--- a/lamindb/models/sqlrecord.py
+++ b/lamindb/models/sqlrecord.py
@@ -1692,8 +1692,6 @@ class BaseSQLRecord(models.Model, metaclass=Registry):
             return type(cls_or_self).describe(  # type: ignore
                 cls_or_self,
                 return_str=return_str,
-                include=include,
-                n_max_features=n_max_features,
             )
         else:
             return describe_postgres_sqlite(

--- a/tests/pydata/test_artifact_describe_to_dataframe.py
+++ b/tests/pydata/test_artifact_describe_to_dataframe.py
@@ -201,6 +201,13 @@ def test_describe_to_dataframe_example_dataset(ccaplog):
     assert "Dataset features" in output_wide
     assert f"extra_cat_{SCHEMA_MEMBER_PREVIEW_LIMIT - 1:02d}" in output_wide
     assert "Skipping values for 5 internal feature(s) in describe()" in ccaplog.text
+    ccaplog.clear()
+    output_wide_custom_limit = artifact3.describe(return_str=True, n_max_features=20)
+    assert "Dataset features" in output_wide_custom_limit
+    assert "extra_cat_19" in output_wide_custom_limit
+    assert "extra_cat_20" not in output_wide_custom_limit
+    assert "Skipping values for 35 internal feature(s) in describe()" in ccaplog.text
+    assert "These features are outside the schema preview limit (20)." in ccaplog.text
 
     # dataset section
     assert (


### PR DESCRIPTION
`artifact.describe()` now accepts `n_max_features`.