### PR TITLE
📝 Create a `manage-records.md` guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,35 +350,32 @@ artifact.features.set_values({
 ln.Artifact.filter(experiment_date == "2025-10-24").to_dataframe(include="features")  # query all artifacts annotated with `experiment_date`
 ```
 
-You can create records for entities underlying your experiments (samples, perturbations, instruments, etc.):
+You can create **records** for entities underlying your experiments (samples, perturbations, instruments, etc.):
 
 ```python
 ln.Record(name="Sample 1", features={gc_content: 0.5}).save()
 ```
 
-You can dynamically create registries and relationships of entities via record types:
+You can create record types and relationships:
 
 ```python
-# create an experiments registry by defining a record type
-experiments_registry = ln.Record(name="Experiments", is_type=True).save()
+# create an Experiments type
+experiments = ln.Record(name="Experiments", is_type=True).save()
 
-# create a record inside the Experiments registry
-ln.Record(name="Experiment 1", type=experiments_registry).save()
+# create a record of that type
+experiment1 = ln.Record(name="Experiment 1", type=experiments).save()
 
-# create a feature that links experiments, creating a relationship
-experiment = ln.Feature(name="experiment", dtype=experiments_registry).save()
+# create a feature that links experiments (a relationship)
+experiment = ln.Feature(name="experiment", dtype=experiments).save()
 
-# create a sample record that links the sample to `Experiment 1` via the `experiment` feature
-ln.Record(name="Sample 2", features={gc_content: 0.5, experiment: "Experiment 1"}).save()
+# create a sample record
+ln.Record(name="Sample 2", features={gc_content: 0.5, experiment: experiment1}).save()
 
-# export a registry to a dataframe
-experiments_registry.to_dataframe()
+# export all experiments
+experiments.to_dataframe()
 ```
 
-<details>
-<summary>You can edit records like Excel sheets on LaminHub.</summary>
-<img width="800px" src="https://lamin-site-assets.s3.amazonaws.com/.lamindb/XSzhWUb0EoHOejiw0003.png">
-</details>
+Watch a mini video: [youtu.be/NRzVQXJaRH8](https://youtu.be/NRzVQXJaRH8)
 
 ### Lakehouse
 

--- a/docs/curate.md
+++ b/docs/curate.md
@@ -5,7 +5,9 @@ execute_via: python
 # Curate datasets
 
 ```{raw} html
+<div align="center">
 <iframe width="560" height="315" src="https://www.youtube.com/embed/Ji6E7hTnReQ?si=K0OnU2MTGv4fIhFo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
 ```
 
 Curating a dataset means three things:

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -15,7 +15,7 @@ query-search
 track
 organize
 manage-changes
-manage-ontologies
+manage-records
 transfer
 ```
 

--- a/docs/manage-changes.md
+++ b/docs/manage-changes.md
@@ -3,7 +3,9 @@
 To manage changes, you can use versioning, branching, an `archive` and the `trash`.
 
 ```{raw} html
+<div align="center">
 <iframe width="560" height="315" src="https://www.youtube.com/embed/rzRwcMj6-fc?si=Eqn4dBZyFDrbcxvm" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
 ```
 
 ## Versioning

--- a/docs/manage-ontologies.md
+++ b/docs/manage-ontologies.md
@@ -7,7 +7,9 @@ execute_via: python
 This guide shows how to manage ontologies for basic biological entities.
 
 ```{raw} html
+<div align="center">
 <iframe width="560" height="315" src="https://www.youtube.com/embed/3vpWjHj3Kw8?si=D0jxqL2zB4idh2QA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
 ```
 
 If instead you're interested in

--- a/docs/manage-records.md
+++ b/docs/manage-records.md
@@ -14,7 +14,9 @@ public-ontologies
 ```
 
 ```{raw} html
+<div align="center">
 <iframe width="560" height="315" src="https://www.youtube.com/embed/NRzVQXJaRH8?si=Eqn4dBZyFDrbcxvm" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
 ```
 
 ## Link transforms to a record

--- a/docs/manage-records.md
+++ b/docs/manage-records.md
@@ -1,5 +1,10 @@
 # Manage records & ontologies
 
+Many use cases involving records management are primarily UI-based. However, the API allows you to perform all UI actions, too, see {class}`~lamindb.Record`.
+Use cases involving ontology management are largely API-based and documented here: {doc}`/manage-ontologies`.
+
+The following video provides an overview of the interplay of flexible records and ontology management on the UI:
+
 ```{toctree}
 :maxdepth: 1
 :hidden:
@@ -11,64 +16,6 @@ public-ontologies
 ```{raw} html
 <iframe width="560" height="315" src="https://www.youtube.com/embed/NRzVQXJaRH8?si=Eqn4dBZyFDrbcxvm" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 ```
-
-For API examples, see {class}`~lamindb.Record`.
-
-## Edit records like sheets
-
-The hub offers a spreadsheet-like edit experience for {class}`~lamindb.Record` types that enforce a schema:
-
-1. Create or select "sheet" on the left navbar under `/records`, e.g., here https://lamin.ai/laminlabs/lamindata/records
-
-   You can organize your sheets using record types, similar to creating folders that contain different groups of related sheets. This hierarchical structure is visualized in the left navigation panel — click the `+` button to create new record types:
-
-   <div align="center">
-   <img src="https://lamin-site-assets.s3.amazonaws.com/.lamindb/e4ueQpX1chfYETo70001.png" style="width: 40%;"/>
-   </div>
-
-2. Select the type you want.
-3. Click on "Edit" to add edit rows in the sheet.
-4. Each value in the sheet becomes a selectable option in dropdown menus.
-
-   You can link columns in one sheet to another sheet or registry by specifying the appropriate data type. This creates relational connections that maintain data integrity and enable powerful cross-referencing.
-
-   In the example shown, the `time_unit` column points to the TimeUnit sheet, which defines the permissible values for this field. This relationship ensures that only valid time units can be selected.
-
-   <div align="center">
-   <img src="https://lamin-site-assets.s3.amazonaws.com/.lamindb/aVUC7UyIkJIxwSXv0000.png" style="width: 80%;"/>
-   </div>
-
-   Column relationships include registry links to predefined registries like TimeUnit or Treatment, ontology references that connect to biological ontologies (bionty.Organism, bionty.Tissue), cross-sheet references that link to records in other custom sheets, and enum constraints that restrict values to predefined lists.
-
-   <div align="center">
-   <img src="https://lamin-site-assets.s3.amazonaws.com/.lamindb/uE0ax5NAXqjTfgGC0000.png" style="width: 80%;"/>
-   </div>
-
-Sheets display field definitions in the headers, showing both field names and their corresponding data types:
-
-<div align="center">
-  <img src="https://lamin-site-assets.s3.amazonaws.com/.lamindb/DQLooUQbCCRxHRlx0000.png" style="width: 50%;"/>
-</div>
-
-<div align="center">
-  <img src="https://lamin-site-assets.s3.amazonaws.com/.lamindb/KeRnttLkyhHYXVag0000.png" style="width: 80%;"/>
-</div>
-
-## Import a csv into a sheet
-
-Click the following button in the upper right corner of a sheet page:
-
-<div align="center">
-  <img src="https://lamin-site-assets.s3.amazonaws.com/.lamindb/g6SXhxeBh7mooqsv0000.png" style="width: 80%;"/>
-</div>
-
-:::{tip}
-Include a `__lamindb_record_name__` column to set the name of each record (mapped to the `record.name` field and not shown as a data column).
-:::
-
-## Export records as artifacts
-
-Click on "Export to Artifact" to save all records under a type as an artifact.
 
 ## Link transforms to a record
 
@@ -89,3 +36,9 @@ You can now launch the transform via the small "Launch" button, directly from th
    <div align="center">
    <img src="https://lamin-site-assets.s3.amazonaws.com/.lamindb/tGS4pGEXqkXVscP90000.png" style="width: 50%;"/>
    </div>
+
+## Export sheets as artifacts
+
+Click on "Export to Artifact" to save all records under a type as an artifact.
+
+In the API, call {meth}`~lamindb.Record.to_artifact()` for a `sheet`.

--- a/docs/manage-records.md
+++ b/docs/manage-records.md
@@ -1,0 +1,91 @@
+# Manage records & ontologies
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+
+manage-ontologies
+public-ontologies
+```
+
+```{raw} html
+<iframe width="560" height="315" src="https://www.youtube.com/embed/NRzVQXJaRH8?si=Eqn4dBZyFDrbcxvm" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+```
+
+For API examples, see {class}`~lamindb.Record`.
+
+## Edit records like sheets
+
+The hub offers a spreadsheet-like edit experience for {class}`~lamindb.Record` types that enforce a schema:
+
+1. Create or select "sheet" on the left navbar under `/records`, e.g., here https://lamin.ai/laminlabs/lamindata/records
+
+   You can organize your sheets using record types, similar to creating folders that contain different groups of related sheets. This hierarchical structure is visualized in the left navigation panel — click the `+` button to create new record types:
+
+   <div align="center">
+   <img src="https://lamin-site-assets.s3.amazonaws.com/.lamindb/e4ueQpX1chfYETo70001.png" style="width: 40%;"/>
+   </div>
+
+2. Select the type you want.
+3. Click on "Edit" to add edit rows in the sheet.
+4. Each value in the sheet becomes a selectable option in dropdown menus.
+
+   You can link columns in one sheet to another sheet or registry by specifying the appropriate data type. This creates relational connections that maintain data integrity and enable powerful cross-referencing.
+
+   In the example shown, the `time_unit` column points to the TimeUnit sheet, which defines the permissible values for this field. This relationship ensures that only valid time units can be selected.
+
+   <div align="center">
+   <img src="https://lamin-site-assets.s3.amazonaws.com/.lamindb/aVUC7UyIkJIxwSXv0000.png" style="width: 80%;"/>
+   </div>
+
+   Column relationships include registry links to predefined registries like TimeUnit or Treatment, ontology references that connect to biological ontologies (bionty.Organism, bionty.Tissue), cross-sheet references that link to records in other custom sheets, and enum constraints that restrict values to predefined lists.
+
+   <div align="center">
+   <img src="https://lamin-site-assets.s3.amazonaws.com/.lamindb/uE0ax5NAXqjTfgGC0000.png" style="width: 80%;"/>
+   </div>
+
+Sheets display field definitions in the headers, showing both field names and their corresponding data types:
+
+<div align="center">
+  <img src="https://lamin-site-assets.s3.amazonaws.com/.lamindb/DQLooUQbCCRxHRlx0000.png" style="width: 50%;"/>
+</div>
+
+<div align="center">
+  <img src="https://lamin-site-assets.s3.amazonaws.com/.lamindb/KeRnttLkyhHYXVag0000.png" style="width: 80%;"/>
+</div>
+
+## Import a csv into a sheet
+
+Click the following button in the upper right corner of a sheet page:
+
+<div align="center">
+  <img src="https://lamin-site-assets.s3.amazonaws.com/.lamindb/g6SXhxeBh7mooqsv0000.png" style="width: 80%;"/>
+</div>
+
+:::{tip}
+Include a `__lamindb_record_name__` column to set the name of each record (mapped to the `record.name` field and not shown as a data column).
+:::
+
+## Export records as artifacts
+
+Click on "Export to Artifact" to save all records under a type as an artifact.
+
+## Link transforms to a record
+
+Click on the "Link" button in the "Transforms" card of the record page, e.g., here: https://lamin.ai/laminlabs/lamindata/record/mPiUOc67hQAw4Pgz
+
+   <div align="center">
+   <img src="https://lamin-site-assets.s3.amazonaws.com/.lamindb/TPoeyphpn6evhJW60000.png" style="width: 80%;"/>
+   </div>
+
+Select a transform:
+
+   <div align="center">
+   <img src="https://lamin-site-assets.s3.amazonaws.com/.lamindb/mfDYB2FrwsVpWy7T0000.png" style="width: 50%;"/>
+   </div>
+
+You can now launch the transform via the small "Launch" button, directly from the record:
+
+   <div align="center">
+   <img src="https://lamin-site-assets.s3.amazonaws.com/.lamindb/tGS4pGEXqkXVscP90000.png" style="width: 50%;"/>
+   </div>

--- a/docs/public-ontologies.md
+++ b/docs/public-ontologies.md
@@ -1,1 +1,3 @@
+# Access public ontologies
+
 <!-- see lamin-usecases/docs for the production source -->

--- a/docs/public-ontologies.md
+++ b/docs/public-ontologies.md
@@ -1,0 +1,1 @@
+<!-- see lamin-usecases/docs for the production source -->

--- a/docs/track.md
+++ b/docs/track.md
@@ -7,7 +7,9 @@ execute_via: python
 This guide walks from tracking data lineage in a notebook to tracking parameters in workflows.
 
 ```{raw} html
+<div align="center">
 <iframe width="560" height="315" src="https://www.youtube.com/embed/yK3ODFZLL1A?si=Eqn4dBZyFDrbcxvm" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
 ```
 
 To run examples, if you don't have a `lamindb` instance, create one:

--- a/lamindb/models/record.py
+++ b/lamindb/models/record.py
@@ -31,16 +31,14 @@ from .query_set import (
     get_default_branch_ids,
 )
 from .run import Run, TracksRun, TracksUpdates, User, current_run, current_user_id
-from lamindb.base.types import Unset
-
 from .sqlrecord import (
+    UNSET,
     BaseSQLRecord,
     Branch,
     HasType,
     IsLink,
     Space,
     SQLRecord,
-    UNSET,
     _get_record_kwargs,
     pop_space_branch_kwargs,
 )
@@ -52,6 +50,8 @@ if TYPE_CHECKING:
     from datetime import datetime
 
     import pandas as pd
+
+    from lamindb.base.types import Unset
 
     from ._feature_manager import FeatureManager
     from .block import RecordBlock
@@ -590,6 +590,8 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
     Examples
     --------
 
+    Also see the guide: :doc:`/manage-records`.
+
     Create a **record** with a single feature::
 
         # create a feature if you don't yet have one
@@ -603,14 +605,14 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
 
     Group records by creating a **record type**, optionally constrained with a :class:`~lamindb.Schema`::
 
-        # use a record type to create an experiments registry
-        experiments_registry = ln.Record(name="Experiments", is_type=True).save()
-        experiment1 = ln.Record(name="Experiment 1", type=experiments_registry).save()
+        # create an Experiments type
+        experiments = ln.Record(name="Experiments", is_type=True).save()
+        experiment1 = ln.Record(name="Experiment 1", type=experiments).save()
 
         # create a feature to link experiments
-        experiment = ln.Feature(name="experiment", dtype=experiments_registry).save()
+        experiment = ln.Feature(name="experiment", dtype=experiments).save()
 
-        # create a samples sheet by constraining a record type with a schema
+        # create a Sample Sheet by constraining a record type with a schema
         schema = ln.Schema([experiment, gc_content.with_config(optional=True)], name="sample_schema").save()
         sample_sheet = ln.Record(name="Sample Sheet", is_type=True, schema=schema).save()
 
@@ -619,14 +621,13 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
         sample1.save()
 
         # reset the feature values for the record including the experiment
-        sample1.features.set_values({
-            gc_content: 0.5,
+        sample1.features.set_values({gc_content: 0.5,
             experiment: "Experiment 1",  # automatically resolves by name, also accepts the experiment1 object
         })
 
     Export all records of a type to a dataframe::
 
-        experiments_registry.to_dataframe()
+        experiments.to_dataframe()
         #> __lamindb_record_name__   ...
         #>            Experiment 1   ...
         #>            Experiment 2   ...
@@ -667,11 +668,6 @@ class Record(SQLRecord, HasType, HasParents, CanCurate, TracksRun, TracksUpdates
 
     Notes
     -----
-
-    You can edit records like spreadsheets in the UI:
-
-    .. image:: https://lamin-site-assets.s3.amazonaws.com/.lamindb/XSzhWUb0EoHOejiw0003.png
-        :width: 800px
 
     .. dropdown:: An index feature maps onto the name field of a record.
 


### PR DESCRIPTION
We did have a terribly outdated `records.md` doc in `lamin-docs` under “The Hub”. This was bad because it makes it seem like records are a hub feature, which they’re not.

The records management guide is now called `manage-records.md` and part of the LaminDB docs under the joint "Manage records & ontologies" header. Records management (frequent updates, flexible schema) and ontology management (less frequent updates, rigid schema) should group together given how closely related they are.

Before | After
--- | ---
<img width="1399" height="957" alt="image" src="https://github.com/user-attachments/assets/bfc61c17-d974-4528-a600-1ef31cc81a19" /> | <img width="1366" height="800" alt="image" src="https://github.com/user-attachments/assets/23ee9115-3441-426e-b0b0-29ee8aa8d6f1" />

Almost nothing is left from the original `records.md` document: In the commit sequence of this PR, I removed outdated screenshots and replaced them with the up-to-date video. Also see the PR below for the doc movement.

- https://github.com/laminlabs/lamin-docs/pull/533

Internal Slack thread: https://laminlabs.slack.com/archives/C04A88BKZPX/p1788877604592619